### PR TITLE
fix: preserve MeshCore hops and add signal propagation UI

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2459,7 +2459,7 @@ ipcMain.handle('db:saveNode', (_event, node) => {
     `);
     return stmt.run({
       role: null,
-      hops_away: null,
+      hops_away: node.hops_away ?? null,
       rssi: null,
       voltage: null,
       channel_utilization: null,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2472,7 +2472,7 @@ ipcMain.handle('db:saveNode', (_event, node) => {
       num_packets_tx: null,
       ...node,
       via_mqtt: node.via_mqtt != null ? (node.via_mqtt ? 1 : 0) : null,
-      hops: node.hops ?? null,
+      hops: node.hops ?? node.hops_away ?? null,
       path: node.path != null ? JSON.stringify(node.path) : null,
     });
   } catch (err) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -352,6 +352,52 @@ export default function App() {
   const handleCollapsedWatermarkActivate = useCallback(() => {
     setSignalPulseKey((prev) => prev ?? Date.now());
   }, []);
+  const [meshTubeLit, setMeshTubeLit] = useState(false);
+  const [meshTubePhase, setMeshTubePhase] = useState<'idle' | 'flicker-on' | 'flicker-off'>('idle');
+  const meshTubePhaseRef = useRef(meshTubePhase);
+  const meshTubeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useLayoutEffect(() => {
+    meshTubePhaseRef.current = meshTubePhase;
+  }, [meshTubePhase]);
+
+  const handleMeshTubeToggle = useCallback(() => {
+    if (meshTubePhase !== 'idle') return;
+    if (!meshTubeLit) {
+      setMeshTubePhase('flicker-on');
+      meshTubeTimeoutRef.current = setTimeout(() => {
+        meshTubeTimeoutRef.current = null;
+        setMeshTubeLit(true);
+        setMeshTubePhase('idle');
+      }, 1500);
+    } else {
+      setMeshTubePhase('flicker-off');
+      meshTubeTimeoutRef.current = setTimeout(() => {
+        meshTubeTimeoutRef.current = null;
+        setMeshTubeLit(false);
+        setMeshTubePhase('idle');
+      }, 1500);
+    }
+  }, [meshTubeLit, meshTubePhase]);
+
+  useEffect(() => {
+    return () => {
+      if (meshTubeTimeoutRef.current) clearTimeout(meshTubeTimeoutRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!sidebarCollapsed) return;
+    if (meshTubeTimeoutRef.current) {
+      clearTimeout(meshTubeTimeoutRef.current);
+      meshTubeTimeoutRef.current = null;
+    }
+    const phase = meshTubePhaseRef.current;
+    if (phase === 'flicker-on') setMeshTubeLit(false);
+    if (phase === 'flicker-off') setMeshTubeLit(true);
+    setMeshTubePhase('idle');
+  }, [sidebarCollapsed]);
+
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [searchModalOpen, setSearchModalOpen] = useState(false);
@@ -1214,15 +1260,13 @@ export default function App() {
         >
           {/* Sidebar-area branding — top-left cell, matches sidebar width */}
           <div
-            aria-hidden={sidebarCollapsed ? false : true}
+            aria-hidden={false}
             className={`bg-deep-black -my-2 flex shrink-0 items-center justify-center self-stretch border-r border-slate-800 transition-[width] duration-300 select-none ${
               sidebarCollapsed ? 'w-16' : 'w-48'
             }`}
           >
-            <div
-              className={`cm-watermark ${sidebarCollapsed ? 'cm-watermark-collapsed' : 'cm-watermark-expanded'}`}
-            >
-              {sidebarCollapsed ? (
+            {sidebarCollapsed ? (
+              <div className="cm-watermark cm-watermark-collapsed">
                 <button
                   type="button"
                   className="m-0 inline-flex cursor-pointer appearance-none border-0 bg-transparent p-0"
@@ -1231,13 +1275,32 @@ export default function App() {
                 >
                   <ColoradoMeshWatermarkMark />
                 </button>
-              ) : (
+                <span className="cm-watermark-text" aria-hidden>
+                  Colorado Mesh
+                </span>
+              </div>
+            ) : (
+              <button
+                type="button"
+                aria-busy={meshTubePhase !== 'idle'}
+                aria-pressed={meshTubeLit}
+                aria-label={
+                  meshTubeLit ? 'Turn off Colorado Mesh sign' : 'Turn on Colorado Mesh sign'
+                }
+                className={[
+                  'cm-watermark cm-watermark-expanded cm-watermark-mesh-tube',
+                  meshTubePhase === 'flicker-on' && 'cm-watermark-mesh-tube--flicker-on',
+                  meshTubePhase === 'flicker-off' && 'cm-watermark-mesh-tube--flicker-off',
+                  meshTubeLit && meshTubePhase === 'idle' && 'cm-watermark-mesh-tube--lit',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                onClick={handleMeshTubeToggle}
+              >
                 <ColoradoMeshWatermarkMark />
-              )}
-              <span className="cm-watermark-text" aria-hidden={sidebarCollapsed}>
-                Colorado Mesh
-              </span>
-            </div>
+                <span className="cm-watermark-text">Colorado Mesh</span>
+              </button>
+            )}
           </div>
           <div className="flex min-w-0 flex-1 justify-start pl-8">
             {/* Protocol context switcher — centered in the gap (narrow) or viewport (xl+ grid) */}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import { HelpTooltip } from './components/HelpTooltip';
 import Sidebar from './components/Sidebar';
 import { LinkIcon } from './components/SignalBars';
+import SignalPropagation from './components/SignalPropagation';
 import { ToastProvider, useToast } from './components/Toast';
 import UpdateStatusIndicator from './components/UpdateStatusIndicator';
 import { useContactGroups } from './hooks/useContactGroups';
@@ -236,6 +237,102 @@ function MqttGlobeIcon({ status }: { status: MQTTStatus }) {
   );
 }
 
+/** Header watermark graphic (collapsed sidebar shows mark; expanded hides via CSS). */
+function ColoradoMeshWatermarkMark() {
+  return (
+    <svg
+      className="cm-watermark-mark"
+      viewBox="0 0 1024 1024"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient
+          id="cmWmMtnGrad"
+          x1="0"
+          y1="0"
+          x2="1"
+          y2="0"
+          gradientUnits="userSpaceOnUse"
+          gradientTransform="matrix(510.141384,0,0,227.403089,280.365777,471.821953)"
+        >
+          <stop offset="0" stopColor="#83ff80" />
+          <stop offset="1" stopColor="#101928" />
+        </linearGradient>
+        <linearGradient
+          id="cmWmArcAlpha"
+          x1="0"
+          y1="0.5"
+          x2="1"
+          y2="0.5"
+          gradientUnits="objectBoundingBox"
+        >
+          <stop offset="0" stopColor="#fff" stopOpacity="0" />
+          <stop offset="0.5" stopColor="#fff" stopOpacity="0.28" />
+          <stop offset="1" stopColor="#fff" stopOpacity="0" />
+        </linearGradient>
+        <mask
+          id="cmWmArcMask"
+          maskUnits="objectBoundingBox"
+          maskContentUnits="objectBoundingBox"
+          x="0"
+          y="0"
+          width="1"
+          height="1"
+        >
+          <rect x="0" y="0" width="1" height="1" fill="url(#cmWmArcAlpha)" />
+        </mask>
+      </defs>
+      <g className="cm-watermark-arches">
+        <g transform="matrix(1.482714,0,0,2.228662,-282.713188,-686.490072)">
+          <path
+            d="M248,604C296.733,449.457 436.333,440.225 508.333,440.225"
+            fill="none"
+            className="cm-watermark-brand-stroke"
+            strokeWidth="14"
+            strokeLinecap="round"
+            vectorEffect="nonScalingStroke"
+            mask="url(#cmWmArcMask)"
+          />
+        </g>
+        <g transform="matrix(-1.482714,0,0,2.124862,1291.713188,-642.794439)">
+          <path
+            d="M248,604C296.733,449.457 436.333,440.225 508.333,440.225"
+            fill="none"
+            className="cm-watermark-brand-stroke"
+            strokeWidth="14"
+            strokeLinecap="round"
+            vectorEffect="nonScalingStroke"
+            mask="url(#cmWmArcMask)"
+          />
+        </g>
+      </g>
+      <g transform="matrix(1.550828,0,0,1.550828,-296.433233,-165.128779)">
+        <path
+          d="M790.245,583.702C790.333,584.309 790.42,584.916 790.507,585.523C788.044,584.513 733.186,553.111 681.69,519.21C640.083,491.819 640.501,491.448 600.434,461.629C596.33,458.575 606.541,489.356 604.241,496.419C601.789,503.946 564.411,456.477 544.209,439.898C540.087,436.514 522.666,450.746 522.214,451.051C503.617,463.621 500.856,442.079 492.1,427.753C485.685,417.259 482.119,427.358 340.171,535.067C300.15,565.436 261.15,599.171 290.779,571.715C325.553,539.491 434.357,430.948 458.868,407.89C503.865,365.56 507.371,354.727 520.344,358.977C527.829,361.43 715.775,533.16 790.245,583.702Z"
+          fill="url(#cmWmMtnGrad)"
+          fillRule="evenodd"
+        />
+      </g>
+      <g transform="matrix(0.451809,0,0,0.451809,273.173684,146.688318)">
+        <circle cx="512" cy="332" r="38" className="cm-watermark-sun" />
+      </g>
+      <g transform="matrix(0.523438,0,0,0.523438,236.5,122.907726)">
+        <circle
+          cx="512"
+          cy="332"
+          r="64"
+          fill="none"
+          className="cm-watermark-brand-stroke"
+          strokeWidth="12"
+          vectorEffect="nonScalingStroke"
+        />
+      </g>
+    </svg>
+  );
+}
+
 export default function App() {
   const [activeTab, setActiveTab] = useState(0);
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
@@ -247,6 +344,13 @@ export default function App() {
       localStorage.setItem('mesh-client:sidebarCollapsed', String(next));
       return next;
     });
+  }, []);
+  const [signalPulseKey, setSignalPulseKey] = useState<number | null>(null);
+  const handleSignalPulseComplete = useCallback(() => {
+    setSignalPulseKey(null);
+  }, []);
+  const handleCollapsedWatermarkActivate = useCallback(() => {
+    setSignalPulseKey((prev) => prev ?? Date.now());
   }, []);
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
@@ -1094,6 +1198,9 @@ export default function App() {
         protocol={protocol}
         onResult={handleFirmwareResult}
       />
+      {signalPulseKey !== null && (
+        <SignalPropagation key={signalPulseKey} onComplete={handleSignalPulseComplete} />
+      )}
       <div className="flex h-screen w-screen min-w-0 flex-col overflow-hidden bg-slate-950">
         {/* Header - full width; sidebar + main start below */}
         <header
@@ -1107,7 +1214,7 @@ export default function App() {
         >
           {/* Sidebar-area branding — top-left cell, matches sidebar width */}
           <div
-            aria-hidden="true"
+            aria-hidden={sidebarCollapsed ? false : true}
             className={`bg-deep-black -my-2 flex shrink-0 items-center justify-center self-stretch border-r border-slate-800 transition-[width] duration-300 select-none ${
               sidebarCollapsed ? 'w-16' : 'w-48'
             }`}
@@ -1115,96 +1222,18 @@ export default function App() {
             <div
               className={`cm-watermark ${sidebarCollapsed ? 'cm-watermark-collapsed' : 'cm-watermark-expanded'}`}
             >
-              <svg
-                className="cm-watermark-mark"
-                viewBox="0 0 1024 1024"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                aria-hidden="true"
-              >
-                <defs>
-                  <linearGradient
-                    id="cmWmMtnGrad"
-                    x1="0"
-                    y1="0"
-                    x2="1"
-                    y2="0"
-                    gradientUnits="userSpaceOnUse"
-                    gradientTransform="matrix(510.141384,0,0,227.403089,280.365777,471.821953)"
-                  >
-                    <stop offset="0" stopColor="#83ff80" />
-                    <stop offset="1" stopColor="#101928" />
-                  </linearGradient>
-                  <linearGradient
-                    id="cmWmArcAlpha"
-                    x1="0"
-                    y1="0.5"
-                    x2="1"
-                    y2="0.5"
-                    gradientUnits="objectBoundingBox"
-                  >
-                    <stop offset="0" stopColor="#fff" stopOpacity="0" />
-                    <stop offset="0.5" stopColor="#fff" stopOpacity="0.28" />
-                    <stop offset="1" stopColor="#fff" stopOpacity="0" />
-                  </linearGradient>
-                  <mask
-                    id="cmWmArcMask"
-                    maskUnits="objectBoundingBox"
-                    maskContentUnits="objectBoundingBox"
-                    x="0"
-                    y="0"
-                    width="1"
-                    height="1"
-                  >
-                    <rect x="0" y="0" width="1" height="1" fill="url(#cmWmArcAlpha)" />
-                  </mask>
-                </defs>
-                <g className="cm-watermark-arches">
-                  <g transform="matrix(1.482714,0,0,2.228662,-282.713188,-686.490072)">
-                    <path
-                      d="M248,604C296.733,449.457 436.333,440.225 508.333,440.225"
-                      fill="none"
-                      className="cm-watermark-brand-stroke"
-                      strokeWidth="14"
-                      strokeLinecap="round"
-                      vectorEffect="nonScalingStroke"
-                      mask="url(#cmWmArcMask)"
-                    />
-                  </g>
-                  <g transform="matrix(-1.482714,0,0,2.124862,1291.713188,-642.794439)">
-                    <path
-                      d="M248,604C296.733,449.457 436.333,440.225 508.333,440.225"
-                      fill="none"
-                      className="cm-watermark-brand-stroke"
-                      strokeWidth="14"
-                      strokeLinecap="round"
-                      vectorEffect="nonScalingStroke"
-                      mask="url(#cmWmArcMask)"
-                    />
-                  </g>
-                </g>
-                <g transform="matrix(1.550828,0,0,1.550828,-296.433233,-165.128779)">
-                  <path
-                    d="M790.245,583.702C790.333,584.309 790.42,584.916 790.507,585.523C788.044,584.513 733.186,553.111 681.69,519.21C640.083,491.819 640.501,491.448 600.434,461.629C596.33,458.575 606.541,489.356 604.241,496.419C601.789,503.946 564.411,456.477 544.209,439.898C540.087,436.514 522.666,450.746 522.214,451.051C503.617,463.621 500.856,442.079 492.1,427.753C485.685,417.259 482.119,427.358 340.171,535.067C300.15,565.436 261.15,599.171 290.779,571.715C325.553,539.491 434.357,430.948 458.868,407.89C503.865,365.56 507.371,354.727 520.344,358.977C527.829,361.43 715.775,533.16 790.245,583.702Z"
-                    fill="url(#cmWmMtnGrad)"
-                    fillRule="evenodd"
-                  />
-                </g>
-                <g transform="matrix(0.451809,0,0,0.451809,273.173684,146.688318)">
-                  <circle cx="512" cy="332" r="38" className="cm-watermark-sun" />
-                </g>
-                <g transform="matrix(0.523438,0,0,0.523438,236.5,122.907726)">
-                  <circle
-                    cx="512"
-                    cy="332"
-                    r="64"
-                    fill="none"
-                    className="cm-watermark-brand-stroke"
-                    strokeWidth="12"
-                    vectorEffect="nonScalingStroke"
-                  />
-                </g>
-              </svg>
+              {sidebarCollapsed ? (
+                <button
+                  type="button"
+                  className="m-0 inline-flex cursor-pointer appearance-none border-0 bg-transparent p-0"
+                  aria-label="Play mesh signal pulse animation"
+                  onClick={handleCollapsedWatermarkActivate}
+                >
+                  <ColoradoMeshWatermarkMark />
+                </button>
+              ) : (
+                <ColoradoMeshWatermarkMark />
+              )}
               <span className="cm-watermark-text" aria-hidden={sidebarCollapsed}>
                 Colorado Mesh
               </span>

--- a/src/renderer/components/SignalPropagation.tsx
+++ b/src/renderer/components/SignalPropagation.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef } from 'react';
+
+export interface SignalPropagationProps {
+  /** Called once when the wave radius exceeds the viewport diagonal (plus glow padding). */
+  onComplete?: () => void;
+}
+
+const DURATION_MS = 2200;
+
+/**
+ * Full-screen canvas pulse from the top-left (0, 0). Animation state lives in refs + rAF only.
+ */
+export default function SignalPropagation({ onComplete }: SignalPropagationProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rafRef = useRef<number>(0);
+  const startTimeRef = useRef<number | null>(null);
+  const maxRadiusRef = useRef(1);
+  const completedRef = useRef(false);
+  const onCompleteRef = useRef(onComplete);
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d', { alpha: true });
+    if (!ctx) return;
+
+    const syncSize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      const bw = Math.max(1, Math.floor(w * dpr));
+      const bh = Math.max(1, Math.floor(h * dpr));
+      canvas.width = bw;
+      canvas.height = bh;
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+      maxRadiusRef.current = Math.hypot(w, h) + 96;
+    };
+
+    syncSize();
+
+    const onResize = () => {
+      syncSize();
+    };
+    window.addEventListener('resize', onResize);
+
+    const draw = (radiusCssPx: number) => {
+      const dpr = window.devicePixelRatio || 1;
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+
+      // Illumination: brief brightening as the wave front passes (radial band from origin).
+      ctx.save();
+      ctx.globalCompositeOperation = 'screen';
+      const innerG = Math.max(0, radiusCssPx - 140);
+      const outerG = radiusCssPx + 120;
+      const glow = ctx.createRadialGradient(0, 0, innerG, 0, 0, outerG);
+      glow.addColorStop(0, 'rgba(0, 255, 0, 0)');
+      glow.addColorStop(0.42, 'rgba(120, 255, 140, 0.045)');
+      glow.addColorStop(0.52, 'rgba(200, 255, 200, 0.1)');
+      glow.addColorStop(0.62, 'rgba(120, 255, 140, 0.04)');
+      glow.addColorStop(1, 'rgba(0, 255, 0, 0)');
+      ctx.fillStyle = glow;
+      ctx.fillRect(0, 0, w, h);
+      ctx.restore();
+
+      // Trail: wider, softer ring slightly inside the leading edge (decay behind the pulse).
+      const trailR = radiusCssPx - 22;
+      if (trailR > 1) {
+        ctx.save();
+        ctx.globalCompositeOperation = 'screen';
+        ctx.beginPath();
+        ctx.arc(0, 0, trailR, 0, Math.PI * 2);
+        ctx.strokeStyle = 'rgba(0, 255, 0, 0.2)';
+        ctx.lineWidth = 32;
+        ctx.shadowBlur = 48;
+        ctx.shadowColor = 'rgba(0, 255, 0, 0.35)';
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      // Primary ring: Meshtastic green + glow.
+      ctx.save();
+      ctx.globalCompositeOperation = 'screen';
+      ctx.beginPath();
+      ctx.arc(0, 0, Math.max(0, radiusCssPx), 0, Math.PI * 2);
+      ctx.strokeStyle = '#00FF00';
+      ctx.lineWidth = 3.5;
+      ctx.shadowBlur = 32;
+      ctx.shadowColor = '#66ff66';
+      ctx.stroke();
+      ctx.restore();
+    };
+
+    const finish = () => {
+      if (completedRef.current) return;
+      completedRef.current = true;
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      onCompleteRef.current?.();
+    };
+
+    const tick = (now: number) => {
+      if (completedRef.current) return;
+
+      startTimeRef.current ??= now;
+
+      const t = now - startTimeRef.current;
+      const maxR = maxRadiusRef.current;
+      const u = Math.min(1, t / DURATION_MS);
+      // Ease-out so the leading edge stays crisp near the end.
+      const eased = 1 - (1 - u) * (1 - u);
+      const radiusCssPx = eased * maxR;
+
+      draw(radiusCssPx);
+
+      if (radiusCssPx >= maxR - 0.5) {
+        finish();
+        return;
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      window.removeEventListener('resize', onResize);
+      if (!completedRef.current) {
+        completedRef.current = true;
+        onCompleteRef.current?.();
+      }
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-[9999]"
+    />
+  );
+}

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -4113,7 +4113,7 @@ export function useMeshCore() {
         /** `outPathLen` from the matching radio contact when we consult `getContacts` (may diverge from UI `hops_away`). */
         let radioContactPathLen: number | null = null;
         /** Multi-hop trace needs the radio’s route bytes; the single-byte pubkey fallback only works for direct peers. */
-        if ((!storedPath || storedPath.length === 0) && (hopsAway == null || hopsAway >= 1)) {
+        if ((!storedPath || storedPath.length <= 1) && (hopsAway == null || hopsAway >= 1)) {
           try {
             const contactsRaw = await conn.getContacts();
             const contacts = contactsRaw.map(meshcoreContactRawFromDevice);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -133,3 +133,176 @@
   opacity: 1;
   transform: scale(1);
 }
+
+/* Expanded header: "Colorado Mesh" cold-cathode / gas-tube toggle (glow via filter drop-shadow only) */
+button.cm-watermark-mesh-tube {
+  box-sizing: border-box;
+  width: 100%;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  font: inherit;
+  margin: 0;
+  text-align: center;
+}
+
+.cm-watermark-mesh-tube .cm-watermark-text {
+  text-shadow: none;
+  transition:
+    color 220ms ease,
+    filter 220ms ease;
+}
+
+.cm-watermark-mesh-tube:not(.cm-watermark-mesh-tube--lit):not(
+    .cm-watermark-mesh-tube--flicker-on
+  ):not(.cm-watermark-mesh-tube--flicker-off)
+  .cm-watermark-text {
+  color: rgb(95 130 125 / 0.92);
+  filter: drop-shadow(0 0 1px rgb(60 100 110 / 0.12));
+}
+
+.cm-watermark-mesh-tube--lit {
+  border-color: rgb(100 190 210 / 0.42);
+  background: linear-gradient(135deg, rgb(12 38 52 / 0.55), rgb(22 58 78 / 0.38));
+  box-shadow:
+    inset 0 1px 0 rgb(180 230 255 / 0.07),
+    0 4px 14px rgb(2 6 23 / 0.2);
+  filter: drop-shadow(0 0 2px rgb(0 255 235 / 0.85)) drop-shadow(0 0 8px rgb(70 210 255 / 0.55))
+    drop-shadow(0 0 16px rgb(100 190 255 / 0.28));
+}
+
+.cm-watermark-mesh-tube--lit .cm-watermark-text {
+  color: rgb(215 255 252 / 0.98);
+}
+
+@keyframes cm-watermark-mesh-tube-flicker-on {
+  0% {
+    filter: drop-shadow(0 0 1px rgb(0 160 180 / 0.12));
+    border-color: rgb(148 163 184 / 0.2);
+  }
+  4% {
+    filter: drop-shadow(0 0 4px rgb(0 240 230 / 0.45));
+  }
+  7% {
+    filter: drop-shadow(0 0 1px rgb(0 80 100 / 0.08));
+  }
+  10% {
+    filter: drop-shadow(0 0 6px rgb(0 255 240 / 0.55));
+  }
+  14% {
+    filter: drop-shadow(0 0 2px rgb(0 120 150 / 0.15));
+  }
+  18% {
+    filter: drop-shadow(0 0 8px rgb(80 230 255 / 0.5));
+  }
+  22% {
+    filter: drop-shadow(0 0 1px rgb(0 60 90 / 0.1));
+  }
+  28% {
+    filter: drop-shadow(0 0 10px rgb(0 255 245 / 0.58));
+  }
+  34% {
+    filter: drop-shadow(0 0 3px rgb(0 140 170 / 0.22));
+  }
+  40% {
+    filter: drop-shadow(0 0 9px rgb(100 220 255 / 0.52));
+  }
+  48% {
+    filter: drop-shadow(0 0 2px rgb(0 100 130 / 0.14));
+  }
+  56% {
+    filter: drop-shadow(0 0 11px rgb(0 250 245 / 0.62));
+  }
+  64% {
+    filter: drop-shadow(0 0 5px rgb(60 200 230 / 0.38));
+  }
+  72% {
+    filter: drop-shadow(0 0 12px rgb(90 215 255 / 0.58));
+  }
+  82% {
+    filter: drop-shadow(0 0 6px rgb(0 200 225 / 0.42));
+  }
+  92% {
+    filter: drop-shadow(0 0 14px rgb(120 225 255 / 0.62));
+  }
+  100% {
+    filter: drop-shadow(0 0 2px rgb(0 255 235 / 0.85)) drop-shadow(0 0 8px rgb(70 210 255 / 0.55))
+      drop-shadow(0 0 16px rgb(100 190 255 / 0.28));
+    border-color: rgb(100 190 210 / 0.42);
+  }
+}
+
+@keyframes cm-watermark-mesh-tube-flicker-off {
+  0% {
+    filter: drop-shadow(0 0 2px rgb(0 255 235 / 0.85)) drop-shadow(0 0 8px rgb(70 210 255 / 0.55))
+      drop-shadow(0 0 16px rgb(100 190 255 / 0.28));
+    border-color: rgb(100 190 210 / 0.42);
+  }
+  8% {
+    filter: drop-shadow(0 0 12px rgb(100 220 255 / 0.55));
+  }
+  16% {
+    filter: drop-shadow(0 0 3px rgb(0 120 150 / 0.2));
+  }
+  24% {
+    filter: drop-shadow(0 0 10px rgb(0 245 240 / 0.5));
+  }
+  32% {
+    filter: drop-shadow(0 0 2px rgb(0 90 110 / 0.12));
+  }
+  42% {
+    filter: drop-shadow(0 0 9px rgb(80 210 255 / 0.45));
+  }
+  52% {
+    filter: drop-shadow(0 0 4px rgb(0 150 180 / 0.25));
+  }
+  62% {
+    filter: drop-shadow(0 0 6px rgb(0 220 230 / 0.38));
+  }
+  74% {
+    filter: drop-shadow(0 0 2px rgb(0 70 95 / 0.1));
+  }
+  86% {
+    filter: drop-shadow(0 0 5px rgb(0 200 215 / 0.28));
+  }
+  100% {
+    filter: drop-shadow(0 0 1px rgb(60 100 110 / 0.12));
+    border-color: rgb(148 163 184 / 0.13);
+  }
+}
+
+.cm-watermark-mesh-tube--flicker-on {
+  animation: cm-watermark-mesh-tube-flicker-on 1.5s ease-out forwards;
+}
+
+.cm-watermark-mesh-tube--flicker-on .cm-watermark-text {
+  color: rgb(200 250 248 / 0.95);
+  animation: cm-watermark-mesh-tube-text-flicker-on 1.5s ease-out forwards;
+}
+
+.cm-watermark-mesh-tube--flicker-off {
+  animation: cm-watermark-mesh-tube-flicker-off 1.5s ease-in forwards;
+}
+
+.cm-watermark-mesh-tube--flicker-off .cm-watermark-text {
+  color: rgb(95 130 125 / 0.92);
+  animation: cm-watermark-mesh-tube-text-flicker-off 1.5s ease-in forwards;
+}
+
+@keyframes cm-watermark-mesh-tube-text-flicker-on {
+  0% {
+    color: rgb(95 130 125 / 0.85);
+  }
+  100% {
+    color: rgb(215 255 252 / 0.98);
+  }
+}
+
+@keyframes cm-watermark-mesh-tube-text-flicker-off {
+  0% {
+    color: rgb(215 255 252 / 0.98);
+  }
+  100% {
+    color: rgb(95 130 125 / 0.92);
+  }
+}


### PR DESCRIPTION
## Summary
- fix: preserve MeshCore hops from node.hops_away on save
- fix(meshcore): refresh radio path when storedPath is 1-byte and node changes
- fix: persist hops_away to database on node save
- feat: add gas-tube flicker toggle for expanded Colorado Mesh watermark
- feat: add collapsed-logo signal propagation pulse