### PR TITLE
fix: MQTT hourglass when BT NAK without packetId; macOS app menu + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,12 @@ CI builds avoid both issues by using short paths and clean agents; local Windows
 - **Windows**: `%APPDATA%\mesh-client\`
 - **Linux**: `~/.config/mesh-client/`
 
+### macOS: "representedObject is not a WeakPtrToElectronMenuModelAsNSObject" when typing in chat
+
+**Cause**: Known Electron/Chromium quirk on macOS when the first responder is a text field (e.g. the chat input). The native menu bridge logs this; it does not affect behavior.
+
+**Fix**: None required — safe to ignore. Copy/paste and other edit actions still work.
+
 ### Update check fails / no update banner
 
 The app functions fully offline — this is not a critical error. If "Update check failed" appears in the console, verify network connectivity. Update checks are rate-limited by the GitHub API and may silently skip when the limit is reached.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,8 @@ let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 /** Retain tray context menu so macOS menu bridge does not see a freed model (avoids console warning / crashes). */
 let trayContextMenu: Menu | null = null;
+/** Retain application menu on macOS so the menu bridge has a stable model. */
+let appMenu: Menu | null = null;
 let isConnected = false;
 let isQuitting = false;
 
@@ -302,6 +304,30 @@ function setupTray(window: BrowserWindow) {
     },
   ]);
   tray.setContextMenu(trayContextMenu);
+}
+
+/** Set a minimal application menu on macOS so the native menu bridge has a stable model (avoids freed-model issues; the "representedObject is not a WeakPtrToElectronMenuModelAsNSObject" console warning when focusing text inputs is a known Electron/Chromium macOS quirk and harmless). */
+function setupAppMenu() {
+  if (process.platform !== 'darwin') return;
+  appMenu = Menu.buildFromTemplate([
+    {
+      label: app.name,
+      submenu: [
+        { role: 'about' as const },
+        { type: 'separator' as const },
+        { role: 'services' as const },
+        { type: 'separator' as const },
+        { role: 'hide' as const },
+        { role: 'hideOthers' as const },
+        { role: 'unhide' as const },
+        { type: 'separator' as const },
+        { role: 'quit' as const },
+      ],
+    },
+    { role: 'editMenu' as const },
+    { role: 'windowMenu' as const },
+  ]);
+  Menu.setApplicationMenu(appMenu);
 }
 
 function createWindow() {
@@ -1040,7 +1066,8 @@ app.whenReady().then(() => {
   try {
     initLogFile();
     initDatabase();
-    // Force the dock icon n development on macOS
+    setupAppMenu();
+    // Force the dock icon in development on macOS
     if (!app.isPackaged && process.platform === 'darwin') {
       const iconPath = path.join(
         __dirname,

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -1551,10 +1551,38 @@ export function useDevice() {
               });
           }
         } else {
-          // No packetId — fall back to clearing any message stuck at 'sending'
-          setMessages((prev) =>
-            prev.map((m) => (m.status === 'sending' ? { ...m, status: 'failed', error } : m)),
-          );
+          // No packetId — clear device status and wire MQTT to the message that has both sending (so MQTT doesn't stay hourglass)
+          setMessages((prev) => {
+            const target = prev.find((m) => m.status === 'sending' && m.mqttStatus === 'sending');
+            const pid = target?.packetId;
+            if (pid !== undefined) {
+              window.electronAPI.db.updateMessageStatus(pid, 'failed', error);
+              if (mqttPromise) {
+                mqttPromise
+                  .then((mqttPacketId) => {
+                    isDuplicate(mqttPacketId);
+                    setMessages((p) =>
+                      p.map((m) =>
+                        m.packetId === pid ? { ...m, mqttStatus: 'acked' as const } : m,
+                      ),
+                    );
+                    window.electronAPI.db.updateMessageStatus(pid, 'failed', error, 'acked');
+                  })
+                  .catch((e) => {
+                    console.debug('[useDevice] sendMessage mqttPromise no-packetId failed', e);
+                    setMessages((p) =>
+                      p.map((m) =>
+                        m.packetId === pid ? { ...m, mqttStatus: 'failed' as const } : m,
+                      ),
+                    );
+                    window.electronAPI.db.updateMessageStatus(pid, 'failed', error, 'failed');
+                  });
+              }
+            }
+            return prev.map((m) =>
+              m.status === 'sending' ? { ...m, status: 'failed' as const, error } : m,
+            );
+          });
         }
       }
     },


### PR DESCRIPTION
## Summary
Fixes the chat panel where MQTT stayed on the hourglass when Bluetooth did not get an ACK but MQTT uplink had already been fired. Also adds an explicit macOS application menu (stable menu model) and documents the known representedObject console warning.

## What changed
- **useDevice sendMessage (hybrid path):** When `sendText` rejects (NAK/timeout) without `packetId` on the error, the handler previously only marked device status failed and never wired `mqttPromise`, so `mqttStatus` stayed `sending` (hourglass). We now find the echo row with both `status` and `mqttStatus` at sending, use its `packetId`, persist `failed` to the DB for the device leg, and attach `mqttPromise` so MQTT settles to acked/failed in the UI.
- **Main process (darwin):** `setupAppMenu()` sets a retained application menu (app name, Edit, Window) so the menu bridge has a stable model; comment notes the harmless representedObject warning when focusing text inputs.
- **README:** New troubleshooting entry for the macOS representedObject message when typing in chat.

## Why
Hybrid sends fire MQTT before device send; if the device throws without packetId, the message row (from echo) still had `mqttStatus: sending` forever. Wiring `mqttPromise` by the echo packetId matches the success-path behavior when packetId is present.

## How to test
1. Connect with MQTT uplink enabled; trigger a send where BT does not ACK and the rejection has no packetId.
2. Confirm MQTT badge updates from hourglass to ✓ or ✗ after publish settles.
3. On macOS, optional: verify app menu appears and typing in chat still works; console may still log representedObject (documented as safe to ignore).

## Risks / follow-ups
None expected; behavior when packetId is present is unchanged. If Electron fixes the representedObject warning upstream, README entry can stay as historical context.