### PR TITLE
fix: harden Linux startup diagnostics and BLE timeout triage

### DIFF
--- a/scripts/start-electron.mjs
+++ b/scripts/start-electron.mjs
@@ -36,6 +36,12 @@ export function classifyElectronStartupError(stderrText) {
   if (hasSharedLibraryFailure && hasMissingFfmpeg && hasCannotOpenSharedObject) {
     return 'linux-libffmpeg-missing';
   }
+  const hasXServerMissing = lower.includes('missing x server or $display');
+  const hasOzoneX11Failure = lower.includes('ozone_platform_x11.cc');
+  const hasAuraPlatformInitFailure = lower.includes('platform failed to initialize');
+  if ((hasXServerMissing || hasOzoneX11Failure) && hasAuraPlatformInitFailure) {
+    return 'linux-display-missing';
+  }
   return null;
 }
 
@@ -47,6 +53,18 @@ export function fedoraLibffmpegRemediation() {
     '  sudo setcap -r ./node_modules/electron/dist/electron',
     '[mesh-client] Then run with ambient capability instead (no file capability on electron):',
     "  sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc 'npm start'",
+  ].join('\n');
+}
+
+export function linuxDisplayMissingRemediation() {
+  return [
+    '[mesh-client] Detected Linux startup failure: no active desktop display (X11/Wayland).',
+    '[mesh-client] Electron could not initialize a GUI backend (Missing X server or $DISPLAY).',
+    '[mesh-client] If you are in SSH or headless mode, launch from a desktop session instead.',
+    '[mesh-client] If already in a desktop session, verify display environment variables:',
+    "  echo \"DISPLAY=$DISPLAY WAYLAND_DISPLAY=$WAYLAND_DISPLAY XDG_SESSION_TYPE=$XDG_SESSION_TYPE\"",
+    '[mesh-client] For Wayland sessions, forcing X11 may help:',
+    "  ELECTRON_OZONE_PLATFORM_HINT=x11 npm start",
   ].join('\n');
 }
 
@@ -73,6 +91,8 @@ export async function runStartElectron(argv = process.argv.slice(2)) {
     const classification = classifyElectronStartupError(stderrBuffer);
     if (classification === 'linux-libffmpeg-missing') {
       process.stderr.write(`\n${fedoraLibffmpegRemediation()}\n`);
+    } else if (classification === 'linux-display-missing') {
+      process.stderr.write(`\n${linuxDisplayMissingRemediation()}\n`);
     }
     if (signal) {
       process.kill(process.pid, signal);

--- a/src/main/start-electron.test.ts
+++ b/src/main/start-electron.test.ts
@@ -19,6 +19,17 @@ describe('start-electron wrapper helpers', () => {
     expect(mod.classifyElectronStartupError('Error: EACCES')).toBeNull();
   });
 
+  it('classifies Linux display backend startup failures', async () => {
+    // @ts-expect-error test import from scripts directory
+    const mod = (await import('../../scripts/start-electron.mjs')) as {
+      classifyElectronStartupError: (stderrText: string) => string | null;
+    };
+    const err =
+      '[40321:0323/203719.272214:ERROR:ui/ozone/platform/x11/ozone_platform_x11.cc:256] Missing X server or $DISPLAY\n' +
+      '[40321:0323/203719.272233:ERROR:ui/aura/env.cc:257] The platform failed to initialize.  Exiting.';
+    expect(mod.classifyElectronStartupError(err)).toBe('linux-display-missing');
+  });
+
   it('prints remediation text with rollback and ambient-cap commands', async () => {
     // @ts-expect-error test import from scripts directory
     const mod = (await import('../../scripts/start-electron.mjs')) as {
@@ -28,6 +39,17 @@ describe('start-electron wrapper helpers', () => {
     expect(text).toContain('sudo setcap -r ./node_modules/electron/dist/electron');
     expect(text).toContain('--ambient-caps +net_raw');
     expect(text).toContain("bash -lc 'npm start'");
+  });
+
+  it('prints remediation text for missing Linux display backend', async () => {
+    // @ts-expect-error test import from scripts directory
+    const mod = (await import('../../scripts/start-electron.mjs')) as {
+      linuxDisplayMissingRemediation: () => string;
+    };
+    const text = mod.linuxDisplayMissingRemediation();
+    expect(text).toContain('Missing X server or $DISPLAY');
+    expect(text).toContain('ELECTRON_OZONE_PLATFORM_HINT=x11 npm start');
+    expect(text).toContain('DISPLAY=$DISPLAY WAYLAND_DISPLAY=$WAYLAND_DISPLAY');
   });
 
   it('resolves macOS electron app binary path', async () => {

--- a/src/renderer/hooks/useMeshCore.ble-timeout.test.tsx
+++ b/src/renderer/hooks/useMeshCore.ble-timeout.test.tsx
@@ -9,6 +9,9 @@ import { withTimeout } from '../../shared/withTimeout';
 import { useMeshCore } from './useMeshCore';
 
 describe('useMeshCore BLE Noble IPC timeout handling', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([]);
@@ -34,6 +37,16 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
     );
 
     expect(window.electronAPI.disconnectNobleBle).toHaveBeenCalledWith('meshcore');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useMeshCore] connect: BLE Noble IPC timed out; advise retry, BLE power-cycle, or Serial/TCP fallback',
+      { stage: 'ipc-open' },
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[useMeshCore] connect error',
+      'Bluetooth connection timed out while opening MeshCore over Noble IPC. Retry, power-cycle BLE on the device, or use Serial/TCP.',
+      'MeshCore BLE IPC open timed out after 20000ms',
+      { bleTimeoutStage: 'ipc-open' },
+    );
   });
 
   it('disconnects and surfaces timeout guidance when protocol handshake stalls', async () => {
@@ -58,5 +71,15 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
 
     expect(window.electronAPI.connectNobleBle).toHaveBeenCalledWith('meshcore', 'ble-device-2');
     expect(window.electronAPI.disconnectNobleBle).toHaveBeenCalledWith('meshcore');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useMeshCore] connect: BLE Noble IPC timed out; advise retry, BLE power-cycle, or Serial/TCP fallback',
+      { stage: 'protocol-handshake' },
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[useMeshCore] connect error',
+      'Bluetooth connection timed out while opening MeshCore over Noble IPC. Retry, power-cycle BLE on the device, or use Serial/TCP.',
+      'MeshCore BLE protocol handshake timed out after 15000ms',
+      { bleTimeoutStage: 'protocol-handshake' },
+    );
   });
 });

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -86,6 +86,14 @@ interface SerialConnectionInstance extends InstanceType<typeof SerialConnection>
 const NOBLE_IPC_CONNECT_TIMEOUT_MS = 20_000;
 const NOBLE_IPC_HANDSHAKE_TIMEOUT_MS = 15_000;
 
