### PR TITLE
fix: Windows postinstall ENOENT when falling back to @electron/rebuild

### DIFF
--- a/scripts/rebuild-native.mjs
+++ b/scripts/rebuild-native.mjs
@@ -67,9 +67,27 @@ if (!fs.existsSync(betterSqlite3Node)) {
   console.log(
     "better-sqlite3 native binary missing after install-app-deps; running @electron/rebuild…",
   );
+  // Run rebuild via node + CLI path so postinstall works on Windows (spawnSync("npx")
+  // fails with ENOENT: npx is npx.cmd and is not a direct executable). Do not use
+  // require.resolve("@electron/rebuild/lib/cli.js") — package exports block that path.
+  const rebuildCli = path.join(
+    projectRoot,
+    "node_modules",
+    "@electron",
+    "rebuild",
+    "lib",
+    "cli.js",
+  );
+  if (!fs.existsSync(rebuildCli)) {
+    console.error(
+      "@electron/rebuild not found; ensure npm install completed (electron-builder brings it in). " +
+        "On Windows, do not rely on npx from spawn — run: npx --yes @electron/rebuild -f -w better-sqlite3",
+    );
+    process.exit(1);
+  }
   const rebuildResult = spawnSync(
-    "npx",
-    ["--yes", "@electron/rebuild", "-f", "-w", "better-sqlite3"],
+    process.execPath,
+    [rebuildCli, "-f", "-w", "better-sqlite3"],
     { cwd: projectRoot, stdio: "inherit", env: { ...process.env } },
   );
   if (rebuildResult.error) {


### PR DESCRIPTION
## Summary

`npm install` was failing on Windows during `postinstall` when `rebuild-native.mjs` fell back to `@electron/rebuild` after `install-app-deps` did not produce `better_sqlite3.node`. `spawnSync('npx', ...)` returns **ENOENT** because on Windows `npx` is a `.cmd` shim and is not a direct executable for Node's `spawn`.

## What changed

- **`scripts/rebuild-native.mjs`** — Replaced `spawnSync('npx', ['--yes', '@electron/rebuild', ...])` with `spawnSync(process.execPath, [rebuildCli, '-f', '-w', 'better-sqlite3'])`, matching the existing pattern used for `install-app-deps` (node + JS entrypoint, no shell).
- **CLI path** — Built with `path.join(projectRoot, 'node_modules', '@electron', 'rebuild', 'lib', 'cli.js')`. `require.resolve('@electron/rebuild/lib/cli.js')` is not used because the package `exports` field blocks that subpath (`ERR_PACKAGE_PATH_NOT_EXPORTED`).
- **Failure mode** — If the CLI file is missing, the script exits with a clear message and suggests the manual `npx` command for Windows users.

## Why

- Unblocks `npm install` on Windows when the rebuild fallback runs.
- Keeps the no-`shell: true` approach (consistent with the install-app-deps invocation and Node DEP0190).

## How to test

1. On Windows, clone/fetch branch and run `npm install` — postinstall should complete if build tools are present.
2. Alternatively run `node scripts/rebuild-native.mjs` after install; when the fallback path runs, it should invoke rebuild without ENOENT.
3. `npm run test:run` (CI parity) — all renderer tests pass; script change is postinstall-only.

## Risks / follow-ups

- Assumes `@electron/rebuild` is present under `node_modules` (transitive via electron-builder). If a future install layout omits it, the new error path directs users to run `npx` manually.