### PR TITLE
fix: diagnose Linux BLE capability failures during scan/connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ From real-time diagnostics to permanent message archives, Mesh-Client delivers t
 
 **Known Bugs:**
 
-- **Linux BLE permissions** — BLE uses `@stoprocent/noble` (native BlueZ), which needs raw socket access. Run `sudo setcap cap_net_raw+eip $(which electron)` once after install, or launch with `sudo` during development. Packaged AppImages include the cap in the installer.
+- **Linux BLE permissions** — BLE uses `@stoprocent/noble` (native BlueZ), which needs raw socket access. If capability setup is missing, the app reports a dedicated Linux capability error (`BLE_LINUX_CAPABILITY_MISSING`) and suggests: `sudo setcap cap_net_raw+eip $(which electron)`.
 
 ---
 
@@ -723,7 +723,7 @@ You're missing build tools for the native modules (e.g. `@serialport/bindings-cp
 
 **Linux-specific:**
 
-- noble requires raw socket capability. Run once after install: `sudo setcap cap_net_raw+eip $(which electron)`. Without this, BLE scanning will silently fail.
+- noble requires raw socket capability. Run once after install: `sudo setcap cap_net_raw+eip $(which electron)`. Without this, BLE scanning may fail and the app should show Linux capability guidance with the same command.
 - If the adapter is present but scanning does not start, restart BlueZ: `sudo systemctl restart bluetooth`.
 
 ### Serial port not detected

