### PR TITLE
fix: restore protocol state memory and clarify null sender handling

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -565,14 +565,19 @@ export default function App() {
   }, [protocol, meshcoreDevice.selfInfo, meshcoreDevice.meshcoreContactsForTelemetry]);
 
   const capabilities = useRadioProvider(protocol);
+  const meshtasticCapabilities = useRadioProvider('meshtastic');
+  const meshcoreCapabilities = useRadioProvider('meshcore');
 
-  const { displayTabNames, tabIndexToPanelIndex } = useMemo(() => {
+  const computeTabMappings = (
+    targetProtocol: MeshProtocol,
+    targetCapabilities: ProtocolCapabilities,
+  ) => {
     const filtered: { name: string; panelIndex: number }[] = [];
     TAB_NAMES.forEach((name, panelIndex) => {
       const requiredCap = TAB_CAPABILITY_REQUIREMENTS[panelIndex];
-      if (requiredCap === undefined || capabilities[requiredCap]) {
+      if (requiredCap === undefined || targetCapabilities[requiredCap]) {
         filtered.push({
-          name: panelIndex === 5 && protocol === 'meshcore' ? 'Repeaters' : name,
+          name: panelIndex === 5 && targetProtocol === 'meshcore' ? 'Repeaters' : name,
           panelIndex,
         });
       }
@@ -581,7 +586,20 @@ export default function App() {
       displayTabNames: filtered.map((t) => t.name),
       tabIndexToPanelIndex: filtered.map((t) => t.panelIndex),
     };
-  }, [protocol, capabilities]);
+  };
+
+  const meshtasticTabs = useMemo(
+    () => computeTabMappings('meshtastic', meshtasticCapabilities),
+    [meshtasticCapabilities],
+  );
+  const meshcoreTabs = useMemo(
+    () => computeTabMappings('meshcore', meshcoreCapabilities),
+    [meshcoreCapabilities],
+  );
+
+  const { displayTabNames, tabIndexToPanelIndex } = useMemo(() => {
+    return protocol === 'meshcore' ? meshcoreTabs : meshtasticTabs;
+  }, [protocol, meshtasticTabs, meshcoreTabs]);
 
   const activePanelIndex = tabIndexToPanelIndex[activeTab] ?? 0;
   const prevPanelIndexForChatFreezeRef = useRef(activePanelIndex);
@@ -616,21 +634,24 @@ export default function App() {
       const savedPanel =
         protocol === 'meshcore' ? lastMeshcorePanel.current : lastMeshtasticPanel.current;
       let next = 0;
+      const targetTabs = protocol === 'meshcore' ? meshcoreTabs : meshtasticTabs;
 
       if (savedPanel != null) {
-        const foundFilteredIndex = tabIndexToPanelIndex.findIndex((p) => p === savedPanel);
-        if (foundFilteredIndex !== -1 && foundFilteredIndex < displayTabNames.length) {
+        const foundFilteredIndex = targetTabs.tabIndexToPanelIndex.findIndex(
+          (p) => p === savedPanel,
+        );
+        if (foundFilteredIndex !== -1 && foundFilteredIndex < targetTabs.displayTabNames.length) {
           next = foundFilteredIndex;
         }
       } else {
         const savedTab =
           protocol === 'meshcore' ? lastMeshcoreTab.current : lastMeshtasticTab.current;
-        next = savedTab < displayTabNames.length ? savedTab : 0;
+        next = savedTab < targetTabs.displayTabNames.length ? savedTab : 0;
       }
 
       setActiveTab(next);
     }
-  }, [activeTab, displayTabNames.length, protocol, tabIndexToPanelIndex]);
+  }, [activeTab, displayTabNames.length, protocol, meshtasticTabs, meshcoreTabs]);
 
   // Reset scroll position when switching tabs
   useEffect(() => {
@@ -673,16 +694,18 @@ export default function App() {
       let targetTab = 0;
 
       if (savedPanel != null) {
-        const targetPanelIndexArr =
-          newProtocol === 'meshcore' ? tabIndexToPanelIndex : tabIndexToPanelIndex;
-        const foundFilteredIndex = targetPanelIndexArr.findIndex((p) => p === savedPanel);
-        if (foundFilteredIndex !== -1 && foundFilteredIndex < displayTabNames.length) {
+        const targetTabs = newProtocol === 'meshcore' ? meshcoreTabs : meshtasticTabs;
+        const foundFilteredIndex = targetTabs.tabIndexToPanelIndex.findIndex(
+          (p) => p === savedPanel,
+        );
+        if (foundFilteredIndex !== -1 && foundFilteredIndex < targetTabs.displayTabNames.length) {
           targetTab = foundFilteredIndex;
         }
       } else {
         const savedTab =
           newProtocol === 'meshcore' ? lastMeshcoreTab.current : lastMeshtasticTab.current;
-        targetTab = savedTab < displayTabNames.length ? savedTab : 0;
+        const targetTabs = newProtocol === 'meshcore' ? meshcoreTabs : meshtasticTabs;
+        targetTab = savedTab < targetTabs.displayTabNames.length ? savedTab : 0;
       }
 
       if (newProtocol === 'meshtastic') {
@@ -699,7 +722,7 @@ export default function App() {
       localStorage.setItem(MESH_PROTOCOL_STORAGE_KEY, newProtocol);
       setProtocol(newProtocol);
     },
-    [protocol, activeTab, activePanelIndex, displayTabNames.length, tabIndexToPanelIndex],
+    [protocol, activeTab, activePanelIndex, meshtasticTabs, meshcoreTabs],
   );
 
   const runReanalysis = useDiagnosticsStore((s) => s.runReanalysis);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2480,7 +2480,6 @@ function FirmwareUpdateNotifier({
     const { status, firmwareVersion } = activeState;
     if (status !== 'configured' || !firmwareVersion) return;
 
-    toastShownRef.current = false;
     onResult({ phase: 'checking' });
     let cancelled = false;
 
@@ -2536,7 +2535,7 @@ function FirmwareUpdateNotifier({
       onResult({ phase: 'idle' });
       toastShownRef.current = false;
     }
-  }, [activeState.status, onResult]);
+  }, [activeState.status, onResult, toastShownRef]);
 
   return null;
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -528,6 +528,8 @@ export default function App() {
   const protocolRef = useRef(protocol);
   const lastMeshtasticTab = useRef(0);
   const lastMeshcoreTab = useRef(0);
+  const lastMeshtasticPanel = useRef<number | null>(null);
+  const lastMeshcorePanel = useRef<number | null>(null);
   const meshtasticMsgsRef = useRef(meshtasticDevice.messages);
   const meshcoreMsgsRef = useRef(meshcoreDevice.messages);
   const meshtasticMyNodeNumRef = useRef(meshtasticDevice.state.myNodeNum);
@@ -593,6 +595,10 @@ export default function App() {
     meshcoreSelfIdRef.current = meshcoreDevice.selfNodeId;
     lastMeshtasticTab.current = protocol === 'meshtastic' ? activeTab : lastMeshtasticTab.current;
     lastMeshcoreTab.current = protocol === 'meshcore' ? activeTab : lastMeshcoreTab.current;
+    lastMeshtasticPanel.current =
+      protocol === 'meshtastic' ? activePanelIndex : lastMeshtasticPanel.current;
+    lastMeshcorePanel.current =
+      protocol === 'meshcore' ? activePanelIndex : lastMeshcorePanel.current;
     activePanelIndexRef.current = activePanelIndex;
   }, [
     activeTab,
@@ -607,12 +613,24 @@ export default function App() {
   // Reset activeTab if it's out of bounds (e.g., switching to meshcore while on Security tab)
   useEffect(() => {
     if (activeTab >= displayTabNames.length) {
-      const savedTab =
-        protocol === 'meshcore' ? lastMeshcoreTab.current : lastMeshtasticTab.current;
-      const next = savedTab < displayTabNames.length ? savedTab : 0;
+      const savedPanel =
+        protocol === 'meshcore' ? lastMeshcorePanel.current : lastMeshtasticPanel.current;
+      let next = 0;
+
+      if (savedPanel != null) {
+        const foundFilteredIndex = tabIndexToPanelIndex.findIndex((p) => p === savedPanel);
+        if (foundFilteredIndex !== -1 && foundFilteredIndex < displayTabNames.length) {
+          next = foundFilteredIndex;
+        }
+      } else {
+        const savedTab =
+          protocol === 'meshcore' ? lastMeshcoreTab.current : lastMeshtasticTab.current;
+        next = savedTab < displayTabNames.length ? savedTab : 0;
+      }
+
       setActiveTab(next);
     }
-  }, [activeTab, displayTabNames.length, protocol]);
+  }, [activeTab, displayTabNames.length, protocol, tabIndexToPanelIndex]);
 
   // Reset scroll position when switching tabs
   useEffect(() => {
@@ -650,15 +668,30 @@ export default function App() {
     (newProtocol: MeshProtocol) => {
       if (newProtocol === protocol) return;
 
-      const savedTab =
-        newProtocol === 'meshcore' ? lastMeshcoreTab.current : lastMeshtasticTab.current;
-      const targetTab = savedTab < displayTabNames.length ? savedTab : 0;
+      const savedPanel =
+        newProtocol === 'meshcore' ? lastMeshcorePanel.current : lastMeshtasticPanel.current;
+      let targetTab = 0;
+
+      if (savedPanel != null) {
+        const targetPanelIndexArr =
+          newProtocol === 'meshcore' ? tabIndexToPanelIndex : tabIndexToPanelIndex;
+        const foundFilteredIndex = targetPanelIndexArr.findIndex((p) => p === savedPanel);
+        if (foundFilteredIndex !== -1 && foundFilteredIndex < displayTabNames.length) {
+          targetTab = foundFilteredIndex;
+        }
+      } else {
+        const savedTab =
+          newProtocol === 'meshcore' ? lastMeshcoreTab.current : lastMeshtasticTab.current;
+        targetTab = savedTab < displayTabNames.length ? savedTab : 0;
+      }
 
       if (newProtocol === 'meshtastic') {
         lastMeshcoreTab.current = activeTab;
+        lastMeshcorePanel.current = activePanelIndex;
         setActiveTab(targetTab);
       } else {
         lastMeshtasticTab.current = activeTab;
+        lastMeshtasticPanel.current = activePanelIndex;
         setActiveTab(targetTab);
       }
 
@@ -666,7 +699,7 @@ export default function App() {
       localStorage.setItem(MESH_PROTOCOL_STORAGE_KEY, newProtocol);
       setProtocol(newProtocol);
     },
-    [protocol, activeTab, displayTabNames.length],
+    [protocol, activeTab, activePanelIndex, displayTabNames.length, tabIndexToPanelIndex],
   );
 
   const runReanalysis = useDiagnosticsStore((s) => s.runReanalysis);

--- a/src/renderer/components/PacketDistributionPanel.tsx
+++ b/src/renderer/components/PacketDistributionPanel.tsx
@@ -140,9 +140,12 @@ function countBy(packets: NormalizedPacket[], key: keyof NormalizedPacket): Map<
   return map;
 }
 
-function resolveNodeKey(k: string, getNodeLabel: (id: number) => string): string {
+function resolveNodeKey(k: string, getNodeLabel: (id: number) => string, variant: Variant): string {
   const id = parseInt(k, 10);
-  return k === 'null' || isNaN(id) ? 'Unknown' : getNodeLabel(id);
+  if (k === 'null' || isNaN(id)) {
+    return variant === 'meshcore' ? 'No sender id in raw frame' : 'Unknown';
+  }
+  return getNodeLabel(id);
 }
 
 function tooltipFormatter(value: unknown, total: number): [string, string] {
@@ -254,8 +257,8 @@ export default function PacketDistributionPanel({
     const sorted = [...counts.entries()]
       .map(([k, count]) => ({ key: k, count }))
       .sort((a, b) => b.count - a.count);
-    return buildSlices(sorted, (k) => resolveNodeKey(k, getNodeLabel));
-  }, [filtered, getNodeLabel]);
+    return buildSlices(sorted, (k) => resolveNodeKey(k, getNodeLabel, variant));
+  }, [filtered, getNodeLabel, variant]);
 
   const typeSlices = useMemo(() => {
     const counts = countBy(filtered, 'packetType');
@@ -286,8 +289,8 @@ export default function PacketDistributionPanel({
     const sorted = [...counts.entries()]
       .map(([k, count]) => ({ key: k, count }))
       .sort((a, b) => b.count - a.count);
-    return buildSlices(sorted, (k) => resolveNodeKey(k, getNodeLabel));
-  }, [filtered, effectiveType, getNodeLabel]);
+    return buildSlices(sorted, (k) => resolveNodeKey(k, getNodeLabel, variant));
+  }, [filtered, effectiveType, getNodeLabel, variant]);
 
   const typeDeviceTotal = typeDeviceSlices.reduce((s, d) => s + d.value, 0);
 

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -1661,7 +1661,9 @@ export function useMeshCore() {
         // Save with on_radio=1 when contacts came from radio
         const now = new Date().toISOString();
         const onRadio = opts?.contactsFromRadio ? 1 : 0;
-        const dbRow = contactToDbRow(contact, undefined, onRadio, now, hopsAway);
+        const prevHopsAway = prevNode?.hops_away;
+        const hopsToSave = hopsAway ?? prevHopsAway ?? undefined;
+        const dbRow = contactToDbRow(contact, undefined, onRadio, now, hopsToSave);
         void window.electronAPI.db.saveMeshcoreContact(dbRow).catch((e: unknown) => {
           console.warn('[useMeshCore] saveMeshcoreContact error', e);
         });


### PR DESCRIPTION
## Summary
- Clarify MeshCore null sender bucket in packet distribution
- Preserve hop count when rebuilding contacts from radio (meshcore)
- Restore sidebar tab memory when switching protocols (prevents losing selected tab)
- Prevent duplicate firmware upgrade toasts from appearing
- Restore correct panel when switching protocols

## Changes
- 2f934c2 fix: clarify MeshCore null sender bucket in packet distribution
- aad3dee fix(meshcore): preserve hop count when rebuilding contacts from radio
- 53089f3 fix: restore sidebar tab memory when switching protocols
- 8c2c658 fix: prevent duplicate firmware upgrade toasts
- 840299e fix: restore correct panel when switching protocols