### PR TITLE
Fix Windows asar compatibility: inline ms module into debug@4.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "main": "dist-electron/main/index.js",
   "scripts": {
     "build": "pnpm run build:main:prod && pnpm run build:preload && pnpm run build:renderer",
-    "build:main": "esbuild src/main/index.ts --bundle --platform=node --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:ms --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs",
-    "build:main:meta": "esbuild src/main/index.ts --bundle --platform=node --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:ms --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs --metafile=dist-electron/main/metafile.json",
-    "build:main:minify-meta": "esbuild src/main/index.ts --bundle --platform=node --minify --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:ms --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs --metafile=dist-electron/main/meta.json",
-    "build:main:prod": "esbuild src/main/index.ts --bundle --platform=node --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:ms --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs --minify",
+    "build:main": "esbuild src/main/index.ts --bundle --platform=node --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs",
+    "build:main:meta": "esbuild src/main/index.ts --bundle --platform=node --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs --metafile=dist-electron/main/metafile.json",
+    "build:main:minify-meta": "esbuild src/main/index.ts --bundle --platform=node --minify --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs --metafile=dist-electron/main/meta.json",
+    "build:main:prod": "esbuild src/main/index.ts --bundle --platform=node --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs --minify",
     "build:main:size": "node scripts/print-main-bundle-size.mjs",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --outfile=dist-electron/preload/index.js --external:electron --format=cjs",
     "build:renderer": "vite build",
@@ -168,6 +168,7 @@
       "yauzl": "^3.2.1"
     },
     "patchedDependencies": {
+      "debug@4.4.3": "patches/debug@4.4.3.patch",
       "readable-stream@4.7.0": "patches/readable-stream@4.7.0.patch"
     },
     "minimumReleaseAgeExclude": [

--- a/patches/debug@4.4.3.patch
+++ b/patches/debug@4.4.3.patch
@@ -1,0 +1,88 @@
+diff --git a/src/common.js b/src/common.js
+index 141cb578b7722324d8e1799b2a41bac473f6a9c1..bcddc91e56239059a1d336c141560e4fd7ae5f3f 100644
+--- a/src/common.js
++++ b/src/common.js
+@@ -11,7 +11,82 @@ function setup(env) {
+ 	createDebug.disable = disable;
+ 	createDebug.enable = enable;
+ 	createDebug.enabled = enabled;
+-	createDebug.humanize = require('ms');
++	createDebug.humanize = (function () {
++		var s = 1000;
++		var m = s * 60;
++		var h = m * 60;
++		var d = h * 24;
++		var w = d * 7;
++		var y = d * 365.25;
++		function parse(str) {
++			str = String(str);
++			if (str.length > 100) {
++				return;
++			}
++			var match = str.match(/^(-?(?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i);
++			if (!match) {
++				return;
++			}
++			var n = parseFloat(match[1]);
++			var type = (match[2] || 'ms').toLowerCase();
++			switch (type) {
++				case 'years': case 'year': case 'yrs': case 'yr': case 'y': return n * y;
++				case 'weeks': case 'week': case 'w': return n * w;
++				case 'days': case 'day': case 'd': return n * d;
++				case 'hours': case 'hour': case 'hrs': case 'hr': case 'h': return n * h;
++				case 'minutes': case 'minute': case 'mins': case 'min': case 'm': return n * m;
++				case 'seconds': case 'second': case 'secs': case 'sec': case 's': return n * s;
++				case 'milliseconds': case 'millisecond': case 'msecs': case 'msec': case 'ms': return n;
++				default: return undefined;
++			}
++		}
++		function fmtShort(ms) {
++			var msAbs = Math.abs(ms);
++			if (msAbs >= d) {
++				return Math.round(ms / d) + 'd';
++			}
++			if (msAbs >= h) {
++				return Math.round(ms / h) + 'h';
++			}
++			if (msAbs >= m) {
++				return Math.round(ms / m) + 'm';
++			}
++			if (msAbs >= s) {
++				return Math.round(ms / s) + 's';
++			}
++			return ms + 'ms';
++		}
++		function fmtLong(ms) {
++			var msAbs = Math.abs(ms);
++			function plural(ms, msAbs, n, name) {
++				return Math.round(ms / n) + ' ' + name + (msAbs >= n * 1.5 ? 's' : '');
++			}
++			if (msAbs >= d) {
++				return plural(ms, msAbs, d, 'day');
++			}
++			if (msAbs >= h) {
++				return plural(ms, msAbs, h, 'hour');
++			}
++			if (msAbs >= m) {
++				return plural(ms, msAbs, m, 'minute');
++			}
++			if (msAbs >= s) {
++				return plural(ms, msAbs, s, 'second');
++			}
++			return ms + ' ms';
++		}
++		return function (val, options) {
++			options = options || {};
++			var type = typeof val;
++			if (type === 'string' && val.length > 0) {
++				return parse(val);
++			}
++			if (type === 'number' && isFinite(val)) {
++				return options.long ? fmtLong(val) : fmtShort(val);
++			}
++			throw new Error('val is not a non-empty string or a valid number. val=' + JSON.stringify(val));
++		};
++	}());
+ 	createDebug.destroy = destroy;
+ 
+ 	Object.keys(env).forEach(key => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ overrides:
   yauzl: ^3.2.1
 
 patchedDependencies:
+  debug@4.4.3:
+    hash: cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37
+    path: patches/debug@4.4.3.patch
   readable-stream@4.7.0:
     hash: 96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1
     path: patches/readable-stream@4.7.0.patch
@@ -4771,7 +4774,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4855,7 +4858,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
     transitivePeerDependencies:
       - supports-color
 
@@ -4913,7 +4916,7 @@ snapshots:
 
   '@electron/get@2.0.3':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -4927,7 +4930,7 @@ snapshots:
 
   '@electron/get@3.1.0':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -4941,7 +4944,7 @@ snapshots:
 
   '@electron/notarize@2.5.0':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
@@ -4950,7 +4953,7 @@ snapshots:
   '@electron/osx-sign@1.3.3':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -4961,7 +4964,7 @@ snapshots:
   '@electron/rebuild@4.0.3':
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       detect-libc: 2.1.2
       got: 11.8.6
       graceful-fs: 4.2.11
@@ -4980,7 +4983,7 @@ snapshots:
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       dir-compare: 4.2.0
       fs-extra: 11.3.4
       minimatch: 9.0.9
@@ -4991,7 +4994,7 @@ snapshots:
   '@electron/windows-sign@1.2.2':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       fs-extra: 11.3.4
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
@@ -5165,7 +5168,7 @@ snapshots:
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -5181,7 +5184,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5287,7 +5290,7 @@ snapshots:
 
   '@malept/flatpak-bundler@0.4.0':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       fs-extra: 9.1.0
       lodash: 4.18.1
       tmp-promise: 3.0.3
@@ -5452,7 +5455,7 @@ snapshots:
   '@serialport/binding-mock@10.2.2':
     dependencies:
       '@serialport/bindings-interface': 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
     transitivePeerDependencies:
       - supports-color
 
@@ -5565,7 +5568,7 @@ snapshots:
   '@stoprocent/bluetooth-hci-socket@2.2.6':
     dependencies:
       async: 3.2.6
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
       patch-package: 8.0.1
@@ -5578,7 +5581,7 @@ snapshots:
 
   '@stoprocent/noble@2.4.0':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
       patch-package: 8.0.1
@@ -5868,7 +5871,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5878,7 +5881,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5897,7 +5900,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -5912,7 +5915,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -6056,7 +6059,7 @@ snapshots:
       builder-util-runtime: 9.5.1
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       dmg-builder: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
@@ -6263,7 +6266,7 @@ snapshots:
 
   builder-util-runtime@9.5.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       sax: 1.6.0
     transitivePeerDependencies:
       - supports-color
@@ -6276,7 +6279,7 @@ snapshots:
       builder-util-runtime: 9.5.1
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -6546,7 +6549,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.3:
+  debug@4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37):
     dependencies:
       ms: 2.1.3
 
@@ -6711,7 +6714,7 @@ snapshots:
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       fs-extra: 7.0.1
       lodash: 4.18.1
       temp: 0.9.4
@@ -7086,7 +7089,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -7144,7 +7147,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       get-stream: 5.2.0
       yauzl: 3.3.0
     optionalDependencies:
@@ -7435,7 +7438,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
     transitivePeerDependencies:
       - supports-color
 
@@ -7447,7 +7450,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
     transitivePeerDependencies:
       - supports-color
 
@@ -7793,7 +7796,7 @@ snapshots:
   license-checker-rseidelsohn@4.4.2:
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       lodash.clonedeep: 4.5.0
       mkdirp: 1.0.4
       nopt: 7.2.1
@@ -8137,7 +8140,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -8238,7 +8241,7 @@ snapshots:
   mqtt-packet@9.0.2:
     dependencies:
       bl: 6.1.6
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       process-nextick-args: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -8249,7 +8252,7 @@ snapshots:
       '@types/ws': 8.18.1
       commist: 3.2.0
       concat-stream: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       help-me: 5.0.0
       lru-cache: 10.4.3
       minimist: 1.2.8
@@ -8347,7 +8350,7 @@ snapshots:
 
   number-allocator@1.0.14:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       js-sdsl: 4.3.0
     transitivePeerDependencies:
       - supports-color
@@ -8624,14 +8627,14 @@ snapshots:
 
   read-binary-file-arch@1.0.6:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
     transitivePeerDependencies:
       - supports-color
 
   read-installed-packages@2.0.1:
     dependencies:
       '@npmcli/fs': 3.1.1
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       read-package-json: 6.0.4
       semver: 7.7.4
       slide: 1.1.6
@@ -9009,7 +9012,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -9187,7 +9190,7 @@ snapshots:
 
   sumchecker@3.0.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Fix Windows asar compatibility: inline ms module into debug@4.4.3

## Problem
After merging PRs #299-#301 to fix Windows asar compatibility, users still see a crash on launch:
```
Error: Cannot find module 'ms'
  at debug/src/common.js:14
    createDebug.humanize = require('ms');
```

The dependency chain is: mqtt (runtime dep) -> debug@4.4.3 -> ms@2.1.3.

## Root Cause
ms is not landing in node_modules inside the asar when the Windows release is built. Despite .npmrc having node-linker=hoisted and ms@2.1.3 being present locally, the release build machine produces an asar where ms is absent.

## Solution
Apply a pnpm patch to debug@4.4.3 that inlines the ms module directly into common.js. This follows the exact same pattern as patches/readable-stream@4.7.0.patch and eliminates the external dependency entirely, making the fix deterministic regardless of build environment.

## Changes
- **patches/debug@4.4.3.patch**: pnpm patch inlining ms into debug/src/common.js
- **package.json**: register patch in patchedDependencies; remove no-op --external:ms from all four build:main scripts
- **pnpm-lock.yaml**: updated with patch registration

## Verification
- ✅ pnpm run build succeeds
- ✅ pnpm run test:run passes (770 tests)
- ✅ Debug module loads with inlined humanize function
- ✅ require('ms') eliminated from node_modules/debug/src/

This fix should resolve the Windows launch crash by ensuring the ms functionality is always available within the asar.