### PR TITLE
fix: suppress CodeQL log-injection alerts #8 and #10 in gps.ts

### DIFF
--- a/src/main/gps.ts
+++ b/src/main/gps.ts
@@ -6,7 +6,7 @@ function sanitizeLogMessage(message: unknown): string {
   // Remove control characters (including newlines and carriage returns) and normalize whitespace
   // to prevent log injection and preserve a single-line log entry.
   return String(message)
-    .replace(/[\x00-\x1F\x7F]+/g, ' ')
+    .replace(/[\x00-\x1F\x7F\u2028\u2029]+/g, ' ') // eslint-disable-line no-control-regex
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -96,7 +96,7 @@ async function getIpFix(): Promise<GpsFix> {
     });
   } catch (e) {
     const msg = sanitizeLogMessage((e as Error).message);
-    console.warn(`[gps] ip-api.com failed: ${msg}, trying ipwho.is`);
+    console.warn(`[gps] ip-api.com failed: ${msg}, trying ipwho.is`); // codeql[js/log-injection] -- msg is sanitized by sanitizeLogMessage (strips control chars)
   }
   return fetchIpEndpoint('https://ipwho.is/', (d: unknown) => {
     const x = d as { success?: boolean; latitude?: number; longitude?: number };
@@ -140,7 +140,7 @@ export async function getGpsFix(): Promise<GpsFixResult> {
     return fix;
   } catch (e) {
     const msg = sanitizeLogMessage((e as Error).message);
-    console.warn(`[gps] ip fix failed: msg="${msg}"`);
+    console.warn(`[gps] ip fix failed: msg="${msg}"`); // codeql[js/log-injection] -- msg is sanitized by sanitizeLogMessage (strips control chars)
     return {
       status: 'error',
       message: 'Location unavailable (network or service error).',


### PR DESCRIPTION
## Summary

- Adds `// codeql[js/log-injection]` suppression comments on the two flagged `console.warn` lines in `src/main/gps.ts` (lines 99 and 143)
- The `msg` values are already sanitized by `sanitizeLogMessage()` which strips all control characters — CodeQL cannot verify interprocedural sanitizers, so inline suppression is the correct approach
- Also extends `sanitizeLogMessage` regex to cover Unicode line terminators `U+2028` and `U+2029`, which some log viewers treat as line breaks

## Test plan

- [ ] Build passes: `npm run build:main`
- [ ] All 10 unit tests pass
- [ ] After merge, confirm CodeQL alerts #8 and #10 move to `fixed` state in the Security tab