### PR TITLE
fix: add missing Linux build deps for AppImage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,19 @@ jobs:
 
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev rpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libudev-dev \
+            libnss3 \
+            libxshmfence-dev \
+            libx11-xcb1 \
+            libxcb1 \
+            libxext6 \
+            libxfixes3 \
+            libxrender1 \
+            libxi6 \
+            rpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -28,6 +28,13 @@
   "build": {
     "mac": {
       "identity": "-"
+    },
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb",
+        "rpm"
+      ]
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Fix missing Linux build dependencies for AppImage (libudev-dev, libnss3, libxshmfence-dev, libx11-xcb1, libxcb1, libxext6, libxfixes3, libxrender1, libxi6, rpm)
- Remove libasound2 (virtual package with no installation candidate in Ubuntu 24.04)