### PR TITLE
fix: tighten classifyPayload Meshtastic heuristic to reduce false positives

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -491,13 +491,13 @@ SNR-based findings (`Wideband Noise Floor`, `Fringe`) are only emitted when `snr
 
 The classifier operates on raw LoRa payload bytes received by the radio before any decryption:
 
-| Rule                 | Byte condition                                                                                                            | Classification |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| MeshCore frame-start | `raw[0] === 0x3c` (`<` in ASCII)                                                                                          | `meshcore`     |
-| Meshtastic header    | bytes 0–3 = valid destId AND bytes 4–7 = valid senderId (both non-zero, non-broadcast `0xFFFFFFFF`, little-endian uint32) | `meshtastic`   |
-| Fallback             | everything else                                                                                                           | `unknown-lora` |
+| Rule                 | Byte condition                                                                                                                                                                                                        | Classification |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| MeshCore frame-start | `raw[0] === 0x3c` (`<` in ASCII)                                                                                                                                                                                      | `meshcore`     |
+| Meshtastic header    | `raw.length >= 16` AND bytes 0–3 = valid destId AND bytes 4–7 = valid senderId (both non-zero, non-broadcast `0xFFFFFFFF`) AND byte 12 flags: `hop_start` (bits [7:5]) ≥ 1 AND `hop_limit` (bits [2:0]) ≤ `hop_start` | `meshtastic`   |
+| Fallback             | everything else                                                                                                                                                                                                       | `unknown-lora` |
 
-The Meshtastic header check reflects the actual wire format: bytes 0–3 are the destination node ID and bytes 4–7 are the sender node ID. The non-zero, non-broadcast check filters out malformed packets.
+The Meshtastic header check requires the full 16-byte header (the actual Meshtastic LoRa minimum). Beyond the non-zero, non-broadcast ID check, byte 12 (the flags byte) is validated for structural consistency: `hop_limit` (bits [2:0]) must be ≤ `hop_start` (bits [7:5]), and `hop_start` must be ≥ 1. This eliminates false positives from MeshCore encrypted/relay packets whose first 8 bytes happen to look like valid Meshtastic node IDs, since MeshCore packets do not carry a conforming Meshtastic flags byte.
 
 **MeshCore log-pattern detection** (`containsMeshCorePattern()`): Device log messages mentioning decode failures and containing `0x3c` (or `<`) are matched via regex — this catches MeshCore traffic even when only the log stream is available (no raw packet data).
 

--- a/src/renderer/lib/foreignLoraDetection.test.ts
+++ b/src/renderer/lib/foreignLoraDetection.test.ts
@@ -89,7 +89,7 @@ describe('classifyPayload', () => {
     expect(classifyPayload(new Uint8Array([0x3c]))).toBe('meshcore');
   });
 
-  it('classifies Meshtastic by 8-byte header with non-zero dest/sender', () => {
+  it('returns unknown-lora for 8-byte packet (too short for Meshtastic header)', () => {
     const header = new Uint8Array(8);
     const dest = 0x01020304;
     const sender = 0x05060708;
@@ -101,7 +101,59 @@ describe('classifyPayload', () => {
     header[5] = (sender >> 8) & 0xff;
     header[6] = (sender >> 16) & 0xff;
     header[7] = (sender >> 24) & 0xff;
-    expect(classifyPayload(header)).toBe('meshtastic');
+    expect(classifyPayload(header)).toBe('unknown-lora');
+  });
+
+  it('classifies Meshtastic with 16-byte header and valid flags (hop_start=3, hop_limit=3)', () => {
+    const packet = new Uint8Array(16);
+    const dest = 0x01020304;
+    const sender = 0x05060708;
+    packet[0] = dest & 0xff;
+    packet[1] = (dest >> 8) & 0xff;
+    packet[2] = (dest >> 16) & 0xff;
+    packet[3] = (dest >> 24) & 0xff;
+    packet[4] = sender & 0xff;
+    packet[5] = (sender >> 8) & 0xff;
+    packet[6] = (sender >> 16) & 0xff;
+    packet[7] = (sender >> 24) & 0xff;
+    // byte 12: flags — hop_start=3 (bits [7:5]=011), hop_limit=3 (bits [2:0]=011) → 0x63
+    packet[12] = 0x63;
+    expect(classifyPayload(packet)).toBe('meshtastic');
+  });
+
+  it('returns unknown-lora for 16-byte packet with invalid flags (hop_limit > hop_start)', () => {
+    const packet = new Uint8Array(16);
+    const dest = 0x01020304;
+    const sender = 0x05060708;
+    packet[0] = dest & 0xff;
+    packet[1] = (dest >> 8) & 0xff;
+    packet[2] = (dest >> 16) & 0xff;
+    packet[3] = (dest >> 24) & 0xff;
+    packet[4] = sender & 0xff;
+    packet[5] = (sender >> 8) & 0xff;
+    packet[6] = (sender >> 16) & 0xff;
+    packet[7] = (sender >> 24) & 0xff;
+    // byte 12: flags — hop_start=1 (bits [7:5]=001), hop_limit=3 (bits [2:0]=011) → 0x23
+    // hop_limit(3) > hop_start(1): structurally impossible in a real Meshtastic packet
+    packet[12] = 0x23;
+    expect(classifyPayload(packet)).toBe('unknown-lora');
+  });
+
+  it('returns unknown-lora for 8–15 byte packets (below Meshtastic header minimum)', () => {
+    const dest = 0x01020304;
+    const sender = 0x05060708;
+    for (const len of [8, 15]) {
+      const packet = new Uint8Array(len);
+      packet[0] = dest & 0xff;
+      packet[1] = (dest >> 8) & 0xff;
+      packet[2] = (dest >> 16) & 0xff;
+      packet[3] = (dest >> 24) & 0xff;
+      packet[4] = sender & 0xff;
+      packet[5] = (sender >> 8) & 0xff;
+      packet[6] = (sender >> 16) & 0xff;
+      packet[7] = (sender >> 24) & 0xff;
+      expect(classifyPayload(packet)).toBe('unknown-lora');
+    }
   });
 
   it('returns unknown-lora for short or non-matching payload', () => {

--- a/src/renderer/lib/foreignLoraDetection.ts
+++ b/src/renderer/lib/foreignLoraDetection.ts
@@ -3,12 +3,23 @@ export type PacketClass = 'meshcore' | 'meshtastic' | 'unknown-lora';
 /** Fingerprint a raw LoRa payload into a packet class. */
 export function classifyPayload(raw: Uint8Array): PacketClass {
   if (raw[0] === 0x3c) return 'meshcore';
-  if (raw.length >= 8) {
+  // Meshtastic LoRa header is exactly 16 bytes: dest[4] + sender[4] + packetId[4] + flags[1] +
+  // channelHash[1] + nextHop[1] + relayNode[1]. Require the full header to avoid false positives
+  // from MeshCore encrypted/relay packets whose first 8 bytes resemble Meshtastic node IDs.
+  if (raw.length >= 16) {
     const destId = (raw[0] | (raw[1] << 8) | (raw[2] << 16) | (raw[3] << 24)) >>> 0;
     const senderId = (raw[4] | (raw[5] << 8) | (raw[6] << 16) | (raw[7] << 24)) >>> 0;
     const BROADCAST = 0xffffffff;
     if (destId !== 0 && destId !== BROADCAST && senderId !== 0 && senderId !== BROADCAST) {
-      return 'meshtastic';
+      // Validate the flags byte (byte 12): hop_limit (bits [2:0]) must be <= hop_start (bits [7:5]),
+      // and hop_start >= 1. This structural invariant holds for all valid Meshtastic packets —
+      // hop_limit starts at hop_start and decrements per relay — and rules out non-Meshtastic packets.
+      const flags = raw[12];
+      const hopLimit = flags & 0x07;
+      const hopStart = (flags >> 5) & 0x07;
+      if (hopStart >= 1 && hopLimit <= hopStart) {
+        return 'meshtastic';
+      }
     }
   }
   return 'unknown-lora';


### PR DESCRIPTION
## Summary

- Require `raw.length >= 16` (full Meshtastic header) instead of 8 bytes before classifying a packet as `meshtastic`
- Add flags byte (byte 12) structural validation: `hop_start >= 1` and `hop_limit <= hop_start` — a physical invariant of the Meshtastic wire format
- Update tests and docs to reflect new classification rules

## Why

MeshCore encrypted/relay packets that don't start with `0x3c` have data in bytes 0–7 that can look like valid Meshtastic node IDs, causing their own mesh traffic to be mislabeled as "Meshtastic Foreign Activity" in the diagnostics panel.

## Test plan

- [ ] `pnpm run test:run` — all 679 tests pass
- [ ] Connect via MeshCore — own-mesh traffic no longer appears in Foreign LoRa diagnostics
- [ ] Real Meshtastic traffic nearby is still detected correctly (16-byte header + valid flags)

Fixes #250