### PR TITLE
fix: harden BLE read-pump for Windows and add connection diagnostics

### DIFF
--- a/src/main/noble-ble-manager.test.ts
+++ b/src/main/noble-ble-manager.test.ts
@@ -87,9 +87,20 @@ describe('NobleBleManager — notify-only fromRadio read pump suppression (regre
     expect(SOURCE).toMatch(/if \(session\.fromRadioNotifyOnly\) return/);
   });
 
-  it('connect() assigns fromRadioNotifyOnly from fromRadioSupportsNotify', () => {
-    // The flag must be derived from the actual characteristic properties at connect time
-    expect(SOURCE).toMatch(/session\.fromRadioNotifyOnly\s*=\s*fromRadioSupportsNotify/);
+  it('connect() sets fromRadioNotifyOnly only when notify is present AND read is absent', () => {
+    // fromRadioNotifyOnly must be true only for pure notify-only characteristics.
+    // Windows NUS TX reports ["read","notify"] — the read flag must gate the assignment.
+    expect(SOURCE).toMatch(
+      /session\.fromRadioNotifyOnly\s*=\s*fromRadioSupportsNotify\s*&&\s*!fromRadioCanRead/,
+    );
+  });
+
+  it('subscribes to fromRadio notify only when notify is set and read is NOT available', () => {
+    // When the characteristic also supports reads (e.g. Windows ["read","notify"]), we use
+    // the read pump instead of notify to avoid Noble WinRT notification delivery issues.
+    expect(SOURCE).toMatch(/if \(fromRadioSupportsNotify && !fromRadioCanRead\)/);
+    // The read pump log must mention canRead and hasNotify for diagnostics
+    expect(SOURCE).toContain('fromRadio supports reads');
   });
 
   it('writeToRadio skips the post-write read-pump timer when fromRadioNotifyOnly is set', () => {

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -55,7 +55,7 @@ interface NobleBleSession {
   toRadioChar: any | null;
   fromRadioChar: any | null;
   fromNumChar: any | null;
-  fromRadioDataHandler: ((data: Buffer) => void) | null;
+  fromRadioDataHandler: ((data: Buffer, isNotification: boolean) => void) | null;
   fromNumDataHandler: ((data: Buffer) => void) | null;
   readPumpActive: boolean;
   readPumpRequested: boolean;
@@ -527,6 +527,9 @@ export class NobleBleManager extends EventEmitter {
           `BLE peripheral not found: ${peripheralId}. Scan for devices before connecting.`,
         );
       }
+      console.debug(
+        `[BLE:${sessionId}] peripheral info — address=${peripheral.address ?? 'unknown'} addressType=${peripheral.addressType ?? 'unknown'} rssi=${peripheral.rssi ?? 'unknown'} state=${peripheral.state} platform=${process.platform}`,
+      );
 
       if (peripheral.state === 'connected') {
         // Check if any other session already owns this peripheral. If so, refuse to connect
@@ -558,7 +561,8 @@ export class NobleBleManager extends EventEmitter {
         }
       }
 
-      const onDisconnected = () => {
+      const onDisconnected = (reason?: string) => {
+        console.debug(`[BLE:${sessionId}] peripheral disconnected — reason=${reason ?? 'none'}`);
         if (session.fromRadioChar && session.fromRadioDataHandler) {
           try {
             session.fromRadioChar.off('data', session.fromRadioDataHandler);
@@ -578,6 +582,11 @@ export class NobleBleManager extends EventEmitter {
       };
       peripheral.once('disconnect', onDisconnected);
       session.connectedPeripheralDisconnectHandler = onDisconnected;
+      // Log MTU negotiation — WinRT sometimes negotiates asynchronously after connect.
+      peripheral.once('mtu', (mtu: number) => {
+        console.debug(`[BLE:${sessionId}] MTU updated: ${mtu}`);
+      });
+      const tConnect = Date.now();
       try {
         await withTimeout(peripheral.connectAsync(), BLE_CONNECT_TIMEOUT_MS, 'BLE connectAsync');
       } catch (err) {
@@ -593,6 +602,9 @@ export class NobleBleManager extends EventEmitter {
         throw err;
       }
       connected = true;
+      console.debug(
+        `[BLE:${sessionId}] connectAsync done in ${Date.now() - tConnect}ms — address=${peripheral.address ?? 'unknown'} mtu=${peripheral.mtu ?? 'null'} state=${peripheral.state}`,
+      );
 
       const isMeshcore = sessionId === 'meshcore';
       const discoverServiceUuids = isMeshcore ? [MESHCORE_SERVICE_UUID] : [SERVICE_UUID];
@@ -600,6 +612,7 @@ export class NobleBleManager extends EventEmitter {
         ? [MESHCORE_RX_UUID, MESHCORE_TX_UUID]
         : [TORADIO_UUID, FROMRADIO_UUID, FROMNUM_UUID];
 
+      const tDiscover = Date.now();
       const { characteristics } = await withTimeout<{
         characteristics: any[];
       }>(
@@ -622,11 +635,14 @@ export class NobleBleManager extends EventEmitter {
         }
       }
       console.debug(
-        `[BLE:${sessionId}] discovered chars — toRadio=${Boolean(session.toRadioChar)} fromRadio=${Boolean(session.fromRadioChar)} fromNum=${Boolean(session.fromNumChar)} toRadioProps=${JSON.stringify(session.toRadioChar?.properties)} fromRadioProps=${JSON.stringify(session.fromRadioChar?.properties)} fromNumProps=${JSON.stringify(session.fromNumChar?.properties)}`,
+        `[BLE:${sessionId}] discovered chars in ${Date.now() - tDiscover}ms — toRadio=${Boolean(session.toRadioChar)} fromRadio=${Boolean(session.fromRadioChar)} fromNum=${Boolean(session.fromNumChar)} toRadioProps=${JSON.stringify(session.toRadioChar?.properties)} fromRadioProps=${JSON.stringify(session.fromRadioChar?.properties)} fromNumProps=${JSON.stringify(session.fromNumChar?.properties)}`,
       );
 
       // FROMNUM is optional for notification-based flow; require only TX/RX characteristics.
       if (!session.toRadioChar || !session.fromRadioChar) {
+        console.warn(
+          `[BLE:${sessionId}] missing required chars — toRadio=${Boolean(session.toRadioChar)} fromRadio=${Boolean(session.fromRadioChar)} discoveredUuids=${characteristics.map((c: any) => c.uuid).join(',')}`, // log-injection-ok noble internal characteristic UUIDs
+        );
         throw new Error('Failed to find required BLE characteristics');
       }
 
@@ -649,26 +665,35 @@ export class NobleBleManager extends EventEmitter {
         : [];
       const fromRadioSupportsNotify =
         fromRadioProps.includes('notify') || fromRadioProps.includes('indicate');
-      // Track whether fromRadioChar is notify-only (no GATT reads). MeshCore NUS TX is
-      // notify-only — attempting readAsync() on it yields a BLE protocol error.
-      session.fromRadioNotifyOnly = fromRadioSupportsNotify;
-      if (fromRadioSupportsNotify) {
+      const fromRadioCanRead = fromRadioProps.includes('read');
+      // fromRadioNotifyOnly=true only when notify is the sole delivery path (no GATT reads).
+      // macOS/Linux NUS TX = ["notify"] → notify-only, read pump skipped.
+      // Windows NUS TX = ["read","notify"] → use read pump; Noble WinRT notification delivery
+      // is unreliable on some devices, and skipping the notify subscription also prevents
+      // duplicate packet delivery when both paths would otherwise fire for the same write.
+      session.fromRadioNotifyOnly = fromRadioSupportsNotify && !fromRadioCanRead;
+      const tSubscribe = Date.now();
+      if (fromRadioSupportsNotify && !fromRadioCanRead) {
         await withTimeout(
           session.fromRadioChar.subscribeAsync(),
           BLE_SUBSCRIBE_TIMEOUT_MS,
           'BLE fromRadio subscribe',
         );
-        session.fromRadioDataHandler = (data: Buffer) => {
+        session.fromRadioDataHandler = (data: Buffer, isNotification: boolean) => {
           if (!data || data.length === 0) return;
-          console.debug(`[BLE:${sessionId}] fromRadio notify: ${data.length} bytes`);
+          console.debug(
+            `[BLE:${sessionId}] fromRadio data: ${data.length} bytes isNotification=${isNotification}`,
+          );
           this.emit('fromRadio', { sessionId, bytes: new Uint8Array(Buffer.from(data)) });
         };
         session.fromRadioChar.on('data', session.fromRadioDataHandler);
       } else {
-        console.debug(`[BLE:${sessionId}] fromRadio has no notify — using read-pump path only`);
+        console.debug(
+          `[BLE:${sessionId}] fromRadio using read-pump path (canRead=${fromRadioCanRead} hasNotify=${fromRadioSupportsNotify})`,
+        );
       }
       console.debug(
-        `[BLE:${sessionId}] subscriptions ready — fromNum=${Boolean(session.fromNumChar)} fromRadioNotify=${fromRadioSupportsNotify}`,
+        `[BLE:${sessionId}] subscriptions ready in ${Date.now() - tSubscribe}ms — fromNum=${Boolean(session.fromNumChar)} fromRadioNotify=${fromRadioSupportsNotify && !fromRadioCanRead} fromRadioReadPump=${fromRadioCanRead} mtu=${peripheral.mtu ?? 'null'}`,
       );
 
       session.connectedPeripheral = peripheral;

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -1437,6 +1437,9 @@ export function useMeshCore() {
                 maxAttempts: NOBLE_IPC_CONNECT_MAX_ATTEMPTS,
                 stage,
               });
+              // Brief pause before retry: gives BlueZ/WinRT time to release adapter state
+              // after a failed or timed-out connect attempt.
+              await new Promise<void>((r) => setTimeout(r, 1500));
             }
           }
           if (!connected) throw lastBleError ?? new Error('BLE connect failed');


### PR DESCRIPTION
## Summary

- **Windows fix**: Noble/WinRT reports MeshCore NUS TX as `["read","notify"]` but notifications never arrive. Changed `fromRadioNotifyOnly` to be `true` only when notify is the *sole* delivery path (no read support). When reads are available (Windows case), the read pump is used instead and the notify subscription is skipped — avoiding both the broken notification path and duplicate packet delivery.
- **Linux**: Added a 1500ms delay between `connectAsync` retry attempts to give BlueZ time to release adapter state after a failed attempt.
- **Diagnostics**: Added targeted logging to `noble-ble-manager.ts` to make the next failure report actionable without needing a debug build.

## New log lines (examples)

```
[BLE:meshcore] peripheral info — address=aa:bb:cc:dd:ee:ff addressType=random rssi=-62 state=disconnected platform=win32
[BLE:meshcore] connectAsync done in 2341ms — address=aa:bb:cc:dd:ee:ff mtu=23 state=connected
[BLE:meshcore] discovered chars in 1284ms — toRadio=true fromRadio=true ...
[BLE:meshcore] MTU updated: 512
[BLE:meshcore] subscriptions ready in 68ms — fromNum=false fromRadioNotify=false fromRadioReadPump=true mtu=512
[BLE:meshcore] fromRadio data: 47 bytes isNotification=false
[BLE:meshcore] peripheral disconnected — reason=Connection Timeout
[BLE:meshcore] missing required chars — toRadio=false fromRadio=true discoveredUuids=6e400003-...
```

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] Windows: connect to MeshCore device — expect `fromRadio data: N bytes isNotification=false` confirming read-pump path works
- [ ] Linux: trigger a connect timeout — logs should show which phase (connectAsync vs discovery vs subscribe) stalled
- [ ] macOS: regression check — NUS TX still shows `fromRadioNotify=true`, notify path unchanged