### PR TITLE
MeshCore ping TTL, Node List Flood Advert, updater IPC fallback, connectivity docs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -260,6 +260,27 @@ With **Wi‑Fi off** or **airplane mode** on, using a **packaged** build if poss
 
 **Fix**: Open the node detail modal for a Repeater node (shown as "Repeater" in the hardware model field).
 
+### MeshCore: Cannot connect via Bluetooth, USB, or HTTP
+
+**Bluetooth:**
+
+- The device must be **flashed as Companion Bluetooth** (the default BLE flashing mode).
+- The device must be **paired** with your computer before connecting:
+  - **Windows**: Pair first in **Settings → Bluetooth & devices → Add device**, then connect from the app.
+  - **Linux**: Use **`bluetoothctl pair <MAC>`** first, or let the app handle the pairing prompt. See [BLE known issues](#ble-known-issues) for detailed steps.
+- **Try in the official MeshCore app first** — if the device connects there, it will work in Mesh-Client.
+- If Bluetooth fails, try serial (USB) or HTTP as alternatives.
+
+**USB (Serial):**
+
+- The device must be **flashed as Companion USB** (not BLE-only firmware).
+- If the serial port is not detected, see [Serial port not detected](#serial-port-not-detected).
+
+**HTTP (WiFi):**
+
+- The device must be **flashed as Companion HTTP** (not BLE-only firmware).
+- If `meshtastic.local` is not resolved, see [HTTP / WiFi connection issues](#http--wifi-connection-issues).
+
 ### MeshCore: Trace Route or Ping trace times out
 
 **Cause**: Nodes you only **hear** on the mesh—but that do **not** have **your** node in **their** contact list—are sometimes called foreign or one-way contacts. MeshCore firmware may not answer **Trace Route** (node detail) or **Ping trace** (Repeaters panel) for those peers, so the app waits until the trace/ping timeout with no TraceData response. You may see **Trace route timed out** in the node detail modal or an error toast from **Ping trace**.

--- a/src/main/updater.contract.test.ts
+++ b/src/main/updater.contract.test.ts
@@ -1,0 +1,13 @@
+// @vitest-environment node
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const UPDATER_SOURCE = readFileSync(join(__dirname, 'updater.ts'), 'utf-8');
+
+describe('updater source contracts', () => {
+  it('falls back to GitHub API when electron-updater is missing instead of skipping IPC handlers', () => {
+    expect(UPDATER_SOURCE).toContain('falling back to GitHub Releases API');
+    expect(UPDATER_SOURCE).toContain('registerGithubReleaseApiHandlers(send, true)');
+  });
+});

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -9,6 +9,9 @@ import { sanitizeLogMessage } from './log-service';
 let autoUpdater: any = null;
 let checkNow: (() => void) | null = null;
 
+/** Last release page URL from a GitHub API check (used when download cannot use electron-updater). */
+let lastGithubReleaseUrl: string | null = null;
+
 /** Returns the current update-check function (set after initUpdater runs). Used by native menu. */
 export function getCheckNow(): (() => void) | null {
   return checkNow;
@@ -31,6 +34,147 @@ function semverGt(remote: string, local: string): boolean {
   return rPat > lPat;
 }
 
+type SendFn = (channel: string, payload?: unknown) => void;
+
+/**
+ * GitHub Releases API check — used in dev, and as a fallback when packaged but
+ * electron-updater is missing or failed to load (so IPC handlers still register).
+ */
+function registerGithubReleaseApiHandlers(send: SendFn, uiReportsPackaged: boolean): void {
+  const doCheck = async () => {
+    lastGithubReleaseUrl = null;
+    try {
+      const res = await fetch(API_URL, {
+        headers: { 'User-Agent': `mesh-client/${app.getVersion()}` },
+      });
+      if (!res.ok) {
+        console.warn('[updater] GitHub API responded with', String(res.status));
+        send('update:error', { message: 'Update check failed — check network connection' });
+        return;
+      }
+      if (res.redirected) {
+        console.warn('[updater] GitHub API redirected to', res.url, '— API_URL may need updating');
+      }
+      const data = (await res.json()) as { tag_name: string; html_url: string };
+      const remoteVersion = data.tag_name.replace(/^v/, '');
+      const localVersion = app.getVersion();
+      if (semverGt(remoteVersion, localVersion)) {
+        lastGithubReleaseUrl = data.html_url;
+        send('update:available', {
+          version: remoteVersion,
+          releaseUrl: data.html_url,
+          isPackaged: uiReportsPackaged,
+          isMac: process.platform === 'darwin',
+        });
+      } else {
+        send('update:not-available');
+      }
+    } catch (e: unknown) {
+      console.warn(
+        '[updater] GitHub API fetch failed:',
+        sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
+      );
+      send('update:error', { message: 'Update check failed — check network connection' });
+    }
+  };
+  checkNow = () => {
+    void doCheck();
+  };
+
+  ipcMain.handle('update:check', doCheck);
+
+  ipcMain.handle('update:download', async () => {
+    if (!uiReportsPackaged) return;
+    if (process.platform === 'darwin') return;
+    try {
+      await shell.openExternal(lastGithubReleaseUrl ?? RELEASES_URL);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn('[updater] update:download (GitHub fallback) failed:', sanitizeLogMessage(msg));
+      send('update:error', { message: msg });
+    }
+  });
+
+  ipcMain.handle('update:install', () => {
+    /* no-op — no downloaded artifact in this path */
+  });
+}
+
+function registerElectronUpdaterHandlers(send: SendFn): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    autoUpdater = require('electron-updater').autoUpdater;
+  } catch (e) {
+    console.error(
+      '[updater] electron-updater not available:',
+      sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
+    );
+    return false;
+  }
+
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  autoUpdater.on('update-available', (info: { version: string }) => {
+    send('update:available', {
+      version: info.version,
+      releaseUrl: `${RELEASES_URL}/tag/v${info.version}`,
+      isPackaged: true,
+      isMac: process.platform === 'darwin',
+    });
+  });
+
+  autoUpdater.on('update-not-available', () => {
+    send('update:not-available');
+  });
+
+  autoUpdater.on('download-progress', (progress: { percent: number }) => {
+    send('update:progress', { percent: Math.round(progress.percent) });
+  });
+
+  autoUpdater.on('update-downloaded', () => {
+    send('update:downloaded');
+  });
+
+  autoUpdater.on('error', (err: Error) => {
+    console.error('[updater] error:', sanitizeLogMessage(err.message));
+    send('update:error', { message: err.message });
+  });
+
+  const doCheck = async () => {
+    try {
+      await autoUpdater.checkForUpdates();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn('[updater] checkForUpdates failed:', sanitizeLogMessage(msg));
+      send('update:error', { message: msg });
+    }
+  };
+  checkNow = () => {
+    void doCheck();
+  };
+
+  ipcMain.handle('update:check', doCheck);
+
+  ipcMain.handle('update:download', async () => {
+    if (process.platform === 'darwin') return;
+    try {
+      await autoUpdater.downloadUpdate();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn('[updater] update:download failed:', sanitizeLogMessage(msg));
+      send('update:error', { message: msg });
+    }
+  });
+
+  ipcMain.handle('update:install', () => {
+    if (process.platform === 'darwin') return;
+    autoUpdater.quitAndInstall(false, true);
+  });
+
+  return true;
+}
+
 export function initUpdater(win: BrowserWindow): void {
   const send = (channel: string, payload?: unknown) => {
     if (win.isDestroyed()) return;
@@ -38,135 +182,15 @@ export function initUpdater(win: BrowserWindow): void {
   };
 
   if (app.isPackaged) {
-    // ── Packaged path: electron-updater ─────────────────────────────
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      autoUpdater = require('electron-updater').autoUpdater;
-    } catch (e) {
-      console.error(
-        '[updater] electron-updater not available:',
-        sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
-      );
-      return;
+    const ok = registerElectronUpdaterHandlers(send);
+    if (!ok) {
+      console.warn('[updater] falling back to GitHub Releases API (packaged build)');
+      registerGithubReleaseApiHandlers(send, true);
     }
-
-    autoUpdater.autoDownload = false;
-    autoUpdater.autoInstallOnAppQuit = false;
-
-    autoUpdater.on('update-available', (info: { version: string }) => {
-      send('update:available', {
-        version: info.version,
-        releaseUrl: `${RELEASES_URL}/tag/v${info.version}`,
-        isPackaged: true,
-        isMac: process.platform === 'darwin',
-      });
-    });
-
-    autoUpdater.on('update-not-available', () => {
-      send('update:not-available');
-    });
-
-    autoUpdater.on('download-progress', (progress: { percent: number }) => {
-      send('update:progress', { percent: Math.round(progress.percent) });
-    });
-
-    autoUpdater.on('update-downloaded', () => {
-      send('update:downloaded');
-    });
-
-    autoUpdater.on('error', (err: Error) => {
-      console.error('[updater] error:', sanitizeLogMessage(err.message));
-      send('update:error', { message: err.message });
-    });
-
-    const doCheck = async () => {
-      try {
-        await autoUpdater.checkForUpdates();
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        console.warn('[updater] checkForUpdates failed:', sanitizeLogMessage(msg));
-        send('update:error', { message: msg });
-      }
-    };
-    checkNow = () => {
-      void doCheck();
-    };
-
-    // Auto-check on startup is triggered from the renderer (respects user preference).
-    ipcMain.handle('update:check', doCheck);
-
-    ipcMain.handle('update:download', async () => {
-      if (process.platform === 'darwin') return; // macOS: open releases page instead
-      try {
-        await autoUpdater.downloadUpdate();
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        console.warn('[updater] update:download failed:', sanitizeLogMessage(msg));
-        send('update:error', { message: msg });
-      }
-    });
-
-    ipcMain.handle('update:install', () => {
-      if (process.platform === 'darwin') return;
-      autoUpdater.quitAndInstall(false, true);
-    });
   } else {
-    // ── Dev / git-clone path: GitHub Releases API ────────────────────
-    const doCheck = async () => {
-      try {
-        const res = await fetch(API_URL, {
-          headers: { 'User-Agent': `mesh-client/${app.getVersion()}` },
-        });
-        if (!res.ok) {
-          console.warn('[updater] GitHub API responded with', String(res.status));
-          send('update:error', { message: 'Update check failed — check network connection' });
-          return;
-        }
-        if (res.redirected) {
-          console.warn(
-            '[updater] GitHub API redirected to',
-            res.url,
-            '— API_URL may need updating',
-          );
-        }
-        const data = (await res.json()) as { tag_name: string; html_url: string };
-        const remoteVersion = data.tag_name.replace(/^v/, '');
-        const localVersion = app.getVersion();
-        if (semverGt(remoteVersion, localVersion)) {
-          send('update:available', {
-            version: remoteVersion,
-            releaseUrl: data.html_url,
-            isPackaged: false,
-            isMac: process.platform === 'darwin',
-          });
-        } else {
-          send('update:not-available');
-        }
-      } catch (e: unknown) {
-        console.warn(
-          '[updater] GitHub API fetch failed:',
-          sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
-        );
-        send('update:error', { message: 'Update check failed — check network connection' });
-      }
-    };
-    checkNow = () => {
-      void doCheck();
-    };
-
-    // Auto-check on startup is triggered from the renderer (respects user preference).
-    // In dev mode, download/install are no-ops; just expose the handlers.
-    ipcMain.handle('update:check', doCheck);
-
-    ipcMain.handle('update:download', () => {
-      /* no-op in dev */
-    });
-    ipcMain.handle('update:install', () => {
-      /* no-op in dev */
-    });
+    registerGithubReleaseApiHandlers(send, false);
   }
 
-  // Shared: open the GitHub releases page
   ipcMain.handle('update:open-releases', async (_event, url?: string) => {
     try {
       console.debug('[IPC] update:open-releases');

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1715,6 +1715,10 @@ export default function App() {
                             meshcorePublicKeyHexByNodeId={
                               protocol === 'meshcore' ? meshcorePublicKeyHexByNodeId : undefined
                             }
+                            onSendAdvert={
+                              protocol === 'meshcore' ? meshcoreDevice.sendAdvert : undefined
+                            }
+                            meshcoreRadioOperational={isOperational}
                           />
                         </Suspense>
                       ) : null}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1072,7 +1072,10 @@ export default function App() {
   // ─── Auto-check for updates on startup ────
   useEffect(() => {
     const t = setTimeout(() => {
-      void window.electronAPI.update.check();
+      void window.electronAPI.update.check().catch((e: unknown) => {
+        console.warn('[App] update check failed', e);
+        setUpdateState((s) => ({ ...s, phase: 'error' }));
+      });
     }, 5000);
     return () => {
       clearTimeout(t);
@@ -2218,7 +2221,10 @@ export default function App() {
                   updateState={updateState}
                   onCheck={() => {
                     setUpdateState({ phase: 'idle' });
-                    void window.electronAPI.update.check();
+                    void window.electronAPI.update.check().catch((e: unknown) => {
+                      console.warn('[App] update check failed', e);
+                      setUpdateState((s) => ({ ...s, phase: 'error' }));
+                    });
                   }}
                   onDownload={() => window.electronAPI.update.download()}
                   onInstall={() => window.electronAPI.update.install()}

--- a/src/renderer/components/NodeListPanel.test.tsx
+++ b/src/renderer/components/NodeListPanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import {
@@ -35,9 +35,13 @@ vi.mock('../stores/diagnosticsStore', () => ({
   },
 }));
 
+const { addToastMock } = vi.hoisted(() => ({
+  addToastMock: vi.fn(),
+}));
+
 vi.mock('./Toast', () => ({
   useToast: () => ({
-    addToast: vi.fn(),
+    addToast: addToastMock,
   }),
 }));
 
@@ -234,5 +238,77 @@ describe('NodeListPanel import contacts', () => {
       />,
     );
     expect(screen.getByText(hex)).toBeInTheDocument();
+  });
+});
+
+describe('NodeListPanel flood advert (MeshCore)', () => {
+  beforeEach(() => {
+    addToastMock.mockClear();
+  });
+
+  it('shows Send flood advert control when meshcore and onSendAdvert provided', async () => {
+    const user = userEvent.setup();
+    const onSendAdvert = vi.fn().mockResolvedValue(undefined);
+    render(
+      <NodeListPanel
+        nodes={new Map()}
+        myNodeNum={0}
+        onNodeClick={vi.fn()}
+        locationFilter={defaultFilter}
+        onToggleFavorite={vi.fn()}
+        mode="meshcore"
+        onSendAdvert={onSendAdvert}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Send flood advert' });
+    expect(btn).toBeEnabled();
+    await user.click(btn);
+    expect(onSendAdvert).toHaveBeenCalledTimes(1);
+    expect(addToastMock).toHaveBeenCalledWith('Flood advert sent', 'success');
+  });
+
+  it('does not show flood advert in meshtastic mode even if onSendAdvert provided', () => {
+    render(
+      <NodeListPanel
+        nodes={new Map()}
+        myNodeNum={0}
+        onNodeClick={vi.fn()}
+        locationFilter={defaultFilter}
+        onToggleFavorite={vi.fn()}
+        mode="meshtastic"
+        onSendAdvert={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Send flood advert' })).not.toBeInTheDocument();
+  });
+
+  it('does not show flood advert when onSendAdvert omitted in meshcore mode', () => {
+    render(
+      <NodeListPanel
+        nodes={new Map()}
+        myNodeNum={0}
+        onNodeClick={vi.fn()}
+        locationFilter={defaultFilter}
+        onToggleFavorite={vi.fn()}
+        mode="meshcore"
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Send flood advert' })).not.toBeInTheDocument();
+  });
+
+  it('disables flood advert when meshcoreRadioOperational is false', () => {
+    render(
+      <NodeListPanel
+        nodes={new Map()}
+        myNodeNum={0}
+        onNodeClick={vi.fn()}
+        locationFilter={defaultFilter}
+        onToggleFavorite={vi.fn()}
+        mode="meshcore"
+        onSendAdvert={vi.fn()}
+        meshcoreRadioOperational={false}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Send flood advert' })).toBeDisabled();
   });
 });

--- a/src/renderer/components/NodeListPanel.tsx
+++ b/src/renderer/components/NodeListPanel.tsx
@@ -134,6 +134,10 @@ interface Props {
   /** MeshCore: show Refresh button on Contacts tab (paired with onRefreshContacts) */
   meshcoreShowRefreshControl?: boolean;
   onRefreshContacts?: () => Promise<void>;
+  /** MeshCore: flood advert (same as Radio panel Device Actions). */
+  onSendAdvert?: () => Promise<void>;
+  /** When false, Flood Advert is disabled (radio not operational). Ignored if onSendAdvert is unset. */
+  meshcoreRadioOperational?: boolean;
   meshcoreShowPublicKeys?: boolean;
   meshcorePublicKeyHexByNodeId?: Map<number, string>;
 }
@@ -155,6 +159,8 @@ export default function NodeListPanel({
   contactGroupsEnabled = true,
   meshcoreShowRefreshControl = false,
   onRefreshContacts,
+  onSendAdvert,
+  meshcoreRadioOperational = true,
   meshcoreShowPublicKeys = false,
   meshcorePublicKeyHexByNodeId,
 }: Props) {
@@ -169,6 +175,7 @@ export default function NodeListPanel({
   const [searchQuery, setSearchQuery] = useState('');
   const [importLoading, setImportLoading] = useState(false);
   const [refreshLoading, setRefreshLoading] = useState(false);
+  const [advertLoading, setAdvertLoading] = useState(false);
 
   useEffect(() => {
     if (mode === 'meshcore' && MESHCORE_INAPPLICABLE_SORT_FIELDS.includes(sortField)) {
@@ -206,6 +213,20 @@ export default function NodeListPanel({
       addToast(`Import failed: ${e instanceof Error ? e.message : String(e)}`, 'error');
     } finally {
       setImportLoading(false);
+    }
+  };
+
+  const handleSendAdvert = async () => {
+    if (!onSendAdvert) return;
+    setAdvertLoading(true);
+    try {
+      await onSendAdvert();
+      addToast('Flood advert sent', 'success');
+    } catch (e) {
+      console.warn('[NodeListPanel] sendAdvert failed:', e instanceof Error ? e.message : e);
+      addToast(`Advert failed: ${e instanceof Error ? e.message : String(e)}`, 'error');
+    } finally {
+      setAdvertLoading(false);
     }
   };
 
@@ -444,6 +465,22 @@ export default function NodeListPanel({
                 <span className="inline-block h-3 w-3 animate-spin rounded-full border border-purple-400 border-t-transparent" />
               ) : null}
               Refresh
+            </button>
+          ) : null}
+          {mode === 'meshcore' && onSendAdvert ? (
+            <button
+              type="button"
+              onClick={() => {
+                void handleSendAdvert();
+              }}
+              disabled={!meshcoreRadioOperational || advertLoading}
+              aria-label="Send flood advert"
+              className="bg-brand-green/20 text-brand-green border-brand-green/30 hover:bg-brand-green/30 flex w-full items-center justify-center gap-2 rounded border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 min-[480px]:w-auto"
+            >
+              {advertLoading ? (
+                <span className="border-brand-green inline-block h-3 w-3 animate-spin rounded-full border border-t-transparent" />
+              ) : null}
+              Flood Advert
             </button>
           ) : null}
           {mode === 'meshcore' && onImportContacts ? (

--- a/src/renderer/hooks/useMeshCore.ping-no-route-error-expiry.test.tsx
+++ b/src/renderer/hooks/useMeshCore.ping-no-route-error-expiry.test.tsx
@@ -1,0 +1,296 @@
+/**
+ * MeshCore ping error: “no route” message auto-expires after {@link MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS}.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { pubkeyToNodeId } from '../lib/meshcoreUtils';
+import { usePathHistoryStore } from '../stores/pathHistoryStore';
+import {
+  MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS,
+  MESHCORE_PING_NO_ROUTE_ERROR_MSG,
+  meshcorePingNoRouteErrorExpiryUpdate,
+  useMeshCore,
+} from './useMeshCore';
+
+const getSelfInfoMock = vi.fn();
+
+const REMOTE_PUBKEY = (() => {
+  const b = new Uint8Array(32);
+  b[0] = 0x33;
+  b[31] = 0x44;
+  return b;
+})();
+const REMOTE_NODE_ID = pubkeyToNodeId(REMOTE_PUBKEY);
+const REMOTE_PUBKEY_HEX = Array.from(REMOTE_PUBKEY)
+  .map((x) => x.toString(16).padStart(2, '0'))
+  .join('');
+
+const SELF_PUBKEY = new Uint8Array(32).fill(0xab);
+const MY_NODE_ID = pubkeyToNodeId(SELF_PUBKEY);
+
+/** Matches {@link MESHCORE_TRACE_PRIME_WAIT_MS} in useMeshCore.ts — wait after flood advert for PathUpdated. */
+const TRACE_PRIME_WAIT_MS = 12_000;
+
+vi.mock('@liamcottle/meshcore.js', () => {
+  class MockWebSerialConnection {
+    private listeners = new Map<string | number, Set<(...args: unknown[]) => void>>();
+
+    constructor(port: unknown) {
+      void port;
+    }
+    on(event: string | number, cb: (...args: unknown[]) => void) {
+      const listeners = this.listeners.get(event) ?? new Set();
+      listeners.add(cb);
+      this.listeners.set(event, listeners);
+      return undefined;
+    }
+    off(event: string | number, cb: (...args: unknown[]) => void) {
+      this.listeners.get(event)?.delete(cb);
+      return undefined;
+    }
+    once(event: string | number, cb: (...args: unknown[]) => void) {
+      const wrapped = (...args: unknown[]) => {
+        this.off(event, wrapped);
+        cb(...args);
+      };
+      this.on(event, wrapped);
+      return undefined;
+    }
+    emit(event: string | number, ...args: unknown[]) {
+      this.listeners.get(event)?.forEach((cb) => {
+        cb(...args);
+      });
+      return undefined;
+    }
+    close = vi.fn().mockResolvedValue(undefined);
+    getSelfInfo = getSelfInfoMock;
+    getContacts = vi.fn().mockResolvedValue([]);
+    getChannels = vi.fn().mockResolvedValue([]);
+    deviceQuery = vi.fn().mockResolvedValue({
+      firmwareVer: 1,
+      firmware_build_date: 'test',
+      manufacturerModel: 'test',
+    });
+    syncDeviceTime = vi.fn().mockResolvedValue(undefined);
+    getWaitingMessages = vi.fn().mockResolvedValue([]);
+    syncNextMessage = vi.fn().mockResolvedValue(null);
+    setOtherParams = vi.fn().mockResolvedValue(undefined);
+    setAutoAddContacts = vi.fn().mockResolvedValue(undefined);
+    setManualAddContacts = vi.fn().mockResolvedValue(undefined);
+    getBatteryVoltage = vi.fn().mockResolvedValue({ batteryMilliVolts: 4200 });
+    getStatsCore = vi.fn().mockResolvedValue({
+      type: 0,
+      raw: new Uint8Array(9),
+      data: { batteryMilliVolts: 4123, uptimeSecs: 456, queueLen: 5 },
+    });
+    getStatsRadio = vi.fn().mockResolvedValue({
+      type: 1,
+      raw: new Uint8Array([1]),
+      data: {
+        noiseFloor: -110,
+        lastRssi: -89,
+        lastSnr: 6.5,
+        txAirSecs: 12,
+        rxAirSecs: 34,
+      },
+    });
+    getStatsPackets = vi.fn().mockResolvedValue({
+      type: 2,
+      raw: new Uint8Array([2]),
+      data: {
+        recv: 100,
+        sent: 50,
+        nSentFlood: 5,
+        nSentDirect: 10,
+        nRecvFlood: 15,
+        nRecvDirect: 20,
+        nRecvErrors: 2,
+      },
+    });
+    sendFloodAdvert = vi.fn().mockResolvedValue(undefined);
+    sendToRadioFrame = vi.fn().mockImplementation((data: Uint8Array) => {
+      void data;
+      this.emit('rx', new Uint8Array([25, 0x0f, 3]));
+    });
+  }
+
+  class MockSerialConnection {
+    async write(bytes: Uint8Array) {
+      await Promise.resolve();
+      void bytes;
+    }
+    async onDataReceived(value: Uint8Array) {
+      await Promise.resolve();
+      void value;
+    }
+    async onConnected() {
+      await Promise.resolve();
+    }
+    onDisconnected() {
+      return undefined;
+    }
+    close = vi.fn().mockResolvedValue(undefined);
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
+  }
+
+  class MockConnection {
+    async write(bytes: Uint8Array) {
+      await Promise.resolve();
+      void bytes;
+    }
+    async sendToRadioFrame(data: Uint8Array) {
+      await Promise.resolve();
+      void data;
+    }
+    async onConnected() {
+      await Promise.resolve();
+    }
+    onDisconnected() {
+      return undefined;
+    }
+    onFrameReceived(frame: Uint8Array) {
+      void frame;
+      return undefined;
+    }
+    close = vi.fn().mockResolvedValue(undefined);
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+  }
+
+  return {
+    CayenneLpp: { parse: vi.fn().mockReturnValue([]) },
+    Connection: MockConnection,
+    SerialConnection: MockSerialConnection,
+    WebSerialConnection: MockWebSerialConnection,
+  };
+});
+
+function makeMockSerialPort() {
+  return {
+    open: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    getInfo: vi.fn().mockReturnValue({ usbVendorId: 0x1234, usbProductId: 0x5678 }),
+  };
+}
+
+describe('meshcorePingNoRouteErrorExpiryUpdate', () => {
+  it('removes the no-route message when it still matches', () => {
+    const prev = new Map<number, string>([[42, MESHCORE_PING_NO_ROUTE_ERROR_MSG]]);
+    const next = meshcorePingNoRouteErrorExpiryUpdate(prev, 42);
+    expect(next.has(42)).toBe(false);
+  });
+
+  it('does not remove a different ping error for the same node', () => {
+    const prev = new Map<number, string>([[42, 'Failed: radio']]);
+    const next = meshcorePingNoRouteErrorExpiryUpdate(prev, 42);
+    expect(next.get(42)).toBe('Failed: radio');
+  });
+});
+
+describe('useMeshCore traceRoute no-route error expiry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePathHistoryStore.setState({ records: new Map(), lruOrder: [] });
+    getSelfInfoMock.mockResolvedValue({
+      name: 'SelfRadio',
+      publicKey: SELF_PUBKEY,
+      type: 1,
+      txPower: 22,
+      radioFreq: 902_000_000,
+    });
+    vi.mocked(window.electronAPI.db.getMeshcoreMessages).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getNodes).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([
+      {
+        node_id: REMOTE_NODE_ID,
+        public_key: REMOTE_PUBKEY_HEX,
+        adv_name: 'RemotePeer',
+        contact_type: 1,
+        last_advert: 1_700_000_000,
+        adv_lat: null,
+        adv_lon: null,
+        last_snr: null,
+        last_rssi: null,
+        favorited: 0,
+        nickname: null,
+        hops_away: 2,
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears the no-route ping error after the display duration (fake timers)', async () => {
+    const port = makeMockSerialPort();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: {
+        requestPort: vi.fn().mockResolvedValue(port),
+      },
+    });
+
+    const { result } = renderHook(() => useMeshCore());
+
+    await waitFor(() => {
+      expect(window.electronAPI.db.getMeshcoreContacts).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    expect(result.current.state.myNodeNum).toBe(MY_NODE_ID);
+    expect(result.current.nodes.get(REMOTE_NODE_ID)?.hops_away).toBe(2);
+
+    vi.useFakeTimers();
+
+    let tracePromise: Promise<void>;
+    await act(async () => {
+      tracePromise = result.current.traceRoute(REMOTE_NODE_ID);
+      await vi.advanceTimersByTimeAsync(TRACE_PRIME_WAIT_MS);
+    });
+
+    await act(async () => {
+      await tracePromise!;
+    });
+
+    expect(result.current.meshcorePingErrors.get(REMOTE_NODE_ID)).toBe(
+      MESHCORE_PING_NO_ROUTE_ERROR_MSG,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS);
+    });
+
+    expect(result.current.meshcorePingErrors.has(REMOTE_NODE_ID)).toBe(false);
+  });
+});

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -296,6 +296,23 @@ const MESHCORE_SEND_FLOOD_ADVERT_TIMEOUT_MS = 25_000;
 /** Max time to wait for PathUpdated (129) after a flood advert when priming trace route. */
 const MESHCORE_TRACE_PRIME_WAIT_MS = 12_000;
 
+/** Shown when multi-hop trace cannot run until the radio reports a route; UI auto-clears after {@link MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS}. */
+export const MESHCORE_PING_NO_ROUTE_ERROR_MSG =
+  'No route from radio yet — multi-hop trace needs a synced path. Wait for contact updates or reconnect.';
+export const MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS = 20_000;
+
+/** Clears {@link MESHCORE_PING_NO_ROUTE_ERROR_MSG} for `nodeId` if unchanged (traceRoute expiry). */
+export function meshcorePingNoRouteErrorExpiryUpdate(
+  prev: Map<number, string>,
+  nodeId: number,
+): Map<number, string> {
+  const next = new Map(prev);
+  if (next.get(nodeId) === MESHCORE_PING_NO_ROUTE_ERROR_MSG) {
+    next.delete(nodeId);
+  }
+  return next;
+}
+
 export function serializeErrorLike(value: unknown): string {
   if (value instanceof Error) return value.message;
   if (typeof value === 'string') return value;
@@ -1171,6 +1188,16 @@ export function useMeshCore() {
   const prevStatsTimestampRef = useRef<number | null>(null);
   /** Periodic poll for local radio stats (see MESHCORE_STATS_POLL_MS in stats effect). */
   const meshcoreStatsPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  /** Auto-expire {@link MESHCORE_PING_NO_ROUTE_ERROR_MSG} after {@link MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS}. */
+  const meshcorePingNoRouteExpiryTimersRef = useRef<Map<number, number>>(new Map());
+
+  const clearMeshcorePingNoRouteExpiryTimer = useCallback((nodeId: number) => {
+    const t = meshcorePingNoRouteExpiryTimersRef.current.get(nodeId);
+    if (t != null) {
+      clearTimeout(t);
+      meshcorePingNoRouteExpiryTimersRef.current.delete(nodeId);
+    }
+  }, []);
 
   /** Fetch and update local radio stats (core, radio, packet). Called by requestRefresh and on connect. */
   const fetchAndUpdateLocalStats = useCallback(async () => {
@@ -1318,6 +1345,7 @@ export function useMeshCore() {
 
   useEffect(() => {
     meshcoreHookMountedRef.current = true;
+    const pingNoRouteTimers = meshcorePingNoRouteExpiryTimersRef.current;
     return () => {
       meshcoreHookMountedRef.current = false;
       if (meshcoreWaitingMessagesPollRef.current) {
@@ -1328,6 +1356,10 @@ export function useMeshCore() {
         clearInterval(meshcoreStatsPollRef.current);
         meshcoreStatsPollRef.current = null;
       }
+      pingNoRouteTimers.forEach((timerId) => {
+        clearTimeout(timerId);
+      });
+      pingNoRouteTimers.clear();
     };
   }, []);
 
@@ -4048,6 +4080,7 @@ export function useMeshCore() {
     async (nodeId: number) => {
       const pubKey = pubKeyMapRef.current.get(nodeId);
       if (!pubKey) {
+        clearMeshcorePingNoRouteExpiryTimer(nodeId);
         setMeshcorePingErrors((prev) => {
           const next = new Map(prev);
           next.set(nodeId, 'Node not found (no encryption key)');
@@ -4056,6 +4089,7 @@ export function useMeshCore() {
         return;
       }
       if (!connRef.current) {
+        clearMeshcorePingNoRouteExpiryTimer(nodeId);
         setMeshcorePingErrors((prev) => {
           const next = new Map(prev);
           next.set(nodeId, 'Not connected to device');
@@ -4063,6 +4097,7 @@ export function useMeshCore() {
         });
         return;
       }
+      clearMeshcorePingNoRouteExpiryTimer(nodeId);
       setMeshcorePingErrors((prev) => {
         const next = new Map(prev);
         next.delete(nodeId);
@@ -4165,14 +4200,18 @@ export function useMeshCore() {
         const uiSaysMultiHop = (hopsAway ?? 0) >= 1;
         const radioSaysMultiHop = radioContactPathLen != null && radioContactPathLen >= 1;
         if (pathTooShort && (uiSaysMultiHop || radioSaysMultiHop)) {
+          clearMeshcorePingNoRouteExpiryTimer(nodeId);
           setMeshcorePingErrors((prev) => {
             const next = new Map(prev);
-            next.set(
-              nodeId,
-              'No route from radio yet — multi-hop trace needs a synced path. Wait for contact updates or reconnect.',
-            );
+            next.set(nodeId, MESHCORE_PING_NO_ROUTE_ERROR_MSG);
             return next;
           });
+          const tid = window.setTimeout(() => {
+            if (!meshcoreHookMountedRef.current) return;
+            setMeshcorePingErrors((prev) => meshcorePingNoRouteErrorExpiryUpdate(prev, nodeId));
+            meshcorePingNoRouteExpiryTimersRef.current.delete(nodeId);
+          }, MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS);
+          meshcorePingNoRouteExpiryTimersRef.current.set(nodeId, tid);
           return;
         }
         let outPath =
@@ -4239,6 +4278,7 @@ export function useMeshCore() {
           });
         useRepeaterSignalStore.getState().recordSignal(nodeId, result.lastSnr);
         bumpMeshcoreNodeLastHeardFromRpc(nodeId);
+        clearMeshcorePingNoRouteExpiryTimer(nodeId);
         setMeshcorePingErrors((prev) => {
           const next = new Map(prev);
           next.delete(nodeId);
@@ -4261,7 +4301,7 @@ export function useMeshCore() {
         console.warn('[useMeshCore] traceRoute error', e);
       }
     },
-    [bumpMeshcoreNodeLastHeardFromRpc],
+    [bumpMeshcoreNodeLastHeardFromRpc, clearMeshcorePingNoRouteExpiryTimer],
   );
 
   const requestRepeaterStatus = useCallback(


### PR DESCRIPTION
## Summary

This PR includes everything on `next` vs `main` (four commits).

### Commits

1. **docs: add MeshCore connectivity troubleshooting section** (`70c5e76`)
   - Troubleshooting for Bluetooth, USB, and HTTP MeshCore connections (Companion firmware, pairing, official app).

2. **fix: register update IPC when electron-updater is unavailable** (`588053f`) — **Fixes #342**
   - Packaged build: if `electron-updater` fails to load, still register IPC and fall back to GitHub Releases API.
   - Renderer: handle rejected `update.check()` so the footer exits “Checking” on error.
   - Source contract test for fallback wiring.

3. **feat(meshcore): add Flood Advert to Node List panel** (`0534cf7`) — **fixes #344**
   - Duplicate Device Actions control next to Refresh/Import for discoverability.

4. **fix(meshcore): expire no-route ping error after display timeout** (`d860b65`) — **Fixes #343**
   - Auto-clear the multi-hop “no route” trace message after `MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS` (20s), with timer cleanup on new ping, success, early errors, and unmount.
   - Vitest coverage (reducer + traceRoute + fake timers).

```
git log origin/main..HEAD --oneline
d860b65 fix(meshcore): expire no-route ping error after display timeout
0534cf7 feat(meshcore): add Flood Advert to Node List panel
588053f fix: register update IPC when electron-updater is unavailable
70c5e76 docs: add MeshCore connectivity troubleshooting section
```
