### PR TITLE
chore: bump GitHub Actions to Node 24 runtime (v6)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,10 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,9 +13,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vitest-report
           path: test-results/


### PR DESCRIPTION
## Summary

Upgrades `actions/checkout`, `actions/setup-node`, and `actions/upload-artifact` to majors that run on **Node 24** so workflows stay valid when GitHub makes Node 24 the default for JS actions (June 2, 2026).

## What changed

- **ci.yaml** — `actions/checkout@v6`, `actions/setup-node@v6`. Build step still uses job Node 20 via `node-version: '20'`; only the action runtime moves off Node 20.
- **tests.yaml** — Same checkout/setup-node bumps; **upload-artifact@v4 → v6** for the vitest-report upload step. Existing `with:` (`name`, `path`, `retention-days`, `if-no-files-found`) unchanged and still supported in v6.
- **release.yaml** — checkout/setup-node v6 for the Electron publish matrix (macOS/Linux/Windows).

## Why

GitHub deprecated Node 20 for JavaScript actions; v4 of checkout/setup-node still use the Node 20 runtime and trigger deprecation notices. v5+ checkout and current setup-node/upload-artifact lines use `node24` per upstream action.yml.

## How to test

- CI and Tests workflows run on push/PR; confirm green checks on this PR.
- Release workflow only runs on version tags; no change to publish behavior expected.

## Risks / follow-ups

- **Self-hosted runners** must be ≥ v2.327.1 for checkout v5+ (hosted runners already satisfy this).
- Job Node remains 20; bumping to 22/24 later should be a separate change after validating Electron/native rebuilds.