### PR TITLE
chore: rename app display name and repo URL to mesh-client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Meshtastic Client
+# Contributing to Mesh Client
 
 Thank you for your interest in contributing. This document covers setup, testing requirements, and the PR process.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)
-![Build Status](https://img.shields.io/github/actions/workflow/status/Colorado-Mesh/meshtastic-client/ci.yaml?branch=main)
+![Build Status](https://img.shields.io/github/actions/workflow/status/Colorado-Mesh/mesh-client/ci.yaml?branch=main)
 
 ---
 
@@ -188,7 +188,7 @@ MeshCore support is available alongside Meshtastic — switch protocols in the C
 
 ## Quick Start
 
-**Pre-built binaries** for **macOS**, **Linux**, and **Windows** are available in the [GitHub Releases](https://github.com/Colorado-Mesh/meshtastic-client/releases) area. Download the installer or archive for your platform — no Node.js or build tools required.
+**Pre-built binaries** for **macOS**, **Linux**, and **Windows** are available in the [GitHub Releases](https://github.com/Colorado-Mesh/mesh-client/releases) area. Download the installer or archive for your platform — no Node.js or build tools required.
 
 **To build from source**, you need:
 
@@ -199,8 +199,8 @@ MeshCore support is available alongside Meshtastic — switch protocols in the C
 ### Mac & Linux
 
 ```bash
-git clone https://github.com/Colorado-Mesh/meshtastic-client
-cd meshtastic-client
+git clone https://github.com/Colorado-Mesh/mesh-client
+cd mesh-client
 npm install
 npm start
 ```
@@ -357,8 +357,8 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 **5. Clone and run:**
 
 ```bash
-git clone https://github.com/Colorado-Mesh/meshtastic-client
-cd meshtastic-client
+git clone https://github.com/Colorado-Mesh/mesh-client
+cd mesh-client
 npm install
 npm start
 ```
@@ -446,7 +446,7 @@ Enter your broker URL, topic, and optional credentials in the MQTT section of th
 ### Project Structure
 
 ```
-meshtastic-client/
+mesh-client/
 ├── .github/
 │   ├── workflows/                # CI and release (ci.yaml, release.yaml, tests.yaml)
 │   ├── ISSUE_TEMPLATE/           # Bug report and feature request templates
@@ -758,12 +758,12 @@ npm run trace-deprecation
 
 **Cause**
 
-1. **Spaces in the project path** — node-gyp is unreliable when the repo lives under a path with spaces (e.g. `C:\Users\Joey Stanford\meshtastic-client`). This can surface as "Attempting to build a module with a space in the path", "Could not find any Visual Studio installation to use", or EPERM. See [node-gyp#65](https://github.com/nodejs/node-gyp/issues/65#issuecomment-368820565).
+1. **Spaces in the project path** — node-gyp is unreliable when the repo lives under a path with spaces (e.g. `C:\Users\Joey Stanford\mesh-client`). This can surface as "Attempting to build a module with a space in the path", "Could not find any Visual Studio installation to use", or EPERM. See [node-gyp#65](https://github.com/nodejs/node-gyp/issues/65#issuecomment-368820565).
 2. **EPERM on unlink** — Something on Windows still has the `.node` file open (another `node`/`electron` process, antivirus/Windows Defender scanning the file, or a stuck handle).
 
 **Fix**
 
-1. **Use a path without spaces** (strongly recommended): clone or copy the repo to e.g. `C:\dev\meshtastic-client`, then `npm install` and `npm run dist:win` from there.
+1. **Use a path without spaces** (strongly recommended): clone or copy the repo to e.g. `C:\dev\mesh-client`, then `npm install` and `npm run dist:win` from there.
 2. **Clear the lock before rebuild**: quit any running Mesh-Client/Electron dev instances, then delete the affected `build` folder under `node_modules` and retry.
 3. **Rebuild then dist**: `npm run rebuild` — if that succeeds, run `npm run dist:win`.
 
@@ -883,4 +883,4 @@ MIT — see [LICENSE](LICENSE)
 
 ## Credits
 
-See [CREDITS.md](CREDITS.md). Created by **[Joey (NV0N)](https://github.com/rinchen)** & **[dude.eth](https://github.com/defidude)**. Based on the [original Mac client](https://github.com/Colorado-Mesh/meshtastic-client). Part of **[Colorado Mesh](https://github.com/Colorado-Mesh/meshtastic-client)**.
+See [CREDITS.md](CREDITS.md). Created by **[Joey (NV0N)](https://github.com/rinchen)** & **[dude.eth](https://github.com/defidude)**. Based on the [original Mac client](https://github.com/Colorado-Mesh/meshtastic_mac_client). Part of **[Colorado Mesh](https://github.com/Colorado-Mesh/mesh-client)**.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Colorado-Mesh/meshtastic-client"
+    "url": "https://github.com/Colorado-Mesh/mesh-client"
   },
   "devDependencies": {
     "@axe-core/react": "^4.11.1",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -549,7 +549,7 @@ function createWindow() {
     height: 800,
     minWidth: 900,
     minHeight: 600,
-    title: 'Meshtastic Client',
+    title: 'Mesh Client',
     // Use the helper to select .ico, .icns, or .png automatically
     icon: getAppIconPath(),
     webPreferences: {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -14,7 +14,7 @@ export function getCheckNow(): (() => void) | null {
   return checkNow;
 }
 
-const REPO = 'Colorado-Mesh/meshtastic-client';
+const REPO = 'Colorado-Mesh/mesh-client';
 const RELEASES_URL = `https://github.com/${REPO}/releases`;
 const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -519,7 +519,7 @@ export default function App() {
         >
           <div className="flex items-center gap-3">
             <h1 className="text-lg font-bold text-bright-green tracking-wide">Colorado Mesh</h1>
-            <span className="text-xs text-muted">Meshtastic Client</span>
+            <span className="text-xs text-muted">Mesh Client</span>
           </div>
 
           <div className="flex items-center gap-2">
@@ -907,7 +907,7 @@ export default function App() {
                 </a>
                 . Code on{' '}
                 <a
-                  href="https://github.com/Colorado-Mesh/meshtastic-client"
+                  href="https://github.com/Colorado-Mesh/mesh-client"
                   title="Colorado Mesh on GitHub"
                   className="text-bright-green underline hover:opacity-80"
                   target="_blank"

--- a/src/renderer/components/DiagnosticsPanel.tsx
+++ b/src/renderer/components/DiagnosticsPanel.tsx
@@ -591,7 +591,7 @@ export default function DiagnosticsPanel({
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold text-gray-200">Network Diagnostics</h2>
         <a
-          href="https://github.com/Colorado-Mesh/meshtastic-client/blob/main/DIAGNOSTICS.md"
+          href="https://github.com/Colorado-Mesh/mesh-client/blob/main/DIAGNOSTICS.md"
           target="_blank"
           rel="noreferrer"
           className="text-xs text-muted hover:text-brand-green transition-colors"

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:* http://localhost:* http://127.0.0.1:* https://*.tile.openstreetmap.org http://* https://*; img-src 'self' data: https://*.tile.openstreetmap.org;" />
-    <title>Meshtastic Client</title>
+    <title>Mesh Client</title>
   </head>
   <body class="bg-gray-900 text-gray-100 overflow-hidden">
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- Renames all UI occurrences of "Meshtastic Client" → "Mesh Client" (window title, header badge, HTML `<title>`, `CONTRIBUTING.md`)
- Updates all GitHub URLs from `Colorado-Mesh/meshtastic-client` → `Colorado-Mesh/mesh-client`, including the update checker's `REPO` constant, about section link, diagnostics doc link, `package.json` repository URL, and `README.md`

## Test plan

- [ ] Launch app and confirm window title and header badge show "Mesh Client"
- [ ] Confirm update checker hits the correct repo (`Colorado-Mesh/mesh-client`)
- [ ] Confirm GitHub link in about/settings section points to new URL