### PR TITLE
fix: macOS 26 packaged app crash (EXC_BREAKPOINT at launch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,8 @@ You're missing build tools for the native SQLite module:
 
 ### App crashes on launch (macOS distributable)
 
-- This may be a native module signing issue — try rebuilding: `npm run dist:mac`
+- **macOS 26 (Tahoe) + EXC_BREAKPOINT at launch**: electron-builder ad-hoc signing can crash during ElectronMain/V8 init before any app code runs. This repo sets `mac.identity: null` in `electron-builder.yml` so the packaged app is unsigned and avoids that re-sign path; first open may require **Right-click → Open** or `xattr -cr` on the app. For notarized releases, set a real Developer ID in `mac.identity` and retest on macOS 26. See [electron#49522](https://github.com/electron/electron/issues/49522) and [electron-builder#9396](https://github.com/electron-userland/electron-builder/issues/9396).
+- This may also be a native module signing issue — try rebuilding: `npm run dist:mac`
 - If building from source: make sure `npm install` completed without errors
 
 ### App shows "disconnected" but device is still on

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,7 +27,12 @@ extraResources:
   - from: resources/icons/mac/macos-menubar-icon-Template/macos-menubar-icon-Template@3x.png
     to: macos-menubar-icon-Template@3x.png
 mac:
-  identity: "-"
+  # macOS 26+: ad-hoc signing (identity "-") can crash at launch with EXC_BREAKPOINT during
+  # ElectronMain/V8 init. identity: null skips signing so the bundled Electron Framework
+  # is not re-signed with a mismatched/ad-hoc identity. For notarized releases, set a real
+  # Developer ID here instead. See https://github.com/electron/electron/issues/49522
+  # and https://github.com/electron-userland/electron-builder/issues/9396
+  identity: null
   category: public.app-category.utilities
   # Hardened runtime improves tamper resistance; required for notarized distribution.
   hardenedRuntime: true


### PR DESCRIPTION
## Summary

Packaged mac builds produced by `npm run dist:mac` were crashing immediately on **macOS 26 (Tahoe)** with **EXC_BREAKPOINT (SIGTRAP)** during ElectronMain / V8 initialization—before any application JavaScript runs. This change stops electron-builder from ad-hoc re-signing the app so the bundled Electron Framework is not left in a state that triggers that native abort on macOS 26.

## What changed

- **electron-builder.yml** — `mac.identity` changed from `"-"` (ad-hoc) to `null` (no signing). Only the `mac:` block is touched; **Linux and Windows builds are unchanged**.
- **README.md** — Troubleshooting section updated: explains the crash, first-open/Gatekeeper behavior for unsigned builds, and points to upstream issues for context.

## Why

- Same failure mode as [electron/electron#49522](https://github.com/electron/electron/issues/49522) and [electron-builder#9396](https://github.com/electron-userland/electron-builder/issues/9396): multiple reports that **identity: null** avoids the crash on macOS 26 when electron-builder’s signing path otherwise leads to EXC_BREAKPOINT during startup.
- Ad-hoc `identity: "-"` was already not notarization-grade; notarized releases should use a real Developer ID in `mac.identity` and be re-tested on macOS 26.

## How to test

1. On macOS 26: `npm run dist:mac`, open the produced `Mesh-client.app` (from DMG or copied to Applications). App should start instead of trapping immediately.
2. First launch may require **Right-click → Open** or `xattr -cr` if Gatekeeper blocks an unsigned app.
3. `npm run dist:linux` / `npm run dist:win` — confirm unchanged (optional).

## Risks / follow-ups

- **Unsigned mac artifacts** until a proper Developer ID is configured for CI/release; release workflow may need `mac.identity` + secrets if signed/notarized mac builds are required.
- If electron-builder ships a fix for the macOS 26 ad-hoc path, we can revisit `identity: "-"` for local ad-hoc builds if desired.