### PR TITLE
fix: stabilize MeshCore BLE on Windows/Linux and align Linux capability guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,11 +722,11 @@ You're missing build tools for the native modules (e.g. `@serialport/bindings-cp
 
 ### Linux Bluetooth (BLE) Permissions
 
-On Linux, applications require special network capabilities to scan for and connect to Bluetooth devices. If you see a **"Linux BLE permissions are missing"** error, grant the `CAP_NET_RAW` capability to the executable.
+On Linux, applications require `CAP_NET_RAW` to scan for and connect to Bluetooth devices. For development (`npm start`), the preferred approach is to launch with an ambient capability using `setpriv` (instead of applying file capabilities directly to Electron).
 
 How you do this depends on how you are running the application:
 
-#### Scenario 1: Running from Source (`npm start`)
+#### Scenario 1: Running from Source (`npm start`) - preferred
 
 When running the app in development mode, `npm start` uses the local Electron binary in your project's `node_modules` folder.
 
@@ -736,28 +736,16 @@ When running the app in development mode, `npm start` uses the local Electron bi
 npm install
 ```
 
-2. Grant the capability to the local Electron binary:
+2. Launch with ambient capability:
 
 ```bash
-sudo setcap cap_net_raw+eip ./node_modules/electron/dist/electron
+sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc 'npm start'
 ```
 
-3. Verify the capability:
+If your desktop session then fails with `Missing X server or $DISPLAY`, preserve display auth:
 
 ```bash
-getcap ./node_modules/electron/dist/electron
-```
-
-Expected output:
-
-```bash
-./node_modules/electron/dist/electron = cap_net_raw+eip
-```
-
-4. Start the app:
-
-```bash
-npm start
+sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc "export DISPLAY=$DISPLAY; export XAUTHORITY=$XAUTHORITY; npm start"
 ```
 
 #### Scenario 2: Running a Downloaded Release Binary
@@ -802,7 +790,7 @@ this is typically caused by applying file capabilities directly to the Electron 
 sudo setcap -r ./node_modules/electron/dist/electron
 ```
 
