### PR TITLE
feat: environmental telemetry charts and resend failed message (#88)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,7 +20,7 @@ import UpdateBanner from './components/UpdateBanner';
 import { useDevice } from './hooks/useDevice';
 import { parseStoredJson } from './lib/parseStoredJson';
 import { applyThemeColors, loadThemeColors } from './lib/themeColors';
-import type { MQTTSettings } from './lib/types';
+import type { ChatMessage, MQTTSettings } from './lib/types';
 import { useDiagnosticsStore } from './stores/diagnosticsStore';
 
 const STATUS_COLOR: Record<string, string> = {
@@ -145,6 +145,16 @@ export default function App() {
   const isInitialLoadRef = useRef(true);
   const [updateState, setUpdateState] = useState<UpdateState>({ phase: 'idle', dismissed: false });
   const [telemetryNoticeDismissed, setTelemetryNoticeDismissed] = useState(false);
+  const [useFahrenheit, setUseFahrenheit] = useState(
+    () => localStorage.getItem('mesh-client:useFahrenheit') === 'true',
+  );
+  const toggleFahrenheit = useCallback(() => {
+    setUseFahrenheit((prev) => {
+      const next = !prev;
+      localStorage.setItem('mesh-client:useFahrenheit', String(next));
+      return next;
+    });
+  }, []);
 
   // ─── Theme colors (localStorage overrides for @theme tokens) ─────
   useLayoutEffect(() => {
@@ -170,6 +180,13 @@ export default function App() {
   const isOperational = isConfigured || device.state.status === 'stale';
   const isConnectedOrOperational = isOperational || device.state.status === 'connected';
   const selectedNode = selectedNodeId ? (device.nodes.get(selectedNodeId) ?? null) : null;
+
+  const handleResend = useCallback(
+    (msg: ChatMessage) => {
+      device.sendMessage(msg.payload, msg.channel, msg.to ?? undefined);
+    },
+    [device],
+  );
 
   const traceRouteHops = useMemo(() => {
     if (!selectedNode) return undefined;
@@ -482,6 +499,7 @@ export default function App() {
                     myNodeNum={device.selfNodeId}
                     onSend={device.sendMessage}
                     onReact={device.sendReaction}
+                    onResend={handleResend}
                     onNodeClick={setSelectedNodeId}
                     isConnected={isOperational || device.mqttStatus === 'connected'}
                     isMqttOnly={!isOperational && device.mqttStatus === 'connected'}
@@ -553,6 +571,9 @@ export default function App() {
                   <TelemetryPanel
                     telemetry={device.telemetry}
                     signalTelemetry={device.signalTelemetry}
+                    environmentTelemetry={device.environmentTelemetry}
+                    useFahrenheit={useFahrenheit}
+                    onToggleFahrenheit={toggleFahrenheit}
                     onRefresh={device.requestRefresh}
                     isConnected={isOperational}
                   />
@@ -668,6 +689,7 @@ export default function App() {
           isConnected={isOperational}
           homeNode={device.nodes.get(device.state.myNodeNum) ?? null}
           neighborInfo={device.neighborInfo}
+          useFahrenheit={useFahrenheit}
         />
       </div>
     </ToastProvider>

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -12,6 +12,7 @@ describe('ChatPanel accessibility', () => {
     myNodeNum: 0,
     onSend: vi.fn().mockResolvedValue(undefined),
     onReact: vi.fn().mockResolvedValue(undefined),
+    onResend: vi.fn(),
     onNodeClick: vi.fn(),
     isConnected: false,
     nodes: new Map(),

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -180,6 +180,7 @@ interface Props {
   myNodeNum: number;
   onSend: (text: string, channel: number, destination?: number, replyId?: number) => void;
   onReact: (emoji: number, replyId: number, channel: number) => Promise<void>;
+  onResend: (msg: ChatMessage) => void;
   onNodeClick: (nodeNum: number) => void;
   isConnected: boolean;
   isMqttOnly?: boolean;
@@ -196,6 +197,7 @@ export default function ChatPanel({
   myNodeNum,
   onSend,
   onReact,
+  onResend,
   onNodeClick,
   isConnected,
   isMqttOnly,
@@ -871,6 +873,30 @@ export default function ChatPanel({
                       {/* Delivery status for own messages */}
                       {isOwn && (msg.status || msg.mqttStatus) && (
                         <div className="flex items-center justify-end gap-1 mt-0.5">
+                          {isOwn && msg.status === 'failed' && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onResend(msg);
+                              }}
+                              className="text-gray-500 hover:text-gray-300 transition-colors"
+                              title="Resend message"
+                            >
+                              <svg
+                                className="w-3.5 h-3.5"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                                />
+                              </svg>
+                            </button>
+                          )}
                           {msg.mqttStatus ? (
                             <>
                               <StatusBadge status={msg.mqttStatus} transport="mqtt" />

--- a/src/renderer/components/NodeDetailModal.tsx
+++ b/src/renderer/components/NodeDetailModal.tsx
@@ -18,6 +18,7 @@ interface NodeDetailModalProps {
   isConnected: boolean;
   homeNode?: MeshNode | null;
   neighborInfo?: Map<number, NeighborInfoRecord>;
+  useFahrenheit?: boolean;
 }
 
 export default function NodeDetailModal({
@@ -33,6 +34,7 @@ export default function NodeDetailModal({
   isConnected,
   homeNode = null,
   neighborInfo,
+  useFahrenheit,
 }: NodeDetailModalProps) {
   const [actionStatus, setActionStatus] = useState<string | null>(null);
   const [positionRequestedAt, setPositionRequestedAt] = useState<number | null>(null);
@@ -205,6 +207,7 @@ export default function NodeDetailModal({
             homeNode={homeNode}
             traceRouteHops={isOurNode ? undefined : traceRouteHops}
             nodes={nodes}
+            useFahrenheit={useFahrenheit}
           />
         </div>
 

--- a/src/renderer/components/NodeInfoBody.tsx
+++ b/src/renderer/components/NodeInfoBody.tsx
@@ -58,12 +58,22 @@ export function InfoRow({
   );
 }
 
+function iaqLabel(iaq: number): string {
+  if (iaq <= 50) return 'Excellent';
+  if (iaq <= 100) return 'Good';
+  if (iaq <= 150) return 'Lightly Polluted';
+  if (iaq <= 200) return 'Moderately Polluted';
+  if (iaq <= 300) return 'Heavily Polluted';
+  return 'Severely Polluted';
+}
+
 export interface NodeInfoBodyProps {
   node: MeshNode;
   homeNode?: MeshNode | null;
   traceRouteHops?: string[];
   /** When set, Mesh Congestion can list originators by name/role (RF duplicate-prone traffic). */
   nodes?: Map<number, MeshNode>;
+  useFahrenheit?: boolean;
 }
 
 const SEVERITY_STYLES: Record<RFDiagnosis['severity'], string> = {
@@ -76,7 +86,13 @@ const SEVERITY_ICON: Record<RFDiagnosis['severity'], string> = {
   info: 'ℹ',
 };
 
-export default function NodeInfoBody({ node, homeNode, traceRouteHops, nodes }: NodeInfoBodyProps) {
+export default function NodeInfoBody({
+  node,
+  homeNode,
+  traceRouteHops,
+  nodes,
+  useFahrenheit = false,
+}: NodeInfoBodyProps) {
   const diagnosticRows = useDiagnosticsStore((s) => s.diagnosticRows);
   const routingRow = getRoutingRowForNode(diagnosticRows, node.node_id);
   const anomaly: NodeAnomaly | null = routingRow ? routingRowToNodeAnomaly(routingRow) : null;
@@ -438,6 +454,50 @@ export default function NodeInfoBody({ node, homeNode, traceRouteHops, nodes }: 
               </span>
             ))}
           </div>
+        </div>
+      )}
+
+      {/* Environment */}
+      {(node.env_temperature !== undefined ||
+        node.env_humidity !== undefined ||
+        node.env_pressure !== undefined ||
+        node.env_iaq !== undefined ||
+        node.env_lux !== undefined ||
+        node.env_wind_speed !== undefined) && (
+        <div className="mt-3 border-t border-gray-700 pt-3">
+          <div className="text-xs font-semibold text-gray-400 uppercase mb-1">Environment</div>
+          {node.env_temperature !== undefined && (
+            <InfoRow
+              label="Temperature"
+              value={
+                useFahrenheit
+                  ? `${((node.env_temperature * 9) / 5 + 32).toFixed(1)}°F`
+                  : `${node.env_temperature.toFixed(1)}°C`
+              }
+            />
+          )}
+          {node.env_humidity !== undefined && (
+            <InfoRow label="Humidity" value={`${node.env_humidity.toFixed(1)}%`} />
+          )}
+          {node.env_pressure !== undefined && (
+            <InfoRow label="Pressure" value={`${node.env_pressure.toFixed(1)} hPa`} />
+          )}
+          {node.env_iaq !== undefined && (
+            <InfoRow label="Air Quality" value={`${node.env_iaq} – ${iaqLabel(node.env_iaq)}`} />
+          )}
+          {node.env_lux !== undefined && (
+            <InfoRow label="Light" value={`${node.env_lux.toFixed(0)} lux`} />
+          )}
+          {node.env_wind_speed !== undefined && (
+            <InfoRow
+              label="Wind"
+              value={
+                node.env_wind_direction !== undefined
+                  ? `${node.env_wind_speed.toFixed(1)} m/s @ ${node.env_wind_direction}°`
+                  : `${node.env_wind_speed.toFixed(1)} m/s`
+              }
+            />
+          )}
         </div>
       )}
 

--- a/src/renderer/components/TelemetryPanel.tsx
+++ b/src/renderer/components/TelemetryPanel.tsx
@@ -10,12 +10,19 @@ import {
   YAxis,
 } from 'recharts';
 
-import type { TelemetryPoint } from '../lib/types';
+import type { EnvironmentTelemetryPoint, TelemetryPoint } from '../lib/types';
 import RefreshButton from './RefreshButton';
+
+function toF(c: number) {
+  return (c * 9) / 5 + 32;
+}
 
 interface Props {
   telemetry: TelemetryPoint[];
   signalTelemetry: TelemetryPoint[];
+  environmentTelemetry: EnvironmentTelemetryPoint[];
+  useFahrenheit: boolean;
+  onToggleFahrenheit: () => void;
   onRefresh: () => Promise<void>;
   isConnected: boolean;
 }
@@ -23,6 +30,9 @@ interface Props {
 export default function TelemetryPanel({
   telemetry,
   signalTelemetry,
+  environmentTelemetry,
+  useFahrenheit,
+  onToggleFahrenheit,
   onRefresh,
   isConnected,
 }: Props) {
@@ -59,20 +69,63 @@ export default function TelemetryPanel({
   const hasBatteryData = chartData.some((d) => d.battery !== undefined || d.voltage !== undefined);
   const hasSignalData = signalChartData.some((d) => d.snr !== undefined || d.rssi !== undefined);
 
+  const envChartData = useMemo(
+    () =>
+      environmentTelemetry.map((t, i) => ({
+        index: i,
+        time: new Date(t.timestamp).toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        }),
+        temperature:
+          t.temperature !== undefined
+            ? useFahrenheit
+              ? parseFloat(toF(t.temperature).toFixed(1))
+              : parseFloat(t.temperature.toFixed(1))
+            : undefined,
+        humidity: t.relativeHumidity,
+        pressure: t.barometricPressure,
+        iaq: t.iaq,
+      })),
+    [environmentTelemetry, useFahrenheit],
+  );
+
+  const hasTemp = envChartData.some((d) => d.temperature !== undefined);
+  const hasHumidity = envChartData.some((d) => d.humidity !== undefined);
+  const hasPressure = envChartData.some((d) => d.pressure !== undefined);
+  const hasIaq = envChartData.some((d) => d.iaq !== undefined);
+
   const handleExportCsv = useCallback(() => {
-    if (telemetry.length === 0 && signalTelemetry.length === 0) return;
+    if (telemetry.length === 0 && signalTelemetry.length === 0 && environmentTelemetry.length === 0)
+      return;
 
     function escapeCsvCell(v: string | number | undefined): string {
       const s = String(v ?? '');
       return /[,"\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
     }
 
-    const headers = ['timestamp', 'type', 'battery_level', 'voltage', 'snr', 'rssi'];
+    const headers = [
+      'timestamp',
+      'type',
+      'battery_level',
+      'voltage',
+      'snr',
+      'rssi',
+      'env_temperature_c',
+      'env_humidity_pct',
+      'env_pressure_hpa',
+      'env_iaq',
+    ];
     const batteryRows = telemetry.map((t) => [
       escapeCsvCell(new Date(t.timestamp).toISOString()),
       escapeCsvCell('battery'),
       escapeCsvCell(t.batteryLevel),
       escapeCsvCell(t.voltage),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
       escapeCsvCell(''),
       escapeCsvCell(''),
     ]);
@@ -83,8 +136,26 @@ export default function TelemetryPanel({
       escapeCsvCell(''),
       escapeCsvCell(t.snr),
       escapeCsvCell(t.rssi),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
     ]);
-    const rows = [...batteryRows, ...signalRows].sort((a, b) => a[0].localeCompare(b[0]));
+    const envRows = environmentTelemetry.map((t) => [
+      escapeCsvCell(new Date(t.timestamp).toISOString()),
+      escapeCsvCell('environment'),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
+      escapeCsvCell(''),
+      escapeCsvCell(t.temperature),
+      escapeCsvCell(t.relativeHumidity),
+      escapeCsvCell(t.barometricPressure),
+      escapeCsvCell(t.iaq),
+    ]);
+    const rows = [...batteryRows, ...signalRows, ...envRows].sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
 
     const csv = [headers.map(escapeCsvCell).join(','), ...rows.map((r) => r.join(','))].join('\n');
 
@@ -95,14 +166,25 @@ export default function TelemetryPanel({
     link.download = `mesh-client-telemetry-${new Date().toISOString().slice(0, 10)}.csv`;
     link.click();
     URL.revokeObjectURL(url);
-  }, [telemetry, signalTelemetry]);
+  }, [telemetry, signalTelemetry, environmentTelemetry]);
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h2 className="text-xl font-semibold text-gray-200">Telemetry</h2>
         <div className="flex items-center gap-2">
-          {(telemetry.length > 0 || signalTelemetry.length > 0) && (
+          {hasTemp && (
+            <button
+              onClick={onToggleFahrenheit}
+              title="Toggle temperature unit"
+              className="px-2 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300"
+            >
+              {useFahrenheit ? '°F' : '°C'}
+            </button>
+          )}
+          {(telemetry.length > 0 ||
+            signalTelemetry.length > 0 ||
+            environmentTelemetry.length > 0) && (
             <button
               onClick={handleExportCsv}
               className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-lg transition-colors"
@@ -128,7 +210,9 @@ export default function TelemetryPanel({
         </div>
       </div>
 
-      {telemetry.length === 0 && signalTelemetry.length === 0 ? (
+      {telemetry.length === 0 &&
+      signalTelemetry.length === 0 &&
+      environmentTelemetry.length === 0 ? (
         <div className="text-center text-muted py-12">
           No telemetry data yet. Connect to a device to see real-time metrics.
         </div>
@@ -264,9 +348,172 @@ export default function TelemetryPanel({
             </div>
           )}
 
+          {/* Temperature & Humidity Chart */}
+          {(hasTemp || hasHumidity) && (
+            <div className="bg-deep-black rounded-lg p-4">
+              <h3 className="text-sm font-medium text-muted mb-3">
+                Temperature {hasHumidity ? '& Humidity' : ''}
+              </h3>
+              <ResponsiveContainer width="100%" height={250}>
+                <LineChart data={envChartData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                  <XAxis dataKey="time" stroke="#6b7280" tick={{ fontSize: 11 }} />
+                  {hasTemp && (
+                    <YAxis
+                      yAxisId="temp"
+                      stroke="#f59e0b"
+                      tick={{ fontSize: 11 }}
+                      label={{
+                        value: useFahrenheit ? '°F' : '°C',
+                        angle: -90,
+                        position: 'insideLeft',
+                        style: { fill: '#f59e0b' },
+                      }}
+                    />
+                  )}
+                  {hasHumidity && (
+                    <YAxis
+                      yAxisId="humidity"
+                      orientation="right"
+                      domain={[0, 100]}
+                      stroke="#06b6d4"
+                      tick={{ fontSize: 11 }}
+                      label={{
+                        value: '%',
+                        angle: 90,
+                        position: 'insideRight',
+                        style: { fill: '#06b6d4' },
+                      }}
+                    />
+                  )}
+                  <Tooltip
+                    contentStyle={{
+                      background: '#1a202c',
+                      border: '1px solid #374151',
+                      borderRadius: '8px',
+                    }}
+                  />
+                  <Legend />
+                  {hasTemp && (
+                    <Line
+                      yAxisId="temp"
+                      type="monotone"
+                      dataKey="temperature"
+                      name={useFahrenheit ? 'Temp °F' : 'Temp °C'}
+                      stroke="#f59e0b"
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls
+                    />
+                  )}
+                  {hasHumidity && (
+                    <Line
+                      yAxisId="humidity"
+                      type="monotone"
+                      dataKey="humidity"
+                      name="Humidity %"
+                      stroke="#06b6d4"
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls
+                    />
+                  )}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {/* Barometric Pressure Chart */}
+          {hasPressure && (
+            <div className="bg-deep-black rounded-lg p-4">
+              <h3 className="text-sm font-medium text-muted mb-3">Barometric Pressure</h3>
+              <ResponsiveContainer width="100%" height={250}>
+                <LineChart data={envChartData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                  <XAxis dataKey="time" stroke="#6b7280" tick={{ fontSize: 11 }} />
+                  <YAxis
+                    yAxisId="pressure"
+                    stroke="#a78bfa"
+                    tick={{ fontSize: 11 }}
+                    label={{
+                      value: 'hPa',
+                      angle: -90,
+                      position: 'insideLeft',
+                      style: { fill: '#a78bfa' },
+                    }}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: '#1a202c',
+                      border: '1px solid #374151',
+                      borderRadius: '8px',
+                    }}
+                  />
+                  <Legend />
+                  <Line
+                    yAxisId="pressure"
+                    type="monotone"
+                    dataKey="pressure"
+                    name="Pressure hPa"
+                    stroke="#a78bfa"
+                    strokeWidth={2}
+                    dot={false}
+                    connectNulls
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {/* Air Quality (IAQ) Chart */}
+          {hasIaq && (
+            <div className="bg-deep-black rounded-lg p-4">
+              <h3 className="text-sm font-medium text-muted mb-3">Air Quality (IAQ)</h3>
+              <ResponsiveContainer width="100%" height={250}>
+                <LineChart data={envChartData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                  <XAxis dataKey="time" stroke="#6b7280" tick={{ fontSize: 11 }} />
+                  <YAxis
+                    yAxisId="iaq"
+                    domain={[0, 500]}
+                    stroke="#34d399"
+                    tick={{ fontSize: 11 }}
+                    label={{
+                      value: 'IAQ',
+                      angle: -90,
+                      position: 'insideLeft',
+                      style: { fill: '#34d399' },
+                    }}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: '#1a202c',
+                      border: '1px solid #374151',
+                      borderRadius: '8px',
+                    }}
+                  />
+                  <Legend />
+                  <Line
+                    yAxisId="iaq"
+                    type="monotone"
+                    dataKey="iaq"
+                    name="IAQ (0–500)"
+                    stroke="#34d399"
+                    strokeWidth={2}
+                    dot={false}
+                    connectNulls
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
           <div className="text-xs text-gray-600 text-center">
-            Battery: {telemetry.length} pts &nbsp;·&nbsp; Signal: {signalTelemetry.length} pts (max
-            50 each)
+            Battery: {telemetry.length} pts &nbsp;·&nbsp; Signal: {signalTelemetry.length} pts
+            {environmentTelemetry.length > 0 && (
+              <> &nbsp;·&nbsp; Env: {environmentTelemetry.length} pts</>
+            )}{' '}
+            (max 50 each)
           </div>
         </>
       )}

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -21,6 +21,7 @@ import type {
   ChatMessage,
   ConnectionType,
   DeviceState,
+  EnvironmentTelemetryPoint,
   MeshNode,
   MeshWaypoint,
   MQTTStatus,
@@ -144,6 +145,7 @@ export function useDevice() {
   const [nodes, setNodes] = useState<Map<number, MeshNode>>(new Map());
   const [telemetry, setTelemetry] = useState<TelemetryPoint[]>([]);
   const [signalTelemetry, setSignalTelemetry] = useState<TelemetryPoint[]>([]);
+  const [environmentTelemetry, setEnvironmentTelemetry] = useState<EnvironmentTelemetryPoint[]>([]);
   const [traceRouteResults, setTraceRouteResults] = useState<
     Map<number, { route: number[]; from: number; timestamp: number }>
   >(new Map());
@@ -1037,9 +1039,64 @@ export function useDevice() {
               numRxDupe?: number;
               numPacketsRx?: number;
               numPacketsTx?: number;
+              // environmentMetrics fields
+              temperature?: number;
+              relativeHumidity?: number;
+              barometricPressure?: number;
+              gasResistance?: number;
+              iaq?: number;
+              lux?: number;
+              windSpeed?: number;
+              windDirection?: number;
+              windGust?: number;
+              windLull?: number;
+              weight?: number;
+              rainfall1h?: number;
+              rainfall24h?: number;
             };
           };
         };
+
+        // Handle environmentMetrics variant
+        if (tel.variant?.case === 'environmentMetrics' && tel.variant.value) {
+          const env = tel.variant.value;
+          const point: EnvironmentTelemetryPoint = {
+            timestamp: Date.now(),
+            nodeNum: packet.from,
+            temperature: env.temperature,
+            relativeHumidity: env.relativeHumidity,
+            barometricPressure: env.barometricPressure,
+            gasResistance: env.gasResistance,
+            iaq: env.iaq,
+            lux: env.lux,
+            windSpeed: env.windSpeed,
+            windDirection: env.windDirection,
+            windGust: env.windGust,
+            windLull: env.windLull,
+            weight: env.weight,
+            rainfall1h: env.rainfall1h,
+            rainfall24h: env.rainfall24h,
+          };
+          setEnvironmentTelemetry((prev) => [...prev, point].slice(-MAX_TELEMETRY_POINTS));
+          updateNodes((prev) => {
+            const updated = new Map(prev);
+            const existing = updated.get(packet.from);
+            if (existing) {
+              updated.set(packet.from, {
+                ...existing,
+                env_temperature: env.temperature ?? existing.env_temperature,
+                env_humidity: env.relativeHumidity ?? existing.env_humidity,
+                env_pressure: env.barometricPressure ?? existing.env_pressure,
+                env_iaq: env.iaq ?? existing.env_iaq,
+                env_lux: env.lux ?? existing.env_lux,
+                env_wind_speed: env.windSpeed ?? existing.env_wind_speed,
+                env_wind_direction: env.windDirection ?? existing.env_wind_direction,
+              });
+            }
+            return updated;
+          });
+          return;
+        }
 
         // Handle localStats variant (connected node's radio statistics)
         if (
@@ -2116,6 +2173,7 @@ export function useDevice() {
     nodes,
     telemetry,
     signalTelemetry,
+    environmentTelemetry,
     channels,
     channelConfigs,
     traceRouteResults,

--- a/src/renderer/lib/types.ts
+++ b/src/renderer/lib/types.ts
@@ -116,6 +116,14 @@ export interface MeshNode {
   num_rx_dupe?: number;
   num_packets_rx?: number;
   num_packets_tx?: number;
+  // Environmental sensor data (session-only, last received reading)
+  env_temperature?: number;
+  env_humidity?: number;
+  env_pressure?: number;
+  env_iaq?: number;
+  env_lux?: number;
+  env_wind_speed?: number;
+  env_wind_direction?: number;
 }
 
 export type RemediationCategory = 'Configuration' | 'Physical' | 'Hardware' | 'Software';
@@ -180,6 +188,24 @@ export interface TelemetryPoint {
   voltage?: number;
   snr?: number;
   rssi?: number;
+}
+
+export interface EnvironmentTelemetryPoint {
+  timestamp: number;
+  nodeNum: number;
+  temperature?: number; // °C
+  relativeHumidity?: number; // %
+  barometricPressure?: number; // hPa
+  gasResistance?: number; // MOhm
+  iaq?: number; // 0–500 (BME680)
+  lux?: number;
+  windSpeed?: number; // m/s
+  windDirection?: number; // degrees 0–360
+  windGust?: number;
+  windLull?: number;
+  weight?: number; // kg
+  rainfall1h?: number;
+  rainfall24h?: number;
 }
 
 export interface DeviceState {


### PR DESCRIPTION
## Summary

Implements two feature-parity items from issue #88 (matching Ian's meshtastic-cli):

- **Environmental telemetry** — capture, store, and visualize `EnvironmentMetrics` packets (BME280/BME680/weather stations) with per-node latest readings and time-series charts
- **Resend failed message** — one-click retry for messages that failed RF/device delivery

## Changes

### `src/renderer/lib/types.ts`
- New `EnvironmentTelemetryPoint` interface with all protobuf env fields: `temperature`, `relativeHumidity`, `barometricPressure`, `gasResistance`, `iaq`, `lux`, `windSpeed`, `windDirection`, `windGust`, `windLull`, `weight`, `rainfall1h`, `rainfall24h`
- Seven new optional `env_*` fields on `MeshNode` (session-only, not persisted to DB — no schema change required)

### `src/renderer/hooks/useDevice.ts`
- Extended `onTelemetryPacket` type cast to include all env metric fields
- New `environmentMetrics` variant handler: records time-series into `environmentTelemetry` state (capped at `MAX_TELEMETRY_POINTS`), and patches per-node `env_*` fields on `MeshNode` via `updateNodes`
- New `environmentTelemetry: EnvironmentTelemetryPoint[]` exported from the hook

### `src/renderer/components/TelemetryPanel.tsx`
- New props: `environmentTelemetry`, `useFahrenheit`, `onToggleFahrenheit`
- `toF()` helper for Celsius → Fahrenheit conversion
- **°C/°F toggle button** in the panel header — only visible when temperature data is present; state persists to `localStorage['mesh-client:useFahrenheit']`
- Three new charts (rendered only when the relevant data exists):
  1. **Temperature & Humidity** — dual Y-axis (°C or °F left, % right)
  2. **Barometric Pressure** — single Y-axis (hPa)
  3. **Air Quality (IAQ)** — single Y-axis 0–500
- CSV export extended with `env_temperature_c`, `env_humidity_pct`, `env_pressure_hpa`, `env_iaq` columns
- Empty-state check and point counter include env data

### `src/renderer/components/NodeInfoBody.tsx`
- `iaqLabel()` helper maps IAQ score (0–500) to human-readable category (Excellent → Severely Polluted)
- New `useFahrenheit?: boolean` prop
- **Environment section** rendered below route info when any env field is set on the node; shows temperature (°C/°F), humidity, pressure, IAQ with label, lux, and wind (speed + direction if available)
- Works in both `NodeDetailModal` and `MapPanel` Leaflet popups automatically

### `src/renderer/components/NodeDetailModal.tsx`
- New `useFahrenheit?: boolean` prop threaded through to `NodeInfoBody`

### `src/renderer/components/ChatPanel.tsx`
- New `onResend: (msg: ChatMessage) => void` prop
- **Resend button** (circular-arrow SVG) appears inline with the status badge when `msg.status === 'failed'` (device/RF transport failure only — not triggered by MQTT-only failure). Clicking calls `onResend(msg)` with `stopPropagation`.

### `src/renderer/App.tsx`
- `useFahrenheit` state with localStorage persistence
- `toggleFahrenheit` callback (stable via `useCallback`)
- `handleResend` callback — calls `device.sendMessage` with original `payload`, `channel`, and `to` (DM destination if set)
- All new props wired: `TelemetryPanel`, `NodeDetailModal`, `ChatPanel`

### `src/renderer/components/ChatPanel.test.tsx`
- Added `onResend: vi.fn()` to the default test props to satisfy the new required prop

## Test plan

- [ ] Connect to a network with a BME280/BME680/weather-station node; open **Telemetry** tab — new charts appear once env packets arrive
- [ ] Open **Node Detail** for an env-equipped node — Environment section shows latest temp/humidity/pressure/IAQ/lux/wind
- [ ] Toggle °C/°F button in Telemetry header — charts and node detail update; preference survives reload
- [ ] Send a message, disconnect mid-send to force failure — circular-arrow icon appears left of the ✗ badge; click it — a new pending message is queued
- [ ] `npm run build:renderer` — no TypeScript or lint errors
- [ ] `npm test` — all 66 tests pass

Fixes #88