### PR TITLE
fix: retain first BLE callback on Linux to avoid immediate "User cancelled"

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,6 +49,8 @@ let isQuitting = false;
 
 // Pending Bluetooth callback from Chromium's Web Bluetooth API
 let pendingBluetoothCallback: ((deviceId: string) => void) | null = null;
+// Accumulated BLE devices for the current discovery session (merged across multiple select-bluetooth-device events)
+const bluetoothDiscoveryDevices = new Map<string, { deviceId: string; deviceName: string }>();
 // Pending Serial callback (mirrors the BLE pattern)
 let pendingSerialCallback: ((portId: string) => void) | null = null;
 // Last discovery sets: only allow selection IPC to resolve callbacks with ids from these sets
@@ -423,24 +425,29 @@ function createWindow() {
   // When the renderer calls navigator.bluetooth.requestDevice(),
   // Chromium fires this event. We intercept it to build our own picker
   // in the renderer instead of the (missing) native Chromium dialog.
+  // On Linux, Chromium can fire the event multiple times during discovery;
+  // if we overwrite the callback each time, the previous promise is rejected
+  // with "User cancelled". Retain the first callback and merge device lists
+  // from subsequent events so the picker updates without cancelling.
   mainWindow.webContents.on('select-bluetooth-device', (event, devices, callback) => {
     event.preventDefault();
 
-    // Chromium fires this event repeatedly during discovery with an
-    // updated device list and a NEW callback each time. Simply overwrite
-    // the reference — Chromium manages the lifecycle of old callbacks.
-    pendingBluetoothCallback = callback;
-
-    // Deduplicate devices by ID before sending to renderer
-    const seen = new Map<string, { deviceId: string; deviceName: string }>();
+    if (!pendingBluetoothCallback) {
+      pendingBluetoothCallback = callback;
+      bluetoothDiscoveryDevices.clear();
+    }
+    // Merge new devices into the accumulated list for this discovery session
     for (const d of devices) {
-      seen.set(d.deviceId, {
+      bluetoothDiscoveryDevices.set(d.deviceId, {
         deviceId: d.deviceId,
         deviceName: d.deviceName || 'Unknown Device',
       });
     }
-    lastBluetoothDeviceIds = new Set(seen.keys());
-    mainWindow?.webContents.send('bluetooth-devices-discovered', Array.from(seen.values()));
+    lastBluetoothDeviceIds = new Set(bluetoothDiscoveryDevices.keys());
+    mainWindow?.webContents.send(
+      'bluetooth-devices-discovered',
+      Array.from(bluetoothDiscoveryDevices.values()),
+    );
   });
 
   // ─── Web Serial: Port Selection ────────────────────────────────────
@@ -617,6 +624,7 @@ ipcMain.on('bluetooth-device-selected', (_event, deviceId: unknown) => {
   pendingBluetoothCallback(id);
   pendingBluetoothCallback = null;
   lastBluetoothDeviceIds.clear();
+  bluetoothDiscoveryDevices.clear();
 });
 
 // ─── IPC: Cancel Bluetooth selection ────────────────────────────────
@@ -626,6 +634,7 @@ ipcMain.on('bluetooth-device-cancelled', () => {
     pendingBluetoothCallback = null;
   }
   lastBluetoothDeviceIds.clear();
+  bluetoothDiscoveryDevices.clear();
 });
 
 // ─── IPC: Serial port selected by user ──────────────────────────────


### PR DESCRIPTION
## Summary

On Linux in MeshCore mode, clicking Connect for BLE immediately failed with "User cancelled the requestDevice() chooser" even though the user did not cancel. This was caused by Chromium firing `select-bluetooth-device` multiple times during discovery; we overwrote the callback each time, so the first promise was rejected when the second event arrived.

## What changed

- **Main process (`src/main/index.ts`):** Retain the **first** `select-bluetooth-device` callback instead of overwriting it on each event. Accumulate devices in a single `bluetoothDiscoveryDevices` map and send the merged list to the renderer on every event so the picker updates as more devices are discovered. Clear the map when the user selects a device or cancels so the next BLE connect starts clean.

## Why

On Linux, Chromium can fire `select-bluetooth-device` repeatedly (e.g. once with an empty list, then again as devices appear). Each event provides a new callback. Overwriting the stored callback meant the previous callback was never invoked, so Chromium rejected that request with "User cancelled". Keeping the first callback and merging device lists preserves a single active request and allows the picker to show and update correctly.

## How to test

1. On Linux, run the app in MeshCore mode.
2. Click Connect and choose BLE.
3. Confirm the BLE device picker appears and stays open (no immediate "User cancelled" error).
4. Select a device and confirm connection succeeds.
5. Cancel from the picker and confirm cancellation works; try connecting again and confirm a fresh discovery.