### PR TITLE
fix(security): SVG attr escaping strategy for Leaflet marker layer

### DIFF
--- a/src/renderer/components/MapPanel.tsx
+++ b/src/renderer/components/MapPanel.tsx
@@ -15,6 +15,7 @@ import {
 
 import type { LocationFilter } from '../App';
 import { getRoutingRowForNode, routingAnomalyNodeIds } from '../lib/diagnostics/diagnosticRows';
+import { escapeSvgAttr } from '../lib/escapeSvg';
 import type { OurPosition } from '../lib/gpsSource';
 import { getNodeStatus, haversineDistanceKm } from '../lib/nodeStatus';
 import type { MeshNode, MeshWaypoint, NodeAnomaly } from '../lib/types';
@@ -108,6 +109,13 @@ function getCUColor(cu: number): string {
   return '#ef4444';
 }
 
+/**
+ * Build a Leaflet SVG marker icon.
+ *
+ * SECURITY: `color` and any future string parameters are interpolated into SVG
+ * attribute values. Always pass internal computed values or wrap user-supplied
+ * strings with `escapeSvgAttr` / `escapeSvgText` before interpolating.
+ */
 function createMarkerIcon(
   color: string,
   isSelf: boolean,
@@ -120,7 +128,7 @@ function createMarkerIcon(
   const haloColor = getCUColor(cu);
   const halo = (c: number) =>
     haloPx > 0
-      ? `<circle cx="${c}" cy="${c}" r="${c - 0.5}" fill="${haloColor}" opacity="0.4"/>`
+      ? `<circle cx="${c}" cy="${c}" r="${c - 0.5}" fill="${escapeSvgAttr(haloColor)}" opacity="0.4"/>`
       : '';
   const mqttBadge = (c: number) =>
     isMqttOnly
@@ -134,7 +142,7 @@ function createMarkerIcon(
   if (isSelf) {
     const total = 32 + 2 * haloPx;
     const c = total / 2;
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="${total}" opacity="${markerOpacity}">${halo(c)}<g transform="translate(${haloPx},${haloPx}) scale(${32 / 24})"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" fill="${color}" stroke="#000" stroke-width="0.5"/></g>${mqttBadge(c)}${repeaterBadge(c)}</svg>`;
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="${total}" opacity="${markerOpacity}">${halo(c)}<g transform="translate(${haloPx},${haloPx}) scale(${32 / 24})"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" fill="${escapeSvgAttr(color)}" stroke="#000" stroke-width="0.5"/></g>${mqttBadge(c)}${repeaterBadge(c)}</svg>`;
     return L.icon({
       iconUrl: `data:image/svg+xml,${encodeURIComponent(svg)}`,
       iconSize: [total, total],
@@ -145,7 +153,7 @@ function createMarkerIcon(
 
   const total = 25 + 2 * haloPx;
   const c = total / 2;
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="${total}" opacity="${markerOpacity}">${halo(c)}<circle cx="${c}" cy="${c}" r="10.4" fill="${color}" stroke="#000" stroke-width="1" opacity="0.9"/><circle cx="${c}" cy="${c}" r="4.2" fill="#fff" opacity="0.8"/>${mqttBadge(c)}${repeaterBadge(c)}</svg>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="${total}" opacity="${markerOpacity}">${halo(c)}<circle cx="${c}" cy="${c}" r="10.4" fill="${escapeSvgAttr(color)}" stroke="#000" stroke-width="1" opacity="0.9"/><circle cx="${c}" cy="${c}" r="4.2" fill="#fff" opacity="0.8"/>${mqttBadge(c)}${repeaterBadge(c)}</svg>`;
   return L.icon({
     iconUrl: `data:image/svg+xml,${encodeURIComponent(svg)}`,
     iconSize: [total, total],

--- a/src/renderer/lib/escapeSvg.ts
+++ b/src/renderer/lib/escapeSvg.ts
@@ -1,0 +1,13 @@
+/** Escape a string for use in an SVG/HTML attribute value (double-quoted). */
+export function escapeSvgAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Escape a string for use as SVG text content. */
+export function escapeSvgText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}


### PR DESCRIPTION
## Summary

- Add `escapeSvgAttr` and `escapeSvgText` utilities in `src/renderer/lib/escapeSvg.ts`
- Apply `escapeSvgAttr` to `color` and `haloColor` at all three `fill=` interpolation sites in `createMarkerIcon`
- Add a `SECURITY:` JSDoc to `createMarkerIcon` documenting the escaping contract for future contributors

## Context

`createMarkerIcon` builds SVG strings via template literals and converts them to `data:image/svg+xml` data URLs for Leaflet. `color` and `haloColor` were interpolated directly into `fill="..."` attributes with no escaping guard. While currently safe (both are internally computed), an unguarded interpolation site means any future caller passing user-controlled data (e.g. a custom node color from device config, or a `short_name` label) would introduce SVG attribute injection / XSS. This establishes the escaping strategy before that happens.

## Test plan

- [ ] Open the map — markers render correctly (encodeURIComponent round-trips `&amp;` safely through the data URL)
- [ ] All CI checks pass (`npm run lint`, `npm test`)