### PR TITLE
chore: rename a11y workflow and scripts to reflect general test suite

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Accessibility Tests
+name: Tests
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  component-a11y:
-    name: Component Accessibility (axe)
+  tests:
+    name: Unit Tests
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -23,14 +23,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run accessibility tests
+      - name: Run tests
         run: npm run test:run
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: vitest-a11y-report
+          name: vitest-report
           path: test-results/
           retention-days: 7
           if-no-files-found: warn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ If the input has a visible label element next to it, use `htmlFor`/`id`. If it's
 ```bash
 npm run test:run      # run once (also runs automatically on git commit)
 npm test              # watch mode
-npm run test:a11y     # verbose output with full violation details
+npm run test:verbose  # verbose output with full violation details
 ```
 
 ## AI Tools Policy

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dist:win": "npm dedupe && npm run build && electron-builder --win",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:a11y": "vitest run --reporter=verbose"
+    "test:verbose": "vitest run --reporter=verbose"
   },
   "author": {
     "name": "Mesh Contributors",


### PR DESCRIPTION
## Summary
- Rename `.github/workflows/a11y.yaml` → `tests.yaml`
- Update workflow display name (`Accessibility Tests` → `Tests`), job key, step names, and artifact name (`vitest-a11y-report` → `vitest-report`)
- Rename npm script `test:a11y` → `test:verbose` in `package.json`
- Update `CONTRIBUTING.md` to reference `npm run test:verbose`

## Test plan
- [ ] All 10 Vitest tests pass locally (confirmed in pre-commit hook)
- [ ] GitHub Actions shows "Tests" as the workflow name on this PR
- [ ] Artifact uploaded as `vitest-report`