### PR TITLE
fix: harden BLE reconnect, localStorage writes, tray icon, and add diagnostic logging

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -305,7 +305,12 @@ function buildTrayIcon(hasUnread: boolean): Electron.NativeImage {
     const trayIconPath = app.isPackaged
       ? path.join(process.resourcesPath, '256x256.png')
       : path.join(__dirname, '../../resources/icons/linux/256x256.png');
-    base = nativeImage.createFromPath(trayIconPath).resize({ width: 22, height: 22 });
+    try {
+      base = nativeImage.createFromPath(trayIconPath).resize({ width: 22, height: 22 });
+    } catch (e) {
+      console.error('[main] tray icon load failed', e); // log-injection-ok: e is a local Error from nativeImage, not user input
+      base = nativeImage.createEmpty();
+    }
   }
 
   if (!hasUnread) return base;
@@ -576,8 +581,10 @@ function createWindow() {
     if (!isQuitting && (isConnected || mqttManager.getStatus() === 'connected')) {
       event.preventDefault();
       if (process.platform === 'darwin') {
+        console.log('[main] window close event: hiding (macOS, device connected)');
         win.hide();
       } else {
+        console.log('[main] window close event: minimizing (device connected)');
         win.minimize();
       }
     }
@@ -645,18 +652,35 @@ ipcMain.on('serial-port-cancelled', () => {
 
 // ─── IPC: Connection status tracking (module-scope, not per-window) ─
 ipcMain.on('device-connected', () => {
+  console.log('[main] device-connected: isConnected = true');
   isConnected = true;
 });
 ipcMain.on('device-disconnected', () => {
+  console.log('[main] device-disconnected: isConnected = false');
   isConnected = false;
 });
 
 // ─── MQTT: Forward manager events to renderer ───────────────────────
-mqttManager.on('status', (s) => mainWindow?.webContents.send('mqtt:status', s));
-mqttManager.on('error', (msg) => mainWindow?.webContents.send('mqtt:error', msg));
-mqttManager.on('clientId', (id) => mainWindow?.webContents.send('mqtt:clientId', id));
-mqttManager.on('nodeUpdate', (n) => mainWindow?.webContents.send('mqtt:node-update', n));
-mqttManager.on('message', (m) => mainWindow?.webContents.send('mqtt:message', m));
+mqttManager.on('status', (s) => {
+  if (mainWindow) mainWindow.webContents.send('mqtt:status', s);
+  else console.debug('[main] mqtt:status dropped (mainWindow not ready)', s);
+});
+mqttManager.on('error', (msg) => {
+  if (mainWindow) mainWindow.webContents.send('mqtt:error', msg);
+  else console.debug('[main] mqtt:error dropped (mainWindow not ready)', msg);
+});
+mqttManager.on('clientId', (id) => {
+  if (mainWindow) mainWindow.webContents.send('mqtt:clientId', id);
+  else console.debug('[main] mqtt:clientId dropped (mainWindow not ready)', id);
+});
+mqttManager.on('nodeUpdate', (n) => {
+  if (mainWindow) mainWindow.webContents.send('mqtt:node-update', n);
+  else console.debug('[main] mqtt:node-update dropped (mainWindow not ready)');
+});
+mqttManager.on('message', (m) => {
+  if (mainWindow) mainWindow.webContents.send('mqtt:message', m);
+  else console.debug('[main] mqtt:message dropped (mainWindow not ready)');
+});
 
 // ─── IPC: MQTT connect/disconnect ───────────────────────────────────
 ipcMain.handle('mqtt:connect', async (_event, settings) => {

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -276,7 +276,11 @@ export default function ChatPanel({
 
   // Persist lastRead timestamps to localStorage
   useEffect(() => {
-    localStorage.setItem('mesh-client:lastRead', JSON.stringify(persistedLastRead));
+    try {
+      localStorage.setItem('mesh-client:lastRead', JSON.stringify(persistedLastRead));
+    } catch (e) {
+      console.warn('[ChatPanel] persist lastRead failed', e);
+    }
   }, [persistedLastRead]);
 
   const getDmLabel = useCallback(

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -287,8 +287,8 @@ export function useDevice() {
     for (const unsub of unsubscribesRef.current) {
       try {
         unsub();
-      } catch {
-        /* ignore */
+      } catch (e) {
+        console.debug('[useDevice] unsubscribe error (ignored)', e);
       }
     }
     unsubscribesRef.current = [];
@@ -362,9 +362,14 @@ export function useDevice() {
       if (isReconnectingRef.current) return;
       const elapsed = Date.now() - lastDataReceivedRef.current;
       const { stale, dead } = getThresholds();
+      const transport = connectionParamsRef.current?.type ?? 'unknown';
       if (elapsed > dead) {
+        console.warn(
+          `[useDevice] watchdog: ${transport} dead for ${elapsed}ms, triggering reconnect`,
+        );
         handleConnectionLostRef.current();
       } else if (elapsed > stale) {
+        console.warn(`[useDevice] watchdog: ${transport} stale for ${elapsed}ms`);
         setState((s) => {
           if (s.status === 'configured' || s.status === 'connected') {
             return { ...s, status: 'stale', lastDataReceived: lastDataReceivedRef.current };

--- a/src/renderer/lib/connection.ts
+++ b/src/renderer/lib/connection.ts
@@ -157,6 +157,12 @@ export async function reconnectBle(): Promise<MeshDevice> {
     target = capturedBleDevice ?? undefined;
   }
 
+  // getDevices() exists but returned [] (common on Windows and some Linux builds
+  // even after a device has been granted). Fall back to the captured reference.
+  if (!target && capturedBleDevice) {
+    target = capturedBleDevice;
+  }
+
   if (!target) {
     throw new Error('No previously connected BLE device found for reconnection');
   }


### PR DESCRIPTION
## Summary

- **BLE reconnect (P0):** `reconnectBle()` now falls back to `capturedBleDevice` when `navigator.bluetooth.getDevices()` exists but returns `[]` — fixes silent reconnect failure on Windows and some Linux builds
- **localStorage safety (P1):** `ChatPanel` `lastRead` persistence wrapped in try-catch to prevent `QuotaExceededError` from crashing the effect chain
- **Tray icon hardening (P2):** `nativeImage.resize()` on Linux/Windows wrapped in try-catch with `createEmpty()` fallback so a missing/corrupt PNG doesn't crash the app
- **Diagnostic logging (P2):** `device-connected`/`device-disconnected` IPC handlers now log state transitions; window close logs hide-vs-minimize; MQTT event forwarders log a debug message when dropped due to null `mainWindow` (startup race); watchdog logs transport type + elapsed ms on stale/dead triggers; unsubscribe errors are debug-logged instead of silently swallowed

## Test plan

- [ ] Connect BLE on Windows/Linux, disconnect, reconnect — should succeed via `capturedBleDevice` fallback even if `getDevices()` returns `[]`
- [ ] Connect/disconnect a device — confirm `[main] device-connected` and watchdog messages appear in Electron main process stdout
- [ ] Replace tray icon PNG with a 0-byte file, launch app — confirm no crash, error logged
- [ ] All 89 unit tests pass (`npm run test:run`)