### PR TITLE
fix: require colon in BREAKING CHANGE detection to avoid false positives

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -33,7 +33,7 @@ detect_version_bump() {
   local has_other=false
 
   # Check for BREAKING CHANGE in commit bodies
-  if echo "$commits" | grep -q "BREAKING CHANGE"; then
+  if echo "$commits" | grep -q "BREAKING CHANGE:"; then
     has_breaking=true
   fi
 


### PR DESCRIPTION
## Summary

- Fixes the release script from incorrectly detecting major version bumps
- The script was matching any text containing "BREAKING CHANGE" in commit bodies, but commit 2989579 had the text "Detect BREAKING CHANGE and feat!/fix! for major bumps" describing a feature being added (not an actual breaking change)
- Changed grep pattern from `BREAKING CHANGE` to `BREAKING CHANGE:` to match the conventional commits spec where breaking changes are denoted with a colon