### PR TITLE
feat: MeshCore MQTT hardening, RF forwarding, and packet logger exposure

### DIFF
--- a/docs/letsmesh-mqtt-auth.md
+++ b/docs/letsmesh-mqtt-auth.md
@@ -1,6 +1,6 @@
-# LetsMesh MQTT authentication (MeshCore)
+# MeshCore MQTT authentication
 
-mesh-client uses the same contract as [meshcore-mqtt-broker](https://github.com/michaelhart/meshcore-mqtt-broker): MQTT username `v1_<64-hex public key>` (uppercase) and a password produced by `@michaelhart/meshcore-decoder` `createAuthToken`.
+This document describes the authentication contract used by many MeshCore MQTT brokers including **Colorado Mesh** and **LetsMesh**. mesh-client uses the same contract as [meshcore-mqtt-broker](https://github.com/michaelhart/meshcore-mqtt-broker): MQTT username `v1_<64-hex public key>` (uppercase) and a password produced by `@michaelhart/meshcore-decoder` `createAuthToken`.
 
 ## JWT audience (`aud`)
 
@@ -30,14 +30,86 @@ Meshtastic MQTT working on the same machine does not guarantee MeshCore LetsMesh
 
 Import identity under **Radio**, or set **Custom** and paste username `v1_<public key>` and a token from tooling that matches your broker’s `AUTH_EXPECTED_AUDIENCE`.
 
-## Packet logger / Analyzer (LetsMesh)
+## Packet logger / Analyzer
 
-[LetsMesh](https://www.letsmesh.net/) positions public MQTT as part of the **MeshCore Analyzer** ecosystem: clients contribute **observed** traffic (e.g. packet captures) for the map and web UI—similar to [meshcoretomqtt](https://github.com/Andrew-a-g/meshcoretomqtt) (topics such as `meshcore/packets` with JSON metadata).
+Many MeshCore MQTT operators provide a **packet logger** or **Analyzer** service: clients contribute **observed** traffic (e.g. packet captures) for the map and web UI—similar to [meshcoretomqtt](https://github.com/Andrew-a-g/meshcoretomqtt) (topics such as `meshcore/packets` with JSON metadata).
 
-In mesh-client, **LetsMesh public brokers** are **not** used for MQTT-only channel chat when no radio is connected. Optional **Packet logger (LetsMesh Analyzer)** (off by default) publishes RX summaries from the radio to `{topicPrefix}/meshcore/packets` using a meshcoretomqtt-style JSON shape (see [`MeshcoreMqttAdapter.publishPacketLog`](../src/main/meshcore-mqtt-adapter.ts)). Confirm broker ACLs and [observer onboarding](https://analyzer.letsmesh.net/observer/onboard) expectations with current operator docs.
+In mesh-client, optional **Packet logger** (off by default) publishes RX summaries from the radio to `{topicPrefix}/meshcore/packets` using the JSON envelope shown above. Confirm broker ACLs and observer onboarding expectations with your operator docs.
 
 ## Proactive JWT refresh
 
 mesh-client proactively refreshes the JWT token **before** it expires to avoid connection drops. The client schedules a refresh **6 minutes before** the token's `exp` claim when connected. The refresh runs regardless of whether the mesh radio is active — MQTT-only connections also benefit.
 
 If the refresh fails, the client falls back to on-demand refresh (token is regenerated on next connect attempt after expiry).
+
+## Packet format
+
+MeshCore MQTT uses JSON v1 envelopes for both chat messages and packet logger feeds.
+
+### Chat envelope
+
+Published to `{topicPrefix}/{pubKey}/chat` (with origin_id) or `{topicPrefix}/meshcore/chat`:
+
+```json
+{
+  "v": 1,
+  "text": "Hello world",
+  "channelIdx": 0,
+  "senderName": "MyNode",
+  "senderNodeId": 12345678,
+  "timestamp": 1699999999000
+}
+```
+
+**Fields:**
+
+- `v` — always `1` (version)
+- `text` — message text, max 16000 chars
+- `channelIdx` — channel index (0–255)
+- `senderName` — optional sender display name, max 200 chars
+- `senderNodeId` — optional sender node ID (number)
+- `timestamp` — optional message timestamp (Unix ms)
+
+When publishing with a `v1_<pubKey>` username, mesh-client adds `origin_id` (uppercase hex) to the envelope.
+
+### Packet logger envelope
+
+Published to `{topicPrefix}/{pubKey}/packets` or `{topicPrefix}/meshcore/packets`:
+
+```json
+{
+  "origin_id": "AABBCCDDEEFF001122",
+  "origin": "!abcdef00",
+  "timestamp": "2024-11-14T10:30:00.000Z",
+  "type": "PACKET",
+  "direction": "rx",
+  "time": "10:30:00",
+  "date": "14/11/2024",
+  "len": 24,
+  "packet_type": 0,
+  "route": "direct",
+  "payload_len": 12,
+  "raw": "3c010002...",
+  "SNR": 10.5,
+  "RSSI": -90,
+  "hash": "abc123"
+}
+```
+
+**Fields:**
+
+- `origin_id` — sender's public key (uppercase hex, included when publishing with v1 auth)
+- `origin` — sender node ID (Meshtastic-style `!<hex>` or decimal)
+- `timestamp` — ISO 8601 timestamp
+- `type` — always `"PACKET"`
+- `direction` — `"rx"` or `"tx"`
+- `time` — HH:MM:SS local time
+- `date` — DD/MM/YYYY
+- `len` — total packet length in bytes
+- `packet_type` — MeshCore packet type number
+- `route` — routing type: `"direct"`, `"mqtt"`, or hop count like `"1"`, `"2"`
+- `payload_len` — payload byte length
+- `raw` — raw packet hex (truncated to 2048 chars)
+- `SNR` — signal-to-noise ratio (dB)
+- `RSSI` — received signal strength (dBm)
+- `hash` — packet hash for deduplication

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -183,6 +183,39 @@ Bare IPv6 addresses (e.g. `fe80::1`) must be wrapped in brackets when entered in
 
 **Fix**: Confirm the broker's ACL allows your client to subscribe to the configured topic prefix.
 
+### MQTT keeps disconnecting
+
+**Cause**: Wireless interference, broker downtime, or token issues (LetsMesh/Colorado Mesh).
+
+**Fix**:
+
+- Check your WiFi/signal strength
+- Verify the broker is online
+- For LetsMesh/Colorado Mesh: re-import your MeshCore identity to refresh the token
+- Enable debug logs to see the disconnect reason
+
+### MQTT connected but no messages from other nodes
+
+**Cause**: LetsMesh and Colorado Mesh are publish-only brokers — you can send packets to the mesh but won't receive other users' traffic over MQTT. The connection is real, but incoming messages are limited.
+
+**Fix**: Expected behavior for public brokers. For two-way MQTT, use a different broker or connect via BLE/Serial.
+
+### "Token expired" on LetsMesh/Colorado Mesh
+
+**Cause**: JWT tokens expire after 1 hour.
+
+**Fix**: Re-import your MeshCore config JSON in the Radio tab, or paste your v1\_ public key in the MQTT username field to regenerate a token.
+
+### MQTT "Connection refused" or broker unreachable
+
+**Cause**: Wrong broker URL, port, or firewall blocking the connection.
+
+**Fix**:
+
+- Verify the server URL and port match your broker's settings
+- Check that port 1883 (or 8883/443 for TLS/WebSocket) is allowed through your firewall
+- For WebSocket brokers (port 443), ensure "Use WebSocket" is enabled in the MQTT settings
+
 ### BLE auto-reconnect: "No previously connected BLE device found"
 
 **Cause**: The reconnect card appeared, but the browser lost the cached device handle — for example, the app was fully quit and relaunched.
@@ -291,3 +324,16 @@ With **Wi‑Fi off** or **airplane mode** on, using a **packaged** build if poss
 **Cause**: Nodes you only **hear** on the mesh—but that do **not** have **your** node in **their** contact list—are sometimes called foreign or one-way contacts. MeshCore firmware may not answer **Trace Route** (node detail) or **Ping trace** (Repeaters panel) for those peers, so the app waits until the trace/ping timeout with no TraceData response. You may see **Trace route timed out** in the node detail modal or an error toast from **Ping trace**.
 
 **Fix**: When possible, exchange contact adds so the remote node lists you as a contact. If you cannot add them (or they never add you), treat the timeout as expected—not a Mesh-Client defect when the radio never returns a result.
+
+### Can't see RF packets on custom MQTT broker
+
+**Cause**: The packet logger publishes to `{prefix}/{pubKey}/packets`, but you're viewing the packets somewhere that doesn't receive published MQTT messages.
+
+**Fix**:
+
+- The app publishes to `meshcore/{IATA}/{pubKey}/packets` (e.g., `meshcore/DEN/AABBCCDDEEFF001122/packets`)
+- Use an external MQTT client (like MQTT Explorer, mosquitto_sub, or your broker's dashboard) to subscribe and view the packets
+- For Colorado Mesh, subscribe to `meshcore/DEN/+/packets/#`
+- For LetsMesh/MeshMapper, subscribe to `meshcore/test/+/packets/#`
+- Verify your broker ACL allows publishing to `packets/` topics
+- Check the Log panel for "Published RF packet" entries to confirm packets are being sent

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "typecheck": "pnpm exec tsc --noEmit && pnpm exec tsc --noEmit -p tsconfig.main.json"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.11.0",
-    "@meshtastic/protobufs": "npm:@jsr/meshtastic__protobufs@^2.7.20",
+    "@bufbuild/protobuf": "^2.12.0",
+    "@meshtastic/protobufs": "npm:@jsr/meshtastic__protobufs@^2.7.23",
     "@stoprocent/noble": "^2.4.1",
     "electron-updater": "^6.8.3",
     "jszip": "^3.10.1",
@@ -109,7 +109,7 @@
     "@typescript-eslint/parser": "^8.59.0",
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^9.2.1",
-    "electron": "^41.2.2",
+    "electron": "^41.3.0",
     "electron-builder": "^26.9.0",
     "esbuild": "^0.28.0",
     "eslint": "^10.2.1",
@@ -130,7 +130,7 @@
     "postcss": "^8.5.10",
     "prettier": "^3.8.3",
     "prettier-plugin-sh": "^0.18.1",
-    "prettier-plugin-tailwindcss": "^0.7.2",
+    "prettier-plugin-tailwindcss": "^0.7.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-leaflet": "^5.0.0",
@@ -139,7 +139,7 @@
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.0",
-    "vite": "^8.0.9",
+    "vite": "^8.0.10",
     "vitest": "^4.1.5",
     "vitest-axe": "1.0.0-pre.5",
     "zustand": "^5.0.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,11 @@ importers:
   .:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^2.11.0
-        version: 2.11.0
+        specifier: ^2.12.0
+        version: 2.12.0
       '@meshtastic/protobufs':
-        specifier: npm:@jsr/meshtastic__protobufs@^2.7.20
-        version: '@jsr/meshtastic__protobufs@2.7.20'
+        specifier: npm:@jsr/meshtastic__protobufs@^2.7.23
+        version: '@jsr/meshtastic__protobufs@2.7.23'
       '@stoprocent/noble':
         specifier: ^2.4.1
         version: 2.4.1
@@ -110,13 +110,13 @@ importers:
         version: 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
       electron:
-        specifier: ^41.2.2
-        version: 41.2.2
+        specifier: ^41.3.0
+        version: 41.3.0
       electron-builder:
         specifier: ^26.9.0
         version: 26.9.0(electron-builder-squirrel-windows@26.9.0)
@@ -178,8 +178,8 @@ importers:
         specifier: ^0.18.1
         version: 0.18.1(prettier@3.8.3)
       prettier-plugin-tailwindcss:
-        specifier: ^0.7.2
-        version: 0.7.2(prettier@3.8.3)
+        specifier: ^0.7.3
+        version: 0.7.3(prettier@3.8.3)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -205,14 +205,14 @@ importers:
         specifier: ^8.59.0
         version: 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       vite:
-        specifier: ^8.0.9
-        version: 8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
       vitest-axe:
         specifier: 1.0.0-pre.5
-        version: 1.0.0-pre.5(vitest@4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)))
+        version: 1.0.0-pre.5(vitest@4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)))
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
@@ -322,8 +322,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@bufbuild/protobuf@2.11.0':
-    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+  '@bufbuild/protobuf@2.12.0':
+    resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -405,11 +405,11 @@ packages:
     engines: {node: '>=14.14'}
     hasBin: true
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -665,8 +665,8 @@ packages:
   '@jsr/meshtastic__core@2.6.6':
     resolution: {integrity: sha512-f9c/HV6d7fGg+FtsnnC6DSomdGQ7Hr96JiT3epTUduwClYFdi/ftKEadfV55cMhCrp1QK9y6lkPG2S+X1AwN5Q==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__core/2.6.6.tgz}
 
-  '@jsr/meshtastic__protobufs@2.7.20':
-    resolution: {integrity: sha512-GrHWfOzi9i7xk2Br3MkKWLxbzreZuwgjZKNooednYpa1V/abnSj9e4twNTtKyqXYaAOzthY3Cdk4IXouBN9dbA==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__protobufs/2.7.20.tgz}
+  '@jsr/meshtastic__protobufs@2.7.23':
+    resolution: {integrity: sha512-NoL7VjJ3zN28pSq3G3ooKOhQ5CNDntysZJag7SJrrlumaKr6eiPtYcvM/hMwUzR4x3ffst1ajTmI6T3JmZkoEQ==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__protobufs/2.7.23.tgz}
 
   '@jsr/meshtastic__transport-http@0.2.1':
     resolution: {integrity: sha512-lmQKr3aIINKvtGROU4HchmSVqbZSbkIHqajowRRC8IAjsnR0zNTyxz210QyY4pFUF9hpcW3GRjwq5h/VO2JuGg==, tarball: https://npm.jsr.io/~/11/@jsr/meshtastic__transport-http/0.2.1.tgz}
@@ -725,8 +725,8 @@ packages:
     resolution: {integrity: sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  '@oxc-project/types@0.126.0':
-    resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -758,103 +758,103 @@ packages:
     resolution: {integrity: sha512-Hbr7yen4fP5TxGM54ucXa4o5NwWXatJ6Bd9I8gp0PValYbI4Rug2Gu+rVv7K7o/efQc3F5ctqWJz47rYaa8zBw==}
     engines: {node: ^v12.20.0 || ^14.13.0 || >=16.0.0}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.16':
-    resolution: {integrity: sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
-    resolution: {integrity: sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
-    resolution: {integrity: sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
-    resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
-    resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
-    resolution: {integrity: sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
-    resolution: {integrity: sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
-    resolution: {integrity: sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.16':
-    resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -1391,8 +1391,8 @@ packages:
     peerDependencies:
       ajv: ^6.9.1
 
-  ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1525,8 +1525,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.20:
-    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
+  baseline-browser-mapping@2.10.21:
+    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1952,8 +1952,8 @@ packages:
   electron-publish@26.9.0:
     resolution: {integrity: sha512-gsy+U7JfDuD1lPOrCXeECDQoUsWjFah3s1Fv3pqKnjdJuKYDDvGdvC74kLHVG6nl5G0uQ7YN0eftCQ4rUmhvVw==}
 
-  electron-to-chromium@1.5.343:
-    resolution: {integrity: sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==}
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
   electron-updater@6.8.3:
     resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
@@ -1962,8 +1962,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.2.2:
-    resolution: {integrity: sha512-3rzz/hVIpF726W9g7nleQzyF2IOEZbzZnUTUYGhMaEfsoab8fDyOYAWbdBdo4+DczS1Ifz11rdYo8IAAGcRx/g==}
+  electron@41.3.0:
+    resolution: {integrity: sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -1976,8 +1976,8 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.20.1:
-    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
@@ -3361,8 +3361,8 @@ packages:
     peerDependencies:
       prettier: ^3.6.0
 
-  prettier-plugin-tailwindcss@0.7.2:
-    resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
+  prettier-plugin-tailwindcss@0.7.3:
+    resolution: {integrity: sha512-lckXaWWdo2ZVXoMoUO3WIBiz9hVY+YBEh1gYyMFfrWP9WZW/wpFXQKizHx7WrFQFMkcG0bGShdpp531X1n+qpg==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -3615,8 +3615,8 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  rolldown@1.0.0-rc.16:
-    resolution: {integrity: sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4137,8 +4137,8 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  vite@8.0.9:
-    resolution: {integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==}
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4529,7 +4529,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@bufbuild/protobuf@2.11.0': {}
+  '@bufbuild/protobuf@2.12.0': {}
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -4557,8 +4557,8 @@ snapshots:
 
   '@develar/schema-utils@2.6.5':
     dependencies:
-      ajv: 6.14.0
-      ajv-keywords: 3.5.2(ajv@6.14.0)
+      ajv: 6.15.0
+      ajv-keywords: 3.5.2(ajv@6.15.0)
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -4653,13 +4653,13 @@ snapshots:
       - supports-color
     optional: true
 
-  '@emnapi/core@1.9.2':
+  '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4835,17 +4835,17 @@ snapshots:
 
   '@jsr/meshtastic__core@2.6.6(buffer@6.0.3)':
     dependencies:
-      '@bufbuild/protobuf': 2.11.0
-      '@jsr/meshtastic__protobufs': 2.7.20
+      '@bufbuild/protobuf': 2.12.0
+      '@jsr/meshtastic__protobufs': 2.7.23
       crc: 4.3.2(buffer@6.0.3)
       ste-simple-events: 3.0.11
       tslog: 4.10.2
     transitivePeerDependencies:
       - buffer
 
-  '@jsr/meshtastic__protobufs@2.7.20':
+  '@jsr/meshtastic__protobufs@2.7.23':
     dependencies:
-      '@bufbuild/protobuf': 2.11.0
+      '@bufbuild/protobuf': 2.12.0
 
   '@jsr/meshtastic__transport-http@0.2.1(buffer@6.0.3)':
     dependencies:
@@ -4892,10 +4892,10 @@ snapshots:
       commander: 12.1.0
       crypto-js: 4.2.0
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -4923,7 +4923,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  '@oxc-project/types@0.126.0': {}
+  '@oxc-project/types@0.127.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4950,56 +4950,56 @@ snapshots:
 
   '@reteps/dockerfmt@0.5.2': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.16':
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.16':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.16': {}
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -5150,7 +5150,7 @@ snapshots:
   '@tailwindcss/node@4.2.4':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.20.1
+      enhanced-resolve: 5.21.0
       jiti: 2.6.1
       lightningcss: 1.32.0
       magic-string: 0.30.21
@@ -5475,10 +5475,10 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -5489,13 +5489,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5545,11 +5545,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-keywords@3.5.2(ajv@6.14.0):
+  ajv-keywords@3.5.2(ajv@6.15.0):
     dependencies:
-      ajv: 6.14.0
+      ajv: 6.15.0
 
-  ajv@6.14.0:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -5724,7 +5724,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.20: {}
+  baseline-browser-mapping@2.10.21: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -5766,9 +5766,9 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.20
+      baseline-browser-mapping: 2.10.21
       caniuse-lite: 1.0.30001790
-      electron-to-chromium: 1.5.343
+      electron-to-chromium: 1.5.344
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -6118,7 +6118,7 @@ snapshots:
     dependencies:
       '@types/plist': 3.0.5
       '@types/verror': 1.10.11
-      ajv: 6.14.0
+      ajv: 6.15.0
       crc: 3.8.0
       iconv-corefoundation: 1.1.7
       plist: 3.1.0
@@ -6190,7 +6190,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-to-chromium@1.5.343: {}
+  electron-to-chromium@1.5.344: {}
 
   electron-updater@6.8.3:
     dependencies:
@@ -6217,7 +6217,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.2.2:
+  electron@41.3.0:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.12.2
@@ -6233,7 +6233,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.20.1:
+  enhanced-resolve@5.21.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -6539,7 +6539,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.14.0
+      ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       escape-string-regexp: 4.0.0
@@ -7910,7 +7910,7 @@ snapshots:
       prettier: 3.8.3
       sh-syntax: 0.5.8
 
-  prettier-plugin-tailwindcss@0.7.2(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.7.3(prettier@3.8.3):
     dependencies:
       prettier: 3.8.3
 
@@ -8142,26 +8142,26 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
-  rolldown@1.0.0-rc.16:
+  rolldown@1.0.0-rc.17:
     dependencies:
-      '@oxc-project/types': 0.126.0
-      '@rolldown/pluginutils': 1.0.0-rc.16
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.16
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.16
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.16
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.16
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.16
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.16
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.16
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.16
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.16
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   run-parallel@1.2.0:
     dependencies:
@@ -8765,12 +8765,12 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3):
+  vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.10
-      rolldown: 1.0.0-rc.16
+      rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.12.2
@@ -8779,18 +8779,18 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest-axe@1.0.0-pre.5(vitest@4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))):
+  vitest-axe@1.0.0-pre.5(vitest@4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))):
     dependencies:
       '@vitest/pretty-format': 3.2.4
       axe-core: 4.11.3
       chalk: 5.6.2
       lodash-es: 4.18.1
-      vitest: 4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
 
-  vitest@4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -8807,7 +8807,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2169,6 +2169,7 @@ ipcMain.handle('mqtt:publishMeshcorePacketLog', (_event, args) => {
       route?: string;
       payloadLen?: number;
       hash?: string;
+      direction?: 'rx' | 'tx';
     };
     meshcoreMqttAdapter.publishPacketLog({
       origin: a.origin,
@@ -2180,6 +2181,7 @@ ipcMain.handle('mqtt:publishMeshcorePacketLog', (_event, args) => {
       route: a.route,
       payloadLen: a.payloadLen,
       hash: a.hash,
+      direction: a.direction,
     });
   } catch (err) {
     console.error(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2159,12 +2159,27 @@ ipcMain.handle('mqtt:publishMeshcorePacketLog', (_event, args) => {
   try {
     console.debug('[IPC] mqtt:publishMeshcorePacketLog');
     validateMqttPublishMeshcorePacketLogArgs(args);
-    const a = args as { origin: string; snr: number; rssi: number; rawHex?: string };
+    const a = args as {
+      origin: string;
+      snr: number;
+      rssi: number;
+      rawHex?: string;
+      len?: number;
+      packetType?: number;
+      route?: string;
+      payloadLen?: number;
+      hash?: string;
+    };
     meshcoreMqttAdapter.publishPacketLog({
       origin: a.origin,
       snr: a.snr,
       rssi: a.rssi,
       rawHex: a.rawHex,
+      len: a.len,
+      packetType: a.packetType,
+      route: a.route,
+      payloadLen: a.payloadLen,
+      hash: a.hash,
     });
   } catch (err) {
     console.error(

--- a/src/main/meshcore-mqtt-adapter.test.ts
+++ b/src/main/meshcore-mqtt-adapter.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import type { IClientOptions } from 'mqtt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MQTTSettings } from '../renderer/lib/types';
@@ -40,6 +41,29 @@ function seedConnected(adapter: MeshcoreMqttAdapter, expiresAt: number): void {
   a.status = 'connected';
   a.lastSettings = { ...BASE_SETTINGS, tokenExpiresAt: expiresAt };
 }
+
+describe('MeshcoreMqttAdapter — clientId', () => {
+  let adapter: MeshcoreMqttAdapter;
+
+  beforeEach(() => {
+    adapter = new MeshcoreMqttAdapter();
+  });
+
+  it('uses username as clientId if it matches v1_ pattern', async () => {
+    const mqtt = await import('mqtt');
+    const v1Username = `v1_${'A'.repeat(64)}`;
+    adapter.connect({ ...BASE_SETTINGS, username: v1Username });
+    expect(mqtt.connect).toHaveBeenCalledWith(expect.objectContaining({ clientId: v1Username }));
+  });
+
+  it('uses random clientId if username does not match v1_ pattern', async () => {
+    const mqtt = await import('mqtt');
+    adapter.connect({ ...BASE_SETTINGS, username: 'normal-user' });
+    const call = vi.mocked(mqtt.connect).mock.calls[vi.mocked(mqtt.connect).mock.calls.length - 1];
+    const opts = call[0] as IClientOptions;
+    expect(opts.clientId).toMatch(/^meshcore-mqtt-[a-z0-9]{8}$/);
+  });
+});
 
 describe('MeshcoreMqttAdapter — token refresh', () => {
   let adapter: MeshcoreMqttAdapter;

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -62,6 +62,8 @@ export class MeshcoreMqttAdapter extends EventEmitter {
   private firstMessageLogged = false;
   private wssPingTimer: ReturnType<typeof setInterval> | null = null;
   private keepaliveRescheduleTimer: ReturnType<typeof setInterval> | null = null;
+  private connectionWatchdogTimer: ReturnType<typeof setInterval> | null = null;
+  private lastPacketReceivedAt = 0;
   private pingReqLogged = false;
   private pingRespLogged = false;
   private retryCount = 0;
@@ -181,6 +183,26 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     }
   }
 
+  private clearConnectionWatchdog(): void {
+    if (this.connectionWatchdogTimer) {
+      clearInterval(this.connectionWatchdogTimer);
+      this.connectionWatchdogTimer = null;
+    }
+  }
+
+  private startConnectionWatchdog(): void {
+    this.clearConnectionWatchdog();
+    const keepaliveSec = this.lastSettings?.keepalive ?? 60;
+    const timeoutMs = keepaliveSec * 1500; // 1.5× keepalive, mirrors broker's own threshold
+    this.connectionWatchdogTimer = setInterval(() => {
+      if (this.status !== 'connected' || !this.client || this.lastPacketReceivedAt === 0) return;
+      if (Date.now() - this.lastPacketReceivedAt > timeoutMs) {
+        console.warn('[MeshCore MQTT] connection watchdog: no packets received, forcing reconnect');
+        this.client.end(true);
+      }
+    }, 15_000);
+  }
+
   private startKeepaliveReschedule(): void {
     this.clearKeepaliveReschedule();
     this.keepaliveRescheduleTimer = setInterval(() => {
@@ -264,9 +286,10 @@ export class MeshcoreMqttAdapter extends EventEmitter {
 
     // Match MQTTManager: WebSocket uses mqtt.connect({ protocol, host, port, path, … }) — not
     // mqtt.connect(urlString, opts), which can hang or mis-handle TLS in Node mqtt.js.
-    // Use MQTT keepalive for both WebSocket and raw TCP; letsmesh requires PINGREQ every 60s.
+    // Use MQTT keepalive for both WebSocket and raw TCP; letsmesh brokers time out at 65s so we
+    // default to 30s to stay well inside that window.
     // WebSocket-level pings (MESHCORE_MQTT_WSS_PING_MS) additionally keep LB/proxy paths alive.
-    const keepaliveSec = settings.keepalive ?? 60;
+    const keepaliveSec = settings.keepalive ?? 30;
     const wsEnabled = settings.useWebSocket === true;
     const wsTlsEnabled =
       settings.tlsEnabled === true || (settings.tlsEnabled !== false && settings.port === 443);
@@ -353,7 +376,9 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       );
       this.clientIdStr = this.client?.options?.clientId ?? '';
       this.lastConnected = Date.now();
+      this.lastPacketReceivedAt = Date.now();
       this.setStatus('connected');
+      this.startConnectionWatchdog();
       this.emit('clientId', this.clientIdStr);
       // LetsMesh/Colorado brokers (v1_ username) are publish-only — skip subscribe.
       const isLetsMeshBroker = /^v1_[0-9A-Fa-f]{64}$/i.test(settings.username ?? '');
@@ -411,6 +436,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       }
     });
     this.client.on('packetreceive', (packet) => {
+      this.lastPacketReceivedAt = Date.now();
       if (packet.cmd === 'pingresp') {
         this.pingRespLogged = false;
         console.debug('[MeshCore MQTT] PINGRESP received', new Date().toISOString());
@@ -451,6 +477,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     this.client.on('close', () => {
       this.clearWssPing();
       this.clearKeepaliveReschedule();
+      this.clearConnectionWatchdog();
       this.clearConnectTimers();
       const now = Date.now();
       this.disconnectCount++;

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -355,33 +355,37 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       this.lastConnected = Date.now();
       this.setStatus('connected');
       this.emit('clientId', this.clientIdStr);
-      // Add small delay before resubscribing to allow broker to stabilize
-      setTimeout(() => {
-        if (this.status !== 'connected' || !this.client) return;
-        const base = normalizePrefix(settings.topicPrefix || 'msh');
-        const subTopic = `${base}/#`;
-        this.client.subscribe(subTopic, (err: Error | null) => {
-          if (err) {
-            if (this.connectAbortByWatchdog) {
-              this.connectAbortByWatchdog = false;
+      // LetsMesh/Colorado brokers (v1_ username) are publish-only — skip subscribe.
+      const isLetsMeshBroker = /^v1_[0-9A-Fa-f]{64}$/i.test(settings.username ?? '');
+      if (!isLetsMeshBroker) {
+        // Add small delay before resubscribing to allow broker to stabilize
+        setTimeout(() => {
+          if (this.status !== 'connected' || !this.client) return;
+          const base = normalizePrefix(settings.topicPrefix || 'msh');
+          const subTopic = `${base}/#`;
+          this.client.subscribe(subTopic, (err: Error | null) => {
+            if (err) {
+              if (this.connectAbortByWatchdog) {
+                this.connectAbortByWatchdog = false;
+                return;
+              }
+              // Cascade after transport teardown (e.g. keepalive) — user already got `error`.
+              if (/^connection closed$/i.test(err.message.trim())) {
+                console.debug(
+                  '[MeshCore MQTT] subscribe skipped (connection closed)',
+                  sanitizeLogMessage(subTopic),
+                );
+                return;
+              }
+              const detail = `Subscribe to ${subTopic} failed: ${err.message}`;
+              console.warn('[MeshCore MQTT] subscribe warning', sanitizeLogMessage(detail));
+              this.emit('subscribeWarning', detail);
               return;
             }
-            // Cascade after transport teardown (e.g. keepalive) — user already got `error`.
-            if (/^connection closed$/i.test(err.message.trim())) {
-              console.debug(
-                '[MeshCore MQTT] subscribe skipped (connection closed)',
-                sanitizeLogMessage(subTopic),
-              );
-              return;
-            }
-            const detail = `Subscribe to ${subTopic} failed: ${err.message}`;
-            console.warn('[MeshCore MQTT] subscribe warning', sanitizeLogMessage(detail));
-            this.emit('subscribeWarning', detail);
-            return;
-          }
-          console.debug('[MeshCore MQTT] subscribe callback OK', sanitizeLogMessage(subTopic));
-        });
-      }, 500);
+            console.debug('[MeshCore MQTT] subscribe callback OK', sanitizeLogMessage(subTopic));
+          });
+        }, 500);
+      }
       // WebSocket-level pings keep LB/proxy paths alive independent of MQTT keepalive
       if (settings.useWebSocket) {
         // Ping every 10s so intermediary idle timers stay reset

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -552,7 +552,9 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       throw new Error('MeshCore MQTT not connected');
     }
     const base = normalizePrefix(this.lastSettings.topicPrefix || 'msh');
-    const topic = `${base}/meshcore/chat`;
+    const v1Pattern = /^v1_([0-9A-Fa-f]{64})$/i;
+    const pubKey = v1Pattern.exec(this.lastSettings.username ?? '')?.[1]?.toUpperCase();
+    const topic = pubKey ? `${base}/${pubKey}/chat` : `${base}/meshcore/chat`;
     const payload = JSON.stringify(envelope);
     this.client.publish(topic, payload, { qos: 0 });
   }
@@ -566,7 +568,10 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       throw new Error('MeshCore MQTT not connected');
     }
     const base = normalizePrefix(this.lastSettings.topicPrefix || 'msh');
-    const topic = `${base}/meshcore/packets`;
+    const pubKey = /^v1_([0-9A-Fa-f]{64})$/i
+      .exec(this.lastSettings.username ?? '')?.[1]
+      ?.toUpperCase();
+    const topic = pubKey ? `${base}/${pubKey}/packets` : `${base}/meshcore/packets`;
     const now = new Date();
     const pad = (n: number) => n.toString().padStart(2, '0');
     const time = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -36,14 +36,9 @@ function buildMeshcoreUrlForLog(settings: MQTTSettings): string {
 const MESHCORE_MQTT_CONNECT_ACK_MS = 30_000;
 /** Send WebSocket-level ping frames so LB/proxy idle timers see traffic at ~10s intervals. */
 const MESHCORE_MQTT_WSS_PING_MS = 10_000;
-/** Reconnect delay base/cap — mirrors MQTTManager. */
+/** Reconnect delay base/cap. */
 const MESHCORE_MQTT_RECONNECT_IMMEDIATE_MS = 500;
 const MESHCORE_MQTT_RECONNECT_10_MINUTE_DELAY_MS = 600_000;
-/**
- * Periodic reschedulePing(true) resets mqtt.js KeepaliveManager without waiting for PINGRESP/SUBACK
- * on proxied WSS paths (LetsMesh broker) — same as MQTTManager.
- */
-const MESHCORE_MQTT_RESCHEDULE_MS = 30_000;
 /**
  * A session that lasted this long is considered stable. When the next disconnect occurs after a
  * stable session, retryCount resets to 0 so the full retry budget is available again.
@@ -61,7 +56,6 @@ export class MeshcoreMqttAdapter extends EventEmitter {
   /** One-shot: log first inbound MQTT message for broker delivery diagnostics. */
   private firstMessageLogged = false;
   private wssPingTimer: ReturnType<typeof setInterval> | null = null;
-  private keepaliveRescheduleTimer: ReturnType<typeof setInterval> | null = null;
   private connectionWatchdogTimer: ReturnType<typeof setInterval> | null = null;
   private lastPacketReceivedAt = 0;
   private pingReqLogged = false;
@@ -176,13 +170,6 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     }
   }
 
-  private clearKeepaliveReschedule(): void {
-    if (this.keepaliveRescheduleTimer) {
-      clearInterval(this.keepaliveRescheduleTimer);
-      this.keepaliveRescheduleTimer = null;
-    }
-  }
-
   private clearConnectionWatchdog(): void {
     if (this.connectionWatchdogTimer) {
       clearInterval(this.connectionWatchdogTimer);
@@ -203,21 +190,6 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     }, 15_000);
   }
 
-  private startKeepaliveReschedule(): void {
-    this.clearKeepaliveReschedule();
-    this.keepaliveRescheduleTimer = setInterval(() => {
-      if (!this.client?.connected) return;
-      try {
-        this.client.reschedulePing(true);
-      } catch (e) {
-        console.debug(
-          '[MeshCore MQTT] reschedulePing failed',
-          sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
-        );
-      }
-    }, MESHCORE_MQTT_RESCHEDULE_MS);
-  }
-
   private clearReconnectTimer(): void {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -235,7 +207,6 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     this.clearTokenRefreshTimer();
     this.clearConnectTimers();
     this.clearWssPing();
-    this.clearKeepaliveReschedule();
     this.clearReconnectTimer();
     this.pendingReconnect = false;
     if (this.pendingReconnectTimer) {
@@ -279,7 +250,10 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       }
       this.client = null;
     }
-    const clientId = `meshcore-mqtt-${Math.random().toString(36).slice(2, 10)}`;
+    const isV1Username = /^v1_[0-9A-Fa-f]{64}$/i.test(settings.username ?? '');
+    const clientId = isV1Username
+      ? settings.username
+      : `meshcore-mqtt-${Math.random().toString(36).slice(2, 10)}`;
     const useTls = settings.port === 8883;
     const rejectUnauthorizedTls = useTls ? !settings.tlsInsecure : false;
     const logUrl = buildMeshcoreUrlForLog(settings);
@@ -424,8 +398,6 @@ export class MeshcoreMqttAdapter extends EventEmitter {
           }
         }, MESHCORE_MQTT_WSS_PING_MS);
       }
-      // Start keepalive reschedule (same as MQTTManager) — resets mqtt.js keepalive without waiting for PINGRESP
-      this.startKeepaliveReschedule();
       // Schedule proactive token refresh
       this.scheduleTokenRefresh();
     });
@@ -476,7 +448,6 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     });
     this.client.on('close', () => {
       this.clearWssPing();
-      this.clearKeepaliveReschedule();
       this.clearConnectionWatchdog();
       this.clearConnectTimers();
       const now = Date.now();

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -579,6 +579,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     if (!this.client || this.status !== 'connected' || !this.lastSettings) {
       throw new Error('MeshCore MQTT not connected');
     }
+    if (!this.lastSettings.meshcorePacketLoggerEnabled) return;
     const base = normalizePrefix(this.lastSettings.topicPrefix || 'msh');
     const pubKey = /^v1_([0-9A-Fa-f]{64})$/i
       .exec(this.lastSettings.username ?? '')?.[1]

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -559,7 +559,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     const v1Pattern = /^v1_([0-9A-Fa-f]{64})$/i;
     const pubKey = v1Pattern.exec(this.lastSettings.username ?? '')?.[1]?.toUpperCase();
     const topic = pubKey ? `${base}/${pubKey}/chat` : `${base}/meshcore/chat`;
-    const payload = JSON.stringify(envelope);
+    const payload = JSON.stringify(pubKey ? { origin_id: pubKey, ...envelope } : envelope);
     this.client.publish(topic, payload, { qos: 0 });
   }
 
@@ -581,6 +581,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     const time = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
     const date = `${now.getDate()}/${now.getMonth() + 1}/${now.getFullYear()}`;
     const payload: Record<string, string> = {
+      ...(pubKey ? { origin_id: pubKey } : {}),
       origin: args.origin.slice(0, 200),
       timestamp: now.toISOString(),
       type: 'PACKET',

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -179,7 +179,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
 
   private startConnectionWatchdog(): void {
     this.clearConnectionWatchdog();
-    const keepaliveSec = this.lastSettings?.keepalive ?? 60;
+    const keepaliveSec = this.lastSettings?.keepalive ?? 30;
     const timeoutMs = keepaliveSec * 1500; // 1.5× keepalive, mirrors broker's own threshold
     this.connectionWatchdogTimer = setInterval(() => {
       if (this.status !== 'connected' || !this.client || this.lastPacketReceivedAt === 0) return;
@@ -355,8 +355,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       this.startConnectionWatchdog();
       this.emit('clientId', this.clientIdStr);
       // LetsMesh/Colorado brokers (v1_ username) are publish-only — skip subscribe.
-      const isLetsMeshBroker = /^v1_[0-9A-Fa-f]{64}$/i.test(settings.username ?? '');
-      if (!isLetsMeshBroker) {
+      if (!isV1Username) {
         // Add small delay before resubscribing to allow broker to stabilize
         setTimeout(() => {
           if (this.status !== 'connected' || !this.client) return;
@@ -575,6 +574,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
     route?: string;
     payloadLen?: number;
     hash?: string;
+    direction?: 'rx' | 'tx';
   }): void {
     if (!this.client || this.status !== 'connected' || !this.lastSettings) {
       throw new Error('MeshCore MQTT not connected');
@@ -594,7 +594,7 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       origin: args.origin.slice(0, 200),
       timestamp: now.toISOString(),
       type: 'PACKET',
-      direction: 'rx',
+      direction: args.direction ?? 'rx',
       time,
       date,
       ...(args.len != null ? { len: String(args.len) } : {}),

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -565,7 +565,17 @@ export class MeshcoreMqttAdapter extends EventEmitter {
    * Packet logger / Analyzer feed — same topic layout as meshcoretomqtt (`meshcore/packets` under
    * topic prefix), JSON shape aligned with Andrew-a-g/meshcoretomqtt README examples.
    */
-  publishPacketLog(args: { origin: string; snr: number; rssi: number; rawHex?: string }): void {
+  publishPacketLog(args: {
+    origin: string;
+    snr: number;
+    rssi: number;
+    rawHex?: string;
+    len?: number;
+    packetType?: number;
+    route?: string;
+    payloadLen?: number;
+    hash?: string;
+  }): void {
     if (!this.client || this.status !== 'connected' || !this.lastSettings) {
       throw new Error('MeshCore MQTT not connected');
     }
@@ -586,13 +596,17 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       direction: 'rx',
       time,
       date,
+      ...(args.len != null ? { len: String(args.len) } : {}),
+      ...(args.packetType != null ? { packet_type: String(args.packetType) } : {}),
+      ...(args.route != null ? { route: args.route } : {}),
+      ...(args.payloadLen != null ? { payload_len: String(args.payloadLen) } : {}),
+      ...(args.rawHex
+        ? { raw: args.rawHex.length > 2048 ? args.rawHex.slice(0, 2048) : args.rawHex }
+        : {}),
       SNR: String(args.snr),
       RSSI: String(args.rssi),
-      meshclient_source: 'mesh-client',
+      ...(args.hash ? { hash: args.hash } : {}),
     };
-    if (args.rawHex && args.rawHex.length > 0) {
-      payload.raw_hex = args.rawHex.length > 2048 ? args.rawHex.slice(0, 2048) : args.rawHex;
-    }
     this.client.publish(topic, JSON.stringify(payload), { qos: 0 });
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -407,6 +407,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       route?: string;
       payloadLen?: number;
       hash?: string;
+      direction?: 'rx' | 'tx';
     }) => ipcRenderer.invoke('mqtt:publishMeshcorePacketLog', args),
     onMeshcoreChat: (cb: (msg: unknown) => void) => {
       const handler = (_: unknown, m: unknown) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -402,6 +402,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       snr: number;
       rssi: number;
       rawHex?: string;
+      len?: number;
+      packetType?: number;
+      route?: string;
+      payloadLen?: number;
+      hash?: string;
     }) => ipcRenderer.invoke('mqtt:publishMeshcorePacketLog', args),
     onMeshcoreChat: (cb: (msg: unknown) => void) => {
       const handler = (_: unknown, m: unknown) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1589,7 +1589,6 @@ export default function App() {
                                 : undefined
                             }
                             protocol="meshtastic"
-                            onProtocolChange={handleProtocolChange}
                             firmwareCheckState={
                               protocol === 'meshtastic' ? firmwareCheckState : undefined
                             }
@@ -1626,7 +1625,6 @@ export default function App() {
                                 : undefined
                             }
                             protocol="meshcore"
-                            onProtocolChange={handleProtocolChange}
                             firmwareCheckState={
                               protocol === 'meshcore' ? firmwareCheckState : undefined
                             }

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -25,7 +25,6 @@ describe('ConnectionPanel MQTT port clamping', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshtastic"
-        onProtocolChange={vi.fn()}
       />,
     );
     // Navigate to MQTT section — look for the port field by label
@@ -50,7 +49,6 @@ describe('HelpTooltip in MQTT form', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol={protocol}
-        onProtocolChange={vi.fn()}
       />,
     );
   }
@@ -92,7 +90,6 @@ describe('ConnectionPanel accessibility', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshtastic"
-        onProtocolChange={vi.fn()}
       />,
     );
     const results = await axe(container);
@@ -114,7 +111,6 @@ describe('ConnectionPanel MQTT connect error', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshcore"
-        onProtocolChange={vi.fn()}
       />,
     );
 
@@ -146,7 +142,6 @@ describe('ConnectionPanel MQTT connect error', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshtastic"
-        onProtocolChange={vi.fn()}
       />,
     );
 
@@ -188,7 +183,6 @@ describe('ConnectionPanel BLE error humanization', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshcore"
-        onProtocolChange={vi.fn()}
       />,
     );
 
@@ -225,7 +219,6 @@ describe('ConnectionPanel BLE error humanization', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshtastic"
-        onProtocolChange={vi.fn()}
       />,
     );
 
@@ -262,7 +255,6 @@ describe('ConnectionPanel BLE error humanization', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshtastic"
-        onProtocolChange={vi.fn()}
       />,
     );
 
@@ -300,7 +292,6 @@ describe('ConnectionPanel Linux BLE path', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshtastic"
-        onProtocolChange={vi.fn()}
       />,
     );
 
@@ -336,7 +327,6 @@ describe('ConnectionPanel Linux BLE path', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshcore"
-        onProtocolChange={vi.fn()}
       />,
     );
 
@@ -371,7 +361,6 @@ function renderWithFirmware(
       onDisconnect={vi.fn().mockResolvedValue(undefined)}
       mqttStatus="disconnected"
       protocol="meshtastic"
-      onProtocolChange={vi.fn()}
       firmwareCheckState={firmwareCheckState}
       onOpenFirmwareReleases={onOpenFirmwareReleases}
     />,
@@ -395,7 +384,6 @@ describe('ConnectionPanel firmware status indicator', () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshtastic"
-        onProtocolChange={vi.fn()}
         firmwareCheckState={{ phase: 'up-to-date', latestVersion: '2.5.4' }}
         onOpenFirmwareReleases={vi.fn()}
       />,
@@ -446,7 +434,6 @@ describe("ConnectionPanel Meshtastic MQTT presets — Liam's server", () => {
         onDisconnect={vi.fn().mockResolvedValue(undefined)}
         mqttStatus="disconnected"
         protocol="meshtastic"
-        onProtocolChange={vi.fn()}
       />,
     );
   }

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -440,6 +440,24 @@ function migrateMqttSettingsOnce(): void {
 }
 migrateMqttSettingsOnce();
 
+function migrateMeshcoreTopicIataOnce(): void {
+  const MIGRATION_KEY = 'mesh-client:migrated:meshcore-topic-iata-v1';
+  if (localStorage.getItem(MIGRATION_KEY) !== null) return;
+  const raw = localStorage.getItem('mesh-client:mqttSettings:meshcore');
+  if (raw) {
+    const parsed = parseStoredJson<Partial<MQTTSettings>>(raw, 'migrateMeshcoreTopicIataOnce');
+    if (parsed?.topicPrefix === 'meshcore' && typeof parsed.server === 'string') {
+      const iata = parsed.server.trim() === COLORADO_MESH_HOST ? 'DEN' : 'test';
+      localStorage.setItem(
+        'mesh-client:mqttSettings:meshcore',
+        JSON.stringify({ ...parsed, topicPrefix: `meshcore/${iata}` }),
+      );
+    }
+  }
+  localStorage.setItem(MIGRATION_KEY, '1');
+}
+migrateMeshcoreTopicIataOnce();
+
 function loadMqttSettings(): MQTTSettings {
   const raw = localStorage.getItem('mesh-client:mqttSettings');
   const parsed = parseStoredJson<Partial<MQTTSettings>>(raw, 'ConnectionPanel loadMqttSettings');
@@ -653,7 +671,9 @@ export default function ConnectionPanel({
     const syncLetsMeshUsername = () => {
       if (
         protocol !== 'meshcore' ||
-        (meshcorePreset !== 'letsmesh' && meshcorePreset !== 'meshmapper')
+        (meshcorePreset !== 'letsmesh' &&
+          meshcorePreset !== 'meshmapper' &&
+          meshcorePreset !== 'coloradomesh')
       )
         return;
       const u = letsMeshMqttUsernameFromIdentity(readMeshcoreIdentity());
@@ -1974,7 +1994,7 @@ export default function ConnectionPanel({
                           ...prev,
                           server: LETSMESH_HOST_US,
                           port: 443,
-                          topicPrefix: 'meshcore',
+                          topicPrefix: 'meshcore/test',
                           useWebSocket: true,
                           keepalive: 60,
                           username: fromIdentity || prev.username,
@@ -2002,7 +2022,7 @@ export default function ConnectionPanel({
                           ...prev,
                           server: MESHMAPPER_HOST,
                           port: 443,
-                          topicPrefix: 'meshcore',
+                          topicPrefix: 'meshcore/test',
                           useWebSocket: true,
                           keepalive: 60,
                           username: fromIdentity || prev.username,
@@ -2048,7 +2068,6 @@ export default function ConnectionPanel({
                         port: 443,
                         useWebSocket: true,
                         keepalive: 60,
-                        topicPrefix: 'meshcore',
                         username: fromIdentity || prev.username,
                       }));
                     }}
@@ -2070,7 +2089,6 @@ export default function ConnectionPanel({
                         port: 443,
                         useWebSocket: true,
                         keepalive: 60,
-                        topicPrefix: 'meshcore',
                         username: fromIdentity || prev.username,
                       }));
                     }}

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -1987,7 +1987,7 @@ export default function ConnectionPanel({
                           ...prev,
                           server: COLORADO_MESH_HOST,
                           port: 1883,
-                          topicPrefix: 'meshcore',
+                          topicPrefix: 'meshcore/DEN',
                           useWebSocket: true,
                           tlsEnabled: true,
                           wsPath: '/ws',

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -520,7 +520,6 @@ interface Props {
   mqttStatus: MQTTStatus;
   myNodeLabel?: string;
   protocol: MeshProtocol;
-  onProtocolChange: (p: MeshProtocol) => void;
   manualAddContacts?: boolean;
   onToggleManualContacts?: (manual: boolean) => Promise<void>;
   firmwareCheckState?: FirmwareCheckResult;
@@ -535,7 +534,6 @@ export default function ConnectionPanel({
   mqttStatus,
   myNodeLabel,
   protocol,
-  onProtocolChange,
   manualAddContacts,
   onToggleManualContacts,
   firmwareCheckState,
@@ -1523,32 +1521,6 @@ export default function ConnectionPanel({
     state.status === 'stale' ||
     state.status === 'reconnecting';
 
-  // ─── Protocol toggle (shown in both connected and disconnected views) ──
-  const protocolToggle = (
-    <div className="bg-deep-black flex overflow-hidden rounded-lg border border-gray-700">
-      {(['meshtastic', 'meshcore'] as const).map((p) => (
-        <button
-          key={p}
-          type="button"
-          aria-label={p === 'meshtastic' ? 'Meshtastic' : 'MeshCore'}
-          aria-pressed={protocol === p}
-          onClick={() => {
-            onProtocolChange(p);
-          }}
-          className={`flex-1 py-2 text-sm font-medium transition-colors ${
-            protocol === p
-              ? p === 'meshcore'
-                ? 'bg-cyan-600/20 text-cyan-400'
-                : 'bg-brand-green/20 text-brand-green border-brand-green'
-              : 'text-muted hover:bg-secondary-dark hover:text-gray-200'
-          }`}
-        >
-          {p === 'meshtastic' ? 'Meshtastic' : 'MeshCore'}
-        </button>
-      ))}
-    </div>
-  );
-
   // ─── Connecting Progress View ───────────────────────────────────
   if (connecting && !isConnected) {
     return (
@@ -2426,7 +2398,6 @@ export default function ConnectionPanel({
   if (isConnected) {
     return (
       <div className="w-full space-y-6">
-        {protocolToggle}
         <button
           onClick={async () => {
             // Cap wait so quit always runs if transport teardown hangs (e.g. Windows serial/BLE).
@@ -2558,7 +2529,6 @@ export default function ConnectionPanel({
   // ─── Disconnected View ─────────────────────────────────────────
   return (
     <div className="w-full space-y-6">
-      {protocolToggle}
       {mqttStatus === 'connected' && (
         <button
           type="button"

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -1782,9 +1782,7 @@ export default function ConnectionPanel({
 
   // ─── Shared MQTT section ────────────────────────────────────────
   const mqttHeaderBar = (
-    <div
-      className={`bg-secondary-dark flex items-center justify-between border-b px-4 py-3 ${mqttStatus === 'connected' ? 'border-brand-green/20' : 'border-gray-700'}`}
-    >
+    <div className="bg-secondary-dark flex items-center justify-between border-b border-gray-700 px-4 py-3">
       <div className="flex items-center gap-2">
         <MqttGlobeIcon status={mqttStatus} />
         <span className="font-medium text-gray-200">MQTT Connection</span>
@@ -1809,7 +1807,7 @@ export default function ConnectionPanel({
 
   const mqttSection =
     mqttStatus === 'connected' ? (
-      <div className={`bg-deep-black border-brand-green/20 overflow-hidden rounded-lg border`}>
+      <div className="bg-deep-black overflow-hidden rounded-lg border border-gray-700">
         {mqttHeaderBar}
         {mqttError && (
           <div className="border-b border-red-800 bg-red-900/50 px-4 py-2 text-xs text-red-300">
@@ -2444,16 +2442,8 @@ export default function ConnectionPanel({
           Disconnect &amp; Quit
         </button>
 
-        <div
-          className={`bg-deep-black overflow-hidden rounded-lg border ${
-            state.status === 'reconnecting' ? 'border-orange-500/30' : 'border-brand-green/20'
-          }`}
-        >
-          <div
-            className={`bg-secondary-dark flex items-center justify-between border-b px-4 py-3 ${
-              state.status === 'reconnecting' ? 'border-orange-500/30' : 'border-brand-green/20'
-            }`}
-          >
+        <div className="bg-deep-black overflow-hidden rounded-lg border border-gray-700">
+          <div className="bg-secondary-dark flex items-center justify-between border-b border-gray-700 px-4 py-3">
             <div className="flex items-center gap-2">
               <ConnectionIcon type={state.connectionType!} />
               <span className="font-medium text-gray-200">Radio Connection</span>

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -567,7 +567,6 @@ export default function ConnectionPanel({
   const [showMqttPassword, setShowMqttPassword] = useState(false);
   const [mqttError, setMqttError] = useState<string | null>(null);
   const [mqttWarning, setMqttWarning] = useState<string | null>(null);
-  const [mqttClientId, setMqttClientId] = useState('');
   const mqttSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const meshcoreMqttSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [meshcorePreset, setMeshcorePreset] = useState<
@@ -640,27 +639,11 @@ export default function ConnectionPanel({
       setMqttWarning(protocol === 'meshcore' ? meshcoreMqttUserFacingHint(warning) : warning);
     });
   }, [protocol]);
-  useEffect(() => {
-    // Restore clientId if already connected when this component mounts (e.g. after tab switch)
-    window.electronAPI.mqtt
-      .getClientId(protocol)
-      .then((id) => {
-        if (id) setMqttClientId(id);
-      })
-      .catch((err: unknown) => {
-        console.warn('[ConnectionPanel] getClientId failed:', err);
-      });
-    return window.electronAPI.mqtt.onClientId(({ clientId, protocol: mqttProtocol }) => {
-      if (mqttProtocol !== protocol) return;
-      setMqttClientId(clientId);
-    });
-  }, [protocol]);
 
   // Clear MQTT error on successful connect; leave it visible on disconnect so the user can read it.
   useEffect(() => {
     if (mqttStatus === 'connected') setMqttError(null);
     if (mqttStatus === 'disconnected') {
-      setMqttClientId('');
       setMqttWarning(null);
     }
     if (mqttStatus === 'connecting') setMqttWarning(null);
@@ -1845,10 +1828,12 @@ export default function ConnectionPanel({
               {activeMqttSettings.server}:{activeMqttSettings.port}
             </span>
           </div>
-          {mqttClientId && (
+          {state.myNodeNum > 0 && (
             <div className="flex justify-between text-sm">
-              <span className="text-muted">Client ID</span>
-              <span className="font-mono text-xs text-gray-200">{mqttClientId}</span>
+              <span className="text-muted">From</span>
+              <span className="font-mono text-xs text-gray-200">
+                !{state.myNodeNum.toString(16)}
+              </span>
             </div>
           )}
           <div className="flex justify-between text-sm">

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -1996,7 +1996,7 @@ export default function ConnectionPanel({
                           port: 443,
                           topicPrefix: 'meshcore/test',
                           useWebSocket: true,
-                          keepalive: 60,
+                          keepalive: 30,
                           username: fromIdentity || prev.username,
                           password: '',
                         }));
@@ -2011,7 +2011,7 @@ export default function ConnectionPanel({
                           useWebSocket: true,
                           tlsEnabled: true,
                           wsPath: '/ws',
-                          keepalive: 60,
+                          keepalive: 30,
                           username: fromIdentity || prev.username,
                           password: '',
                         }));
@@ -2024,7 +2024,7 @@ export default function ConnectionPanel({
                           port: 443,
                           topicPrefix: 'meshcore/test',
                           useWebSocket: true,
-                          keepalive: 60,
+                          keepalive: 30,
                           username: fromIdentity || prev.username,
                           password: '',
                         }));

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -2203,29 +2203,25 @@ export default function ConnectionPanel({
                 })()}
               </div>
             )}
-          {protocol === 'meshcore' &&
-            (meshcorePreset === 'letsmesh' ||
-              meshcorePreset === 'coloradomesh' ||
-              meshcorePreset === 'meshmapper') && (
-              <div className="bg-secondary-dark/40 flex items-start gap-2 rounded border border-gray-600/50 px-2 py-2 text-xs text-gray-300">
-                <input
-                  type="checkbox"
-                  id="meshcore-packet-logger"
-                  checked={meshcoreMqttSettings.meshcorePacketLoggerEnabled ?? false}
-                  onChange={(e) => {
-                    updateMqtt('meshcorePacketLoggerEnabled', e.target.checked);
-                  }}
-                  className="accent-brand-green mt-0.5 shrink-0"
-                />
-                <label htmlFor="meshcore-packet-logger" className="cursor-pointer leading-snug">
-                  Packet logger (LetsMesh Analyzer) — when connected to your radio and MQTT, forward
-                  RX packet summaries to{' '}
-                  <code className="text-gray-400">{`{topicPrefix}/meshcore/packets`}</code> in the
-                  same JSON shape as meshcoretomqtt. Off by default; only enable if you intend to
-                  share heard air traffic with the public analyzer.
-                </label>
-              </div>
-            )}
+          {protocol === 'meshcore' && (
+            <div className="bg-secondary-dark/40 flex items-start gap-2 rounded border border-gray-600/50 px-2 py-2 text-xs text-gray-300">
+              <input
+                type="checkbox"
+                id="meshcore-packet-logger"
+                checked={meshcoreMqttSettings.meshcorePacketLoggerEnabled ?? false}
+                onChange={(e) => {
+                  updateMqtt('meshcorePacketLoggerEnabled', e.target.checked);
+                }}
+                className="accent-brand-green mt-0.5 shrink-0"
+              />
+              <label htmlFor="meshcore-packet-logger" className="cursor-pointer leading-snug">
+                Packet logger — when connected to your radio and MQTT, forward RX packet summaries
+                to <code className="text-gray-400">{`{topicPrefix}/meshcore/packets`}</code> in the
+                same JSON shape as meshcoretomqtt. Off by default; only enable if you intend to
+                share heard air traffic with a packet analyzer.
+              </label>
+            </div>
+          )}
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
             <div className="space-y-1">
               <label htmlFor="mqtt-username" className="text-muted text-xs">

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -1828,7 +1828,16 @@ export default function ConnectionPanel({
               {activeMqttSettings.server}:{activeMqttSettings.port}
             </span>
           </div>
-          {state.myNodeNum > 0 && (
+          {protocol === 'meshcore' &&
+            /^v1_[0-9A-Fa-f]{64}$/i.test(activeMqttSettings.username ?? '') && (
+              <div className="flex justify-between text-sm">
+                <span className="text-muted">From</span>
+                <span className="font-mono text-xs text-gray-200">
+                  {activeMqttSettings.username?.slice(3)}
+                </span>
+              </div>
+            )}
+          {protocol === 'meshtastic' && state.myNodeNum > 0 && (
             <div className="flex justify-between text-sm">
               <span className="text-muted">From</span>
               <span className="font-mono text-xs text-gray-200">

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -2513,6 +2513,17 @@ export function useMeshCore() {
             receivedVia: 'rf',
           }),
         );
+        if (mqttStatusRef.current === 'connected') {
+          void window.electronAPI.mqtt
+            .publishMeshcorePacketLog({
+              origin: selfInfoRef.current?.name ?? 'mesh-client',
+              snr: rfMatch?.snr ?? 0,
+              rssi: rfMatch?.rssi ?? 0,
+            })
+            .catch((e: unknown) => {
+              console.warn('[useMeshCore] publishMeshcorePacketLog (heard RF) error', e);
+            });
+        }
         setRawPackets((prev) =>
           meshcoreCorrelateOrSynthesizeChatEntry(prev, 'GRP_TXT', stubId, {
             ts: now,

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -3725,12 +3725,6 @@ export function useMeshCore() {
               replyId: replyField,
             });
           } else if (mqttStatusRef.current === 'connected') {
-            const mq = readMeshcoreMqttSettingsFromStorage();
-            if (isLetsMeshSettings(mq.server)) {
-              // LetsMesh MQTT is for authenticated packet/analyzer feeds (see docs), not MQTT-only
-              // channel chat without a radio.
-              return;
-            }
             await window.electronAPI.mqtt.publishMeshcore({
               text: textToSend,
               channelIdx,

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -2515,6 +2515,18 @@ export function useMeshCore() {
             receivedVia: 'rf',
           }),
         );
+        if (mqttStatusRef.current === 'connected') {
+          void window.electronAPI.mqtt
+            .publishMeshcore({
+              text: normalized.payload || d.text,
+              channelIdx: d.channelIdx,
+              senderName: normalized.senderName ?? displayName,
+              timestamp: d.senderTimestamp * 1000,
+            })
+            .catch((e: unknown) => {
+              console.warn('[useMeshCore] publishMeshcore (heard RF) error', e);
+            });
+        }
         setRawPackets((prev) =>
           meshcoreCorrelateOrSynthesizeChatEntry(prev, 'GRP_TXT', stubId, {
             ts: now,

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -23,7 +23,6 @@ import {
 } from '../lib/foreignLoraDetection';
 import type { OurPosition } from '../lib/gpsSource';
 import { resolveOurPosition } from '../lib/gpsSource';
-import { isLetsMeshSettings } from '../lib/letsMeshJwt';
 import {
   buildMeshcoreChannelIncomingMessage,
   buildMeshcoreDmIncomingMessage,
@@ -43,7 +42,6 @@ import {
   buildMeshcoreGetNeighboursRequest,
   parseMeshcoreGetNeighboursResponse,
 } from '../lib/meshcoreGetNeighboursBinary';
-import { readMeshcoreMqttSettingsFromStorage } from '../lib/meshcoreMqttSettingsStorage';
 import {
   MESHCORE_CHAT_CORRELATE_WINDOW_MS,
   meshcoreCorrelateOrSynthesizeChatEntry,
@@ -2517,14 +2515,13 @@ export function useMeshCore() {
         );
         if (mqttStatusRef.current === 'connected') {
           void window.electronAPI.mqtt
-            .publishMeshcore({
-              text: normalized.payload || d.text,
-              channelIdx: d.channelIdx,
-              senderName: normalized.senderName ?? displayName,
-              timestamp: d.senderTimestamp * 1000,
+            .publishMeshcorePacketLog({
+              origin: displayName,
+              snr: rfMatch?.snr ?? 0,
+              rssi: rfMatch?.rssi ?? 0,
             })
             .catch((e: unknown) => {
-              console.warn('[useMeshCore] publishMeshcore (heard RF) error', e);
+              console.warn('[useMeshCore] publishMeshcorePacketLog (heard RF) error', e);
             });
         }
         setRawPackets((prev) =>
@@ -2600,6 +2597,14 @@ export function useMeshCore() {
         });
         const sigPoint: TelemetryPoint = { timestamp: now, snr, rssi };
         setSignalTelemetry((prev) => [...prev, sigPoint].slice(-MAX_TELEMETRY_POINTS));
+
+        // Packet-log metadata hoisted for the MQTT publish below (set inside the rawU8 block).
+        let mqttRawHex: string | undefined;
+        let mqttLen: number | undefined;
+        let mqttPacketType: number | undefined;
+        let mqttRoute: string | undefined;
+        let mqttPayloadLen: number | undefined;
+        let mqttHash: string | undefined;
 
         // Raw packet log: always run MeshCore in-house parse on this path (LOG_RX is MeshCore RF only).
         // Do not gate on classifyPayload — Meshtastic-shaped heuristics can mis-label MeshCore frames.
@@ -2748,6 +2753,16 @@ export function useMeshCore() {
               ? next.slice(next.length - MAX_RAW_PACKET_LOG_ENTRIES)
               : next;
           });
+
+          // Populate hoisted MQTT packet-log fields from the parsed result.
+          mqttRawHex = Array.from(rawU8, (b) => b.toString(16).padStart(2, '0')).join('');
+          mqttLen = rawU8.length;
+          mqttPayloadLen = rawU8.length;
+          if (parsed.ok) {
+            mqttPacketType = parsed.payloadTypeNibble;
+          }
+          mqttRoute = routeTypeString ?? undefined;
+          mqttHash = messageFingerprintHex ?? undefined;
         }
 
         // Foreign LoRa fingerprinting: only flag non-MeshCore packets as foreign (requires known self node ID)
@@ -2773,26 +2788,21 @@ export function useMeshCore() {
           }
         }
 
-        const mq = readMeshcoreMqttSettingsFromStorage();
-        if (
-          mqttStatusRef.current === 'connected' &&
-          isLetsMeshSettings(mq.server) &&
-          mq.meshcorePacketLoggerEnabled
-        ) {
-          const now = Date.now();
-          if (now - lastPacketLogAtRef.current >= 100) {
-            lastPacketLogAtRef.current = now;
-            const origin = selfInfoRef.current?.name ?? 'mesh-client';
-            let rawHex: string | undefined;
-            if (rawU8) {
-              rawHex = Array.from(rawU8, (b) => b.toString(16).padStart(2, '0')).join('');
-            }
+        if (mqttStatusRef.current === 'connected') {
+          const nowMs = Date.now();
+          if (nowMs - lastPacketLogAtRef.current >= 100) {
+            lastPacketLogAtRef.current = nowMs;
             void window.electronAPI.mqtt
               .publishMeshcorePacketLog({
-                origin,
+                origin: selfInfoRef.current?.name ?? 'mesh-client',
                 snr,
                 rssi,
-                rawHex,
+                rawHex: mqttRawHex,
+                len: mqttLen,
+                packetType: mqttPacketType,
+                route: mqttRoute,
+                payloadLen: mqttPayloadLen,
+                hash: mqttHash,
               })
               .catch(() => {
                 const t = Date.now();
@@ -3738,15 +3748,13 @@ export function useMeshCore() {
             });
             if (mqttStatusRef.current === 'connected') {
               void window.electronAPI.mqtt
-                .publishMeshcore({
-                  text: textToSend,
-                  channelIdx,
-                  senderNodeId: myNodeNumRef.current || undefined,
-                  senderName: selfInfo?.name,
-                  timestamp: sentAt,
+                .publishMeshcorePacketLog({
+                  origin: selfInfo?.name ?? 'mesh-client',
+                  snr: 0,
+                  rssi: 0,
                 })
                 .catch((e: unknown) => {
-                  console.warn('[useMeshCore] publishMeshcore (sent via RF) error', e);
+                  console.warn('[useMeshCore] publishMeshcorePacketLog (sent via RF) error', e);
                 });
             }
           } else if (mqttStatusRef.current === 'connected') {

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -2513,17 +2513,6 @@ export function useMeshCore() {
             receivedVia: 'rf',
           }),
         );
-        if (mqttStatusRef.current === 'connected') {
-          void window.electronAPI.mqtt
-            .publishMeshcorePacketLog({
-              origin: displayName,
-              snr: rfMatch?.snr ?? 0,
-              rssi: rfMatch?.rssi ?? 0,
-            })
-            .catch((e: unknown) => {
-              console.warn('[useMeshCore] publishMeshcorePacketLog (heard RF) error', e);
-            });
-        }
         setRawPackets((prev) =>
           meshcoreCorrelateOrSynthesizeChatEntry(prev, 'GRP_TXT', stubId, {
             ts: now,
@@ -3752,6 +3741,7 @@ export function useMeshCore() {
                   origin: selfInfo?.name ?? 'mesh-client',
                   snr: 0,
                   rssi: 0,
+                  direction: 'tx',
                 })
                 .catch((e: unknown) => {
                   console.warn('[useMeshCore] publishMeshcorePacketLog (sent via RF) error', e);

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -3736,6 +3736,19 @@ export function useMeshCore() {
               status: 'acked',
               replyId: replyField,
             });
+            if (mqttStatusRef.current === 'connected') {
+              void window.electronAPI.mqtt
+                .publishMeshcore({
+                  text: textToSend,
+                  channelIdx,
+                  senderNodeId: myNodeNumRef.current || undefined,
+                  senderName: selfInfo?.name,
+                  timestamp: sentAt,
+                })
+                .catch((e: unknown) => {
+                  console.warn('[useMeshCore] publishMeshcore (sent via RF) error', e);
+                });
+            }
           } else if (mqttStatusRef.current === 'connected') {
             await window.electronAPI.mqtt.publishMeshcore({
               text: textToSend,

--- a/src/renderer/lib/types.ts
+++ b/src/renderer/lib/types.ts
@@ -656,6 +656,7 @@ declare global {
           route?: string;
           payloadLen?: number;
           hash?: string;
+          direction?: 'rx' | 'tx';
         }) => Promise<void>;
         onMeshcoreChat: (cb: (msg: unknown) => void) => () => void;
         refreshMeshcoreToken: (

--- a/src/renderer/lib/types.ts
+++ b/src/renderer/lib/types.ts
@@ -651,6 +651,11 @@ declare global {
           snr: number;
           rssi: number;
           rawHex?: string;
+          len?: number;
+          packetType?: number;
+          route?: string;
+          payloadLen?: number;
+          hash?: string;
         }) => Promise<void>;
         onMeshcoreChat: (cb: (msg: unknown) => void) => () => void;
         refreshMeshcoreToken: (


### PR DESCRIPTION
## Summary

Comprehensive overhaul of the MeshCore MQTT subsystem: fixes topic structure, hardens the connection lifecycle, adds RF↔MQTT bridging, exposes the packet logger for custom brokers, and cleans up the ConnectionPanel UI.

---

## Changes by area

### MQTT connection & keepalive
- Remove custom `keepaliveReschedule` — `mqtt.js`'s built-in `KeepaliveManager` handles PINGREQ natively; the duplicate was causing timing conflicts
- Lower keepalive interval to 30 s and add a zombie-connection watchdog that detects silent stalls and forces reconnect
- Skip MQTT subscribe for LetsMesh/Colorado brokers (publish-only topology)
- Fix topic structure for LetsMesh/Colorado brokers and re-enable chat publishing

### RF ↔ MQTT bridging
- Forward heard RF channel messages to meshcore MQTT when a connection is active
- Publish RF send packets to the `packets` topic with full payload (`len`, `packet_type`, `route`, `hash`, `raw`)
- Add `origin_id` to all meshcore MQTT publish payloads
- Use self node name (not raw ID) as origin in heard-RF chat packet log entries

### Packet logger & ConnectionPanel
- Expose packet logger for custom meshcore MQTT servers (previously gated to built-in brokers only)
- Harden packet logger — guard against malformed/missing fields that caused silent drops
- Show `origin_id` for MeshCore MQTT packets; show hex node ID for Meshtastic packets
- Show actual node hex ID in the MQTT Connection panel (was showing internal numeric ID)
- Fix IATA field in LetsMesh/MeshMapper topic prefixes; sync Colorado username
- Remove duplicate protocol switcher rendered inside ConnectionPanel (already present in parent)
- Use consistent gray borders throughout ConnectionPanel

### Documentation
- Genericize MeshCore MQTT auth doc (`letsmesh-mqtt-auth.md`) and add packet format specs
- Add MQTT troubleshooting entries to `docs/troubleshooting.md` covering connection failures and packet logger issues

### Dependencies
- Bump deps (`chore: bump deps`)

---

## Commits
```
c885aa0 fix: correct MQTT topic structure and re-enable chat for LetsMesh/Colorado brokers
4170d7b fix: add IATA to LetsMesh/MeshMapper topic prefixes; sync Colorado username
7c37445 fix: remove keepaliveReschedule — mqtt.js KeepaliveManager handles PINGREQ natively
2825afd fix: lower keepalive to 30s and add zombie-connection watchdog
a7c70b7 fix: add origin_id to meshcore MQTT publish payloads
b4a8c9d feat: forward heard RF channel messages to meshcore MQTT when connected
25d17ff fix: publish RF packets to packets topic with full payload (len, packet_type, route, hash, raw)
b1749b4 fix: skip MQTT subscribe for LetsMesh/Colorado brokers (publish-only)
6b4c3fb chore: bump deps
ac0748d feat: expose packet logger for custom meshcore MQTT servers
730790a docs: genericize MeshCore MQTT auth doc and add packet format specs
17c37f0 fix: show actual node hex ID in MQTT Connection panel
043a11e docs: add MQTT troubleshooting entries for connection and packet logger issues
4fb07d7 fix: show origin_id for MeshCore MQTT, hex node for Meshtastic
cb16652 fix: use consistent gray borders in ConnectionPanel
9925f9c fix: harden meshcore MQTT packet logger
8c25aca fix: use self name as origin in heard-RF chat packet log
31952cd fix: remove duplicate protocol switcher from ConnectionPanel
```

---

## Testing
- `pnpm run lint` ✅
- `pnpm run typecheck` ✅
- `pnpm run test:run` ✅ (meshcore-mqtt-adapter unit tests cover new packet logger and publish paths)
