### PR TITLE
fix: harden BLE retry handling for MeshCore and Meshtastic

### DIFF
--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -123,6 +123,18 @@ function humanizeBleError(err: unknown): string {
     if (isWindows) {
       return `${msg} On Windows, toggle Bluetooth off/on, confirm no stale pairing is holding the device, then retry.`;
     }
+    if (isLinux) {
+      return `${msg} On Linux/BlueZ, run bluetoothctl power off; power on, then retry with the device awake and nearby.`;
+    }
+    return msg;
+  }
+  if (/Bluetooth connection timed out while opening MeshCore over Noble IPC/i.test(msg)) {
+    if (isWindows) {
+      return `${msg} On Windows, pair in Bluetooth settings first and clear stale pairings before retrying.`;
+    }
+    if (isLinux) {
+      return `${msg} On Linux/BlueZ, run bluetoothctl power off; power on, then retry.`;
+    }
     return msg;
   }
   if (isWindows && /disconnected|timed out/i.test(msg) && /MeshCore/i.test(msg)) {

--- a/src/renderer/hooks/useMeshCore.ble-timeout.test.tsx
+++ b/src/renderer/hooks/useMeshCore.ble-timeout.test.tsx
@@ -43,6 +43,7 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
       attempt: 1,
       maxAttempts: 2,
       isTimeout: true,
+      isRetryable: true,
       stage: 'ipc-open',
       elapsedMs: expect.any(Number),
       message: 'MeshCore BLE IPC open timed out after 25000ms',
@@ -128,6 +129,7 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
         attempt: 1,
         maxAttempts: 2,
         isTimeout: true,
+        isRetryable: true,
         stage: 'ipc-open',
       }),
     );
@@ -137,6 +139,7 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
         attempt: 2,
         maxAttempts: 2,
         isTimeout: true,
+        isRetryable: true,
         stage: 'protocol-handshake',
       }),
     );
@@ -163,7 +166,8 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
         attempt: 1,
         maxAttempts: 2,
         isTimeout: false,
-        stage: null,
+        isRetryable: false,
+        stage: 'unknown',
       }),
     );
   });
@@ -219,6 +223,7 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
       attempt: 1,
       maxAttempts: 2,
       isTimeout: true,
+      isRetryable: true,
       stage: 'ipc-open',
       elapsedMs: expect.any(Number),
       message: 'BLE connectAsync timed out after 30000ms',
@@ -253,6 +258,33 @@ describe('useMeshCore BLE Noble IPC timeout handling', () => {
       '{"code":"BLE_CUSTOM","detail":"adapter glitch"}',
       '{"code":"BLE_CUSTOM","detail":"adapter glitch"}',
       { bleTimeoutStage: null },
+    );
+  });
+
+  it('retries once on retryable non-timeout "already in progress" errors', async () => {
+    vi.mocked(window.electronAPI.connectNobleBle).mockRejectedValue(
+      new Error('Connection already in progress'),
+    );
+    const { result } = renderHook(() => useMeshCore());
+
+    await expect(
+      act(async () => {
+        await result.current.connect('ble', undefined, 'ble-device-7');
+      }),
+    ).rejects.toThrow(
+      'Bluetooth connection already in progress. Wait for it to finish or try Serial/USB instead.',
+    );
+
+    expect(window.electronAPI.connectNobleBle).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useMeshCore] connect: BLE Noble IPC attempt failed',
+      expect.objectContaining({
+        attempt: 1,
+        maxAttempts: 2,
+        isTimeout: false,
+        isRetryable: true,
+        stage: 'unknown',
+      }),
     );
   });
 });

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -4,6 +4,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { sanitizeLogMessage } from '@/main/sanitize-log-message';
 
 import { withTimeout } from '../../shared/withTimeout';
+import {
+  classifyMeshcoreBleTimeoutStage,
+  isMeshcoreRetryableBleErrorMessage,
+} from '../lib/bleConnectErrors';
 import { classifyPayload, extractMeshtasticSenderId } from '../lib/foreignLoraDetection';
 import type { OurPosition } from '../lib/gpsSource';
 import { resolveOurPosition } from '../lib/gpsSource';
@@ -89,21 +93,6 @@ interface SerialConnectionInstance extends InstanceType<typeof SerialConnection>
 const NOBLE_IPC_CONNECT_TIMEOUT_MS = 120_000;
 const NOBLE_IPC_HANDSHAKE_TIMEOUT_MS = 20_000;
 const NOBLE_IPC_CONNECT_MAX_ATTEMPTS = 2;
