### PR TITLE
fix: Windows Disconnect & Quit hang and complete app:quit teardown

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1499,8 +1499,32 @@ ipcMain.handle('app:quit', async () => {
     meshcoreMqttAdapter.disconnect();
 
     await nobleBleManager.stopAllScanning();
+    try {
+      await nobleBleManager.disconnectAll();
+    } catch (err) {
+      console.error(
+        '[IPC] app:quit BLE disconnectAll failed:',
+        sanitizeLogMessage(err instanceof Error ? err.message : String(err)),
+      );
+    }
 
     closeDatabase();
+
+    if (meshcoreTcpSocket) {
+      try {
+        meshcoreTcpSocket.destroy();
+      } catch (err) {
+        console.debug(
+          '[IPC] app:quit TCP socket destroy (ignored):',
+          err instanceof Error ? err.message : err,
+        ); // log-injection-ok internal Node.js socket error during cleanup
+      }
+      meshcoreTcpSocket = null;
+    }
+    if (powerSaveBlockerId !== null && powerSaveBlocker.isStarted(powerSaveBlockerId)) {
+      powerSaveBlocker.stop(powerSaveBlockerId);
+    }
+    powerSaveBlockerId = null;
 
     nobleBleManager.releaseNobleProcessHandles();
     tray?.destroy();

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -273,6 +273,11 @@ export class NobleBleManager extends EventEmitter {
   }
 
   private doStopScanning(): Promise<void> {
+    // If nothing is scanning, noble's stopScanning callback may never run (observed on Windows),
+    // which would hang shutdown forever.
+    if (!this.scanningActive) {
+      return Promise.resolve();
+    }
     return new Promise((resolve) => {
       try {
         noble.stopScanning(() => {

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -1570,9 +1570,13 @@ export default function ConnectionPanel({
         {protocolToggle}
         <button
           onClick={async () => {
-            await onDisconnect();
-            window.electronAPI.mqtt.disconnect();
-            window.electronAPI.quitApp();
+            // Cap wait so quit always runs if transport teardown hangs (e.g. Windows serial/BLE).
+            await Promise.race([
+              onDisconnect(),
+              new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
+            ]);
+            void window.electronAPI.mqtt.disconnect();
+            await window.electronAPI.quitApp();
           }}
           className="w-full px-6 py-2.5 border border-red-700 text-red-400 hover:bg-red-900/30 hover:text-red-300 font-medium rounded-lg transition-colors text-sm"
         >


### PR DESCRIPTION
## Summary

Fixes **Disconnect & Quit** (and the `app:quit` IPC path) failing to finish on Windows: the app could stay running because main-process shutdown waited forever on Noble's `stopScanning` callback when no scan was active, and the renderer could block on transport teardown before invoking quit.

## What changed

- **`NobleBleManager.doStopScanning`**: If nothing is scanning (`!scanningActive`), return immediately instead of calling `noble.stopScanning`. On Windows the completion callback may never run in that idle case, which blocked `app:quit` at `await stopAllScanning()`.
- **`app:quit` handler** (`src/main/index.ts`): After stopping scans, **`await disconnectAll()`** so BLE sessions are torn down from the main process (errors are logged; quit continues). Also **destroy the MeshCore TCP bridge socket** and **stop the power-save blocker** before `releaseNobleProcessHandles` / `app.exit(0)`, because `app.exit` does not emit `will-quit` and those cleanups were previously skipped on this path.
- **`ConnectionPanel`**: **`Promise.race`** between `onDisconnect()` and a **10s** timeout, **`await quitApp()`**, and `void mqtt.disconnect()` so quit always runs even if renderer disconnect stalls (e.g. serial close on Windows).

## Why

Users reported Disconnect & Quit not working on Windows while other platforms behaved. The Noble idle-stop hang and missing IPC-side teardown were the main gaps; the renderer timeout is a safety net.

## How to test

1. On **Windows**, connect via a transport that can stall on close (e.g. USB serial), open **Connection** → **Disconnect & Quit**. The process should exit within a few seconds (or up to ~10s if disconnect is slow).
2. Confirm **MeshCore TCP** and **power-save** behavior: connect MeshCore over TCP if applicable, then Disconnect & Quit; process should exit cleanly.
3. `npm run typecheck` and `npm run test:run` (pass).

## Risks / follow-ups

- If `onDisconnect()` exceeds 10s, quit still proceeds; the main process may still be tearing down a stuck transport. That matches the intended tradeoff for a reliable exit.
