### PR TITLE
fix: resolve CodeQL alerts for __dirname in ESM and unclosed HTTP response

### DIFF
--- a/src/main/gps.ts
+++ b/src/main/gps.ts
@@ -55,9 +55,12 @@ function fetchIpEndpoint(url: string, extract: (data: unknown) => GpsFix | null)
     const request = protocol.request(parsedUrl, { method: 'GET' }, (response) => {
       let body = '';
       response.on('data', (chunk: Buffer) => {
-        if (body.length + chunk.length <= MAX_IP_RESPONSE_BYTES) {
-          body += chunk.toString();
+        if (body.length + chunk.length > MAX_IP_RESPONSE_BYTES) {
+          clearTimeout(timer);
+          request.destroy(new Error('response too large'));
+          return;
         }
+        body += chunk.toString();
       });
       response.on('end', () => {
         clearTimeout(timer);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
@@ -15,6 +18,6 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: { '@': path.resolve(__dirname, 'src') },
+    alias: { '@': resolve(__dirname, 'src') },
   },
 });


### PR DESCRIPTION
## Summary

- **`vitest.config.ts`**: Replace CommonJS `__dirname` with ESM-compatible `dirname(fileURLToPath(import.meta.url))` — fixes CodeQL alert for `__dirname` being unavailable in ES module context (runtime error risk).
- **`src/main/gps.ts`**: When `MAX_IP_RESPONSE_BYTES` is exceeded, call `request.destroy(new Error('response too large'))` instead of silently dropping chunks — fixes CodeQL alert for unclosed HTTP connections that continue buffering data unnecessarily. The existing `request.on('error', ...)` handler propagates the rejection cleanly.

## Test plan

- [x] `npm run build:main` — compiles without errors
- [x] `npm test` — all 10 tests pass
- [x] Prettier and ESLint pass (pre-commit hooks green)