### PR TITLE
chore: remove debug instrumentation + sync docs after dep-upgrade merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Enter your broker URL, topic, and optional credentials in the MQTT section of th
 | Component  | Technology                                                                                                                         |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Desktop    | Electron                                                                                                                           |
-| UI         | React 19 + TypeScript                                                                                                              |
+| UI         | React 19 + TypeScript 6                                                                                                            |
 | Styling    | Tailwind CSS v4                                                                                                                    |
 | Meshtastic | @meshtastic/core + transport-http, transport-web-serial (JSR); BLE via @stoprocent/noble (macOS/Windows) and Web Bluetooth (Linux) |
 | MeshCore   | @liamcottle/meshcore.js (BLE, Web Serial, TCP via main-process IPC)                                                                |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,7 +8,7 @@ contributor guide lives in the repository at
 
 ## Local Setup
 
-- Use Node 22 (`22.12.0+` recommended).
+- Use Node 22 (`22.13.0+` recommended; see `package.json` `engines.node`).
 - Install dependencies: `pnpm install`
 - Start dev mode: `pnpm run dev`
 

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -25,7 +25,9 @@ We were inspired by features from these projects:
 
 ## Libraries & Tools
 
-### Runtime Dependencies
+Exact semver ranges live in [`package.json`](https://github.com/Colorado-Mesh/mesh-client/blob/main/package.json) at the repository root; the tables below mirror them for attribution.
+
+### Runtime dependencies
 
 | Package               | Version                                  | License      | Description                     |
 | --------------------- | ---------------------------------------- | ------------ | ------------------------------- |
@@ -39,27 +41,52 @@ We were inspired by features from these projects:
 | node-forge            | ^1.4.0                                   | BSD-3-Clause | Crypto utilities                |
 | systeminformation     | ^5.31.5                                  | MIT          | System info gathering           |
 
-### Development Dependencies
+### Development dependencies
 
 | Package                          | Version                                            | License    | Description                      |
 | -------------------------------- | -------------------------------------------------- | ---------- | -------------------------------- |
-| @axe-core/react                  | ^4.11.1                                            | MIT        | Accessibility testing            |
+| @axe-core/react                  | ^4.11.2                                            | MIT        | Accessibility testing            |
+| @eslint/js                       | ^10.0.1                                            | MIT        | ESLint flat-config helpers       |
 | @liamcottle/meshcore.js          | ^1.13.0                                            | MIT        | MeshCore JS library              |
 | @meshtastic/core                 | npm:@jsr/meshtastic\_\_core@^2.6.6                 | Apache-2.0 | Meshtastic core                  |
 | @meshtastic/transport-http       | npm:@jsr/meshtastic\_\_transport-http@^0.2.1       | Apache-2.0 | HTTP transport                   |
 | @meshtastic/transport-web-serial | npm:@jsr/meshtastic\_\_transport-web-serial@^0.2.5 | Apache-2.0 | Web Serial transport             |
-| @michaelhart/meshcore-decoder    | ^0.2.7                                             | MIT        | MeshCore decoder                 |
+| @michaelhart/meshcore-decoder    | ^0.3.0                                             | MIT        | MeshCore decoder                 |
 | @tailwindcss/postcss             | ^4.2.2                                             | MIT        | Tailwind CSS for PostCSS         |
-| @tanstack/react-virtual          | ^3.13.23                                           | MIT        | Virtual scrolling for React      |
+| @tanstack/react-virtual          | ^3.13.24                                           | MIT        | Virtual scrolling for React      |
+| @testing-library/jest-dom        | ^6.9.1                                             | MIT        | Jest DOM matchers                |
+| @testing-library/react           | ^16.3.2                                            | MIT        | React testing utilities          |
+| @testing-library/user-event      | ^14.6.1                                            | MIT        | User event simulation            |
 | @types/leaflet                   | ^1.9.21                                            | ISC        | TypeScript types for Leaflet     |
-| @types/node                      | ^22.19.17                                          | MIT        | TypeScript types for Node.js     |
+| @types/node                      | ^24.12.2                                           | MIT        | TypeScript types for Node.js     |
 | @types/node-forge                | ^1.3.14                                            | MIT        | TypeScript types for node-forge  |
 | @types/react                     | ^19.2.14                                           | MIT        | TypeScript types for React       |
 | @types/react-dom                 | ^19.2.3                                            | MIT        | TypeScript types for React DOM   |
-| @vitejs/plugin-react             | ^5.2.0                                             | MIT        | Vite React plugin                |
+| @typescript-eslint/eslint-plugin | ^8.58.2                                            | MIT        | ESLint TypeScript plugin         |
+| @typescript-eslint/parser        | ^8.58.2                                            | MIT        | ESLint TypeScript parser         |
+| @vitejs/plugin-react             | ^6.0.1                                             | MIT        | Vite React plugin                |
 | concurrently                     | ^9.2.1                                             | MIT        | Run multiple commands            |
+| electron                         | ^41.2.1                                            | MIT        | Desktop app framework            |
+| electron-builder                 | ^26.8.1                                            | MIT        | Electron app packaging           |
+| esbuild                          | ^0.28.0                                            | MIT        | Bundler                          |
+| eslint                           | ^10.2.1                                            | MIT        | Linter                           |
+| eslint-config-prettier           | ^10.1.8                                            | MIT        | Prettier ESLint config           |
+| eslint-plugin-electron           | ^7.0.0                                             | MIT        | ESLint Electron rules            |
+| eslint-plugin-import             | ^2.32.0                                            | MIT        | ESLint import rules              |
+| eslint-plugin-jsx-a11y           | ^6.10.2                                            | MIT        | ESLint JSX accessibility         |
+| eslint-plugin-no-secrets         | ^2.3.3                                             | MIT        | Detect hardcoded secrets         |
+| eslint-plugin-prettier           | ^5.5.5                                             | MIT        | ESLint Prettier integration      |
+| eslint-plugin-react              | ^7.37.5                                            | MIT        | ESLint React rules               |
+| eslint-plugin-react-hooks        | ^7.1.1                                             | MIT        | ESLint React hooks               |
+| eslint-plugin-security           | ^4.0.0                                             | MIT        | ESLint security rules            |
+| eslint-plugin-simple-import-sort | ^13.0.0                                            | MIT        | ESLint import sorting            |
+| eslint-plugin-vitest             | ^0.5.4                                             | MIT        | ESLint Vitest rules              |
+| jsdom                            | ^29.0.2                                            | MIT        | DOM for Node.js                  |
 | leaflet                          | ^1.9.4                                             | ISC        | Interactive maps                 |
-| prettier                         | ^3.8.2                                             | MIT        | Code formatter                   |
+| license-checker-rseidelsohn      | ^4.4.2                                             | MIT        | License checking                 |
+| markdownlint-cli2                | ^0.22.0                                            | MIT        | Markdown linting                 |
+| postcss                          | ^8.5.10                                            | MIT        | CSS processing                   |
+| prettier                         | ^3.8.3                                             | MIT        | Code formatter                   |
 | prettier-plugin-sh               | ^0.18.1                                            | MIT        | Prettier shell script support    |
 | prettier-plugin-tailwindcss      | ^0.7.2                                             | MIT        | Prettier Tailwind class ordering |
 | react                            | ^19.2.5                                            | MIT        | UI framework                     |
@@ -68,57 +95,9 @@ We were inspired by features from these projects:
 | recharts                         | ^3.8.1                                             | MIT        | Charting library                 |
 | sort-package-json                | ^3.6.1                                             | MIT        | Sort package.json                |
 | tailwindcss                      | ^4.2.2                                             | MIT        | CSS framework                    |
-| typescript                       | ^5.9.3                                             | Apache-2.0 | Type checking                    |
-| vite                             | ^7.3.2                                             | MIT        | Build tool                       |
+| typescript                       | ^6.0.3                                             | Apache-2.0 | Type checking                    |
+| typescript-eslint                | ^8.58.2                                            | MIT        | ESLint flat-config helper        |
+| vite                             | ^8.0.8                                             | MIT        | Build tool                       |
+| vitest                           | ^4.1.4                                             | MIT        | Testing framework                |
+| vitest-axe                       | 1.0.0-pre.5                                        | MIT        | Vitest accessibility testing     |
 | zustand                          | ^5.0.12                                            | MIT        | State management                 |
-
-### Testing
-
-| Package                     | Version     | License | Description                  |
-| --------------------------- | ----------- | ------- | ---------------------------- |
-| @testing-library/jest-dom   | ^6.9.1      | MIT     | Jest DOM matchers            |
-| @testing-library/react      | ^16.3.2     | MIT     | React testing utilities      |
-| @testing-library/user-event | ^14.6.1     | MIT     | User event simulation        |
-| jsdom                       | ^25.0.1     | MIT     | DOM for Node.js              |
-| vitest                      | ^4.1.4      | MIT     | Testing framework            |
-| vitest-axe                  | 1.0.0-pre.5 | MIT     | Vitest accessibility testing |
-
-### Build & Tooling
-
-| Package          | Version  | License | Description            |
-| ---------------- | -------- | ------- | ---------------------- |
-| electron         | ^40.8.5  | MIT     | Desktop app framework  |
-| electron-builder | ^26.8.1  | MIT     | Electron app packaging |
-| esbuild          | ^0.25.12 | MIT     | Bundler                |
-| postcss          | ^8.5.9   | MIT     | CSS processing         |
-
-### Linting & Code Quality
-
-| Package                          | Version | License | Description                 |
-| -------------------------------- | ------- | ------- | --------------------------- |
-| @typescript-eslint/eslint-plugin | ^8.58.1 | MIT     | ESLint TypeScript plugin    |
-| @typescript-eslint/parser        | ^8.58.1 | MIT     | ESLint TypeScript parser    |
-| eslint                           | ^9.39.4 | MIT     | Linter                      |
-| eslint-config-prettier           | ^10.1.8 | MIT     | Prettier ESLint config      |
-| eslint-plugin-electron           | ^7.0.0  | MIT     | ESLint Electron rules       |
-| eslint-plugin-import             | ^2.32.0 | MIT     | ESLint import rules         |
-| eslint-plugin-jsx-a11y           | ^6.10.2 | MIT     | ESLint JSX accessibility    |
-| eslint-plugin-no-secrets         | ^2.3.3  | MIT     | Detect hardcoded secrets    |
-| eslint-plugin-prettier           | ^5.5.5  | MIT     | ESLint Prettier integration |
-| eslint-plugin-react              | ^7.37.5 | MIT     | ESLint React rules          |
-| eslint-plugin-react-hooks        | ^5.2.0  | MIT     | ESLint React hooks          |
-| eslint-plugin-security           | ^4.0.0  | MIT     | ESLint security rules       |
-| eslint-plugin-simple-import-sort | ^12.1.1 | MIT     | ESLint import sorting       |
-| eslint-plugin-vitest             | ^0.5.4  | MIT     | ESLint Vitest rules         |
-| markdownlint-cli2                | ^0.22.0 | MIT     | Markdown linting            |
-| license-checker-rseidelsohn      | ^4.4.2  | MIT     | License checking            |
-
-### Transport & Mesh Libraries
-
-| Package                          | Version                                            | License    | Description          |
-| -------------------------------- | -------------------------------------------------- | ---------- | -------------------- |
-| @liamcottle/meshcore.js          | ^1.13.0                                            | MIT        | MeshCore JS library  |
-| @meshtastic/core                 | npm:@jsr/meshtastic\_\_core@^2.6.6                 | Apache-2.0 | Meshtastic core      |
-| @meshtastic/transport-http       | npm:@jsr/meshtastic\_\_transport-http@^0.2.1       | Apache-2.0 | HTTP transport       |
-| @meshtastic/transport-web-serial | npm:@jsr/meshtastic\_\_transport-web-serial@^0.2.5 | Apache-2.0 | Web Serial transport |
-| @michaelhart/meshcore-decoder    | ^0.2.7                                             | MIT        | MeshCore decoder     |

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -9,7 +9,7 @@ These requirements apply to all platforms.
 ### 1) Required software
 
 - Git
-- Node.js **22.12.0+** (match [CI](https://github.com/Colorado-Mesh/mesh-client/blob/main/.github/workflows/ci.yaml); `CONTRIBUTING.md` recommends the same)
+- Node.js **22.13.0+** (`package.json` `engines.node`; [CI](https://github.com/Colorado-Mesh/mesh-client/blob/main/.github/workflows/ci.yaml) uses Node 22)
 - pnpm **10+**
 - Python 3 + `pip` (needed for MkDocs documentation build and yamllint)
 
@@ -323,7 +323,7 @@ These scripts try to install optional tooling automatically. If they fail (for e
    ```bash
    xcode-select --install
    ```
-2. Install Node 22 (22.12.0+ recommended via nvm) and npm:
+2. Install Node 22 (22.13.0+ recommended via nvm) and npm:
    ```bash
    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
    export NVM_DIR="$HOME/.nvm"
@@ -440,7 +440,7 @@ Fix:
 
 ### Install prerequisites
 
-Install Node 22 (22.12.0+ recommended), `make`, and C++ build tools (`g++`/`gcc-c++`) with native build dependencies.
+Install Node 22 (22.13.0+ recommended), `make`, and C++ build tools (`g++`/`gcc-c++`) with native build dependencies.
 
 Debian/Ubuntu:
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -424,6 +424,7 @@ export default function App() {
   }, [protocol, capabilities]);
 
   const activePanelIndex = tabIndexToPanelIndex[activeTab] ?? 0;
+  const prevPanelIndexForChatFreezeRef = useRef(activePanelIndex);
 
   useEffect(() => {
     activeTabRef.current = activeTab;
@@ -450,7 +451,8 @@ export default function App() {
     if (activeTab >= displayTabNames.length) {
       const savedTab =
         protocol === 'meshcore' ? lastMeshcoreTab.current : lastMeshtasticTab.current;
-      setActiveTab(savedTab < displayTabNames.length ? savedTab : 0);
+      const next = savedTab < displayTabNames.length ? savedTab : 0;
+      setActiveTab(next);
     }
   }, [activeTab, displayTabNames.length, protocol]);
 
@@ -581,24 +583,34 @@ export default function App() {
     nodes: typeof nodesForUi;
   } | null>(null);
 
+  // Chat tab freeze: run BEFORE protocol reset on the same commit so protocol clear wins when both fire.
   useEffect(() => {
-    queueMicrotask(() => {
-      setChatTabVisited(false);
-      setChatPanelFreeze(null);
-    });
-  }, [protocol]);
+    const was = prevPanelIndexForChatFreezeRef.current;
+    const now = activePanelIndex;
+    prevPanelIndexForChatFreezeRef.current = now;
 
-  useEffect(() => {
-    if (activePanelIndex !== 1) return;
-    queueMicrotask(() => {
+    if (now === 1) {
       setChatTabVisited(true);
+    }
+
+    if (was === 1 && now !== 1) {
       setChatPanelFreeze({
         messages: device.messages,
         channels: chatChannels,
         nodes: nodesForUi,
       });
-    });
-  }, [activePanelIndex, device.messages, chatChannels, nodesForUi, device]);
+    }
+    // Intentionally only activePanelIndex: snapshot is taken on tab transition, not on every
+    // messages/nodes identity change (that caused an infinite setState loop on Chat).
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- freeze capture uses render snapshot at leave
+  }, [activePanelIndex]);
+
+  useEffect(() => {
+    setChatTabVisited(false);
+    setChatPanelFreeze(null);
+    prevPanelIndexForChatFreezeRef.current = activePanelIndex;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- protocol-only reset; capture current panel for ref sync
+  }, [protocol]);
 
   const isChatPanelFrozen = chatTabVisited && activePanelIndex !== 1;
   const freeze = chatPanelFreeze;


### PR DESCRIPTION
## Summary

Follow-up to the merged dependency upgrade work ([original PR](https://github.com/Colorado-Mesh/mesh-client/pull/332)): two commits that were prepared on `dep-upgrade` but landed only after the branch was merged.

## Commits (cherry-picked)

1. **`chore: remove NDJSON debug instrumentation from App`** — Drops localhost NDJSON `fetch` logging from `App.tsx` (post Chat-freeze investigation).
2. **`docs: align credits and Node requirement with package.json`** — Refreshes `docs/credits.md` from `package.json`, sets Node **22.13.0+** in contributor docs, notes TypeScript 6 in README.

## Verify

```bash
pnpm run lint
pnpm run typecheck
pnpm run lint:md
```