### PR TITLE
fix: add missing Linux build deps for AppImage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,20 @@ jobs:
 
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev rpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libudev-dev \
+            libnss3 \
+            libxshmfence-dev \
+            libx11-xcb1 \
+            libxcb1 \
+            libxext6 \
+            libxfixes3 \
+            libxrender1 \
+            libxi6 \
+            libasound2 \
+            rpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -28,6 +28,13 @@
   "build": {
     "mac": {
       "identity": "-"
+    },
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb",
+        "rpm"
+      ]
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Add missing X11/shared libraries (libxshmfence-dev, libx11-xcb1, libnss3, libasound2) required for AppImage builds
- Disable snap target in electron-builder config to avoid snapcraft dependency