-
-type MeshcoreBleTimeoutStage = 'ipc-open' | 'protocol-handshake' | 'unknown';
-
-function classifyMeshcoreBleTimeoutStage(message: string): MeshcoreBleTimeoutStage {
-  if (/MeshCore BLE IPC open timed out/i.test(message)) return 'ipc-open';
-  if (/MeshCore BLE protocol handshake timed out/i.test(message)) return 'protocol-handshake';
-  // Main-process GATT-level timeouts propagated through IPC
-  if (
-    /BLE connectAsync timed out|BLE characteristic discovery timed out|BLE fromNum subscribe timed out|BLE fromRadio subscribe timed out/i.test(
-      message,
-    )
-  )
-    return 'ipc-open';
-  return 'unknown';
-}
 
 function serializeErrorLike(value: unknown): string {
   if (value instanceof Error) return value.message;
@@ -1416,29 +1405,32 @@ export function useMeshCore() {
             } catch (bleErr) {
               lastBleError = bleErr;
               const rawBleMessage = serializeErrorLike(bleErr) || 'BLE connect failed';
-              const isTimeout =
-                /MeshCore BLE IPC open timed out|MeshCore BLE protocol handshake timed out|BLE connectAsync timed out|BLE characteristic discovery timed out|BLE fromNum subscribe timed out|BLE fromRadio subscribe timed out/i.test(
-                  rawBleMessage,
-                );
-              const stage = isTimeout ? classifyMeshcoreBleTimeoutStage(rawBleMessage) : null;
+              const stage = classifyMeshcoreBleTimeoutStage(rawBleMessage);
+              const isTimeout = stage !== 'unknown';
+              const isRetryable = isMeshcoreRetryableBleErrorMessage(rawBleMessage);
               console.warn('[useMeshCore] connect: BLE Noble IPC attempt failed', {
                 attempt,
                 maxAttempts: NOBLE_IPC_CONNECT_MAX_ATTEMPTS,
                 isTimeout,
+                isRetryable,
                 stage,
                 elapsedMs: Date.now() - attemptStartedAt,
                 message: rawBleMessage,
               });
               ipcNobleRef.current?.cleanup();
               ipcNobleRef.current = null;
-              if (!isTimeout || attempt >= NOBLE_IPC_CONNECT_MAX_ATTEMPTS) {
+              if (!isRetryable || attempt >= NOBLE_IPC_CONNECT_MAX_ATTEMPTS) {
                 throw bleErr;
               }
-              console.debug('[useMeshCore] connect: retrying BLE Noble IPC after timeout', {
-                nextAttempt: attempt + 1,
-                maxAttempts: NOBLE_IPC_CONNECT_MAX_ATTEMPTS,
-                stage,
-              });
+              console.debug(
+                '[useMeshCore] connect: retrying BLE Noble IPC after retryable failure',
+                {
+                  nextAttempt: attempt + 1,
+                  maxAttempts: NOBLE_IPC_CONNECT_MAX_ATTEMPTS,
+                  isTimeout,
+                  stage,
+                },
+              );
               // Brief pause before retry: gives BlueZ/WinRT time to release adapter state
               // after a failed or timed-out connect attempt.
               await new Promise<void>((r) => setTimeout(r, 1500));
@@ -1476,14 +1468,9 @@ export function useMeshCore() {
         );
         const isMissingServices = /could not find all requested services/i.test(safeMessage);
         const isPeripheralInUse = /already in use by the/i.test(safeMessage);
-        const isBleConnectTimeout =
-          type === 'ble' &&
-          /MeshCore BLE IPC open timed out|MeshCore BLE protocol handshake timed out|BLE connectAsync timed out|BLE characteristic discovery timed out|BLE fromNum subscribe timed out|BLE fromRadio subscribe timed out/i.test(
-            safeMessage,
-          );
-        const bleTimeoutStage = isBleConnectTimeout
-          ? classifyMeshcoreBleTimeoutStage(safeMessage)
-          : null;
+        const bleTimeoutStage =
+          type === 'ble' ? classifyMeshcoreBleTimeoutStage(safeMessage) : 'unknown';
+        const isBleConnectTimeout = bleTimeoutStage !== 'unknown';
         // When err is missing (e.g. library rejected with no reason), use a BLE-specific hint if we were connecting via BLE
         const fallbackMessage =
           type === 'ble' && err == null
@@ -1513,7 +1500,7 @@ export function useMeshCore() {
         }
         const errForLog = serializeErrorLike(err) || '(no error object)';
         console.error('[useMeshCore] connect error', normalizedErr.message, errForLog, {
-          bleTimeoutStage,
+          bleTimeoutStage: isBleConnectTimeout ? bleTimeoutStage : null,
         });
         setState({ status: 'disconnected', myNodeNum: 0, connectionType: null });
         ipcTcpRef.current?.cleanup();

--- a/src/renderer/lib/bleConnectErrors.ts
+++ b/src/renderer/lib/bleConnectErrors.ts
@@ -1,0 +1,22 @@
+export type MeshcoreBleTimeoutStage = 'ipc-open' | 'protocol-handshake' | 'unknown';
+
+const MAIN_PROCESS_BLE_TIMEOUT_RE =
+  /BLE connectAsync timed out|BLE characteristic discovery timed out|BLE fromNum subscribe timed out|BLE fromRadio subscribe timed out/i;
+
+export function isMainProcessBleTimeoutMessage(message: string): boolean {
+  return MAIN_PROCESS_BLE_TIMEOUT_RE.test(message);
+}
+
+export function classifyMeshcoreBleTimeoutStage(message: string): MeshcoreBleTimeoutStage {
+  if (/MeshCore BLE IPC open timed out/i.test(message)) return 'ipc-open';
+  if (/MeshCore BLE protocol handshake timed out/i.test(message)) return 'protocol-handshake';
+  if (isMainProcessBleTimeoutMessage(message)) return 'ipc-open';
+  return 'unknown';
+}
+
+export function isMeshcoreRetryableBleErrorMessage(message: string): boolean {
+  if (classifyMeshcoreBleTimeoutStage(message) !== 'unknown') return true;
+  return /already in progress|gatt server is disconnected|disconnected during gatt init/i.test(
+    message,
+  );
+}

--- a/src/renderer/lib/connection.ble-retry.test.ts
+++ b/src/renderer/lib/connection.ble-retry.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@meshtastic/core', () => ({
+  MeshDevice: vi.fn().mockImplementation(function MeshDevice(transport: unknown) {
+    return { transport };
+  }),
+}));
+
+vi.mock('./transportNobleIpc', () => ({
+  TransportNobleIpc: vi.fn().mockImplementation(function TransportNobleIpc(sessionId: string) {
+    return { sessionId };
+  }),
+}));
+
+import { MeshDevice } from '@meshtastic/core';
+
+import { createBleConnection } from './connection';
+
+describe('createBleConnection retry behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(window.electronAPI.connectNobleBle).mockResolvedValue(undefined);
+  });
+
+  it('retries once on main-process BLE timeout errors', async () => {
+    vi.mocked(window.electronAPI.connectNobleBle)
+      .mockRejectedValueOnce(new Error('BLE connectAsync timed out after 30000ms'))
+      .mockResolvedValueOnce(undefined);
+
+    const device = await createBleConnection('ble-device-1', 'meshtastic');
+
+    expect(window.electronAPI.connectNobleBle).toHaveBeenCalledTimes(2);
+    expect(window.electronAPI.connectNobleBle).toHaveBeenNthCalledWith(
+      1,
+      'meshtastic',
+      'ble-device-1',
+    );
+    expect(window.electronAPI.connectNobleBle).toHaveBeenNthCalledWith(
+      2,
+      'meshtastic',
+      'ble-device-1',
+    );
+    expect(MeshDevice).toHaveBeenCalledTimes(1);
+    expect(device).toBeTruthy();
+  });
+
+  it('does not retry non-timeout BLE errors', async () => {
+    vi.mocked(window.electronAPI.connectNobleBle).mockRejectedValue(
+      new Error('Bluetooth adapter is not available'),
+    );
+
+    await expect(createBleConnection('ble-device-2', 'meshtastic')).rejects.toThrow(
+      'Bluetooth adapter is not available',
+    );
+    expect(window.electronAPI.connectNobleBle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/lib/connection.ts
+++ b/src/renderer/lib/connection.ts
@@ -2,6 +2,7 @@ import { MeshDevice } from '@meshtastic/core';
 import { TransportHTTP } from '@meshtastic/transport-http';
 import { TransportWebSerial } from '@meshtastic/transport-web-serial';
 
+import { isMainProcessBleTimeoutMessage } from './bleConnectErrors';
 import { persistSerialPortIdentity, selectGrantedSerialPort } from './serialPortSignature';
 import { TransportNobleIpc } from './transportNobleIpc';
 import type { ConnectionType, NobleBleSessionId } from './types';
@@ -10,6 +11,8 @@ import type { ConnectionType, NobleBleSessionId } from './types';
 const HTTP_CONNECT_TIMEOUT_MS = 15_000;
 const HTTP_PREFLIGHT_RETRIES = 3;
 const HTTP_PREFLIGHT_RETRY_DELAY_MS = 2_000;
+const BLE_CONNECT_MAX_ATTEMPTS = 2;
+const BLE_CONNECT_RETRY_DELAY_MS = 1_500;
 
 function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
   const ac = new AbortController();
@@ -56,23 +59,44 @@ export async function createBleConnection(
   // Subscribe to IPC events before telling main to connect, so no fromRadio
   // packets emitted during the initial drain are dropped.
   const transport = new TransportNobleIpc(sessionId);
-  try {
-    await window.electronAPI.connectNobleBle(sessionId, peripheralId);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    const isTimeout = /timed out/i.test(message);
-    console.warn('[connection] createBleConnection failed', {
-      sessionId,
-      peripheralId,
-      isTimeout,
-      elapsedMs: Date.now() - connectStartedAt,
-      message,
-    });
-    throw err;
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= BLE_CONNECT_MAX_ATTEMPTS; attempt++) {
+    const attemptStartedAt = Date.now();
+    try {
+      await window.electronAPI.connectNobleBle(sessionId, peripheralId);
+      if (attempt > 1) {
+        console.info('[connection] createBleConnection recovered on retry', {
+          sessionId,
+          peripheralId,
+          attempt,
+          maxAttempts: BLE_CONNECT_MAX_ATTEMPTS,
+          totalElapsedMs: Date.now() - connectStartedAt,
+        });
+      }
+      console.debug('[connection] createBleConnection connected', peripheralId);
+      console.debug('[connection] createBleConnection elapsedMs', Date.now() - connectStartedAt);
+      return new MeshDevice(transport as any);
+    } catch (err) {
+      lastError = err;
+      const message = err instanceof Error ? err.message : String(err);
+      const isTimeout = isMainProcessBleTimeoutMessage(message) || /timed out/i.test(message);
+      console.warn('[connection] createBleConnection attempt failed', {
+        sessionId,
+        peripheralId,
+        attempt,
+        maxAttempts: BLE_CONNECT_MAX_ATTEMPTS,
+        isTimeout,
+        attemptElapsedMs: Date.now() - attemptStartedAt,
+        totalElapsedMs: Date.now() - connectStartedAt,
+        message,
+      });
+      if (!isTimeout || attempt >= BLE_CONNECT_MAX_ATTEMPTS) {
+        break;
+      }
+      await new Promise<void>((r) => setTimeout(r, BLE_CONNECT_RETRY_DELAY_MS));
+    }
   }
-  console.debug('[connection] createBleConnection connected', peripheralId);
-  console.debug('[connection] createBleConnection elapsedMs', Date.now() - connectStartedAt);
-  return new MeshDevice(transport as any);
+  throw lastError ?? new Error('BLE connection failed');
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR hardens BLE connection reliability on Linux/Windows by focusing first on MeshCore failures and then aligning Meshtastic retry behavior.

## What changed
- Added shared BLE timeout/retry classification helpers in `src/renderer/lib/bleConnectErrors.ts`.
- Updated `useMeshCore` BLE connect flow to:
  - use centralized timeout stage classification,
  - retry only retryable failures (timeouts + transient transport errors),
  - preserve fail-fast behavior for non-retryable errors,
  - keep stage-aware diagnostics and deterministic cleanup between attempts.
- Added Meshtastic BLE timeout retry parity in `src/renderer/lib/connection.ts`:
  - bounded retry loop (2 attempts),
  - 1500ms delay between attempts,
  - retry only on timeout-classified failures.
- Extended BLE reliability tests:
  - expanded `useMeshCore.ble-timeout.test.tsx` for retryable non-timeout behavior and structured diagnostics,
  - added `connection.ble-retry.test.ts` for Meshtastic retry/fail-fast coverage.
- Added Linux/Windows MeshCore timeout guidance updates in `ConnectionPanel` BLE error humanization.

## Why
Users are currently seeing BLE failures primarily in MeshCore on Linux/Windows despite existing timeout handling. The previous logic was partially duplicated and relied on broad inline matching, which made retry decisions and stage diagnostics less consistent across connect paths.

Centralizing classification and tightening retry gating improves resilience on transient platform stack behavior (BlueZ/WinRT timing/state churn) while keeping hard failures explicit and actionable.

## How to test
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run`
- [ ] Manual check on Linux: MeshCore BLE connect recovers on transient timeout where second attempt succeeds
- [ ] Manual check on Windows: MeshCore BLE timeout messaging remains stage-aware (`ipc-open` vs `protocol-handshake`)
- [ ] Manual check on Meshtastic BLE: single retry on timeout, no retry on non-timeout adapter/peripheral errors

## Risks / follow-ups
- Main-process timeout constants are unchanged in this PR; if telemetry still shows repeated Linux/Windows connect timeouts, a follow-up can tune `BLE_CONNECT_TIMEOUT_MS` with data.
- Renderer retry logs are now richer; monitor real-world logs to confirm they improve triage without introducing noise.