### PR TITLE
fix: copy README homepage in docs deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,4 +20,20 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install -r docs/requirements.txt
+      - run: cp README.md docs/index.md
+      - name: Rewrite README links for MkDocs root
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import re
+
+          index = Path("docs/index.md")
+          text = index.read_text(encoding="utf-8")
+
+          # Convert README-style docs-relative links to MkDocs page-relative links.
+          text = re.sub(r"\]\(docs/([^)]+)\)", r"](\1)", text)
+          text = re.sub(r'src="docs/([^"]+)"', r'src="\1"', text)
+
+          index.write_text(text, encoding="utf-8")
+          PY
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
This PR fixes docs publishing so the GitHub Pages homepage is consistently built from `README.md`, and README links still resolve correctly once copied into `docs/index.md`.

## What changed
- In `.github/workflows/docs.yml`, added a step to copy `README.md` to `docs/index.md` before deployment.
- Added a rewrite step that normalizes README-style links after copy:
  - Markdown links: `](docs/...)` -> `](...)`
  - HTML image sources: `src=\"docs/...\"` -> `src=\"...\"`
- Kept existing install/deploy flow (`pip install -r docs/requirements.txt`, `mkdocs gh-deploy --force`).

## Why
The production docs homepage was still showing MkDocs placeholder content instead of the README-based landing page, and copied README links can break if left as `docs/...` when rendered at docs root. This change makes deploy behavior deterministic and keeps homepage links/images valid.

## Test plan
- [x] `npm run test:run`
- [x] Verified workflow file diff for copy + rewrite + deploy order.

## Risks / follow-ups
- The rewrite rules intentionally target only `docs/...` link patterns. If additional README path formats are introduced later, we can extend this script safely.