### PR TITLE
fix: reduce noisy MQTT logs for undecryptable packets

### DIFF
--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -607,10 +607,6 @@ export class MQTTManager extends EventEmitter {
       const nodeId = packet.from;
       const packetId = packet.id;
 
-      console.debug(
-        `[MQTT] Binary packet: nodeId=0x${nodeId.toString(16)} packetId=0x${packetId.toString(16)} topic=${topic}`,
-      ); // log-filter-ok Meshtastic MQTT logs → App log panel
-
       if (packetId && this.isDuplicate(packetId)) return;
 
       const payloadCase = packet.payloadVariant?.case;
@@ -632,15 +628,7 @@ export class MQTTManager extends EventEmitter {
             `[MQTT] Decryption succeeded: portnum=${decodedData.portnum} nodeId=0x${nodeId.toString(16)}`,
           ); // log-filter-ok Meshtastic MQTT logs → App log panel
           this.handleDecoded(nodeId, packetId, decodedData);
-        } else {
-          console.debug(
-            `[MQTT] Decryption failed: nodeId=${nodeId} packetId=${packetId} — not adding to nodes`,
-          ); // log-filter-ok Meshtastic MQTT logs → App log panel
         }
-      } else {
-        console.debug(
-          `[MQTT] Unknown payloadVariant case: ${payloadCase} nodeId=0x${nodeId.toString(16)}`,
-        ); // log-filter-ok Meshtastic MQTT logs → App log panel
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Remove "Binary packet" log that fired for every MQTT message
- Remove "Decryption failed" log for packets we don't have a PSK for
- Remove "Unknown payloadVariant case" log for packets without usable payload

This eliminates ~700+ duplicate log lines per MQTT session for packets we can't decrypt.

## Testing
- pnpm run lint ✓
- pnpm run typecheck ✓
- pnpm run test:run ✓ (706 tests)