### PR TITLE
docs: update GPS fallback note and vitest coverage mention

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,21 +17,21 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contribute to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community.
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community.
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of any kind
-* Trolling, insulting, or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address, without
-   their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting, or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without
+  their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 
@@ -57,7 +57,7 @@ reported to the community leaders responsible for enforcement at
 admin@coloradomesh.org.
 All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the 
+All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
 
 ## Enforcement Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ If the input has a visible label element next to it, use `htmlFor`/`id`. If it's
 
 ### Running the tests
 
+The vitest suite covers main-process utilities including GPS helpers (`src/main/gps.ts`).
+
 ```bash
 npm run test:run      # run once (also runs automatically on git commit)
 npm test              # watch mode

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ npm run trace-deprecation
 
 - Grant location permission when prompted by the app.
 - Or set coordinates manually via the **Radio** tab → Fixed Position.
-- Note: The IP-geolocation fallback provides city-level accuracy only — not suitable for position broadcasting.
+- Note: The IP-geolocation fallback (ip-api.com, then ipwho.is) provides city-level accuracy only — not suitable for position broadcasting. If both services are unreachable, "Location unavailable" is shown.
 
 ### "Something went wrong" blank screen
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,16 +5,17 @@ We take the security of our project seriously and appreciate your efforts to hel
 ## Reporting a Vulnerability
 
 If you believe you have found a security vulnerability, please **do not report it via a public GitHub issue**. Instead, please
- * send an email to: **nv0n@coloradomesh.org** or,
- * DM nv0n on our Discord
+
+- send an email to: **nv0n@coloradomesh.org** or,
+- DM nv0n on our Discord
 
 To help us investigate and triage the issue as quickly as possible, please include:
 
-* **Type of issue** (e.g., buffer overflow, SQL injection, cross-site scripting).
-* **Full paths of source files** related to the manifestation of the issue.
-* **Step-by-step instructions** to reproduce the vulnerability.
-* **Proof-of-concept or exploit code** (if possible).
-* **Impact of the issue**, including how an attacker might exploit it.
+- **Type of issue** (e.g., buffer overflow, SQL injection, cross-site scripting).
+- **Full paths of source files** related to the manifestation of the issue.
+- **Step-by-step instructions** to reproduce the vulnerability.
+- **Proof-of-concept or exploit code** (if possible).
+- **Impact of the issue**, including how an attacker might exploit it.
 
 ## Response Timeline
 


### PR DESCRIPTION
## Summary

- **README**: Expanded the GPS troubleshooting note to name both IP geolocation fallback services (`ip-api.com` → `ipwho.is`) and document the "Location unavailable" message shown when both are unreachable.
- **CONTRIBUTING**: Added a sentence clarifying that the vitest suite covers main-process utilities including `gps.ts` helpers.
- **CODE_OF_CONDUCT / SECURITY**: Prettier formatting fixes (flagged by pre-commit hook).

## Test plan

- [ ] Verify README GPS troubleshooting section reads naturally at the fallback note
- [ ] Verify CONTRIBUTING testing section clearly explains vitest scope
- [ ] All vitest tests pass (`npm run test:run` — 10/10 ✓)