### PR TITLE
fix: install libudev-dev before npm install on Ubuntu CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,15 +34,15 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Install Linux build dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev rpm
+
       - name: Install dependencies
         run: npm install
-    
+
       - name: Rebuild native dependencies
         run: npm run rebuild
-
-      - name: Install Linux package build tools
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y rpm
 
       - name: Build and Publish
         env:


### PR DESCRIPTION
## Summary
- Moves Linux system dependency installation to before `npm install` so the `usb` native module can find `libudev.h` during compilation
- Consolidates the two separate `apt-get` steps into one (`libudev-dev` + `rpm`)

## Root Cause
The release workflow was installing `rpm` (for `.rpm` package builds) *after* `npm install`, but `libudev-dev` was never installed at all. The `usb` native module requires `libudev.h` at compile time, causing the Ubuntu build to fail with:
```
fatal error: libudev.h: No such file or directory
```

Fixes https://github.com/Colorado-Mesh/meshtastic-client/actions/runs/23393554972/job/68052442262