### PR TITLE
fix: persist log panel visibility when closed via close button

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1164,7 +1164,14 @@ export default function App() {
                   }))
             }
             variant="overlay"
-            onClose={() => setLogPanelVisible(false)}
+            onClose={() => {
+              setLogPanelVisible(false);
+              try {
+                localStorage.setItem(LOG_PANEL_VISIBLE_KEY, 'false');
+              } catch (e) {
+                console.debug('[App] persist logPanelVisible', e);
+              }
+            }}
           />
         )}
 


### PR DESCRIPTION
## Summary
- The overlay log panel's "Close" button only updated React state but skipped writing to `localStorage`
- The settings checkbox correctly called `onLogPanelVisibleChange` which persisted state; the close button only called `setLogPanelVisible(false)`
- Now the close button also writes `mesh-client:logPanelVisible = 'false'` to localStorage, matching the checkbox behavior

## Test plan
- [ ] Open the app with the log panel visible
- [ ] Click the "Close" button on the log panel
- [ ] Reload/relaunch the app
- [ ] Confirm the log panel stays closed