### PR TITLE
feat: show cached node name in serial port picker

### DIFF
--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -212,6 +212,15 @@ function getBleDeviceName(deviceId: string): string | null {
   return cache[deviceId] ?? null;
 }
 
+function getSerialPortNodeName(portId: string): string | null {
+  const cache =
+    parseStoredJson<Record<string, string>>(
+      localStorage.getItem('mesh-client:serialPortNodeNames'),
+      'ConnectionPanel serialPortNodeNames',
+    ) ?? {};
+  return cache[portId] ?? null;
+}
+
 /** Inline SVG icon for each connection type */
 function ConnectionIcon({ type }: { type: ConnectionType }) {
   const cls = 'w-5 h-5 shrink-0';
@@ -1061,8 +1070,9 @@ export default function ConnectionPanel({
                 </div>
               ) : (
                 serialPorts.map((port) => {
+                  const cachedNodeName = getSerialPortNodeName(port.portId);
                   const serialDetails = `${port.portName}${port.vendorId ? ` (VID: ${port.vendorId})` : ''}${port.productId ? ` PID: ${port.productId}` : ''}`;
-                  const serialAriaLabel = `${port.displayName} ${serialDetails}`;
+                  const serialAriaLabel = `${cachedNodeName ? `${cachedNodeName} ` : ''}${port.displayName} ${serialDetails}`;
                   return (
                     <button
                       key={port.portId}
@@ -1075,7 +1085,7 @@ export default function ConnectionPanel({
                     >
                       <div className="text-sm text-gray-200 flex items-center gap-2">
                         <ConnectionIcon type="serial" />
-                        {port.displayName}
+                        {cachedNodeName ?? port.displayName}
                       </div>
                       <div className="text-xs text-muted font-mono ml-7">
                         {port.portName}

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -17,6 +17,7 @@ import { resolveOurPosition } from '../lib/gpsSource';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import { MESHTASTIC_CAPABILITIES } from '../lib/radio/BaseRadioProvider';
 import { normalizeReactionEmoji } from '../lib/reactions';
+import { LAST_SERIAL_PORT_KEY } from '../lib/serialPortSignature';
 import { TransportManager } from '../lib/transport/TransportManager';
 import type { StatusUpdateEvent } from '../lib/transport/types';
 import type {
@@ -1123,6 +1124,24 @@ export function useDevice() {
               localStorage.setItem(key, JSON.stringify(cache));
             } catch {
               // catch-no-log-ok localStorage write for BLE device name cache — non-critical
+            }
+          }
+        }
+        if (type === 'serial' && nodeNum === myNodeNumRef.current) {
+          const portId = localStorage.getItem(LAST_SERIAL_PORT_KEY);
+          const shortName = info.user?.shortName ?? info.user?.longName ?? null;
+          if (portId && shortName) {
+            try {
+              const key = 'mesh-client:serialPortNodeNames';
+              const cache =
+                parseStoredJson<Record<string, string>>(
+                  localStorage.getItem(key),
+                  'useDevice serialPortNodeNames cache',
+                ) ?? {};
+              cache[portId] = shortName;
+              localStorage.setItem(key, JSON.stringify(cache));
+            } catch {
+              // catch-no-log-ok localStorage write for serial port node name cache — non-critical
             }
           }
         }

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -30,7 +30,12 @@ import {
   minimalMeshcoreChatNode,
   pubkeyToNodeId,
 } from '../lib/meshcoreUtils';
-import { persistSerialPortIdentity, selectGrantedSerialPort } from '../lib/serialPortSignature';
+import { parseStoredJson } from '../lib/parseStoredJson';
+import {
+  LAST_SERIAL_PORT_KEY,
+  persistSerialPortIdentity,
+  selectGrantedSerialPort,
+} from '../lib/serialPortSignature';
 import type {
   ChatMessage,
   DeviceState,
@@ -1518,6 +1523,24 @@ export function useMeshCore() {
 
         if (!conn) throw new Error('Connection initialization failed');
         await initConn(conn);
+        if (type === 'serial') {
+          const portId = localStorage.getItem(LAST_SERIAL_PORT_KEY);
+          const nodeName = selfInfoRef.current?.name?.trim() || null;
+          if (portId && nodeName) {
+            try {
+              const key = 'mesh-client:serialPortNodeNames';
+              const cache =
+                parseStoredJson<Record<string, string>>(
+                  localStorage.getItem(key),
+                  'useMeshCore serialPortNodeNames cache',
+                ) ?? {};
+              cache[portId] = nodeName;
+              localStorage.setItem(key, JSON.stringify(cache));
+            } catch {
+              // catch-no-log-ok localStorage write for serial port node name cache — non-critical
+            }
+          }
+        }
         console.debug('[useMeshCore] connect: handshake complete, type=', type);
       } catch (err) {
         const rawMessage = serializeErrorLike(err) || 'Connection failed';


### PR DESCRIPTION
## Summary

- After a successful serial connection the node's name is cached in `localStorage` (`mesh-client:serialPortNodeNames`) keyed by port ID
- On subsequent connections the serial picker shows the node name (e.g. `KD0ABC`) instead of the raw OS port name, matching the existing BLE behaviour
- Covers both **Meshtastic** (`useDevice.ts` — `onNodeInfoPacket`, uses `shortName`/`longName`) and **MeshCore** (`useMeshCore.ts` — post-`initConn`, uses `selfInfo.name`)
- First connection still shows port name as before (no cache yet); cache updates automatically if the node is renamed

## Test plan

- [ ] Connect to a serial device (Meshtastic or MeshCore), reach configured state
- [ ] Disconnect and reopen the serial picker — node name should appear in the top line
- [ ] Verify port name / VID / PID detail line still shows below it
- [ ] Confirm no regression for BLE device name display
- [ ] `npm test` passes (20/20)