-2. Use ambient capability for launch instead:
+2. Use ambient capability for launch instead (recommended for source runs):
 
 ```bash
 sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc 'npm start'

--- a/scripts/start-electron.mjs
+++ b/scripts/start-electron.mjs
@@ -48,11 +48,13 @@ export function classifyElectronStartupError(stderrText) {
 export function fedoraLibffmpegRemediation() {
   return [
     '[mesh-client] Detected Linux startup failure: libffmpeg.so could not be loaded.',
-    '[mesh-client] This can happen on Fedora/glibc after applying setcap directly to Electron.',
+    '[mesh-client] Preferred Linux BLE launch for npm start uses ambient capability (setpriv), not file capabilities on Electron.',
+    '[mesh-client] This failure can happen on Fedora/glibc after applying setcap directly to Electron.',
+    '[mesh-client] Launch with ambient capability:',
+    "  sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc 'npm start'",
     '[mesh-client] Remove file capability from the local Electron binary:',
     '  sudo setcap -r ./node_modules/electron/dist/electron',
-    '[mesh-client] Then run with ambient capability instead (no file capability on electron):',
-    "  sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc 'npm start'",
+    '[mesh-client] Keep file capabilities for packaged release binaries only (setcap on extracted executable).',
   ].join('\n');
 }
 
@@ -62,11 +64,11 @@ export function linuxDisplayMissingRemediation() {
     '[mesh-client] Electron could not initialize a GUI backend (Missing X server or $DISPLAY).',
     '[mesh-client] If you are in SSH or headless mode, launch from a desktop session instead.',
     '[mesh-client] If already in a desktop session, verify display environment variables:',
-    "  echo \"DISPLAY=$DISPLAY WAYLAND_DISPLAY=$WAYLAND_DISPLAY XDG_SESSION_TYPE=$XDG_SESSION_TYPE\"",
+    '  echo "DISPLAY=$DISPLAY WAYLAND_DISPLAY=$WAYLAND_DISPLAY XDG_SESSION_TYPE=$XDG_SESSION_TYPE"',
     '[mesh-client] If BLE only works via setpriv, preserve display auth when launching:',
-    "  sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc \"export DISPLAY=$DISPLAY; export XAUTHORITY=$XAUTHORITY; npm start\"",
+    '  sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc "export DISPLAY=$DISPLAY; export XAUTHORITY=$XAUTHORITY; npm start"',
     '[mesh-client] For Wayland sessions, forcing X11 may help:',
-    "  ELECTRON_OZONE_PLATFORM_HINT=x11 npm start",
+    '  ELECTRON_OZONE_PLATFORM_HINT=x11 npm start',
   ].join('\n');
 }
 

--- a/src/main/linux-ble-guidance.contract.test.ts
+++ b/src/main/linux-ble-guidance.contract.test.ts
@@ -7,6 +7,12 @@ const README = readFileSync(join(__dirname, '../../README.md'), 'utf-8');
 const NOBLE_MANAGER = readFileSync(join(__dirname, 'noble-ble-manager.ts'), 'utf-8');
 
 describe('Linux BLE guidance contracts (regression)', () => {
+  it('documents setpriv as the preferred npm start flow', () => {
+    expect(README).toContain('Scenario 1: Running from Source (`npm start`) - preferred');
+    expect(README).toContain('--ambient-caps +net_raw');
+    expect(README).toContain("bash -lc 'npm start'");
+  });
+
   it('documents release guidance for extracted binaries and AppImage limitations', () => {
     expect(README).toContain('Scenario 2: Running a Downloaded Release Binary');
     expect(README).toContain('For extracted archives (`.tar.gz`, `.zip`, or `linux-unpacked`)');
@@ -14,6 +20,9 @@ describe('Linux BLE guidance contracts (regression)', () => {
   });
 
   it('keeps runtime capability error wording aligned with release guidance', () => {
+    expect(NOBLE_MANAGER).toContain('Preferred for npm start: run with ambient capability');
+    expect(NOBLE_MANAGER).toContain('sudo setpriv --reuid=$USER --regid=$(id -g)');
+    expect(NOBLE_MANAGER).toContain('sudo setcap -r ./node_modules/electron/dist/electron');
     expect(NOBLE_MANAGER).toContain('For release builds, run setcap on the extracted executable');
     expect(NOBLE_MANAGER).toContain('not the .AppImage wrapper');
   });

--- a/src/main/noble-ble-manager.behavior.test.ts
+++ b/src/main/noble-ble-manager.behavior.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+import { EventEmitter } from 'node:events';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface CharacteristicBehavior {
+  properties: string[];
+  subscribeFails?: boolean;
+  readResults?: Buffer[];
+}
+
+class FakeCharacteristic extends EventEmitter {
+  public readonly uuid: string;
+  public readonly properties: string[];
+  public subscribeCalls = 0;
+  public readCalls = 0;
+  public writeCalls = 0;
+  private readonly subscribeFails: boolean;
+  private readQueue: Buffer[];
+
+  constructor(uuid: string, behavior: CharacteristicBehavior) {
+    super();
+    this.uuid = uuid;
+    this.properties = behavior.properties;
+    this.subscribeFails = Boolean(behavior.subscribeFails);
+    this.readQueue = behavior.readResults ?? [Buffer.alloc(0)];
+  }
+
+  async subscribeAsync(): Promise<void> {
+    this.subscribeCalls += 1;
+    if (this.subscribeFails) throw new Error('subscribe failed');
+  }
+
+  async unsubscribeAsync(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async readAsync(): Promise<Buffer> {
+    this.readCalls += 1;
+    return this.readQueue.length > 0 ? this.readQueue.shift()! : Buffer.alloc(0);
+  }
+
+  async writeAsync(): Promise<void> {
+    this.writeCalls += 1;
+  }
+}
+
+class FakePeripheral extends EventEmitter {
+  public readonly id: string;
+  public readonly address = '20:6e:f1:b8:8d:99';
+  public readonly addressType = 'public';
+  public readonly rssi = -80;
+  public state: 'disconnected' | 'connected' = 'disconnected';
+  public mtu = 172;
+  private readonly characteristics: FakeCharacteristic[];
+
+  constructor(id: string, characteristics: FakeCharacteristic[]) {
+    super();
+    this.id = id;
+    this.characteristics = characteristics;
+  }
+
+  async connectAsync(): Promise<void> {
+    this.state = 'connected';
+  }
+
+  async disconnectAsync(): Promise<void> {
+    this.state = 'disconnected';
+    this.emit('disconnect', 'manual');
+  }
+
+  async discoverSomeServicesAndCharacteristicsAsync(): Promise<{
+    characteristics: FakeCharacteristic[];
+  }> {
+    return { characteristics: this.characteristics };
+  }
+}
+
+class FakeNoble extends EventEmitter {
+  public state = 'poweredOn';
+  async startScanning(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  stopScanning(): void {
+    // no-op for behavior tests
+  }
+
+  stop(): void {
+    // no-op for behavior tests
+  }
+}
+
+const MESHCORE_RX_UUID = '6e400002b5a3f393e0a9e50e24dcca9e';
+const MESHCORE_TX_UUID = '6e400003b5a3f393e0a9e50e24dcca9e';
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('NobleBleManager behavior (notify-first + fallback)', () => {
+  let fakeNoble: FakeNoble;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fakeNoble = new FakeNoble();
+    vi.doMock('@stoprocent/noble', () => fakeNoble);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function setupMeshcoreConnection(txBehavior: CharacteristicBehavior) {
+    const mod = await import('./noble-ble-manager');
+    const manager = new mod.NobleBleManager();
+    (manager as any).adapterReady = true;
+    (manager as any).lastAdapterState = 'poweredOn';
+
+    const toRadio = new FakeCharacteristic(MESHCORE_RX_UUID, { properties: ['write'] });
+    const fromRadio = new FakeCharacteristic(MESHCORE_TX_UUID, txBehavior);
+    const peripheral = new FakePeripheral('meshcore-peripheral', [toRadio, fromRadio]);
+    (manager as any).knownPeripherals.set(peripheral.id, peripheral);
+
+    await manager.connect('meshcore', peripheral.id);
+    return { manager, toRadio, fromRadio };
+  }
+
+  it('uses notify-first for read+notify characteristics and forwards notify payloads', async () => {
+    const { manager, fromRadio } = await setupMeshcoreConnection({
+      properties: ['read', 'notify'],
+      readResults: [Buffer.alloc(0)],
+    });
+
+    expect(fromRadio.subscribeCalls).toBe(1);
+    expect(fromRadio.readCalls).toBe(0);
+
+    const received: Uint8Array[] = [];
+    manager.on('fromRadio', ({ bytes }) => {
+      received.push(bytes);
+    });
+    fromRadio.emit('data', Buffer.from([1, 2, 3]), true);
+
+    expect(received).toHaveLength(1);
+    expect(Array.from(received[0])).toEqual([1, 2, 3]);
+  });
+
+  it('falls back to read-pump when subscribe fails on read+notify characteristics', async () => {
+    const { manager, fromRadio } = await setupMeshcoreConnection({
+      properties: ['read', 'notify'],
+      subscribeFails: true,
+      readResults: [Buffer.from([9]), Buffer.alloc(0)],
+    });
+
+    expect(fromRadio.subscribeCalls).toBe(1);
+    // Initial connect path triggers one read-pump burst in fallback mode.
+    await wait(20);
+    expect(fromRadio.readCalls).toBeGreaterThan(0);
+
+    const readsAfterConnect = fromRadio.readCalls;
+    await manager.writeToRadio('meshcore', Buffer.from([0xaa]));
+    await wait(140);
+    expect(fromRadio.readCalls).toBeGreaterThan(readsAfterConnect);
+  });
+
+  it('fails connect when fromRadio supports neither notify nor read', async () => {
+    const mod = await import('./noble-ble-manager');
+    const manager = new mod.NobleBleManager();
+    (manager as any).adapterReady = true;
+    (manager as any).lastAdapterState = 'poweredOn';
+    const toRadio = new FakeCharacteristic(MESHCORE_RX_UUID, { properties: ['write'] });
+    const fromRadio = new FakeCharacteristic(MESHCORE_TX_UUID, { properties: [] });
+    const peripheral = new FakePeripheral('meshcore-no-rx', [toRadio, fromRadio]);
+    (manager as any).knownPeripherals.set(peripheral.id, peripheral);
+
+    await expect(manager.connect('meshcore', peripheral.id)).rejects.toThrow(
+      'fromRadio characteristic supports neither notify nor read',
+    );
+  });
+
+  it('does not trigger read-pump after write when notify-first succeeds', async () => {
+    const { manager, fromRadio } = await setupMeshcoreConnection({
+      properties: ['read', 'notify'],
+      readResults: [Buffer.alloc(0)],
+    });
+
+    expect(fromRadio.readCalls).toBe(0);
+    await manager.writeToRadio('meshcore', Buffer.from([0xbb]));
+    await wait(140);
+    expect(fromRadio.readCalls).toBe(0);
+  });
+});

--- a/src/main/noble-ble-manager.test.ts
+++ b/src/main/noble-ble-manager.test.ts
@@ -63,10 +63,9 @@ describe('NobleBleManager.connect — per-session UUID selection (regression)', 
 });
 
 /**
- * Regression guard: MeshCore NUS TX (6e400003) is notify-only — it does not support GATT reads.
- * Previously, the read pump called readAsync() on it unconditionally, producing "Protocol error
- * while reading characteristic 6e400003-b5a3-f393-e0a9-e50e24dcca9e" on every connect and write.
- * Fix: session.fromRadioNotifyOnly suppresses the read pump and post-write timer entirely.
+ * Regression guard: MeshCore NUS TX may advertise both read+notify on some stacks, but
+ * protocol reads can fail at runtime. We should prefer notify delivery when available and
+ * fall back to the read pump only if subscribe fails or notify is unavailable.
  */
 describe('NobleBleManager — notify-only fromRadio read pump suppression (regression)', () => {
   it('declares fromRadioNotifyOnly in session state and initialises it to false', () => {
@@ -87,20 +86,15 @@ describe('NobleBleManager — notify-only fromRadio read pump suppression (regre
     expect(SOURCE).toMatch(/if \(session\.fromRadioNotifyOnly\) return/);
   });
 
-  it('connect() sets fromRadioNotifyOnly only when notify is present AND read is absent', () => {
-    // fromRadioNotifyOnly must be true only for pure notify-only characteristics.
-    // Windows NUS TX reports ["read","notify"] — the read flag must gate the assignment.
-    expect(SOURCE).toMatch(
-      /session\.fromRadioNotifyOnly\s*=\s*fromRadioSupportsNotify\s*&&\s*!fromRadioCanRead/,
-    );
+  it('connect() starts fromRadioNotifyOnly as false before strategy selection', () => {
+    expect(SOURCE).toMatch(/session\.fromRadioNotifyOnly\s*=\s*false/);
   });
 
-  it('subscribes to fromRadio notify only when notify is set and read is NOT available', () => {
-    // When the characteristic also supports reads (e.g. Windows ["read","notify"]), we use
-    // the read pump instead of notify to avoid Noble WinRT notification delivery issues.
-    expect(SOURCE).toMatch(/if \(fromRadioSupportsNotify && !fromRadioCanRead\)/);
-    // The read pump log must mention canRead and hasNotify for diagnostics
-    expect(SOURCE).toContain('fromRadio supports reads');
+  it('uses notify-first strategy and logs explicit fallback-read path', () => {
+    expect(SOURCE).toMatch(/if \(fromRadioSupportsNotify\)/);
+    expect(SOURCE).toContain('fromRadio strategy=notify-first');
+    expect(SOURCE).toContain('fromRadio subscribe failed; falling back to read-pump');
+    expect(SOURCE).toContain('fromRadio strategy=fallback-read');
   });
 
   it('writeToRadio skips the post-write read-pump timer when fromRadioNotifyOnly is set', () => {
@@ -163,8 +157,9 @@ describe('NobleBleManager — Linux BLE capability diagnostics (regression)', ()
   });
 
   it('includes both source and release capability guidance in the classified error', () => {
-    expect(SOURCE).toContain('If running from source, run:');
-    expect(SOURCE).toContain('sudo setcap cap_net_raw+eip ./node_modules/electron/dist/electron');
+    expect(SOURCE).toContain('Preferred for npm start: run with ambient capability');
+    expect(SOURCE).toContain('sudo setpriv --reuid=$USER --regid=$(id -g)');
+    expect(SOURCE).toContain('sudo setcap -r ./node_modules/electron/dist/electron');
     expect(SOURCE).toContain(
       'For release builds, run setcap on the extracted executable (not the .AppImage wrapper).',
     );

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -395,7 +395,7 @@ export class NobleBleManager extends EventEmitter {
     }
     const detail = capabilityProbe.detail ? ` (${capabilityProbe.detail})` : '';
     return new Error(
-      `${BLE_LINUX_CAPABILITY_MISSING}: Linux BLE scan permissions are missing or not applied${detail}. If running from source, run: sudo setcap cap_net_raw+eip ./node_modules/electron/dist/electron (then verify with getcap ./node_modules/electron/dist/electron). For release builds, run setcap on the extracted executable (not the .AppImage wrapper).`,
+      `${BLE_LINUX_CAPABILITY_MISSING}: Linux BLE scan permissions are missing or not applied${detail}. Preferred for npm start: run with ambient capability (sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc 'npm start'). If you previously used file capabilities and hit startup issues, remove them with: sudo setcap -r ./node_modules/electron/dist/electron. For release builds, run setcap on the extracted executable (not the .AppImage wrapper).`,
     );
   }
 
@@ -666,34 +666,50 @@ export class NobleBleManager extends EventEmitter {
       const fromRadioSupportsNotify =
         fromRadioProps.includes('notify') || fromRadioProps.includes('indicate');
       const fromRadioCanRead = fromRadioProps.includes('read');
-      // fromRadioNotifyOnly=true only when notify is the sole delivery path (no GATT reads).
-      // macOS/Linux NUS TX = ["notify"] → notify-only, read pump skipped.
-      // Windows NUS TX = ["read","notify"] → use read pump; Noble WinRT notification delivery
-      // is unreliable on some devices, and skipping the notify subscription also prevents
-      // duplicate packet delivery when both paths would otherwise fire for the same write.
-      session.fromRadioNotifyOnly = fromRadioSupportsNotify && !fromRadioCanRead;
+      // Notify-first strategy:
+      // - Prefer notifications whenever the characteristic advertises notify/indicate.
+      // - Fall back to read-pump only if subscribe fails or notify is unavailable.
+      // This avoids Windows/Linux stacks that advertise "read" but fail protocol reads at runtime.
+      session.fromRadioNotifyOnly = false;
       const tSubscribe = Date.now();
-      if (fromRadioSupportsNotify && !fromRadioCanRead) {
-        await withTimeout(
-          session.fromRadioChar.subscribeAsync(),
-          BLE_SUBSCRIBE_TIMEOUT_MS,
-          'BLE fromRadio subscribe',
-        );
-        session.fromRadioDataHandler = (data: Buffer, isNotification: boolean) => {
-          if (!data || data.length === 0) return;
-          console.debug(
-            `[BLE:${sessionId}] fromRadio data: ${data.length} bytes isNotification=${isNotification}`,
+      let fromRadioSubscribed = false;
+      if (fromRadioSupportsNotify) {
+        try {
+          await withTimeout(
+            session.fromRadioChar.subscribeAsync(),
+            BLE_SUBSCRIBE_TIMEOUT_MS,
+            'BLE fromRadio subscribe',
           );
-          this.emit('fromRadio', { sessionId, bytes: new Uint8Array(Buffer.from(data)) });
-        };
-        session.fromRadioChar.on('data', session.fromRadioDataHandler);
-      } else {
+          session.fromRadioDataHandler = (data: Buffer, isNotification: boolean) => {
+            if (!data || data.length === 0) return;
+            console.debug(
+              `[BLE:${sessionId}] fromRadio data: ${data.length} bytes isNotification=${isNotification}`,
+            );
+            this.emit('fromRadio', { sessionId, bytes: new Uint8Array(Buffer.from(data)) });
+          };
+          session.fromRadioChar.on('data', session.fromRadioDataHandler);
+          fromRadioSubscribed = true;
+          session.fromRadioNotifyOnly = true;
+          console.debug(
+            `[BLE:${sessionId}] fromRadio strategy=notify-first (hasNotify=${fromRadioSupportsNotify} canRead=${fromRadioCanRead})`,
+          );
+        } catch (err) {
+          console.warn(
+            `[BLE:${sessionId}] fromRadio subscribe failed; falling back to read-pump (hasNotify=${fromRadioSupportsNotify} canRead=${fromRadioCanRead}):`,
+            sanitizeLogMessage(err instanceof Error ? err.message : String(err)),
+          );
+        }
+      }
+      if (!fromRadioSubscribed) {
+        if (!fromRadioCanRead) {
+          throw new Error('fromRadio characteristic supports neither notify nor read');
+        }
         console.debug(
-          `[BLE:${sessionId}] fromRadio using read-pump path (canRead=${fromRadioCanRead} hasNotify=${fromRadioSupportsNotify})`,
+          `[BLE:${sessionId}] fromRadio strategy=fallback-read (hasNotify=${fromRadioSupportsNotify} canRead=${fromRadioCanRead})`,
         );
       }
       console.debug(
-        `[BLE:${sessionId}] subscriptions ready in ${Date.now() - tSubscribe}ms — fromNum=${Boolean(session.fromNumChar)} fromRadioNotify=${fromRadioSupportsNotify && !fromRadioCanRead} fromRadioReadPump=${fromRadioCanRead} mtu=${peripheral.mtu ?? 'null'}`,
+        `[BLE:${sessionId}] subscriptions ready in ${Date.now() - tSubscribe}ms — fromNum=${Boolean(session.fromNumChar)} fromRadioNotify=${fromRadioSubscribed} fromRadioReadPump=${!fromRadioSubscribed && fromRadioCanRead} mtu=${peripheral.mtu ?? 'null'}`,
       );
 
       session.connectedPeripheral = peripheral;

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -126,7 +126,7 @@ describe('ConnectionPanel MQTT connect error', () => {
 });
 
 describe('ConnectionPanel BLE error humanization', () => {
-  it('shows Linux setcap guidance for classified Linux capability errors', async () => {
+  it('shows Linux setpriv-first guidance for classified Linux capability errors', async () => {
     const user = userEvent.setup();
     vi.mocked(window.electronAPI.startNobleBleScanning).mockRejectedValueOnce(
       new Error(
@@ -151,7 +151,10 @@ describe('ConnectionPanel BLE error humanization', () => {
     await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
 
     expect(await screen.findByText(/Linux BLE permissions are missing/i)).toBeInTheDocument();
-    expect(screen.getByText(/setcap cap_net_raw\+eip/i)).toBeInTheDocument();
+    expect(screen.getByText(/setpriv --reuid=\$USER/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/setcap -r \.\/node_modules\/electron\/dist\/electron/i),
+    ).toBeInTheDocument();
   });
 
   it('shows Windows handshake guidance for MeshCore BLE handshake timeout/disconnect', async () => {

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -102,10 +102,10 @@ function humanizeBleError(err: unknown): string {
   const isWindows = navigator.userAgent.toLowerCase().includes('windows');
   const isLinux = navigator.userAgent.toLowerCase().includes('linux');
   if (msg.includes('BLE_LINUX_CAPABILITY_MISSING')) {
-    return 'Linux BLE permissions are missing. For npm start: sudo setcap cap_net_raw+eip ./node_modules/electron/dist/electron. For releases: run setcap on the extracted executable (AppImage must be extracted first), then restart the app.';
+    return "Linux BLE permissions are missing. Preferred for npm start: launch with ambient capability using sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc 'npm start'. If setcap was previously applied to local Electron, remove it with sudo setcap -r ./node_modules/electron/dist/electron. For releases: run setcap on the extracted executable (AppImage must be extracted first), then restart the app.";
   }
   if (isLinux && /operation not permitted|permission denied|\beperm\b/i.test(msg)) {
-    return `${msg} — Linux BLE may be missing permissions. For npm start use: sudo setcap cap_net_raw+eip ./node_modules/electron/dist/electron`;
+    return `${msg} — Linux BLE may be missing permissions. Preferred for npm start: sudo setpriv --reuid=$USER --regid=$(id -g) --init-groups --inh-caps +net_raw --ambient-caps +net_raw --reset-env bash -lc 'npm start'`;
   }
   if (msg.includes('Bluetooth adapter not found') || msg.includes('adapter is not available')) {
     if (isWindows) {


### PR DESCRIPTION
## Summary
This PR stabilizes MeshCore BLE connections on Windows/Linux where the TX characteristic advertises both `read` and `notify` but protocol reads can fail at runtime, causing handshake timeouts and disconnects. It also aligns Linux BLE setup messaging to recommend ambient capability launch (`setpriv`) for `npm start`, with clear rollback guidance for `setcap`-related startup failures.

## What changed
- Switched MeshCore `fromRadio` handling in `src/main/noble-ble-manager.ts` to **notify-first with fallback-read**:
  - Prefer `subscribeAsync()` whenever notify/indicate is available.
  - Fall back to read-pump only if subscribe fails or notify is unavailable.
  - Added explicit strategy logs for notify-first and fallback-read paths.
  - Added a hard failure if `fromRadio` supports neither notify nor read.
- Added behavior-level regression tests in `src/main/noble-ble-manager.behavior.test.ts` for:
  - notify-first on dual-capability (`read` + `notify`)
  - subscribe failure fallback to read-pump
  - failure when no RX path exists
  - post-write read-pump behavior by strategy
- Updated/extended contract and source regression tests:
  - `src/main/noble-ble-manager.test.ts`
  - `src/main/linux-ble-guidance.contract.test.ts`
  - `src/renderer/components/ConnectionPanel.test.tsx`
- Unified Linux user guidance across:
  - `scripts/start-electron.mjs`
  - `src/main/noble-ble-manager.ts`
  - `src/renderer/components/ConnectionPanel.tsx`
  - `README.md`
  to prefer `setpriv` for source runs while retaining `setcap -r` rollback and extracted-binary guidance.

## Why
Users reported repeated `readAsync` protocol errors against MeshCore NUS TX (`6e400003...`) on Windows/Linux (`fromRadioProps=["read","notify"]`), followed by handshake timeout/disconnect. The previous path prioritized reads in this dual-capability case, which is brittle on some BLE stacks. A notify-first strategy with read fallback improves cross-platform resilience while preserving a recovery path.

## How to test
- Automated checks run locally:
  - `npm run lint`
  - `npm run typecheck`
  - `npm run test:run -- src/main/noble-ble-manager.behavior.test.ts src/main/noble-ble-manager.test.ts src/main/linux-ble-guidance.contract.test.ts src/main/start-electron.test.ts`
- Manual verification:
  - Windows/Linux MeshCore BLE connect should avoid repeated `readAsync` protocol errors when notify works.
  - If notify subscribe fails, fallback-read should still allow progression.
  - Linux startup remediation text should present `setpriv` as default for `npm start` and keep `setcap -r` rollback guidance.

## Risks / follow-ups
- Behavior tests use a fake noble peripheral model and direct manager state setup to avoid native noble dependency in CI; this is intentional for deterministic coverage.
- Optional future hardening: add a lightweight integration harness around IPC boundaries if we want end-to-end transport coverage beyond manager-level behavior tests.