### PR TITLE
fix: use NUS UUIDs for MeshCore BLE connections

### DIFF
--- a/src/main/noble-ble-manager.test.ts
+++ b/src/main/noble-ble-manager.test.ts
@@ -19,3 +19,45 @@ describe('NobleBleManager.startScanning (regression)', () => {
     expect(SOURCE).toMatch(/emit\('deviceDiscovered'/);
   });
 });
+
+/**
+ * MeshCore BLE uses the Nordic UART Service (NUS), not Meshtastic's custom GATT UUIDs.
+ * Regression guard: connect() must select UUIDs based on sessionId so MeshCore devices
+ * don't get "Could not find all requested services" when we try to discover Meshtastic chars.
+ */
+describe('NobleBleManager.connect — per-session UUID selection (regression)', () => {
+  it('defines MeshCore NUS UUID constants distinct from Meshtastic UUIDs', () => {
+    // NUS service UUID
+    expect(SOURCE).toContain('6e400001b5a3f393e0a9e50e24dcca9e');
+    // NUS RX characteristic (we write to it)
+    expect(SOURCE).toContain('6e400002b5a3f393e0a9e50e24dcca9e');
+    // NUS TX characteristic (we read/notify from it)
+    expect(SOURCE).toContain('6e400003b5a3f393e0a9e50e24dcca9e');
+
+    // Must be separate from Meshtastic service UUID
+    expect(SOURCE).toContain('6ba1b21815a8461f9fa85dcae273eafd');
+  });
+
+  it('branches on sessionId to pick the correct service UUID for discovery', () => {
+    // There must be a conditional that distinguishes meshcore from meshtastic sessions
+    expect(SOURCE).toMatch(/sessionId\s*===\s*['"]meshcore['"]/);
+    // MeshCore path uses NUS service; Meshtastic path uses its own service UUID
+    expect(SOURCE).toMatch(/MESHCORE_SERVICE_UUID/);
+    expect(SOURCE).toMatch(/SERVICE_UUID/);
+  });
+
+  it('maps NUS RX char to toRadioChar and NUS TX char to fromRadioChar for meshcore sessions', () => {
+    // RX uuid → toRadioChar (we write to radio via RX)
+    expect(SOURCE).toMatch(/MESHCORE_RX_UUID.*toRadioChar|toRadioChar.*MESHCORE_RX_UUID/);
+    // TX uuid → fromRadioChar (radio writes to us via TX)
+    expect(SOURCE).toMatch(/MESHCORE_TX_UUID.*fromRadioChar|fromRadioChar.*MESHCORE_TX_UUID/);
+  });
+
+  it('does not assign fromNumChar for meshcore sessions (NUS has no equivalent)', () => {
+    // The meshcore branch must not set fromNumChar — it only maps RX and TX
+    const meshcoreBranchMatch = SOURCE.match(/if\s*\(isMeshcore\)\s*\{([^}]+)\}/s);
+    expect(meshcoreBranchMatch).not.toBeNull();
+    const meshcoreBranch = meshcoreBranchMatch![1];
+    expect(meshcoreBranch).not.toContain('fromNumChar');
+  });
+});

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -12,6 +12,12 @@ const TORADIO_UUID = 'f75c76d2129e4dada1dd7866124401e7';
 const FROMRADIO_UUID = '2c55e69e499311edb8780242ac120002';
 const FROMNUM_UUID = 'ed9da18ca8004f66a670aa7547e34453';
 
+// MeshCore BLE GATT UUIDs — Nordic UART Service (NUS)
+// RX = we write to it (radio reads from it); TX = we read/notify from it (radio writes to it)
+const MESHCORE_SERVICE_UUID = '6e400001b5a3f393e0a9e50e24dcca9e';
+const MESHCORE_RX_UUID = '6e400002b5a3f393e0a9e50e24dcca9e';
+const MESHCORE_TX_UUID = '6e400003b5a3f393e0a9e50e24dcca9e';
+
 /** Max iterations per read-pump burst (avoids infinite spin on misbehaving stacks). */
 const BLE_READ_PUMP_MAX_ITERATIONS = 512;
 /** Timeout for a single fromRadio GATT read. */
@@ -415,21 +421,32 @@ export class NobleBleManager extends EventEmitter {
       await withTimeout(peripheral.connectAsync(), 15000, 'BLE connectAsync');
       connected = true;
 
+      const isMeshcore = sessionId === 'meshcore';
+      const discoverServiceUuids = isMeshcore ? [MESHCORE_SERVICE_UUID] : [SERVICE_UUID];
+      const discoverCharUuids = isMeshcore
+        ? [MESHCORE_RX_UUID, MESHCORE_TX_UUID]
+        : [TORADIO_UUID, FROMRADIO_UUID, FROMNUM_UUID];
+
       const { characteristics } = await withTimeout<{
         characteristics: any[];
       }>(
         peripheral.discoverSomeServicesAndCharacteristicsAsync(
-          [SERVICE_UUID],
-          [TORADIO_UUID, FROMRADIO_UUID, FROMNUM_UUID],
+          discoverServiceUuids,
+          discoverCharUuids,
         ),
         15000,
         'BLE characteristic discovery',
       );
       for (const char of characteristics) {
         const uuid = normalizeUuid(char.uuid);
-        if (uuid === TORADIO_UUID) session.toRadioChar = char;
-        else if (uuid === FROMRADIO_UUID) session.fromRadioChar = char;
-        else if (uuid === FROMNUM_UUID) session.fromNumChar = char;
+        if (isMeshcore) {
+          if (uuid === MESHCORE_RX_UUID) session.toRadioChar = char;
+          else if (uuid === MESHCORE_TX_UUID) session.fromRadioChar = char;
+        } else {
+          if (uuid === TORADIO_UUID) session.toRadioChar = char;
+          else if (uuid === FROMRADIO_UUID) session.fromRadioChar = char;
+          else if (uuid === FROMNUM_UUID) session.fromNumChar = char;
+        }
       }
       console.debug(
         `[BLE:${sessionId}] discovered chars — toRadio=${Boolean(session.toRadioChar)} fromRadio=${Boolean(session.fromRadioChar)} fromNum=${Boolean(session.fromNumChar)} toRadioProps=${JSON.stringify(session.toRadioChar?.properties)} fromRadioProps=${JSON.stringify(session.fromRadioChar?.properties)} fromNumProps=${JSON.stringify(session.fromNumChar?.properties)}`,
@@ -437,7 +454,7 @@ export class NobleBleManager extends EventEmitter {
 
       // FROMNUM is optional for notification-based flow; require only TX/RX characteristics.
       if (!session.toRadioChar || !session.fromRadioChar) {
-        throw new Error('Failed to find required Meshtastic BLE toRadio/fromRadio characteristics');
+        throw new Error('Failed to find required BLE characteristics');
       }
 
       if (session.fromNumChar) {


### PR DESCRIPTION
## Summary

- MeshCore BLE connections were failing with **"Could not find all requested services"** because `NobleBleManager.connect()` unconditionally used Meshtastic's custom GATT service UUID for every session, including `meshcore`
- MeshCore companions expose the **Nordic UART Service (NUS)** — a completely different set of UUIDs — so noble's `discoverSomeServicesAndCharacteristicsAsync` always threw
- Fix: branch on `sessionId` to select the correct service and characteristics at discovery time
  - `meshcore`: NUS service (`6e400001…`), RX char → `toRadioChar` (write), TX char → `fromRadioChar` (subscribe/notify)
  - `meshtastic`: unchanged (existing custom service + toRadio/fromRadio/fromNum)
- NUS has no FROMNUM equivalent, so `fromNumChar` stays `null` for MeshCore sessions; the existing notify-based data path handles the rest without any additional changes
- Add 4 regression tests locking in the UUID constants, the per-session branch, the RX/TX mapping direction, and the absence of `fromNumChar` in the MeshCore branch

## Test plan

- [ ] Connect to a MeshCore companion via Bluetooth — should no longer error with "Could not find all requested services"
- [ ] Connect to a Meshtastic device via Bluetooth — should be unaffected
- [ ] `npm test` passes (299 + 4 new tests)