### PR TITLE
fix: add missing sendToRadioFrame mock to test files

### DIFF
--- a/src/renderer/hooks/useMeshCore.db-pubkey-backfill.test.tsx
+++ b/src/renderer/hooks/useMeshCore.db-pubkey-backfill.test.tsx
@@ -52,6 +52,7 @@ vi.mock('@liamcottle/meshcore.js', () => {
     syncDeviceTime = vi.fn().mockResolvedValue(undefined);
     getBatteryVoltage = vi.fn().mockResolvedValue({ batteryMilliVolts: 4200 });
     sendTextMessage = sendTextMessageMock;
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
   }
 
   class MockSerialConnection {
@@ -84,6 +85,7 @@ vi.mock('@liamcottle/meshcore.js', () => {
     emit() {
       return undefined;
     }
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
   }
 
   class MockConnection {

--- a/src/renderer/hooks/useMeshCore.serial-cleanup.test.tsx
+++ b/src/renderer/hooks/useMeshCore.serial-cleanup.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@liamcottle/meshcore.js', () => {
     getChannels = vi.fn().mockResolvedValue([]);
     syncDeviceTime = vi.fn().mockResolvedValue(undefined);
     getBatteryVoltage = vi.fn().mockResolvedValue({ batteryMilliVolts: 4200 });
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
   }
 
   class MockSerialConnection {
@@ -79,6 +80,7 @@ vi.mock('@liamcottle/meshcore.js', () => {
       void args;
       return undefined;
     }
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
   }
 
   /** Base class for Noble-over-IPC (same surface as meshcore.js Connection). */


### PR DESCRIPTION
## Summary

- Adds missing `sendToRadioFrame` mock method to test files to fix `TypeError: conn.sendToRadioFrame is not a function` error during connection initialization
- The production code calls `sendToRadioFrame` in `refreshMeshcoreAutoaddFromDevice()` during the init phase, which the test mocks were missing