### PR TITLE
fix: MeshCore packet decode improvements and Meshtastic MQTT log sampling

### DIFF
--- a/src/main/mqtt-manager.test.ts
+++ b/src/main/mqtt-manager.test.ts
@@ -2,7 +2,7 @@
 import { create, fromBinary, toBinary } from '@bufbuild/protobuf';
 import { Mesh, Mqtt as MqttProto, Portnums } from '@meshtastic/protobufs';
 import { createCipheriv } from 'crypto';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MQTTManager, parsePsk } from './mqtt-manager';
 
@@ -965,6 +965,67 @@ describe('onMessage — JSON nodeinfo', () => {
     expect(update.node_id).toBe(nodeId);
     expect(update.long_name).toBe('Root Level Node');
     expect(update.short_name).toBe('RLN');
+  });
+});
+
+describe('onMessage — JSON sampled handling', () => {
+  let manager: MQTTManager;
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    manager = new MQTTManager();
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  it('suppresses unhandled log noise for empty type + missing portnum messages', () => {
+    const payload = Buffer.from(
+      JSON.stringify({
+        from: 0x6982c484,
+        to: 0xa2d67b68,
+        type: '',
+      }),
+    );
+
+    (manager as any).onMessage('msh/US/CO/2/json/LongFast/!6982c484', payload);
+
+    expect(
+      debugSpy.mock.calls.some((args: unknown[]) =>
+        String(args[0]).includes('JSON message missing type/portnum ignored'),
+      ),
+    ).toBe(true);
+    expect(
+      debugSpy.mock.calls.some((args: unknown[]) =>
+        String(args[0]).includes('JSON message unhandled'),
+      ),
+    ).toBe(false);
+  });
+
+  it('treats traceroute JSON as known and avoids unhandled logging', () => {
+    const payload = Buffer.from(
+      JSON.stringify({
+        from: 0x698524e8,
+        to: 0x6982c484,
+        type: 'traceroute',
+        payload: { route: ['A', 'B'] },
+      }),
+    );
+
+    (manager as any).onMessage('msh/US/CO/2/json/LongFast/!698524e8', payload);
+
+    expect(
+      debugSpy.mock.calls.some((args: unknown[]) =>
+        String(args[0]).includes('JSON traceroute message ignored'),
+      ),
+    ).toBe(true);
+    expect(
+      debugSpy.mock.calls.some((args: unknown[]) =>
+        String(args[0]).includes('JSON message unhandled'),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -87,6 +87,12 @@ const MESHTASTIC_MQTT_WSS_PING_MS = 25_000;
  * on proxied WSS paths (LetsMesh broker).
  */
 const MESHTASTIC_MQTT_RESCHEDULE_MS = 30_000;
+const NOISY_DEBUG_LOG_INTERVAL_MS = 60_000;
+
+interface SampledDebugLogState {
+  lastLoggedAt: number;
+  suppressedCount: number;
+}
 
 export class MQTTManager extends EventEmitter {
   private client: mqtt.MqttClient | null = null;
@@ -101,6 +107,7 @@ export class MQTTManager extends EventEmitter {
   private extraPsks: Buffer[] = [];
   private wssPingTimer: ReturnType<typeof setInterval> | null = null;
   private keepaliveRescheduleTimer: ReturnType<typeof setInterval> | null = null;
+  private sampledDebugLogs = new Map<string, SampledDebugLogState>();
   /** Wall time at start of last `_doConnect` (CONNACK timing in connect logs). */
   private meshtasticConnectT0 = 0;
   /** After `connack timeout`, reconnect with {@link MESHTASTIC_MQTT_RECONNECT_AFTER_CONNACK_TIMEOUT_MS}. */
@@ -649,13 +656,12 @@ export class MQTTManager extends EventEmitter {
         }
       }
     } catch (err) {
+      // catch-no-log-ok decode failures are sampled via logSampledDebug (avoid duplicate console lines)
       const msg = err instanceof Error ? err.message : String(err);
-      console.debug(
-        '[Meshtastic MQTT] ServiceEnvelope decode failed:',
-        sanitizeLogMessage(msg),
-        '| Topic:',
-        sanitizeLogMessage(topic),
-      ); // log-filter-ok Meshtastic MQTT logs → App log panel
+      this.logSampledDebug(
+        'service-envelope-decode-failed',
+        `[Meshtastic MQTT] ServiceEnvelope decode failed: ${sanitizeLogMessage(msg)} | Topic: ${sanitizeLogMessage(topic)}`,
+      );
     }
   }
 
@@ -668,29 +674,38 @@ export class MQTTManager extends EventEmitter {
     const jsonStr = JSON.stringify(json).slice(0, 500);
     console.debug(`[Meshtastic MQTT] JSON content: ${jsonStr}`); // log-filter-ok Meshtastic MQTT logs → App log panel
 
-    const type = json.type as string | undefined;
+    const typeRaw = json.type;
+    const type = typeof typeRaw === 'string' ? typeRaw.trim() : '';
+    const typeLower = type.toLowerCase();
 
-    if (type === 'nodeinfo' || type === 'USER') {
+    if (typeLower === 'nodeinfo' || typeLower === 'user') {
       this.handleJsonNodeInfo(json, topic);
       return;
     }
 
-    if (type === 'position' || type === 'POSITION') {
+    if (typeLower === 'position') {
       this.handleJsonPosition(json, topic);
       return;
     }
 
-    if (type === 'telemetry' || type === 'TELEMETRY') {
+    if (typeLower === 'telemetry') {
       this.handleJsonTelemetry(json, topic);
       return;
     }
 
-    if (type === 'neighborinfo' || type === 'NEIGHBORINFO') {
+    if (typeLower === 'neighborinfo') {
       this.handleJsonNeighborInfo(json, topic);
       return;
     }
 
     const portnumRaw = json.portnum as number | undefined;
+    if (typeLower === 'traceroute') {
+      this.logSampledDebug(
+        'json-traceroute',
+        `[Meshtastic MQTT] JSON traceroute message ignored: topic=${sanitizeLogMessage(topic)}`,
+      );
+      return;
+    }
     if (portnumRaw === PortNum.NODEINFO_APP) {
       this.handleJsonNodeInfo(json, topic);
       return;
@@ -707,10 +722,18 @@ export class MQTTManager extends EventEmitter {
       this.handleJsonNodeInfo(json, topic);
       return;
     }
+    if (typeLower.length === 0 && portnumRaw === undefined) {
+      this.logSampledDebug(
+        'json-empty-type',
+        `[Meshtastic MQTT] JSON message missing type/portnum ignored: topic=${sanitizeLogMessage(topic)}`,
+      );
+      return;
+    }
 
-    console.debug(
-      `[Meshtastic MQTT] JSON message unhandled: type="${type}" portnum=${portnumRaw} topic=${topic}`,
-    ); // log-filter-ok Meshtastic MQTT logs → App log panel
+    this.logSampledDebug(
+      `json-unhandled:${typeLower || 'empty'}:${String(portnumRaw)}`,
+      `[Meshtastic MQTT] JSON message unhandled: type="${sanitizeLogMessage(type || '<empty>')}" portnum=${String(portnumRaw)} topic=${sanitizeLogMessage(topic)}`,
+    );
   }
 
   /**
@@ -1125,8 +1148,7 @@ export class MQTTManager extends EventEmitter {
     console.debug(
       `[Meshtastic MQTT] Decrypt attempt: trying ${allKeys.length} PSKs (1 default + ${this.extraPsks.length} custom) for nodeId=0x${from.toString(16)}`,
     ); // log-filter-ok Meshtastic MQTT logs → App log panel
-    for (let i = 0; i < allKeys.length; i++) {
-      const key = allKeys[i];
+    for (const key of allKeys) {
       const raw = this.tryDecryptWithKey(encrypted, packetId, from, key);
       if (!raw) continue;
       try {
@@ -1137,12 +1159,40 @@ export class MQTTManager extends EventEmitter {
           replyId?: number;
         };
       } catch {
-        // Wrong PSK produces garbage bytes that fail protobuf decode — try next key
-        console.debug(
-          `[Meshtastic MQTT] decrypt attempt ${i + 1}/${allKeys.length} failed (protobuf decode error)`,
-        ); // log-filter-ok Meshtastic MQTT logs → App log panel
+        // catch-no-log-ok wrong PSK produces garbage bytes that fail protobuf decode — try next key
       }
     }
+    this.logSampledDebug(
+      'decrypt-protobuf-fail',
+      `[Meshtastic MQTT] Could not decrypt packet (protobuf decode failed for all ${allKeys.length} PSKs), nodeId=0x${from.toString(16)} packetId=${packetId >>> 0}`,
+    );
     return null;
+  }
+
+  private logSampledDebug(
+    key: string,
+    message: string,
+    intervalMs = NOISY_DEBUG_LOG_INTERVAL_MS,
+  ): void {
+    const now = Date.now();
+    const state = this.sampledDebugLogs.get(key);
+    if (!state) {
+      this.sampledDebugLogs.set(key, { lastLoggedAt: now, suppressedCount: 0 });
+      console.debug(message); // log-filter-ok Meshtastic MQTT logs → App log panel
+      return;
+    }
+
+    if (now - state.lastLoggedAt >= intervalMs) {
+      const suffix =
+        state.suppressedCount > 0
+          ? ` (suppressed ${state.suppressedCount} similar message${state.suppressedCount === 1 ? '' : 's'})`
+          : '';
+      console.debug(`${message}${suffix}`); // log-filter-ok Meshtastic MQTT logs → App log panel
+      state.lastLoggedAt = now;
+      state.suppressedCount = 0;
+      return;
+    }
+
+    state.suppressedCount += 1;
   }
 }

--- a/src/renderer/components/RawPacketLogPanel.test.tsx
+++ b/src/renderer/components/RawPacketLogPanel.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RxPacketEntry } from '../hooks/useMeshCore';
+import RawPacketLogPanel from './RawPacketLogPanel';
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: () => ({
+    getVirtualItems: () => [{ index: 0, start: 0 }],
+    getTotalSize: () => 36,
+    measureElement: () => {},
+  }),
+}));
+
+function hexToU8(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function meshcorePacket(rawHex: string, payloadTypeString: string): RxPacketEntry {
+  return {
+    ts: 1_710_000_000_000,
+    snr: 2.5,
+    rssi: -90,
+    raw: hexToU8(rawHex),
+    routeTypeString: 'FLOOD',
+    payloadTypeString,
+    hopCount: 1,
+    fromNodeId: null,
+    messageFingerprintHex: 'TEST1234',
+    transportScopeCode: null,
+    transportReturnCode: null,
+    advertName: null,
+    advertLat: null,
+    advertLon: null,
+    advertTimestampSec: null,
+    parseOk: true,
+  };
+}
+
+describe('RawPacketLogPanel meshcore expanded details', () => {
+  it('shows GRP_TXT channel hash plus MAC/ciphertext info', () => {
+    const packets = [
+      meshcorePacket(
+        '150107819d28f7a0d427af7cbd3c6057b29763736b3878eb027514687b110abe33456565ca1117316f81033b1de05496a57ab1c44335f53749008b593a19cd9c9e340d34f076',
+        'GRP_TXT',
+      ),
+    ];
+    render(
+      <RawPacketLogPanel
+        variant="meshcore"
+        packets={packets}
+        onClear={vi.fn()}
+        getNodeLabel={() => 'node'}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('GRP_TXT'));
+    expect(screen.getByText(/Channel hash:/)).toBeInTheDocument();
+    expect(screen.getByText(/MAC:/)).toBeInTheDocument();
+    expect(screen.getByText(/Ciphertext bytes:/)).toBeInTheDocument();
+  });
+
+  it('shows CONTROL subtype details for payload nibble 0xB', () => {
+    const packets = [
+      meshcorePacket(
+        '2e0092f3420d28240700fecd503efbf79ee0d400fbf0dfb7c1a3da95be0e71ab1ba8da3d1bd0d0b3',
+        'CONTROL',
+      ),
+    ];
+    render(
+      <RawPacketLogPanel
+        variant="meshcore"
+        packets={packets}
+        onClear={vi.fn()}
+        getNodeLabel={() => 'node'}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('CONTROL'));
+    expect(screen.getByText(/Control:/)).toBeInTheDocument();
+    expect(screen.getByText(/subtype=0x9\(DISCOVER_RESP\)/)).toBeInTheDocument();
+    expect(screen.getByText(/tag=0x24280D42/)).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/RawPacketLogPanel.tsx
+++ b/src/renderer/components/RawPacketLogPanel.tsx
@@ -7,6 +7,11 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { formatLogTimeOfDay } from '../../shared/formatLogTimestamp';
 import { parseMeshCoreRfPacket } from '../../shared/meshcoreRfPacketParse';
+import {
+  MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE,
+  MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE,
+  MESHCORE_PAYLOAD_TYPE_RESPONSE_NIBBLE,
+} from '../../shared/meshcoreRfPath';
 import type { RxPacketEntry } from '../hooks/useMeshCore';
 import { meshcoreRawPacketSenderColumnText } from '../lib/nodeLongNameOrHex';
 import type { MeshtasticRawPacketEntry } from '../lib/rawPacketLogConstants';
@@ -39,12 +44,35 @@ function innerPayloadFirstU32Hex(inner: Uint8Array): { be: string; le: string } 
   return { be, le };
 }
 
+function hexByte(byte: number): string {
+  return byte.toString(16).padStart(2, '0');
+}
+
 function MeshcoreExpandedDetails({ p }: { p: RxPacketEntry }) {
   if (!p.parseOk) return null;
   const reparsed = parseMeshCoreRfPacket(p.raw);
   const innerWords =
     reparsed.ok && reparsed.innerPayload.length >= 4
       ? innerPayloadFirstU32Hex(reparsed.innerPayload)
+      : null;
+  const inner = reparsed.ok ? reparsed.innerPayload : null;
+  const nibble = reparsed.ok ? reparsed.payloadTypeNibble : null;
+  const reqRespHashes =
+    inner != null &&
+    (nibble === 0 || nibble === MESHCORE_PAYLOAD_TYPE_RESPONSE_NIBBLE) &&
+    inner.length >= 2
+      ? { dest: hexByte(inner[0]), src: hexByte(inner[1]) }
+      : null;
+  const grpTxtChannelHash =
+    inner != null && nibble === MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE && inner.length >= 1
+      ? hexByte(inner[0])
+      : null;
+  const anonReqFields =
+    inner != null && nibble === MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE && inner.length >= 7
+      ? {
+          dest: hexByte(inner[0]),
+          senderKeyPrefix: toHex(inner.subarray(1, 7)),
+        }
       : null;
   return (
     <div className="mb-2 space-y-0.5 text-[10px] text-gray-400">
@@ -57,6 +85,23 @@ function MeshcoreExpandedDetails({ p }: { p: RxPacketEntry }) {
         <p title="First four bytes after path prefix; not a node id. Meaning depends on payload type.">
           <span className="text-muted">Inner first u32 (debug):</span>{' '}
           {`BE 0x${innerWords.be} · LE 0x${innerWords.le}`}
+        </p>
+      )}
+      {reqRespHashes != null && (
+        <p>
+          <span className="text-muted">Dest hash:</span> {reqRespHashes.dest}{' '}
+          <span className="text-muted">Src hash:</span> {reqRespHashes.src}
+        </p>
+      )}
+      {grpTxtChannelHash != null && (
+        <p>
+          <span className="text-muted">Channel hash:</span> {grpTxtChannelHash}
+        </p>
+      )}
+      {anonReqFields != null && (
+        <p>
+          <span className="text-muted">Dest hash:</span> {anonReqFields.dest}{' '}
+          <span className="text-muted">Sender key (prefix):</span> {anonReqFields.senderKeyPrefix}
         </p>
       )}
       {p.transportScopeCode != null && p.transportReturnCode != null && (

--- a/src/renderer/components/RawPacketLogPanel.tsx
+++ b/src/renderer/components/RawPacketLogPanel.tsx
@@ -9,6 +9,7 @@ import { formatLogTimeOfDay } from '../../shared/formatLogTimestamp';
 import { parseMeshCoreRfPacket } from '../../shared/meshcoreRfPacketParse';
 import {
   MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE,
+  MESHCORE_PAYLOAD_TYPE_CONTROL_NIBBLE,
   MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE,
   MESHCORE_PAYLOAD_TYPE_RESPONSE_NIBBLE,
 } from '../../shared/meshcoreRfPath';
@@ -48,6 +49,16 @@ function hexByte(byte: number): string {
   return byte.toString(16).padStart(2, '0');
 }
 
+function readU32LEAt(bytes: Uint8Array, offset: number): number | null {
+  if (offset + 4 > bytes.length) return null;
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return dv.getUint32(offset, true);
+}
+
+function toSignedI8(byte: number): number {
+  return byte > 127 ? byte - 256 : byte;
+}
+
 function MeshcoreExpandedDetails({ p }: { p: RxPacketEntry }) {
   if (!p.parseOk) return null;
   const reparsed = parseMeshCoreRfPacket(p.raw);
@@ -67,6 +78,14 @@ function MeshcoreExpandedDetails({ p }: { p: RxPacketEntry }) {
     inner != null && nibble === MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE && inner.length >= 1
       ? hexByte(inner[0])
       : null;
+  const grpTxtMac =
+    inner != null && nibble === MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE && inner.length >= 3
+      ? toHex(inner.subarray(1, 3))
+      : null;
+  const grpTxtCiphertextLen =
+    inner != null && nibble === MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE && inner.length >= 3
+      ? inner.length - 3
+      : null;
   const anonReqFields =
     inner != null && nibble === MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE && inner.length >= 7
       ? {
@@ -74,6 +93,38 @@ function MeshcoreExpandedDetails({ p }: { p: RxPacketEntry }) {
           senderKeyPrefix: toHex(inner.subarray(1, 7)),
         }
       : null;
+  const controlFields = (() => {
+    if (inner == null || nibble !== MESHCORE_PAYLOAD_TYPE_CONTROL_NIBBLE || inner.length < 1) {
+      return null;
+    }
+    const flags = inner[0];
+    const subtype = (flags >> 4) & 0x0f;
+    const subtypeName = subtype === 0x8 ? 'DISCOVER_REQ' : subtype === 0x9 ? 'DISCOVER_RESP' : null;
+    const prefixOnly = subtype === 0x8 ? (flags & 0x01) === 1 : null;
+    const nodeType = subtype === 0x9 ? flags & 0x0f : null;
+    const snrRaw = subtype === 0x9 && inner.length >= 2 ? toSignedI8(inner[1]) : null;
+    const tag = inner.length >= 6 ? readU32LEAt(inner, 2) : null;
+    const since = subtype === 0x8 && inner.length >= 10 ? readU32LEAt(inner, 6) : null;
+    const typeFilter = subtype === 0x8 && inner.length >= 2 ? inner[1] : null;
+    const pubkeyBytes = subtype === 0x9 && inner.length > 6 ? Math.min(32, inner.length - 6) : null;
+    const pubkeyPrefix =
+      subtype === 0x9 && inner.length > 6
+        ? toHex(inner.subarray(6, Math.min(inner.length, 12)))
+        : null;
+    return {
+      flags,
+      subtype,
+      subtypeName,
+      prefixOnly,
+      typeFilter,
+      nodeType,
+      snrRaw,
+      tag,
+      since,
+      pubkeyBytes,
+      pubkeyPrefix,
+    };
+  })();
   return (
     <div className="mb-2 space-y-0.5 text-[10px] text-gray-400">
       {p.messageFingerprintHex != null && (
@@ -98,10 +149,36 @@ function MeshcoreExpandedDetails({ p }: { p: RxPacketEntry }) {
           <span className="text-muted">Channel hash:</span> {grpTxtChannelHash}
         </p>
       )}
+      {grpTxtMac != null && (
+        <p>
+          <span className="text-muted">MAC:</span> {grpTxtMac}{' '}
+          <span className="text-muted">Ciphertext bytes:</span> {grpTxtCiphertextLen}
+        </p>
+      )}
       {anonReqFields != null && (
         <p>
           <span className="text-muted">Dest hash:</span> {anonReqFields.dest}{' '}
           <span className="text-muted">Sender key (prefix):</span> {anonReqFields.senderKeyPrefix}
+        </p>
+      )}
+      {controlFields != null && (
+        <p>
+          <span className="text-muted">Control:</span>{' '}
+          {`flags=0x${hexByte(controlFields.flags)} subtype=0x${controlFields.subtype.toString(16)}${controlFields.subtypeName != null ? `(${controlFields.subtypeName})` : ''}`}
+          {controlFields.typeFilter != null
+            ? ` type_filter=0x${hexByte(controlFields.typeFilter)}`
+            : ''}
+          {controlFields.prefixOnly != null
+            ? ` prefix_only=${String(controlFields.prefixOnly)}`
+            : ''}
+          {controlFields.nodeType != null ? ` node_type=${controlFields.nodeType}` : ''}
+          {controlFields.snrRaw != null ? ` snr=${(controlFields.snrRaw / 4).toFixed(2)}dB` : ''}
+          {controlFields.tag != null
+            ? ` tag=0x${controlFields.tag.toString(16).toUpperCase().padStart(8, '0')}`
+            : ''}
+          {controlFields.since != null ? ` since=${controlFields.since}` : ''}
+          {controlFields.pubkeyBytes != null ? ` pubkey_bytes=${controlFields.pubkeyBytes}` : ''}
+          {controlFields.pubkeyPrefix != null ? ` pubkey_prefix=${controlFields.pubkeyPrefix}` : ''}
         </p>
       )}
       {p.transportScopeCode != null && p.transportReturnCode != null && (

--- a/src/renderer/hooks/useMeshCore.stats.test.tsx
+++ b/src/renderer/hooks/useMeshCore.stats.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getSelfInfoMock = vi.fn();
 const getStatsCoreMock = vi.fn();
@@ -150,8 +150,11 @@ function makeMockSerialPort() {
 }
 
 describe('useMeshCore stats parsing', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([]);
     vi.mocked(window.electronAPI.db.getMeshcoreMessages).mockResolvedValue([]);
     getSelfInfoMock.mockResolvedValue({
@@ -202,6 +205,10 @@ describe('useMeshCore stats parsing', () => {
     });
   });
 
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it('hydrates queueStatus from the meshcore.js stats payload data field', async () => {
     const port = makeMockSerialPort();
     Object.defineProperty(navigator, 'serial', {
@@ -250,5 +257,10 @@ describe('useMeshCore stats parsing', () => {
       expect(result.current.state.status).toBe('configured');
       expect(result.current.queueStatus).toEqual({ free: 249, maxlen: 256, res: 0 });
     });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useMeshCore] fetchAndUpdateLocalStats radio/packet error:',
+      'radio stats timeout',
+    );
   });
 });

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -1149,7 +1149,15 @@ export function useMeshCore() {
     try {
       [radioStats, packetStats] = await Promise.all([conn.getStatsRadio(), conn.getStatsPackets()]);
     } catch (e: unknown) {
-      console.warn('[useMeshCore] fetchAndUpdateLocalStats radio/packet error', e);
+      const reason =
+        e instanceof Error
+          ? e.message
+          : typeof e === 'string'
+            ? e
+            : e == null
+              ? 'no error details'
+              : JSON.stringify(e);
+      console.warn('[useMeshCore] fetchAndUpdateLocalStats radio/packet error:', reason);
       return;
     }
 

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -44,6 +44,7 @@ import {
   parseMeshcoreGetNeighboursResponse,
 } from '../lib/meshcoreGetNeighboursBinary';
 import { readMeshcoreMqttSettingsFromStorage } from '../lib/meshcoreMqttSettingsStorage';
+import { meshcoreCorrelateOrSynthesizeChatEntry } from '../lib/meshcoreRawPacketCorrelate';
 import {
   meshcoreRawPacketLogFromBytesFallback,
   meshcoreRawPacketResolveFromParsed,
@@ -2230,6 +2231,7 @@ export function useMeshCore() {
 
       // Incoming DM — event 7
       conn.on(7, (data: unknown) => {
+        const now = Date.now();
         const d = data as {
           pubKeyPrefix: Uint8Array;
           text: string;
@@ -2311,10 +2313,32 @@ export function useMeshCore() {
             to: myNodeNumRef.current || undefined,
           }),
         );
+        const resolvedSenderId = senderId !== 0 ? senderId : null;
+        setRawPackets((prev) =>
+          meshcoreCorrelateOrSynthesizeChatEntry(prev, 'TXT_MSG', resolvedSenderId, {
+            ts: now,
+            snr: 0,
+            rssi: 0,
+            raw: new Uint8Array(0),
+            routeTypeString: null,
+            payloadTypeString: 'TXT_MSG',
+            hopCount: 0,
+            fromNodeId: resolvedSenderId,
+            messageFingerprintHex: null,
+            transportScopeCode: null,
+            transportReturnCode: null,
+            advertName: null,
+            advertLat: null,
+            advertLon: null,
+            advertTimestampSec: null,
+            parseOk: false,
+          }),
+        );
       });
 
       // Incoming channel message — event 8
       conn.on(8, (data: unknown) => {
+        const now = Date.now();
         const d = data as { channelIdx: number; text: string; senderTimestamp: number };
         if (isMeshcoreTransportStatusChatLine(d.text)) {
           logTransportLineAsDevice(d.text);
@@ -2346,6 +2370,26 @@ export function useMeshCore() {
             channel: d.channelIdx,
             timestamp: d.senderTimestamp * 1000,
             receivedVia: 'rf',
+          }),
+        );
+        setRawPackets((prev) =>
+          meshcoreCorrelateOrSynthesizeChatEntry(prev, 'GRP_TXT', stubId, {
+            ts: now,
+            snr: 0,
+            rssi: 0,
+            raw: new Uint8Array(0),
+            routeTypeString: null,
+            payloadTypeString: 'GRP_TXT',
+            hopCount: 0,
+            fromNodeId: stubId,
+            messageFingerprintHex: null,
+            transportScopeCode: null,
+            transportReturnCode: null,
+            advertName: null,
+            advertLat: null,
+            advertLon: null,
+            advertTimestampSec: null,
+            parseOk: false,
           }),
         );
       });

--- a/src/renderer/lib/meshcoreRawPacketCorrelate.test.ts
+++ b/src/renderer/lib/meshcoreRawPacketCorrelate.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ChatCorrelateRxLike,
+  MESHCORE_CHAT_CORRELATE_WINDOW_MS,
+  meshcoreCorrelateOrSynthesizeChatEntry,
+} from './meshcoreRawPacketCorrelate';
+import { MAX_RAW_PACKET_LOG_ENTRIES } from './rawPacketLogConstants';
+
+function entry(
+  partial: Partial<ChatCorrelateRxLike> & Pick<ChatCorrelateRxLike, 'ts'>,
+): ChatCorrelateRxLike {
+  return {
+    payloadTypeString: 'TXT_MSG',
+    fromNodeId: null,
+    ...partial,
+  };
+}
+
+function synth(ts: number): ChatCorrelateRxLike {
+  return { ts, payloadTypeString: 'TXT_MSG', fromNodeId: 0xabc };
+}
+
+const WINDOW = MESHCORE_CHAT_CORRELATE_WINDOW_MS;
+
+describe('meshcoreCorrelateOrSynthesizeChatEntry', () => {
+  it('backfills fromNodeId on the most recent unattributed TXT_MSG within window', () => {
+    const base: ChatCorrelateRxLike[] = [entry({ ts: 1000 }), entry({ ts: 2000 })];
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(
+      base,
+      'TXT_MSG',
+      0xdeadbeef,
+      synth(2100),
+      WINDOW,
+    );
+    expect(result).toHaveLength(2);
+    expect(result[1].fromNodeId).toBe(0xdeadbeef);
+    expect(result[0].fromNodeId).toBeNull();
+  });
+
+  it('backfills the last unattributed entry, not earlier ones', () => {
+    const base: ChatCorrelateRxLike[] = [
+      entry({ ts: 1000 }),
+      entry({ ts: 1500 }),
+      entry({ ts: 2000 }),
+    ];
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(
+      base,
+      'TXT_MSG',
+      0x1111,
+      synth(2050),
+      WINDOW,
+    );
+    expect(result[2].fromNodeId).toBe(0x1111);
+    expect(result[1].fromNodeId).toBeNull();
+    expect(result[0].fromNodeId).toBeNull();
+  });
+
+  it('does not touch entries outside the window', () => {
+    const old = entry({ ts: 0 });
+    const base: ChatCorrelateRxLike[] = [old];
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(
+      base,
+      'TXT_MSG',
+      0x1234,
+      synth(WINDOW + 1),
+      WINDOW,
+    );
+    // Out of window -> appends synthetic
+    expect(result).toHaveLength(2);
+    expect(result[0].fromNodeId).toBeNull();
+    expect(result[1].fromNodeId).toBe(0xabc);
+  });
+
+  it('does not overwrite an entry that already has fromNodeId', () => {
+    const base: ChatCorrelateRxLike[] = [entry({ ts: 1000, fromNodeId: 0x9999 })];
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(
+      base,
+      'TXT_MSG',
+      0x1111,
+      synth(1100),
+      WINDOW,
+    );
+    // Already attributed -> appends synthetic
+    expect(result).toHaveLength(2);
+    expect(result[0].fromNodeId).toBe(0x9999);
+  });
+
+  it('appends synthetic when no matching entry exists', () => {
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(
+      [],
+      'TXT_MSG',
+      0xabc,
+      synth(5000),
+      WINDOW,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].fromNodeId).toBe(0xabc);
+    expect(result[0].payloadTypeString).toBe('TXT_MSG');
+  });
+
+  it('appends synthetic when only entry has wrong payload type', () => {
+    const base: ChatCorrelateRxLike[] = [entry({ ts: 1000, payloadTypeString: 'ADVERT' })];
+    const grpSynth: ChatCorrelateRxLike = { ts: 1200, payloadTypeString: 'GRP_TXT', fromNodeId: 7 };
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(base, 'GRP_TXT', 7, grpSynth, WINDOW);
+    expect(result).toHaveLength(2);
+    expect(result[1].payloadTypeString).toBe('GRP_TXT');
+  });
+
+  it('works for GRP_TXT payload type', () => {
+    const base: ChatCorrelateRxLike[] = [entry({ ts: 1000, payloadTypeString: 'GRP_TXT' })];
+    const grpSynth: ChatCorrelateRxLike = {
+      ts: 1100,
+      payloadTypeString: 'GRP_TXT',
+      fromNodeId: 55,
+    };
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(base, 'GRP_TXT', 55, grpSynth, WINDOW);
+    expect(result).toHaveLength(1);
+    expect(result[0].fromNodeId).toBe(55);
+  });
+
+  it('caps array at MAX_RAW_PACKET_LOG_ENTRIES when synthetic is appended', () => {
+    const base: ChatCorrelateRxLike[] = Array.from({ length: MAX_RAW_PACKET_LOG_ENTRIES }, (_, i) =>
+      entry({ ts: i, payloadTypeString: 'ADVERT' }),
+    );
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(
+      base,
+      'TXT_MSG',
+      1,
+      synth(MAX_RAW_PACKET_LOG_ENTRIES + 1),
+      WINDOW,
+    );
+    expect(result).toHaveLength(MAX_RAW_PACKET_LOG_ENTRIES);
+    expect(result[result.length - 1].payloadTypeString).toBe('TXT_MSG');
+  });
+
+  it('passes null fromNodeId through to synthetic when sender is unknown', () => {
+    const result = meshcoreCorrelateOrSynthesizeChatEntry(
+      [],
+      'TXT_MSG',
+      null,
+      { ts: 1000, payloadTypeString: 'TXT_MSG', fromNodeId: null },
+      WINDOW,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].fromNodeId).toBeNull();
+  });
+});

--- a/src/renderer/lib/meshcoreRawPacketCorrelate.ts
+++ b/src/renderer/lib/meshcoreRawPacketCorrelate.ts
@@ -1,0 +1,42 @@
+import { MAX_RAW_PACKET_LOG_ENTRIES } from './rawPacketLogConstants';
+
+/** Correlation window: event 7/8 must arrive within this many ms of the matching event 136. */
+export const MESHCORE_CHAT_CORRELATE_WINDOW_MS = 1500;
+
+/** Minimal shape needed for chat-entry correlation (avoids importing RxPacketEntry from useMeshCore). */
+export interface ChatCorrelateRxLike {
+  ts: number;
+  payloadTypeString: string | null;
+  fromNodeId: number | null;
+}
+
+/**
+ * Correlate an incoming DM (event 7) or channel message (event 8) with raw packet log entries.
+ *
+ * Two outcomes:
+ * - If a recent unattributed entry of the matching payload type is found within `windowMs`, its
+ *   `fromNodeId` is backfilled (fixes "no sender name" for TXT_MSG/GRP_TXT rows).
+ * - If no match is found, `synthetic` is appended (fixes chat packets missing from raw log).
+ */
+export function meshcoreCorrelateOrSynthesizeChatEntry<T extends ChatCorrelateRxLike>(
+  prev: T[],
+  payloadTypeString: 'TXT_MSG' | 'GRP_TXT',
+  fromNodeId: number | null,
+  synthetic: T,
+  windowMs: number = MESHCORE_CHAT_CORRELATE_WINDOW_MS,
+): T[] {
+  const now = synthetic.ts;
+  for (let i = prev.length - 1; i >= 0; i--) {
+    const e = prev[i];
+    if (now - e.ts > windowMs) break;
+    if (e.payloadTypeString === payloadTypeString && e.fromNodeId === null) {
+      const updated = prev.slice();
+      updated[i] = { ...e, fromNodeId };
+      return updated;
+    }
+  }
+  const next = [...prev, synthetic];
+  return next.length > MAX_RAW_PACKET_LOG_ENTRIES
+    ? next.slice(next.length - MAX_RAW_PACKET_LOG_ENTRIES)
+    : next;
+}

--- a/src/renderer/lib/meshcoreRawPacketSender.test.ts
+++ b/src/renderer/lib/meshcoreRawPacketSender.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { meshcoreRawPacketResolveFromNodeId } from './meshcoreRawPacketSender';
+import { parseMeshCoreRfPacket } from '../../shared/meshcoreRfPacketParse';
+import {
+  meshcoreRawPacketResolveFromNodeId,
+  meshcoreRawPacketResolveFromParsed,
+} from './meshcoreRawPacketSender';
 import { pubkeyToNodeId } from './meshcoreUtils';
 import { MESHCORE_PAYLOAD_TYPE_ADVERT } from './rawPacketLogConstants';
 
@@ -54,5 +58,44 @@ describe('meshcoreRawPacketResolveFromNodeId', () => {
         new Map(),
       ),
     ).toBeNull();
+  });
+});
+
+describe('meshcoreRawPacketResolveFromParsed', () => {
+  it('resolves ANON_REQ sender from inner[1:33] sender_pubkey', () => {
+    const senderKey = new Uint8Array(32);
+    for (let i = 0; i < senderKey.length; i++) senderKey[i] = (i * 11 + 3) & 0xff;
+
+    const raw = new Uint8Array(2 + 1 + senderKey.length + 2 + 1);
+    raw[0] = 0x1d; // FLOOD + ANON_REQ nibble
+    raw[1] = 0x00; // path length 0, hash size 1
+    raw[2] = 0x03; // dest hash
+    raw.set(senderKey, 3);
+    raw[35] = 0x88; // mac[0]
+    raw[36] = 0x71; // mac[1]
+    raw[37] = 0x06; // ciphertext[0]
+
+    const parsed = parseMeshCoreRfPacket(raw);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const expected = pubkeyToNodeId(senderKey);
+    expect(expected).not.toBe(0);
+    const wrongOffsetId = pubkeyToNodeId(parsed.innerPayload.subarray(0, 32));
+    expect(wrongOffsetId).not.toBe(expected);
+    expect(meshcoreRawPacketResolveFromParsed(parsed, new Map())).toBe(expected);
+  });
+
+  it('skips GRP_TXT prefix map lookup from inner[0:6]', () => {
+    const raw = new Uint8Array([
+      0x15, 0x00, 0x11, 0x13, 0x37, 0xa7, 0x09, 0xeb, 0x7f, 0x50, 0xa1, 0xa9,
+    ]);
+    const parsed = parseMeshCoreRfPacket(raw);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const prefixHex = Array.from(parsed.innerPayload.subarray(0, 6))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    const map = new Map<string, number>([[prefixHex, 0x11223344]]);
+    expect(meshcoreRawPacketResolveFromParsed(parsed, map)).toBeNull();
   });
 });

--- a/src/renderer/lib/meshcoreRawPacketSender.ts
+++ b/src/renderer/lib/meshcoreRawPacketSender.ts
@@ -1,6 +1,8 @@
 import type { MeshCoreRfParseOk } from '../../shared/meshcoreRfPacketParse';
 import {
   decodeMeshCorePathPrefix,
+  MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE,
+  MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE,
   meshCorePayloadTypeNibble,
   meshCorePayloadTypeStringFromByte0,
   meshCoreRouteTypeStringFromByte0,
@@ -58,7 +60,20 @@ export function meshcoreRawPacketResolveFromParsed(
     if (id !== 0) return id;
     const mapped = pubKeyPrefixMap.get(pubkeyPrefixHex6(key)) ?? 0;
     if (mapped !== 0) return mapped;
-  } else if (inner.length >= 6) {
+  } else if (parsed.payloadTypeNibble === MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE) {
+    // ANON_REQ inner: dest_hash(1) | sender_pubkey(32) | mac(2) | ciphertext
+    if (inner.length >= 33) {
+      const key = inner.subarray(1, 33);
+      const id = pubkeyToNodeId(key);
+      if (id !== 0) return id;
+      const mapped = pubKeyPrefixMap.get(pubkeyPrefixHex6(key)) ?? 0;
+      if (mapped !== 0) return mapped;
+    }
+  } else if (
+    parsed.payloadTypeNibble !== MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE &&
+    inner.length >= 6
+  ) {
+    // GRP_TXT inner starts with channel_hash, not a pubkey prefix — skip prefix lookup
     const mapped = pubKeyPrefixMap.get(pubkeyPrefixHex6(inner)) ?? 0;
     if (mapped !== 0) return mapped;
   }
@@ -97,7 +112,24 @@ export function meshcoreRawPacketLogFromBytesFallback(
           if (mapped !== 0) fromNodeId = mapped;
         }
       }
-    } else if (raw.length >= pathEndOffset + 6) {
+    } else if (payloadNibble === MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE) {
+      // ANON_REQ inner: dest_hash(1) | sender_pubkey(32) | mac(2) | ciphertext
+      if (raw.length >= pathEndOffset + 33) {
+        const key = raw.subarray(pathEndOffset + 1, pathEndOffset + 33);
+        const id = pubkeyToNodeId(key);
+        if (id !== 0) {
+          fromNodeId = id;
+        } else {
+          const prefix = pubkeyPrefixHex6(key);
+          const mapped = pubKeyPrefixMap.get(prefix) ?? 0;
+          if (mapped !== 0) fromNodeId = mapped;
+        }
+      }
+    } else if (
+      payloadNibble !== MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE &&
+      raw.length >= pathEndOffset + 6
+    ) {
+      // GRP_TXT inner starts with channel_hash, not a pubkey prefix — skip prefix lookup
       const inner = raw.subarray(pathEndOffset);
       const mapped = pubKeyPrefixMap.get(pubkeyPrefixHex6(inner)) ?? 0;
       if (mapped !== 0) fromNodeId = mapped;

--- a/src/shared/meshcoreRfPacketParse.test.ts
+++ b/src/shared/meshcoreRfPacketParse.test.ts
@@ -70,6 +70,22 @@ describe('parseMeshCoreRfPacket', () => {
       0;
     expect(innerBeU32).toBe(0x111337a7);
   });
+
+  it('maps byte0 nibble 1 to RESPONSE label', () => {
+    const p = parseMeshCoreRfPacket(new Uint8Array([0x05, 0x00, 0xaa, 0xbb, 0xcc]));
+    expect(p.ok).toBe(true);
+    if (!p.ok) return;
+    expect(p.payloadTypeNibble).toBe(1);
+    expect(p.payloadTypeString).toBe('RESPONSE');
+  });
+
+  it('maps byte0 nibble 7 to ANON_REQ label', () => {
+    const p = parseMeshCoreRfPacket(new Uint8Array([0x1d, 0x00, 0x03, 0x88, 0x71, 0x06, 0xdb]));
+    expect(p.ok).toBe(true);
+    if (!p.ok) return;
+    expect(p.payloadTypeNibble).toBe(7);
+    expect(p.payloadTypeString).toBe('ANON_REQ');
+  });
 });
 
 describe('meshCoreTransportCodeForRegion', () => {

--- a/src/shared/meshcoreRfPacketParse.test.ts
+++ b/src/shared/meshcoreRfPacketParse.test.ts
@@ -86,6 +86,38 @@ describe('parseMeshCoreRfPacket', () => {
     expect(p.payloadTypeNibble).toBe(7);
     expect(p.payloadTypeString).toBe('ANON_REQ');
   });
+
+  it('maps byte0 nibble 6 to GRP_DATA label', () => {
+    const p = parseMeshCoreRfPacket(new Uint8Array([0x19, 0x00, 0xaa]));
+    expect(p.ok).toBe(true);
+    if (!p.ok) return;
+    expect(p.payloadTypeNibble).toBe(6);
+    expect(p.payloadTypeString).toBe('GRP_DATA');
+  });
+
+  it('maps byte0 nibble 0xA to MULTIPART label', () => {
+    const p = parseMeshCoreRfPacket(new Uint8Array([0x29, 0x00, 0xaa]));
+    expect(p.ok).toBe(true);
+    if (!p.ok) return;
+    expect(p.payloadTypeNibble).toBe(10);
+    expect(p.payloadTypeString).toBe('MULTIPART');
+  });
+
+  it('maps byte0 nibble 0xB to CONTROL label', () => {
+    const p = parseMeshCoreRfPacket(new Uint8Array([0x2d, 0x00, 0x92, 0xf3]));
+    expect(p.ok).toBe(true);
+    if (!p.ok) return;
+    expect(p.payloadTypeNibble).toBe(11);
+    expect(p.payloadTypeString).toBe('CONTROL');
+  });
+
+  it('maps byte0 nibble 0xF to RAW_CUSTOM label', () => {
+    const p = parseMeshCoreRfPacket(new Uint8Array([0x3d, 0x00, 0xaa]));
+    expect(p.ok).toBe(true);
+    if (!p.ok) return;
+    expect(p.payloadTypeNibble).toBe(15);
+    expect(p.payloadTypeString).toBe('RAW_CUSTOM');
+  });
 });
 
 describe('meshCoreTransportCodeForRegion', () => {

--- a/src/shared/meshcoreRfPath.ts
+++ b/src/shared/meshcoreRfPath.ts
@@ -14,6 +14,10 @@ export const PAYLOAD_TYPE_TRACE = 0x09;
 export const MESHCORE_PAYLOAD_TYPE_ADVERT_NIBBLE = 4;
 /** Align with `@liamcottle/meshcore.js` `Packet.PAYLOAD_TYPE_GRP_TXT` (0x05). */
 export const MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE = 5;
+/** Response to REQ_RESP or ANON_REQ (nibble 1). Inner: dest_hash(1)|src_hash(1)|mac(2)|ciphertext. */
+export const MESHCORE_PAYLOAD_TYPE_RESPONSE_NIBBLE = 1;
+/** Anonymous request with plaintext sender pubkey (nibble 7). Inner: dest_hash(1)|sender_pubkey(32)|mac(2)|ciphertext. */
+export const MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE = 7;
 
 const ROUTE_TYPE_TRANSPORT_FLOOD = 0x00;
 const ROUTE_TYPE_TRANSPORT_DIRECT = 0x03;
@@ -110,12 +114,16 @@ export function meshCorePayloadTypeStringFromByte0(byte0: number): string {
   switch (t) {
     case 0:
       return 'REQ_RESP';
+    case MESHCORE_PAYLOAD_TYPE_RESPONSE_NIBBLE:
+      return 'RESPONSE';
     case 2:
       return 'TXT_MSG';
     case 4:
       return 'ADVERT';
     case MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE:
       return 'GRP_TXT';
+    case MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE:
+      return 'ANON_REQ';
     case 8:
       return 'PATH';
     case 9:

--- a/src/shared/meshcoreRfPath.ts
+++ b/src/shared/meshcoreRfPath.ts
@@ -14,10 +14,18 @@ export const PAYLOAD_TYPE_TRACE = 0x09;
 export const MESHCORE_PAYLOAD_TYPE_ADVERT_NIBBLE = 4;
 /** Align with `@liamcottle/meshcore.js` `Packet.PAYLOAD_TYPE_GRP_TXT` (0x05). */
 export const MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE = 5;
+/** Group datagram payload type nibble (0x06). */
+export const MESHCORE_PAYLOAD_TYPE_GRP_DATA_NIBBLE = 6;
 /** Response to REQ_RESP or ANON_REQ (nibble 1). Inner: dest_hash(1)|src_hash(1)|mac(2)|ciphertext. */
 export const MESHCORE_PAYLOAD_TYPE_RESPONSE_NIBBLE = 1;
 /** Anonymous request with plaintext sender pubkey (nibble 7). Inner: dest_hash(1)|sender_pubkey(32)|mac(2)|ciphertext. */
 export const MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE = 7;
+/** Multipart payload type nibble (0x0a). */
+export const MESHCORE_PAYLOAD_TYPE_MULTIPART_NIBBLE = 10;
+/** Control payload type nibble (0x0b). */
+export const MESHCORE_PAYLOAD_TYPE_CONTROL_NIBBLE = 11;
+/** Raw custom payload type nibble (0x0f). */
+export const MESHCORE_PAYLOAD_TYPE_RAW_CUSTOM_NIBBLE = 15;
 
 const ROUTE_TYPE_TRANSPORT_FLOOD = 0x00;
 const ROUTE_TYPE_TRANSPORT_DIRECT = 0x03;
@@ -122,12 +130,20 @@ export function meshCorePayloadTypeStringFromByte0(byte0: number): string {
       return 'ADVERT';
     case MESHCORE_PAYLOAD_TYPE_GRP_TXT_NIBBLE:
       return 'GRP_TXT';
+    case MESHCORE_PAYLOAD_TYPE_GRP_DATA_NIBBLE:
+      return 'GRP_DATA';
     case MESHCORE_PAYLOAD_TYPE_ANON_REQ_NIBBLE:
       return 'ANON_REQ';
     case 8:
       return 'PATH';
     case 9:
       return 'TRACE';
+    case MESHCORE_PAYLOAD_TYPE_MULTIPART_NIBBLE:
+      return 'MULTIPART';
+    case MESHCORE_PAYLOAD_TYPE_CONTROL_NIBBLE:
+      return 'CONTROL';
+    case MESHCORE_PAYLOAD_TYPE_RAW_CUSTOM_NIBBLE:
+      return 'RAW_CUSTOM';
     default:
       return `PAYLOAD_0x${t.toString(16)}`;
   }


### PR DESCRIPTION
## Summary

This branch improves MeshCore raw-packet decoding and correlation for chat/debug flows, and reduces noisy Meshtastic MQTT decrypt/JSON logs plus clearer MeshCore local-stats warnings when radio/packet stats fail.

## Commits on this branch (`origin/main..HEAD`)

- `750ed57` — **fix:** sample Meshtastic MQTT decrypt/decode and JSON handling; normalize stats fetch warnings in `useMeshCore`.
- `013ec7d` — **fix(meshcore):** decode CONTROL payloads in packet sniffer.
- `bb2df76` — **fix(meshcore):** resolve ANON_REQ sender and label raw packet inners.
- `60fc8f5` — **fix(meshcore):** correlate event 7/8 with raw packet log for chat sender resolution.

## What changed

**MeshCore / diagnostics**

- Correlate firmware events with raw packet log entries where applicable for clearer sender attribution.
- Improve ANON_REQ and inner payload labeling in the raw packet path.
- Decode CONTROL payloads in the packet sniffer so they are not opaque noise.

**Meshtastic MQTT / logging**

- Sample repeated debug lines for ServiceEnvelope decode failures, failed decrypt-after-all-PSKs, and noisy JSON cases (e.g. empty `type`, `traceroute`).
- Case-insensitive JSON `type` routing; explicit ignore paths for known non-node payloads.

**Renderer**

- `fetchAndUpdateLocalStats`: warn with a normalized reason string when `getStatsRadio` / `getStatsPackets` reject (avoids `undefined` in logs).

## Why

Shared MQTT traffic and wrong PSK attempts produce high-volume decrypt noise that drowns real issues; sampling keeps logs usable. MeshCore fixes close gaps between firmware events and raw logs for debugging chat and control traffic.

## How to test

- `pnpm run lint` and `pnpm run test:run` (pre-commit covers these).
- Exercise MeshCore BLE/serial: confirm raw packet panel and chat correlation behave as before; spot-check logs for reduced MQTT spam when subscribed to busy topics.
- Connect Meshtastic MQTT to a busy channel: confirm decrypt lines are sampled, not per-packet floods.

## Risks / follow-ups

- Sampled logs may hide rapid distinct failures that share the same sampling key; increase log level or adjust keys if we need finer granularity in support scenarios.
- MeshCore behavior depends on firmware; verify on your target radio if something still looks uncorrelated.