+type MeshcoreBleTimeoutStage = 'ipc-open' | 'protocol-handshake' | 'unknown';
+
+function classifyMeshcoreBleTimeoutStage(message: string): MeshcoreBleTimeoutStage {
+  if (/MeshCore BLE IPC open timed out/i.test(message)) return 'ipc-open';
+  if (/MeshCore BLE protocol handshake timed out/i.test(message)) return 'protocol-handshake';
+  return 'unknown';
+}
+
 /** TCP connection implemented over IPC bridge (main-process net.Socket). */
 class IpcTcpConnection {
   private host: string;
@@ -1403,6 +1411,9 @@ export function useMeshCore() {
           /MeshCore BLE IPC open timed out|MeshCore BLE protocol handshake timed out/i.test(
             safeMessage,
           );
+        const bleTimeoutStage = isBleConnectTimeout
+          ? classifyMeshcoreBleTimeoutStage(safeMessage)
+          : null;
         // When err is missing (e.g. library rejected with no reason), use a BLE-specific hint if we were connecting via BLE
         const fallbackMessage =
           type === 'ble' && err == null
@@ -1423,11 +1434,14 @@ export function useMeshCore() {
         if (isBleConnectTimeout) {
           console.warn(
             '[useMeshCore] connect: BLE Noble IPC timed out; advise retry, BLE power-cycle, or Serial/TCP fallback',
+            { stage: bleTimeoutStage },
           );
         }
         const errForLog =
           err != null ? (err instanceof Error ? err.message : String(err)) : '(no error object)';
-        console.error('[useMeshCore] connect error', normalizedErr.message, errForLog);
+        console.error('[useMeshCore] connect error', normalizedErr.message, errForLog, {
+          bleTimeoutStage,
+        });
         setState({ status: 'disconnected', myNodeNum: 0, connectionType: null });
         ipcTcpRef.current?.cleanup();
         ipcTcpRef.current = null;


### PR DESCRIPTION
## Summary
Improve Linux development support by combining runtime diagnostics for startup/BLE triage with clearer distro-specific dependency guidance in the development guide.

## What changed
- Startup wrapper now classifies Linux X11/ozone display initialization failures (`Missing X server or $DISPLAY` + platform init failure) and prints actionable remediation.
- Added dedicated display-environment guidance in `start-electron` output, including environment checks and an `ELECTRON_OZONE_PLATFORM_HINT=x11` fallback.
- `useMeshCore` now annotates BLE timeout logs with structured stage context (`ipc-open` vs `protocol-handshake`) while preserving existing user-facing timeout copy.
- Expanded Linux development dependency docs in `docs/development-environment.md`:
  - Base toolchain commands now use distro meta-packages (`@development-tools` on Fedora, `build-essential` on Debian/Ubuntu) with duplicate package entries removed.
  - Added NSS/NSPR package requirements for Debian/Ubuntu and Fedora/RedHat.
  - Added distro-specific runtime library install commands for Fedora/Bazzite/Aurora in Distrobox/Toolbox and for Ubuntu/Debian environments.
  - Added CUPS and Cairo runtime library dependencies (`cups-libs` / `libcups2`, `cairo` / `libcairo2`) to prevent missing shared object startup errors.
  - Added a Fedora fallback command for missing GTK/Pango/GDK shared objects (`libgtk-3.so.0`, `libgdk-3.so.0`, `libpangocairo-1.0.so.0`, `libpangoft2-1.0.so.0`, `libgdk_pixbuf-2.0.so.0`).
  - Added Fedora `*-devel` dependency guidance for native build/debug header requirements.
- Extended tests for behavior changes:
  - `src/main/start-electron.test.ts`
  - `src/renderer/hooks/useMeshCore.ble-timeout.test.tsx`

## Why
Linux users were encountering startup and environment friction from both opaque display initialization failures and missing runtime/system libraries. At the same time, BLE timeout logs lacked stage context needed for quick support triage. These changes reduce onboarding friction and improve diagnosability without changing expected fail-fast behavior.

## How to test
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run`
- [x] `npm run test:run -- src/main/start-electron.test.ts src/renderer/hooks/useMeshCore.ble-timeout.test.tsx`

## Risks / follow-ups
- Linux display remediation is advisory and can still vary by distro/session manager.
- Package names may differ on less common Linux distributions beyond those documented.