### PR TITLE
fix: remove asar.integrity — unsupported in electron-builder 26.9.0

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,8 +11,6 @@ files:
 asarUnpack:
   - 'node_modules/systeminformation/**/*'
   - 'node_modules/@stoprocent/**/*'
-asar:
-  integrity: true
 publish:
   provider: github
   owner: Colorado-Mesh


### PR DESCRIPTION
Removes `asar.integrity` from `electron-builder.yml`. This property is not valid in electron-builder 26.9.0, causing CI builds to fail with a schema validation error.

Fixes: https://github.com/Colorado-Mesh/mesh-client/actions/runs/24906114628/job/72935784126