### PR TITLE
feat: center protocol toggle and Windows/Linux About menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -601,47 +601,80 @@ async function showAboutDialog(): Promise<void> {
 }
 
 /**
- * macOS: set a minimal application menu so the native menu bridge has a stable model.
- * `role: 'editMenu'` is required for Cmd+C/V/X/Z/A keyboard shortcuts — macOS routes
- * these through AppKit, not Chromium. It may log WeakPtrToElectronMenuModelAsNSObject
- * when focusing text inputs, but that warning is a known harmless Electron/Chromium quirk.
+ * Application menu: macOS uses the app-name menu (About, updates, Hide, Quit) plus editMenu
+ * for Cmd+C/V/X/Z/A via AppKit. Windows/Linux get File (Quit), Edit, and Help (About, updates)
+ * so About is reachable from the menu bar and standard edit shortcuts work.
  */
 function setupAppMenu() {
-  if (process.platform !== 'darwin') return;
-  appMenu = Menu.buildFromTemplate([
-    {
-      label: app.name,
-      submenu: [
-        {
-          label: `About ${app.name}`,
-          click: () => void showAboutDialog(),
-        },
-        { type: 'separator' as const },
-        {
-          label: 'Check for Updates\u2026',
-          click: () => getCheckNow()?.(),
-        },
-        { type: 'separator' as const },
-        {
-          label: 'Hide',
-          accelerator: 'Command+H',
-          click: () => app.hide(),
-        },
-        { type: 'separator' as const },
-        {
-          label: 'Quit',
-          accelerator: 'Command+Q',
-          click: () => {
-            isQuitting = true;
-            mqttManager.disconnect();
-            meshcoreMqttAdapter.disconnect();
-            app.quit();
+  if (process.platform === 'darwin') {
+    appMenu = Menu.buildFromTemplate([
+      {
+        label: app.name,
+        submenu: [
+          {
+            label: `About ${app.name}`,
+            click: () => void showAboutDialog(),
           },
-        },
-      ],
-    },
-    { role: 'editMenu' as const },
-  ]);
+          { type: 'separator' as const },
+          {
+            label: 'Check for Updates\u2026',
+            click: () => getCheckNow()?.(),
+          },
+          { type: 'separator' as const },
+          {
+            label: 'Hide',
+            accelerator: 'Command+H',
+            click: () => app.hide(),
+          },
+          { type: 'separator' as const },
+          {
+            label: 'Quit',
+            accelerator: 'Command+Q',
+            click: () => {
+              isQuitting = true;
+              mqttManager.disconnect();
+              meshcoreMqttAdapter.disconnect();
+              app.quit();
+            },
+          },
+        ],
+      },
+      { role: 'editMenu' as const },
+    ]);
+  } else {
+    appMenu = Menu.buildFromTemplate([
+      {
+        label: 'File',
+        submenu: [
+          {
+            label: 'Quit',
+            accelerator: 'Ctrl+Q',
+            click: () => {
+              isQuitting = true;
+              mqttManager.disconnect();
+              meshcoreMqttAdapter.disconnect();
+              app.quit();
+            },
+          },
+        ],
+      },
+      { role: 'editMenu' as const },
+      {
+        label: 'Help',
+        submenu: [
+          {
+            label: `About ${app.name}`,
+            click: () => void showAboutDialog(),
+          },
+          { type: 'separator' as const },
+          {
+            label: 'Check for Updates\u2026',
+            click: () => getCheckNow()?.(),
+          },
+        ],
+      },
+    ]);
+  }
   Menu.setApplicationMenu(appMenu);
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -610,7 +610,7 @@ export default function App() {
       <div className="flex flex-col h-screen">
         {/* Header */}
         <header
-          className={`relative flex items-center justify-between px-4 py-2 bg-deep-black border-b ${
+          className={`relative flex items-center px-4 py-2 bg-deep-black border-b ${
             isConfigured
               ? protocol === 'meshcore'
                 ? 'border-cyan-500/20'
@@ -618,12 +618,12 @@ export default function App() {
               : 'border-gray-700'
           }`}
         >
-          <div className="flex items-center gap-3">
+          <div className="flex flex-1 min-w-0 items-center justify-start gap-3">
             <h1 className="text-lg font-bold text-bright-green tracking-wide">Colorado Mesh</h1>
             <span className="text-xs text-muted">Mesh Client</span>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center justify-center px-2">
             {/* Protocol context switcher */}
             <div
               role="group"
@@ -668,6 +668,9 @@ export default function App() {
                 )}
               </button>
             </div>
+          </div>
+
+          <div className="flex flex-1 min-w-0 items-center justify-end gap-2">
             <div className="flex items-center gap-1.5 mr-3 pr-3 border-r border-gray-700">
               <MqttGlobeIcon connected={device.mqttStatus === 'connected'} />
               <span


### PR DESCRIPTION
## Summary

Centers the Meshtastic/MeshCore protocol switcher in the main window header (fixes Windows layout where it appeared pinned to the right) and adds a standard application menu on Windows and Linux so **About** and **Check for Updates** are available from the menu bar, matching macOS discoverability.

## What changed

- **Renderer (`src/renderer/App.tsx`):** Header uses a three-column flex layout: title (left, `flex-1`), protocol pill (center, `shrink-0`), connection/MQTT/status (right, `flex-1 justify-end`).
- **Main (`src/main/index.ts`):** `setupAppMenu()` no longer no-ops on non-macOS. macOS keeps the existing app-name + Edit menu. Windows/Linux get **File** (Quit, Ctrl+Q), **Edit**, and **Help** (About, Check for Updates) with the same handlers as the macOS menu and tray.

## Why

- Two-column `justify-between` put the switcher in the right cluster; different window chrome/fonts on Windows made that read as "floating right" instead of centered.
- `setupAppMenu()` previously returned early except on darwin, so Windows had no menu-bar path to the About dialog (only tray).

## How to test

1. `npm run test:run` — all tests pass.
2. On **Windows:** open the app; confirm the protocol toggle is centered in the header; use **Help → About** and **Help → Check for Updates…**.
3. On **Linux:** same menu checks.
4. On **macOS:** confirm behavior unchanged (app menu + shortcuts).

## Risks / follow-ups

- None expected; Help menu is standard on Win/Linux Electron apps.