### PR TITLE
fix: patch readable-stream@4.7.0 to resolve process/ on Windows

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -72,7 +72,6 @@ linux:
 deb:
 rpm:
 win:
-  asar: false
   target:
     - target: nsis
       arch:

--- a/package.json
+++ b/package.json
@@ -167,6 +167,9 @@
       "tar": "^7.5.11",
       "yauzl": "^3.2.1"
     },
+    "patchedDependencies": {
+      "readable-stream@4.7.0": "patches/readable-stream@4.7.0.patch"
+    },
     "minimumReleaseAgeExclude": [
       "lodash",
       "lodash-es"

--- a/patches/readable-stream@4.7.0.patch
+++ b/patches/readable-stream@4.7.0.patch
@@ -1,0 +1,89 @@
+diff --git a/lib/internal/streams/destroy.js b/lib/internal/streams/destroy.js
+index 38292315ee9ae159634fc0646faa57bd46088a6f..1e5e81db24b2b91f8a2766f7e5929cb81ebeded6 100644
+--- a/lib/internal/streams/destroy.js
++++ b/lib/internal/streams/destroy.js
+@@ -2,7 +2,7 @@
+ 
+ /* replacement start */
+ 
+-const process = require('process/')
++const process = require('process')
+ 
+ /* replacement end */
+ 
+diff --git a/lib/internal/streams/duplexify.js b/lib/internal/streams/duplexify.js
+index 05740d70ff018aae02fceb6ffd0ee669f1ef6c1c..46fdecbd5e02274977c79d76a0a9d0554c7ce737 100644
+--- a/lib/internal/streams/duplexify.js
++++ b/lib/internal/streams/duplexify.js
+@@ -1,6 +1,6 @@
+ /* replacement start */
+ 
+-const process = require('process/')
++const process = require('process')
+ 
+ /* replacement end */
+ 
+diff --git a/lib/internal/streams/end-of-stream.js b/lib/internal/streams/end-of-stream.js
+index 94d18321d29026450ce0b0fdff88875e7e82281d..92b8aeadca3764416639b67eab4b1abf4cb6aca7 100644
+--- a/lib/internal/streams/end-of-stream.js
++++ b/lib/internal/streams/end-of-stream.js
+@@ -5,7 +5,7 @@
+ 
+ /* replacement start */
+ 
+-const process = require('process/')
++const process = require('process')
+ 
+ /* replacement end */
+ 
+diff --git a/lib/internal/streams/from.js b/lib/internal/streams/from.js
+index c7e75314028794c050b62171a07b654366203c88..2b3a8411bbd4f7df606f43340e18354bdb6cb154 100644
+--- a/lib/internal/streams/from.js
++++ b/lib/internal/streams/from.js
+@@ -2,7 +2,7 @@
+ 
+ /* replacement start */
+ 
+-const process = require('process/')
++const process = require('process')
+ 
+ /* replacement end */
+ 
+diff --git a/lib/internal/streams/pipeline.js b/lib/internal/streams/pipeline.js
+index a2bab880069748ab2b1ab0a0ffa9426fbfabce47..a6eaa23f0b118bd880cde6aac4b8c495129e5dba 100644
+--- a/lib/internal/streams/pipeline.js
++++ b/lib/internal/streams/pipeline.js
+@@ -1,6 +1,6 @@
+ /* replacement start */
+ 
+-const process = require('process/')
++const process = require('process')
+ 
+ /* replacement end */
+ // Ported from https://github.com/mafintosh/pump with
+diff --git a/lib/internal/streams/readable.js b/lib/internal/streams/readable.js
+index 90c7316056a73edb694a7e7b54fe2d772f3c8a60..5b293f1372fdda78793424562095231a6415e908 100644
+--- a/lib/internal/streams/readable.js
++++ b/lib/internal/streams/readable.js
+@@ -23,7 +23,7 @@
+ 
+ /* replacement start */
+ 
+-const process = require('process/')
++const process = require('process')
+ 
+ /* replacement end */
+ 
+diff --git a/lib/internal/streams/writable.js b/lib/internal/streams/writable.js
+index b4ecf0e21dd929fb374f3b0af31ad2d5ecdf04ca..9f4c2f8943c3a627d1c5820221adca7ef9639329 100644
+--- a/lib/internal/streams/writable.js
++++ b/lib/internal/streams/writable.js
+@@ -27,7 +27,7 @@
+ 
+ /* replacement start */
+ 
+-const process = require('process/')
++const process = require('process')
+ 
+ /* replacement end */
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,11 @@ overrides:
   tar: ^7.5.11
   yauzl: ^3.2.1
 
+patchedDependencies:
+  readable-stream@4.7.0:
+    hash: 96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1
+    path: patches/readable-stream@4.7.0.patch
+
 importers:
 
   .:
@@ -6205,7 +6210,7 @@ snapshots:
       '@types/readable-stream': 4.0.23
       buffer: 6.0.3
       inherits: 2.0.4
-      readable-stream: 4.7.0
+      readable-stream: 4.7.0(patch_hash=96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1)
 
   boolean@3.2.0:
     optional: true
@@ -8250,7 +8255,7 @@ snapshots:
       minimist: 1.2.8
       mqtt-packet: 9.0.2
       number-allocator: 1.0.14
-      readable-stream: 4.7.0
+      readable-stream: 4.7.0(patch_hash=96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1)
       rfdc: 1.4.1
       socks: 2.8.7
       split2: 4.2.0
@@ -8658,7 +8663,7 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  readable-stream@4.7.0:
+  readable-stream@4.7.0(patch_hash=96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1):
     dependencies:
       abort-controller: 3.0.0
       buffer: 6.0.3


### PR DESCRIPTION
## Summary

- `readable-stream@4.7.0` (nested under `mqtt`) uses `require('process/')` with a trailing slash in 7 files. On Windows, the path resolver treats the slash literally and fails — macOS/Linux silently normalize it, masking the bug.
- Applies a pnpm native patch (`patches/readable-stream@4.7.0.patch`) that changes `require('process/')` → `require('process')` in all 7 affected files inside `lib/internal/streams/`.
- With the source bug fixed, re-enables asar on Windows by removing the `win.asar: false` workaround added in #299.

## Affected files patched

- `destroy.js`, `duplexify.js`, `end-of-stream.js`, `from.js`, `pipeline.js`, `readable.js`, `writable.js`

## Test plan

- [ ] Run `pnpm install` — confirm patch applies cleanly (no errors)
- [ ] Run `pnpm run dist:win` (Windows CI or local)
- [ ] Launch the built app on Windows — confirm no `Cannot find module 'process/'` crash on startup
- [ ] Verify MQTT connectivity still works end-to-end on Windows
- [ ] If a `ms` module error surfaces after this fix, grep `node_modules` for `require('ms/')` and apply a second patch