### PR TITLE
fix: Dev DB init had missing columns and schema changes. 

### DIFF
--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -123,10 +123,10 @@ describe('meshcore_messages dedup index and fresh DB version', () => {
     expect(DB_SOURCE).toMatch(/meshcore_contacts.*contact_flags INTEGER DEFAULT 0/s);
   });
 
-  it('fresh DB init stamps user_version = CURRENT_SCHEMA_VERSION', () => {
-    expect(DB_SOURCE).toMatch(/const CURRENT_SCHEMA_VERSION = \d+/);
+  it('fresh DB init stamps user_version = BASE_SCHEMA_VERSION then runs migrations', () => {
+    expect(DB_SOURCE).toMatch(/const BASE_SCHEMA_VERSION = \d+/);
     expect(DB_SOURCE).toMatch(
-      /if \(userVersion === 0\) \{[\s\S]*?createBaseTables\(\)[\s\S]*?pragma\(`user_version = \$\{CURRENT_SCHEMA_VERSION\}`\)/,
+      /if \(userVersion === 0\) \{[\s\S]*?createBaseTables\(\)[\s\S]*?pragma\(`user_version = \$\{BASE_SCHEMA_VERSION\}`\)[\s\S]*?\}\s*runMigrations\(\)/,
     );
   });
 

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -123,8 +123,11 @@ describe('meshcore_messages dedup index and fresh DB version', () => {
     expect(DB_SOURCE).toMatch(/meshcore_contacts.*contact_flags INTEGER DEFAULT 0/s);
   });
 
-  it('fresh DB init stamps user_version 26 inside isFreshDb', () => {
-    expect(DB_SOURCE).toMatch(/if \(isFreshDb\) \{[\s\S]*?pragma\('user_version = 26'\)/);
+  it('fresh DB init stamps user_version = CURRENT_SCHEMA_VERSION', () => {
+    expect(DB_SOURCE).toMatch(/const CURRENT_SCHEMA_VERSION = \d+/);
+    expect(DB_SOURCE).toMatch(
+      /if \(userVersion === 0\) \{[\s\S]*?createBaseTables\(\)[\s\S]*?pragma\(`user_version = \$\{CURRENT_SCHEMA_VERSION\}`\)/,
+    );
   });
 
   it('createBaseTables defines protocol-neutral contact_groups tables', () => {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -8,7 +8,7 @@ import { sanitizeLogMessage } from './log-service';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-const CURRENT_SCHEMA_VERSION = 27;
+const BASE_SCHEMA_VERSION = 27;
 
 let db: NodeSqliteDB | null = null;
 
@@ -50,10 +50,9 @@ export function initDatabase(): void {
       const userVersion = db!.pragma('user_version', { simple: true }) as number;
       if (userVersion === 0) {
         createBaseTables();
-        db!.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
-      } else {
-        runMigrations();
+        db!.pragma(`user_version = ${BASE_SCHEMA_VERSION}`);
       }
+      runMigrations();
     });
     setup();
 

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -8,6 +8,8 @@ import { sanitizeLogMessage } from './log-service';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+const CURRENT_SCHEMA_VERSION = 27;
+
 let db: NodeSqliteDB | null = null;
 
 export function getDatabasePath(): string {
@@ -44,26 +46,11 @@ export function initDatabase(): void {
     db.pragma('busy_timeout = 5000');
     db.pragma('foreign_keys = ON');
 
-    // Detect fresh DB before running setup (user_version = 0, no tables yet)
-    const isFreshDb =
-      (db.pragma('user_version', { simple: true }) as number) === 0 &&
-      !db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='messages'").get();
-
     const setup = db.transaction(() => {
-      createBaseTables();
-      if (isFreshDb) {
-        // Base DDL already includes all columns; create constraint indexes that
-        // migrations would otherwise add, then stamp current schema version.
-        // idx_msg_packet_dedup is omitted from createBaseTables so that existing
-        // databases can be migrated safely (v12 deduplicates first).
-        db!
-          .prepare(
-            `CREATE UNIQUE INDEX IF NOT EXISTS idx_msg_packet_dedup
-           ON messages(sender_id, packet_id)
-           WHERE packet_id IS NOT NULL`,
-          )
-          .run();
-        db!.pragma('user_version = 27');
+      const userVersion = db!.pragma('user_version', { simple: true }) as number;
+      if (userVersion === 0) {
+        createBaseTables();
+        db!.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
       } else {
         runMigrations();
       }
@@ -151,7 +138,9 @@ function createBaseTables(): void {
         reply_id INTEGER,
         to_node INTEGER,
         mqtt_status TEXT,
-        received_via TEXT
+        received_via TEXT,
+        reply_preview_text TEXT,
+        reply_preview_sender TEXT
       );
 
       CREATE TABLE IF NOT EXISTS nodes (
@@ -185,6 +174,12 @@ function createBaseTables(): void {
       CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
       CREATE INDEX IF NOT EXISTS idx_messages_channel_ts ON messages(channel, timestamp DESC);
       CREATE INDEX IF NOT EXISTS idx_messages_packet_id ON messages(packet_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_reaction_dedup
+        ON messages(sender_id, reply_id, emoji)
+        WHERE emoji IS NOT NULL AND reply_id IS NOT NULL;
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_msg_packet_dedup
+        ON messages(sender_id, packet_id)
+        WHERE packet_id IS NOT NULL;
       CREATE INDEX IF NOT EXISTS idx_nodes_last_heard ON nodes(last_heard);
 
       CREATE TABLE IF NOT EXISTS meshcore_contacts (
@@ -201,7 +196,10 @@ function createBaseTables(): void {
         nickname     TEXT,
         contact_flags INTEGER DEFAULT 0,
         last_rf_transport_scope  INTEGER,
-        last_rf_transport_return   INTEGER
+        last_rf_transport_return   INTEGER,
+        hops_away    INTEGER,
+        on_radio     INTEGER DEFAULT 0,
+        last_synced_from_radio TEXT
       );
 
       CREATE TABLE IF NOT EXISTS meshcore_messages (
@@ -217,7 +215,9 @@ function createBaseTables(): void {
         reply_id    INTEGER,
         to_node     INTEGER,
         received_via TEXT,
-        rx_packet_fingerprint TEXT
+        rx_packet_fingerprint TEXT,
+        reply_preview_text TEXT,
+        reply_preview_sender TEXT
       );
 
       CREATE INDEX IF NOT EXISTS idx_mc_msgs_ts ON meshcore_messages(timestamp);


### PR DESCRIPTION
Added the schema columns, and changed the freshDb slightly until a better structure is built. 

Made the concept of base version and squashed the schema to build this version, every old db version user will run migrations like normal, but a fresh user will be built to v27, then run any migrations after that