### PR TITLE
fix: increase BLE timeouts and retry coverage for Windows and Linux

### DIFF
--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -26,6 +26,16 @@ const BLE_READ_PUMP_MAX_ITERATIONS = 512;
 const BLE_FROM_RADIO_READ_TIMEOUT_MS = 2000;
 /** Delay before kicking read pump after a write (device prep time). */
 const POST_WRITE_READ_PUMP_DELAY_MS = 100;
+
+// BlueZ (Linux) and WinRT (Windows) BLE stacks are significantly slower than macOS
+// CBCentralManager. Use generous timeouts on those platforms.
+const IS_DARWIN = process.platform === 'darwin';
+/** Timeout for peripheral.connectAsync(). */
+const BLE_CONNECT_TIMEOUT_MS = IS_DARWIN ? 15_000 : 30_000;
+/** Timeout for GATT service/characteristic discovery. */
+const BLE_DISCOVERY_TIMEOUT_MS = IS_DARWIN ? 15_000 : 30_000;
+/** Timeout for characteristic subscribeAsync(). */
+const BLE_SUBSCRIBE_TIMEOUT_MS = IS_DARWIN ? 10_000 : 20_000;
 const BLE_LINUX_CAPABILITY_MISSING = 'BLE_LINUX_CAPABILITY_MISSING';
 
 function normalizeUuid(uuid: string): string {
@@ -503,7 +513,8 @@ export class NobleBleManager extends EventEmitter {
       }
       // CBCentralManager on macOS cannot scan and connect simultaneously.
       // Stop scanning without clearing scanRequesters — it will resume in the finally block.
-      if (this.scanningActive) {
+      // On Linux (BlueZ) and Windows (WinRT) this restriction does not apply.
+      if (process.platform === 'darwin' && this.scanningActive) {
         await this.doStopScanning();
       }
       await this.disconnect(sessionId);
@@ -567,7 +578,20 @@ export class NobleBleManager extends EventEmitter {
       };
       peripheral.once('disconnect', onDisconnected);
       session.connectedPeripheralDisconnectHandler = onDisconnected;
-      await withTimeout(peripheral.connectAsync(), 15000, 'BLE connectAsync');
+      try {
+        await withTimeout(peripheral.connectAsync(), BLE_CONNECT_TIMEOUT_MS, 'BLE connectAsync');
+      } catch (err) {
+        if (err instanceof Error && /BLE connectAsync timed out/i.test(err.message)) {
+          const hint =
+            process.platform === 'linux'
+              ? ' On Linux/BlueZ: reset the adapter (bluetoothctl power off; power on) and ensure the device is not connected to another host.'
+              : process.platform === 'win32'
+                ? ' On Windows: try pairing the device in Windows Bluetooth settings first, then retry.'
+                : '';
+          throw new Error(err.message + hint);
+        }
+        throw err;
+      }
       connected = true;
 
       const isMeshcore = sessionId === 'meshcore';
@@ -583,7 +607,7 @@ export class NobleBleManager extends EventEmitter {
           discoverServiceUuids,
           discoverCharUuids,
         ),
-        15000,
+        BLE_DISCOVERY_TIMEOUT_MS,
         'BLE characteristic discovery',
       );
       for (const char of characteristics) {
@@ -607,7 +631,11 @@ export class NobleBleManager extends EventEmitter {
       }
 
       if (session.fromNumChar) {
-        await withTimeout(session.fromNumChar.subscribeAsync(), 10000, 'BLE fromNum subscribe');
+        await withTimeout(
+          session.fromNumChar.subscribeAsync(),
+          BLE_SUBSCRIBE_TIMEOUT_MS,
+          'BLE fromNum subscribe',
+        );
         session.fromNumDataHandler = () => {
           console.debug(
             `[BLE:${sessionId}] fromNum notify — pump active=${session.readPumpActive}`,
@@ -625,7 +653,11 @@ export class NobleBleManager extends EventEmitter {
       // notify-only — attempting readAsync() on it yields a BLE protocol error.
       session.fromRadioNotifyOnly = fromRadioSupportsNotify;
       if (fromRadioSupportsNotify) {
-        await withTimeout(session.fromRadioChar.subscribeAsync(), 10000, 'BLE fromRadio subscribe');
+        await withTimeout(
+          session.fromRadioChar.subscribeAsync(),
+          BLE_SUBSCRIBE_TIMEOUT_MS,
+          'BLE fromRadio subscribe',
+        );
         session.fromRadioDataHandler = (data: Buffer) => {
           if (!data || data.length === 0) return;
           console.debug(`[BLE:${sessionId}] fromRadio notify: ${data.length} bytes`);

--- a/src/renderer/hooks/useMeshCore.ble-timeout.test.tsx
+++ b/src/renderer/hooks/useMeshCore.ble-timeout.test.tsx
@@ -196,6 +196,45 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
     expect(warnSpy).toHaveBeenCalledWith('[IpcNobleConnection:meshcore] peripheral disconnected');
   });
 
+  it('retries and surfaces timeout guidance when main-process BLE connectAsync times out', async () => {
+    // Simulates the Linux/Windows case where peripheral.connectAsync() in the main process
+    // times out and the error propagates through IPC to the renderer.
+    vi.mocked(window.electronAPI.connectNobleBle).mockRejectedValue(
+      new Error('BLE connectAsync timed out after 30000ms'),
+    );
+
+    const { result } = renderHook(() => useMeshCore());
+
+    await expect(
+      act(async () => {
+        await result.current.connect('ble', undefined, 'ble-device-linux');
+      }),
+    ).rejects.toThrow(
+      'Bluetooth connection timed out while opening MeshCore over Noble IPC. Retry, power-cycle BLE on the device, or use Serial/TCP.',
+    );
+
+    // Should retry once (main-process timeout is now recognized as a retryable timeout).
+    expect(window.electronAPI.connectNobleBle).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith('[useMeshCore] connect: BLE Noble IPC attempt failed', {
+      attempt: 1,
+      maxAttempts: 2,
+      isTimeout: true,
+      stage: 'ipc-open',
+      elapsedMs: expect.any(Number),
+      message: 'BLE connectAsync timed out after 30000ms',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useMeshCore] connect: BLE Noble IPC timed out; advise retry, BLE power-cycle, or Serial/TCP fallback',
+      { stage: 'ipc-open' },
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[useMeshCore] connect error',
+      'Bluetooth connection timed out while opening MeshCore over Noble IPC. Retry, power-cycle BLE on the device, or use Serial/TCP.',
+      'BLE connectAsync timed out after 30000ms',
+      { bleTimeoutStage: 'ipc-open' },
+    );
+  });
+
   it('stringifies object-shaped non-timeout BLE errors', async () => {
     vi.mocked(window.electronAPI.connectNobleBle).mockRejectedValue({
       code: 'BLE_CUSTOM',

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -83,7 +83,10 @@ function messageToDbRow(
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface SerialConnectionInstance extends InstanceType<typeof SerialConnection> {}
 
-const NOBLE_IPC_CONNECT_TIMEOUT_MS = 25_000;
+// Umbrella timeout for the IPC call to main process to connect BLE.
+// Must exceed the sum of all per-operation GATT timeouts on the slowest platform:
+// non-macOS: connectAsync(30s) + discovery(30s) + subscribe×2(20s each) = 100s.
+const NOBLE_IPC_CONNECT_TIMEOUT_MS = 120_000;
 const NOBLE_IPC_HANDSHAKE_TIMEOUT_MS = 20_000;
 const NOBLE_IPC_CONNECT_MAX_ATTEMPTS = 2;
 
@@ -92,6 +95,13 @@ type MeshcoreBleTimeoutStage = 'ipc-open' | 'protocol-handshake' | 'unknown';
 function classifyMeshcoreBleTimeoutStage(message: string): MeshcoreBleTimeoutStage {
   if (/MeshCore BLE IPC open timed out/i.test(message)) return 'ipc-open';
   if (/MeshCore BLE protocol handshake timed out/i.test(message)) return 'protocol-handshake';
+  // Main-process GATT-level timeouts propagated through IPC
+  if (
+    /BLE connectAsync timed out|BLE characteristic discovery timed out|BLE fromNum subscribe timed out|BLE fromRadio subscribe timed out/i.test(
+      message,
+    )
+  )
+    return 'ipc-open';
   return 'unknown';
 }
 
@@ -1405,7 +1415,7 @@ export function useMeshCore() {
               lastBleError = bleErr;
               const rawBleMessage = serializeErrorLike(bleErr) || 'BLE connect failed';
               const isTimeout =
-                /MeshCore BLE IPC open timed out|MeshCore BLE protocol handshake timed out/i.test(
+                /MeshCore BLE IPC open timed out|MeshCore BLE protocol handshake timed out|BLE connectAsync timed out|BLE characteristic discovery timed out|BLE fromNum subscribe timed out|BLE fromRadio subscribe timed out/i.test(
                   rawBleMessage,
                 );
               const stage = isTimeout ? classifyMeshcoreBleTimeoutStage(rawBleMessage) : null;
@@ -1462,7 +1472,7 @@ export function useMeshCore() {
         const isPeripheralInUse = /already in use by the/i.test(safeMessage);
         const isBleConnectTimeout =
           type === 'ble' &&
-          /MeshCore BLE IPC open timed out|MeshCore BLE protocol handshake timed out/i.test(
+          /MeshCore BLE IPC open timed out|MeshCore BLE protocol handshake timed out|BLE connectAsync timed out|BLE characteristic discovery timed out|BLE fromNum subscribe timed out|BLE fromRadio subscribe timed out/i.test(
             safeMessage,
           );
         const bleTimeoutStage = isBleConnectTimeout


### PR DESCRIPTION
## Problem

Users on Windows (WinRT BLE) and Fedora Linux (BlueZ) consistently time out when connecting to MeshCore devices via BLE. Two distinct failure modes:

1. **Linux**: `peripheral.connectAsync()` times out at 15s. The error message (`BLE connectAsync timed out after 15000ms`) doesn't match the renderer's `isTimeout` regex, so **no retry** happens and the connection fails immediately.

2. **Windows**: The WinRT BLE stack is slower for all GATT operations. The cumulative time for connect + discovery + subscribe can exceed the renderer's 25s umbrella timeout, triggering "MeshCore BLE IPC open timed out". Retry fires but hits the same tight limits again.

The timeouts were tuned for macOS CBCentralManager, which is significantly faster than BlueZ or WinRT.

## Changes

### `src/main/noble-ble-manager.ts`
- Add platform-aware GATT timeout constants: `connectAsync` 15s→30s, discovery 15s→30s, subscribe 10s→20s on non-macOS
- Wrap `connectAsync` timeout to re-throw with a platform-specific recovery hint (bluetoothctl reset on Linux, pair-in-settings on Windows)
- Guard scan-stop-before-connect to `darwin` only — stopping scan on Linux/Windows is unnecessary (not a CBCentralManager limitation) and could disrupt adapter state

### `src/renderer/hooks/useMeshCore.ts`
- Increase `NOBLE_IPC_CONNECT_TIMEOUT_MS` 25s→120s — the umbrella must exceed the sum of all per-op GATT timeouts on slow platforms (30+30+20+20 = 100s)
- Broaden `isTimeout` regex and `isBleConnectTimeout` check to include main-process timeout messages (`BLE connectAsync timed out`, `BLE characteristic discovery timed out`, etc.) — this was the key Linux bug: the error didn't trigger retry
- Update `classifyMeshcoreBleTimeoutStage` to map new messages to `'ipc-open'`

### `src/renderer/hooks/useMeshCore.ble-timeout.test.tsx`
- Add test verifying that a main-process `BLE connectAsync timed out` error propagated through IPC now triggers retry and surfaces the correct user-facing message

## Test plan
- [ ] All 341 existing tests pass (`pnpm test`)
- [ ] New test passes: main-process `BLE connectAsync timed out` triggers retry and correct guidance message
- [ ] Manual: BLE connect on Linux (Fedora) no longer fails immediately on `connectAsync` timeout — retries and has a 30s window
- [ ] Manual: BLE connect on Windows completes within the new timeout budget for a nearby device