--- a/src/main/noble-ble-manager.test.ts
+++ b/src/main/noble-ble-manager.test.ts
@@ -107,10 +107,12 @@ describe('NobleBleManager — notify-only fromRadio read pump suppression (regre
  * Fix: startScanning waits up to 5s for the adapterState event before throwing.
  */
 describe('NobleBleManager — Linux/BlueZ adapter init race (regression)', () => {
-  it('defines waitForAdapterReady and resolves it via the adapterState event', () => {
+  it('defines waitForAdapterReady and keeps listening for adapterState events', () => {
     expect(SOURCE).toContain('waitForAdapterReady');
     // Must listen to the manager's own adapterState event (emitted by stateChange handler)
-    expect(SOURCE).toMatch(/this\.once\('adapterState'/);
+    expect(SOURCE).toMatch(/this\.on\('adapterState'/);
+    // Should ignore transient non-ready states until timeout or poweredOn
+    expect(SOURCE).toMatch(/if \(this\.adapterReady \|\| Date\.now\(\) >= deadline\)/);
   });
 
   it('startScanning awaits waitForAdapterReady before throwing the adapter-not-ready error', () => {
@@ -131,5 +133,21 @@ describe('NobleBleManager — Linux/BlueZ adapter init race (regression)', () =>
     expect(SOURCE).toMatch(
       /doStartScanning[\s\S]{0,200}if \(this\.scanningActive\) return Promise\.resolve\(\)/,
     );
+  });
+});
+
+describe('NobleBleManager — Linux BLE capability diagnostics (regression)', () => {
+  it('defines a dedicated Linux capability error code', () => {
+    expect(SOURCE).toContain('BLE_LINUX_CAPABILITY_MISSING');
+  });
+
+  it('classifies Linux scan errors through classifyLinuxBleError before rejecting', () => {
+    expect(SOURCE).toMatch(/const classifiedErr = this\.classifyLinuxBleError\(err\)/);
+    expect(SOURCE).toMatch(/reject\(classifiedErr\)/);
+  });
+
+  it('probes executable capabilities via getcap and process.execPath', () => {
+    expect(SOURCE).toMatch(/execFileSync\('getcap', \[process\.execPath\]/);
+    expect(SOURCE).toMatch(/cap_net_raw/);
   });
 });

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from 'node:child_process';
+
 import { EventEmitter } from 'events';
 
 import { withTimeout } from '../shared/withTimeout';
@@ -24,6 +26,7 @@ const BLE_READ_PUMP_MAX_ITERATIONS = 512;
 const BLE_FROM_RADIO_READ_TIMEOUT_MS = 2000;
 /** Delay before kicking read pump after a write (device prep time). */
 const POST_WRITE_READ_PUMP_DELAY_MS = 100;
+const BLE_LINUX_CAPABILITY_MISSING = 'BLE_LINUX_CAPABILITY_MISSING';
 
 function normalizeUuid(uuid: string): string {
   return uuid.toLowerCase().replace(/-/g, '');
@@ -73,6 +76,7 @@ export class NobleBleManager extends EventEmitter {
   private adapterReady = false;
   /** True only while noble.startScanning() has actually been called and confirmed active. */
   private scanningActive = false;
+  private lastAdapterState = String(noble.state ?? 'unknown');
 
   constructor() {
     super();
@@ -82,6 +86,7 @@ export class NobleBleManager extends EventEmitter {
     // this manager was constructed (avoids false "adapter not powered on" errors on startup).
     this.adapterReady = noble.state === 'poweredOn';
     noble.on('stateChange', (state: string) => {
+      this.lastAdapterState = state;
       this.adapterReady = state === 'poweredOn';
       this.emit('adapterState', state);
       if (this.adapterReady && this.scanRequesters.size > 0) {
@@ -283,7 +288,13 @@ export class NobleBleManager extends EventEmitter {
       );
       await this.waitForAdapterReady(5000);
     }
-    if (!this.adapterReady) throw new Error('Bluetooth adapter is not powered on');
+    if (!this.adapterReady) {
+      const capabilityErr = this.getLinuxCapabilityError(
+        `Adapter state remained ${this.lastAdapterState} after startup wait`,
+      );
+      if (capabilityErr) throw capabilityErr;
+      throw new Error('Bluetooth adapter is not powered on');
+    }
     await this.doStartScanning();
   }
 
@@ -312,8 +323,9 @@ export class NobleBleManager extends EventEmitter {
     return new Promise((resolve, reject) => {
       noble.startScanning(filter, false, (err: Error | null) => {
         if (err) {
-          console.error('[NobleBleManager] startScanning error:', err); // log-injection-ok noble internal error
-          reject(err);
+          const classifiedErr = this.classifyLinuxBleError(err);
+          console.error('[NobleBleManager] startScanning error:', classifiedErr); // log-injection-ok noble internal error
+          reject(classifiedErr);
           return;
         }
         this.scanningActive = true;
@@ -333,20 +345,72 @@ export class NobleBleManager extends EventEmitter {
   private waitForAdapterReady(timeoutMs: number): Promise<void> {
     if (this.adapterReady) return Promise.resolve();
     return new Promise<void>((resolve) => {
+      const deadline = Date.now() + timeoutMs;
       const cleanup = () => {
-        clearTimeout(timer);
+        clearTimeout(timeout);
         this.off('adapterState', onState);
       };
       const onState = () => {
-        cleanup();
-        resolve();
+        if (this.adapterReady || Date.now() >= deadline) {
+          cleanup();
+          resolve();
+        }
       };
-      const timer = setTimeout(() => {
+      // Keep waiting through transient non-powered states (e.g. unknown/resetting) until
+      // poweredOn arrives or timeout is reached.
+      const timeout = setTimeout(() => {
         cleanup();
         resolve();
       }, timeoutMs);
-      this.once('adapterState', onState);
+      this.on('adapterState', onState);
     });
+  }
+
+  private classifyLinuxBleError(err: unknown): Error {
+    if (!(err instanceof Error)) return new Error(String(err));
+    const capabilityErr = this.getLinuxCapabilityError(err.message);
+    return capabilityErr ?? err;
+  }
+
+  private getLinuxCapabilityError(context: string): Error | null {
+    if (process.platform !== 'linux') return null;
+    const lowerContext = context.toLowerCase();
+    const looksPermissionRelated =
+      /\beperm\b|operation not permitted|permission denied|not permitted|set scan parameters/i.test(
+        lowerContext,
+      ) || /\bhci\d+\b/.test(lowerContext);
+    const capabilityProbe = this.probeLinuxBleCapability();
+    if (!looksPermissionRelated && capabilityProbe.hasBleCapabilities) {
+      return null;
+    }
+    const detail = capabilityProbe.detail ? ` (${capabilityProbe.detail})` : '';
+    return new Error(
+      `${BLE_LINUX_CAPABILITY_MISSING}: Linux BLE scan permissions are missing or not applied${detail}. Run: sudo setcap cap_net_raw+eip "$(which electron)"`,
+    );
+  }
+
+  private probeLinuxBleCapability(): { hasBleCapabilities: boolean; detail: string } {
+    if (process.platform !== 'linux') {
+      return { hasBleCapabilities: true, detail: '' };
+    }
+    try {
+      const output = execFileSync('getcap', [process.execPath], {
+        encoding: 'utf8',
+      }).trim();
+      const normalized = output.toLowerCase();
+      const hasRaw = normalized.includes('cap_net_raw');
+      const hasAdmin = normalized.includes('cap_net_admin');
+      return {
+        hasBleCapabilities: hasRaw || hasAdmin,
+        detail: output || `no capabilities set on ${process.execPath}`,
+      };
+    } catch {
+      // catch-no-log-ok capability probe fallback: handled by returned detail message
+      return {
+        hasBleCapabilities: false,
+        detail: `unable to read capabilities for ${process.execPath}`,
+      };
+    }
   }
 
   private doStopScanning(): Promise<void> {
@@ -431,6 +495,10 @@ export class NobleBleManager extends EventEmitter {
     );
     try {
       if (!this.adapterReady) {
+        const capabilityErr = this.getLinuxCapabilityError(
+          `connect() called while adapter state is ${this.lastAdapterState}`,
+        );
+        if (capabilityErr) throw capabilityErr;
         throw new Error('Bluetooth adapter is not powered on');
       }
       // CBCentralManager on macOS cannot scan and connect simultaneously.

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -124,3 +124,35 @@ describe('ConnectionPanel MQTT connect error', () => {
     expect(await screen.findByText('broker refused')).toBeInTheDocument();
   });
 });
+
+describe('ConnectionPanel BLE error humanization', () => {
+  it('shows Linux setcap guidance for classified Linux capability errors', async () => {
+    const user = userEvent.setup();
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockRejectedValueOnce(
+      new Error(
+        'BLE_LINUX_CAPABILITY_MISSING: Linux BLE scan permissions are missing or not applied',
+      ),
+    );
+
+    render(
+      <ConnectionPanel
+        state={disconnectedState}
+        onConnect={vi.fn().mockResolvedValue(undefined)}
+        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+        onDisconnect={vi.fn().mockResolvedValue(undefined)}
+        mqttStatus="disconnected"
+        protocol="meshtastic"
+        onProtocolChange={vi.fn()}
+      />,
+    );
+
+    const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
+    expect(radioCard).toBeTruthy();
+    await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
+
+    expect(
+      await screen.findByText(/Linux BLE permissions are missing for Electron/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/setcap cap_net_raw\+eip/i)).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -88,6 +88,13 @@ function humanizeHttpError(address: string, err: unknown): string {
 function humanizeBleError(err: unknown): string {
   const msg = err instanceof Error ? err.message : String(err);
   const isWindows = navigator.userAgent.toLowerCase().includes('windows');
+  const isLinux = navigator.userAgent.toLowerCase().includes('linux');
+  if (msg.includes('BLE_LINUX_CAPABILITY_MISSING')) {
+    return 'Linux BLE permissions are missing for Electron. Run: sudo setcap cap_net_raw+eip "$(which electron)" and restart the app.';
+  }
+  if (isLinux && /operation not permitted|permission denied|\beperm\b/i.test(msg)) {
+    return `${msg} — Linux BLE may be missing permissions. Run: sudo setcap cap_net_raw+eip "$(which electron)"`;
+  }
   if (msg.includes('Bluetooth adapter not found') || msg.includes('adapter is not available')) {
     if (isWindows) {
       return `${msg} — Check Settings > Bluetooth & devices. If Bluetooth is on but unavailable, update your Bluetooth driver in Device Manager.`;


### PR DESCRIPTION
## Summary
This change makes Linux BLE scan/connect failures actionable by separating real adapter-power issues from missing process capabilities (`setcap`) and surfacing explicit remediation in the UI.

## What changed
- Updated `NobleBleManager` adapter readiness waiting so Linux startup/transient adapter states do not fail on the first event; it now waits through state transitions until `poweredOn` or timeout.
- Added Linux capability diagnostics in `NobleBleManager`:
  - Introduced `BLE_LINUX_CAPABILITY_MISSING` classification.
  - Probe executable capabilities via `getcap` on `process.execPath`.
  - Map permission-style BLE failures (`EPERM`, `Operation not permitted`, related signatures) to capability guidance.
  - Apply the same classification on scan start and connect pre-check paths.
- Extended `ConnectionPanel` BLE error humanization:
  - Recognize `BLE_LINUX_CAPABILITY_MISSING` and show direct `setcap` guidance.
  - Provide Linux fallback guidance for permission-style BLE errors.
- Updated README Linux BLE troubleshooting copy to reflect explicit runtime capability diagnostics instead of “silent fail” wording.
- Added regression guards:
  - Main-process tests for updated wait semantics and capability classification/probing.
  - Renderer test ensuring Linux capability errors produce `setcap` guidance.

## Why
After #181, Linux users could observe a scan delay and then still receive the generic “Bluetooth adapter is not powered on” error when the real issue was missing or unapplied `setcap` capabilities. This change preserves the adapter init race fix while making permission-related failures diagnosable and actionable.

## How to test
- Linux dev environment without BLE capability applied:
  - Attempt BLE scan.
  - Confirm user-facing guidance references Linux BLE permissions and `sudo setcap cap_net_raw+eip "$(which electron)"`.
- Linux with capabilities correctly applied and Bluetooth on:
  - Start scan and confirm no false capability error.
- Linux with Bluetooth genuinely off/unavailable:
  - Confirm adapter-not-ready behavior still surfaces appropriately.
- Run automated checks:
  - `npm run lint`
  - `npm run typecheck`
  - `npm run test:run`

## Risks / follow-ups
- Capability probing depends on `getcap` availability in PATH; fallback messaging is included when probing cannot be read.
- Distros/environments with atypical capability or BlueZ behavior may still need future refinement of error signature matching.