### PR TITLE
fix(build): restore builder config and stabilize ad-hoc mac app launch

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,6 @@ node_modules
 # Logs & temp
 *.log
 tmp/
+
+# Files unsupported by prettier parser
+*.plist

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,12 +27,8 @@ extraResources:
   - from: resources/icons/mac/macos-menubar-icon-Template/macos-menubar-icon-Template@3x.png
     to: macos-menubar-icon-Template@3x.png
 mac:
-  # macOS 26+: ad-hoc signing (identity "-") can crash at launch with EXC_BREAKPOINT during
-  # ElectronMain/V8 init. identity: null skips signing so the bundled Electron Framework
-  # is not re-signed with a mismatched/ad-hoc identity. For notarized releases, set a real
-  # Developer ID here instead. See https://github.com/electron/electron/issues/49522
-  # and https://github.com/electron-userland/electron-builder/issues/9396
-  identity: null
+  # Ad-hoc signing test path.
+  identity: '-'
   category: public.app-category.utilities
   # Hardened runtime improves tamper resistance; required for notarized distribution.
   hardenedRuntime: true

--- a/package.json
+++ b/package.json
@@ -25,18 +25,6 @@
     "megabear - KD5IHC"
   ],
   "main": "dist-electron/main/index.js",
-  "build": {
-    "mac": {
-      "identity": "-"
-    },
-    "linux": {
-      "target": [
-        "AppImage",
-        "deb",
-        "rpm"
-      ]
-    }
-  },
   "scripts": {
     "build": "pnpm run build:main:prod && pnpm run build:preload && pnpm run build:renderer",
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --outfile=dist-electron/main/index.js --external:electron --external:electron-updater --external:systeminformation --external:@stoprocent/noble --external:node-forge --external:jszip --external:mqtt --external:@bufbuild/protobuf --external:@meshtastic/protobufs --format=cjs",

--- a/resources/entitlements.mac.inherit.plist
+++ b/resources/entitlements.mac.inherit.plist
@@ -6,5 +6,11 @@
   <false/>
   <key>com.apple.security.inherit</key>
   <true/>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
 </dict>
 </plist>

--- a/resources/entitlements.mac.plist
+++ b/resources/entitlements.mac.plist
@@ -8,6 +8,8 @@
   <true/>
   <key>com.apple.security.files.user-selected.read-write</key>
   <true/>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>


### PR DESCRIPTION
## Summary
- remove the `package.json` `build` override so `electron-builder.yml` remains the single source of packaging metadata and targets
- keep mac packaging on ad-hoc identity (`mac.identity: '-'`) while preserving existing app metadata (`Mesh-client`)
- add mac runtime entitlements for both app and inherited helper context (`allow-jit`, `allow-unsigned-executable-memory`, and `disable-library-validation`) to prevent startup crash on macOS 26 ad-hoc builds
- ignore `*.plist` in Prettier so pre-commit formatting does not fail on entitlements files

## Test plan
- [x] `pnpm run dist:mac` completes and signs app with ad-hoc identity
- [x] built `Mesh-client.app` launches locally after packaging
- [ ] verify GitHub Actions macOS build uploads expected artifacts under `release/**`