### PR TITLE
fix: add mkdocs to docs requirements for GitHub Actions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+mkdocs
 mkdocs-material
 


### PR DESCRIPTION
## Summary
- Add `mkdocs` to `docs/requirements.txt` since the GitHub Actions workflow installs packages from this file but `mkdocs` was missing (only `mkdocs-material` was listed)
- This fixes the "mkdocs: command not found" error in the Publish Docs workflow