### PR TITLE
fix: BLE race conditions, Client Mute position suppression, and scan filter

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1126,6 +1126,10 @@ ipcMain.handle('noble-ble-to-radio', async (_event, sessionId: unknown, bytes: u
     console.debug(`[main] noble-ble-to-radio: ignoring session=${sessionId} (app is quitting)`);
     return;
   }
+  if (!nobleBleManager.isConnected(sessionId)) {
+    console.debug(`[main] noble-ble-to-radio: session=${sessionId} not connected, ignoring`);
+    return;
+  }
   const buf = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes as Uint8Array);
   if (buf.length > NOBLE_BLE_TO_RADIO_MAX_BYTES) {
     return Promise.reject(

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -83,6 +83,26 @@ export class NobleBleManager extends EventEmitter {
     });
 
     noble.on('discover', (peripheral: any) => {
+      // Client-side filter: noble's server-side UUID filter is unreliable on macOS.
+      // When only the meshtastic session is scanning, only pass devices that advertise
+      // the meshtastic service UUID. Devices that advertise zero service UUIDs are passed
+      // through (older firmware omits UUIDs from advertisement data) with a debug log.
+      if (!this.scanRequesters.has('meshcore') && this.scanRequesters.has('meshtastic')) {
+        const advUuids: string[] = (peripheral.advertisement?.serviceUuids ?? []).map((u: string) =>
+          u.toLowerCase().replace(/-/g, ''),
+        );
+        if (advUuids.length > 0 && !advUuids.includes(SERVICE_UUID)) {
+          console.debug(
+            `[NobleBleManager] discover: skipping non-meshtastic peripheral ${peripheral.id} (${peripheral.advertisement?.localName ?? 'unnamed'}) — advertised UUIDs: [${advUuids.join(', ')}]`,
+          );
+          return;
+        }
+        if (advUuids.length === 0) {
+          console.debug(
+            `[NobleBleManager] discover: passing peripheral ${peripheral.id} (${peripheral.advertisement?.localName ?? 'unnamed'}) with no advertised service UUIDs — may not be meshtastic`,
+          );
+        }
+      }
       const id: string = peripheral.id;
       const name: string = peripheral.advertisement?.localName || peripheral.address || id;
       const isNew = !this.knownPeripherals.has(id);
@@ -279,23 +299,17 @@ export class NobleBleManager extends EventEmitter {
   }
 
   private doStopScanning(): Promise<void> {
-    // If nothing is scanning, noble's stopScanning callback may never run (observed on Windows),
-    // which would hang shutdown forever.
-    if (!this.scanningActive) {
-      return Promise.resolve();
+    if (!this.scanningActive) return Promise.resolve();
+    // Mark stopped immediately — noble's stopScanning callback is unreliable on some platforms
+    // (may never fire on Windows; can hang on macOS if CBCentralManager state is inconsistent).
+    // CoreBluetooth receives the stop command regardless; we don't need to await confirmation.
+    this.scanningActive = false;
+    try {
+      noble.stopScanning();
+    } catch (err) {
+      console.debug('[NobleBleManager] stopScanning error (ignored):', err); // log-injection-ok noble internal error
     }
-    return new Promise((resolve) => {
-      try {
-        noble.stopScanning(() => {
-          this.scanningActive = false;
-          resolve();
-        });
-      } catch (err) {
-        console.debug('[NobleBleManager] stopScanning error (ignored):', err); // log-injection-ok noble internal error
-        this.scanningActive = false;
-        resolve();
-      }
-    });
+    return Promise.resolve();
   }
 
   /**
@@ -406,6 +420,20 @@ export class NobleBleManager extends EventEmitter {
       session.connectedPeripheralDisconnectHandler = onDisconnected;
 
       if (peripheral.state === 'connected') {
+        // Check if any other session already owns this peripheral. If so, refuse to connect
+        // rather than destructively disconnecting the other session's active GATT link.
+        for (const [otherSessionId, otherSession] of this.sessions.entries()) {
+          if (
+            otherSessionId !== sessionId &&
+            otherSession.connectedPeripheral?.id === peripheral.id
+          ) {
+            throw new Error(
+              `Peripheral ${peripheral.id} is already in use by the ${otherSessionId} session`,
+            );
+          }
+        }
+        // Peripheral is connected in noble's internal state but not claimed by any session
+        // (e.g. leftover from a previous crashed session). Disconnect before reconnecting.
         console.warn(
           `[BLE:${sessionId}] peripheral already connected in noble — disconnecting before reconnect`,
         );
@@ -528,6 +556,11 @@ export class NobleBleManager extends EventEmitter {
         });
       }
     }
+  }
+
+  isConnected(sessionId: NobleSessionId): boolean {
+    const session = this.sessions.get(sessionId);
+    return session != null && session.toRadioChar != null;
   }
 
   async writeToRadio(sessionId: NobleSessionId, data: Buffer): Promise<void> {

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -82,6 +82,7 @@ function getOrCreateVirtualNodeId(): number {
 
 const MQTT_ONLY_VIRTUAL_LONG_NAME = 'MQTT-only Virtual Address';
 const ROLE_CLIENT = 0;
+const ROLE_CLIENT_MUTE = 1;
 
 export function useDevice() {
   const deviceRef = useRef<MeshDevice | null>(null);
@@ -288,6 +289,7 @@ export function useDevice() {
     if (pollRef.current) return; // Already polling
     const intervalMs = connectionType === 'http' ? HTTP_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
     pollRef.current = setInterval(() => {
+      if (nodesRef.current.get(myNodeNumRef.current)?.role === ROLE_CLIENT_MUTE) return;
       deviceRef.current?.requestPosition(0xffffffff).catch((e) => {
         console.debug('[useDevice] requestPosition poll', e);
       });
@@ -995,6 +997,8 @@ export function useDevice() {
         };
         if (!info.num) return;
         const nodeNum = info.num;
+        const prevOwnRole =
+          nodeNum === myNodeNumRef.current ? nodesRef.current.get(nodeNum)?.role : undefined;
 
         updateNodes((prev) => {
           const updated = new Map(prev);
@@ -1066,6 +1070,15 @@ export function useDevice() {
           window.electronAPI.db.saveNode(node);
           return updated;
         });
+        if (
+          nodeNum === myNodeNumRef.current &&
+          nodesRef.current.get(nodeNum)?.role === ROLE_CLIENT_MUTE &&
+          prevOwnRole !== ROLE_CLIENT_MUTE
+        ) {
+          console.info(
+            '[useDevice] Device role is Client Mute — position reports to device suppressed',
+          );
+        }
         const updatedRfNode = nodesRef.current.get(nodeNum);
         if (updatedRfNode) {
           useDiagnosticsStore
@@ -2170,10 +2183,12 @@ export function useDevice() {
           });
         }
 
-        const shouldSendToDevice =
+        const isClientMute = nodesRef.current.get(myNodeNumRef.current)?.role === ROLE_CLIENT_MUTE;
+        const wouldSendWithoutMute =
           deviceRef.current &&
           ((pos.source === 'static' && deviceGpsModeRef.current !== 1) ||
             (pos.source === 'browser' && deviceGpsModeRef.current === 2));
+        const shouldSendToDevice = !isClientMute && wouldSendWithoutMute;
 
         if (shouldSendToDevice && deviceRef.current) {
           deviceRef.current
@@ -2205,6 +2220,7 @@ export function useDevice() {
 
   const sendPositionToDevice = useCallback(async (lat: number, lon: number, alt?: number) => {
     if (!deviceRef.current) return;
+    if (nodesRef.current.get(myNodeNumRef.current)?.role === ROLE_CLIENT_MUTE) return;
     await deviceRef.current.setPosition(
       create(Mesh.PositionSchema, {
         latitudeI: Math.round(lat * 1e7),

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -1371,6 +1371,8 @@ export function useMeshCore() {
         const isAlreadyInProgress = /already in progress|Connection already in progress/i.test(
           safeMessage,
         );
+        const isMissingServices = /could not find all requested services/i.test(safeMessage);
+        const isPeripheralInUse = /already in use by the/i.test(safeMessage);
         // When err is missing (e.g. library rejected with no reason), use a BLE-specific hint if we were connecting via BLE
         const fallbackMessage =
           type === 'ble' && err == null
@@ -1380,7 +1382,11 @@ export function useMeshCore() {
         const normalizedErr = new Error(
           isAlreadyInProgress
             ? 'Bluetooth connection already in progress. Wait for it to finish or try Serial/USB instead.'
-            : displayMessage,
+            : isMissingServices
+              ? 'Device does not support the MeshCore BLE protocol. Make sure the device is running MeshCore firmware.'
+              : isPeripheralInUse
+                ? 'This device is already connected via Meshtastic BLE. Disconnect it first before connecting as MeshCore.'
+                : displayMessage,
         );
         const errForLog =
           err != null ? (err instanceof Error ? err.message : String(err)) : '(no error object)';


### PR DESCRIPTION
## Summary

- **BLE cross-session guard**: `NobleBleManager.connect()` now throws instead of disconnecting when a peripheral is already owned by another session. This was the root cause of meshcore killing an active meshtastic BLE connection when both protocols had a saved BLE last-connection to the same device.
- **`noble-ble-to-radio` disconnect guard**: Added `isConnected()` check in the IPC handler so writes after BLE teardown are silently dropped rather than throwing spurious errors.
- **`doStopScanning` hang fix**: Made stop fire-and-forget — noble's `stopScanning` callback is unreliable on macOS and was causing `connect()` to hang indefinitely, triggering the "reply was never sent" IPC error.
- **BLE scan client-side filter**: Added a `discover` handler filter (with debug logging) that skips non-meshtastic peripherals when only the meshtastic session is scanning.
- **Client Mute position suppression**: Position poll (`requestPosition`) and `sendPositionToDevice` are now no-ops when the own node's role is `ROLE_CLIENT_MUTE`. A single `console.info` is logged on role transition instead of repeated debug logs.
- **Friendly BLE error messages**: `useMeshCore` now surfaces user-readable messages for "could not find all requested services" (not MeshCore firmware) and "already in use by another session" (peripheral conflict).

## Test plan

- [ ] Connect meshtastic via BLE — verify meshcore BLE auto-connect to the same device is rejected gracefully (error shown in meshcore panel, meshtastic stays connected)
- [ ] Connect meshtastic and meshcore to different BLE devices — verify both connect successfully in parallel
- [ ] Connect meshtastic via BLE — verify no `noble-ble-to-radio: Not connected` errors appear after disconnect/reconnect
- [ ] Open BLE picker in meshtastic mode — verify non-meshtastic devices are filtered (check debug logs for skipped peripherals)
- [ ] Set device to Client Mute role — verify position reports stop and a single info log appears on transition