### PR TITLE
Fix meshcore repeater reliability and signal fallback

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -984,9 +984,6 @@ export function mergeDatabase(sourcePath: string) {
   try {
     sourceDb = new NodeSqliteDB(sourcePath, { readonly: true });
 
-    const sourceNodes = sourceDb.prepare('SELECT * FROM nodes').all() as any[];
-    const sourceMessages = sourceDb.prepare('SELECT * FROM messages').all() as any[];
-
     return targetDb.transaction(() => {
       let nodesAdded = 0;
       let messagesAdded = 0;
@@ -1016,7 +1013,7 @@ export function mergeDatabase(sourcePath: string) {
         )
       `);
 
-      for (const node of sourceNodes) {
+      for (const node of sourceDb!.prepare('SELECT * FROM nodes').iterate()) {
         try {
           // Basic shape validation: must have a finite node_id; ignore obviously malformed rows.
           const nodeId = Number((node as { node_id?: unknown }).node_id);
@@ -1036,7 +1033,7 @@ export function mergeDatabase(sourcePath: string) {
         }
       }
 
-      for (const msg of sourceMessages) {
+      for (const msg of sourceDb!.prepare('SELECT * FROM messages').iterate()) {
         try {
           const senderId = (msg as { sender_id?: unknown }).sender_id;
           const timestamp = (msg as { timestamp?: unknown }).timestamp;

--- a/src/main/db-compat.ts
+++ b/src/main/db-compat.ts
@@ -111,6 +111,14 @@ class WrappedStatement {
     return (this.stmt.run as any)(...this.prep(args)) as RunResult;
   }
 
+  *iterate(...args: unknown[]): Generator<Record<string, unknown>, void, unknown> {
+    for (const row of (this.stmt.all as (...a: unknown[]) => Record<string, unknown>[])(
+      ...this.prep(args),
+    )) {
+      yield row;
+    }
+  }
+
   get(...args: unknown[]): unknown {
     return (this.stmt.get as any)(...this.prep(args));
   }

--- a/src/main/index.contract.test.ts
+++ b/src/main/index.contract.test.ts
@@ -51,7 +51,9 @@ describe('MeshCore DB IPC (source contract)', () => {
     expect(INDEX_SOURCE).toContain("'db:updateMeshcoreContactLastRf'");
     expect(INDEX_SOURCE).toContain('last_snr = ?,');
     expect(INDEX_SOURCE).toContain('last_rssi = ?,');
-    expect(INDEX_SOURCE).toContain('hops_away = COALESCE(?, hops_away),');
+    expect(INDEX_SOURCE).toContain(
+      'hops_away = CASE WHEN ? IS NOT NULL AND (hops_away IS NULL OR ? < hops_away) THEN ? ELSE hops_away END,',
+    );
     expect(INDEX_SOURCE).toContain('last_advert = CASE WHEN ? IS NOT NULL');
   });
 
@@ -59,6 +61,9 @@ describe('MeshCore DB IPC (source contract)', () => {
     expect(INDEX_SOURCE).toContain("'db:saveMeshcoreContact'");
     expect(INDEX_SOURCE).toContain('ON CONFLICT(node_id) DO UPDATE SET');
     expect(INDEX_SOURCE).toContain('favorited = meshcore_contacts.favorited');
+    expect(INDEX_SOURCE).toContain(
+      'hops_away = CASE WHEN excluded.hops_away IS NOT NULL AND (meshcore_contacts.hops_away IS NULL OR excluded.hops_away < meshcore_contacts.hops_away) THEN excluded.hops_away ELSE meshcore_contacts.hops_away END,',
+    );
     expect(INDEX_SOURCE).not.toContain('INSERT OR REPLACE INTO meshcore_contacts');
   });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2488,7 +2488,10 @@ ipcMain.handle('db:saveNode', (_event, node) => {
         latitude = CASE WHEN excluded.latitude IS NOT NULL AND excluded.latitude != 0 THEN excluded.latitude ELSE nodes.latitude END,
         longitude = CASE WHEN excluded.longitude IS NOT NULL AND excluded.longitude != 0 THEN excluded.longitude ELSE nodes.longitude END,
         role = COALESCE(excluded.role, nodes.role),
-        hops_away = COALESCE(excluded.hops_away, nodes.hops_away),
+        hops_away = CASE
+          WHEN excluded.hops_away IS NOT NULL AND (nodes.hops_away IS NULL OR excluded.hops_away < nodes.hops_away) THEN excluded.hops_away
+          ELSE nodes.hops_away
+        END,
         via_mqtt = COALESCE(excluded.via_mqtt, nodes.via_mqtt),
         voltage = COALESCE(excluded.voltage, nodes.voltage),
         channel_utilization = COALESCE(excluded.channel_utilization, nodes.channel_utilization),
@@ -2502,7 +2505,10 @@ ipcMain.handle('db:saveNode', (_event, node) => {
         num_rx_dupe = COALESCE(excluded.num_rx_dupe, num_rx_dupe),
         num_packets_rx = COALESCE(excluded.num_packets_rx, num_packets_rx),
         num_packets_tx = COALESCE(excluded.num_packets_tx, num_packets_tx),
-        hops = COALESCE(excluded.hops, nodes.hops),
+        hops = CASE
+          WHEN excluded.hops IS NOT NULL AND (nodes.hops IS NULL OR excluded.hops < nodes.hops) THEN excluded.hops
+          ELSE nodes.hops
+        END,
         path = COALESCE(excluded.path, nodes.path)
     `);
     return stmt.run({
@@ -3266,7 +3272,7 @@ ipcMain.handle('db:saveMeshcoreContact', (_event, contact) => {
           'favorited = meshcore_contacts.favorited, ' +
           'nickname = COALESCE(excluded.nickname, meshcore_contacts.nickname), ' +
           'contact_flags = COALESCE(excluded.contact_flags, meshcore_contacts.contact_flags), ' +
-          'hops_away = COALESCE(excluded.hops_away, meshcore_contacts.hops_away), ' +
+          'hops_away = CASE WHEN excluded.hops_away IS NOT NULL AND (meshcore_contacts.hops_away IS NULL OR excluded.hops_away < meshcore_contacts.hops_away) THEN excluded.hops_away ELSE meshcore_contacts.hops_away END, ' +
           'on_radio = excluded.on_radio, ' +
           'last_synced_from_radio = excluded.last_synced_from_radio',
       )
@@ -3788,13 +3794,15 @@ ipcMain.handle(
           'UPDATE meshcore_contacts SET ' +
             'last_snr = ?, ' +
             'last_rssi = ?, ' +
-            'hops_away = COALESCE(?, hops_away), ' +
+            'hops_away = CASE WHEN ? IS NOT NULL AND (hops_away IS NULL OR ? < hops_away) THEN ? ELSE hops_away END, ' +
             'last_advert = CASE WHEN ? IS NOT NULL AND ? > COALESCE(last_advert, 0) THEN ? ELSE last_advert END ' +
             'WHERE node_id = ?',
         )
         .run(
           lastSnr,
           lastRssi,
+          hops ?? null,
+          hops ?? null,
           hops ?? null,
           timestamp ?? null,
           timestamp ?? null,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4209,12 +4209,6 @@ ipcMain.handle('http:connect', async (_event, host: unknown, tls: unknown) => {
     httpDevice = null;
   }
   await httpPreflight(host, tls);
-  let controller: { enqueue: (chunk: { type: string; data: Uint8Array }) => void };
-  void new ReadableStream({
-    start(ctrl) {
-      controller = ctrl;
-    },
-  });
   const intervalId = setInterval(() => {
     void (async () => {
       try {
@@ -4230,10 +4224,6 @@ ipcMain.handle('http:connect', async (_event, host: unknown, tls: unknown) => {
           readBuffer = await response.arrayBuffer();
           if (readBuffer.byteLength > 0) {
             const data = new Uint8Array(readBuffer);
-            controller.enqueue({
-              type: 'packet',
-              data,
-            });
             mainWindow?.webContents.send('http:data', data);
           }
         }

--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -128,6 +128,7 @@ export class MQTTManager extends EventEmitter {
   private wssPingTimer: ReturnType<typeof setInterval> | null = null;
   private keepaliveRescheduleTimer: ReturnType<typeof setInterval> | null = null;
   private sampledDebugLogs = new Map<string, SampledDebugLogState>();
+  private static MAX_SAMPLED_LOGS = 1000;
   /** Wall time at start of last `_doConnect` (CONNACK timing in connect logs). */
   private meshtasticConnectT0 = 0;
   /** After `connack timeout`, reconnect with {@link MESHTASTIC_MQTT_RECONNECT_AFTER_CONNACK_TIMEOUT_MS}. */
@@ -1379,6 +1380,7 @@ export class MQTTManager extends EventEmitter {
     const now = Date.now();
     const state = this.sampledDebugLogs.get(key);
     if (!state) {
+      this.pruneSampledLogs();
       this.sampledDebugLogs.set(key, { lastLoggedAt: now, suppressedCount: 0 });
       console.debug(message); // log-filter-ok Meshtastic MQTT logs → App log panel
       return;
@@ -1396,5 +1398,20 @@ export class MQTTManager extends EventEmitter {
     }
 
     state.suppressedCount += 1;
+  }
+
+  private pruneSampledLogs(): void {
+    while (this.sampledDebugLogs.size > MQTTManager.MAX_SAMPLED_LOGS) {
+      let oldestKey: string | undefined;
+      let oldestTime = Infinity;
+      for (const [k, v] of this.sampledDebugLogs) {
+        if (v.lastLoggedAt < oldestTime) {
+          oldestTime = v.lastLoggedAt;
+          oldestKey = k;
+        }
+      }
+      if (oldestKey) this.sampledDebugLogs.delete(oldestKey);
+      else break;
+    }
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1933,6 +1933,7 @@ export default function App() {
                               meshcoreCliHistories={meshcoreDevice.meshcoreCliHistories}
                               meshcoreCliErrors={meshcoreDevice.meshcoreCliErrors}
                               onClearCliHistory={meshcoreDevice.clearCliHistory}
+                              onToggleFavorite={meshcoreDevice.setNodeFavorited}
                             />
                           </Suspense>
                         </ErrorBoundary>

--- a/src/renderer/components/RepeatersPanel.test.tsx
+++ b/src/renderer/components/RepeatersPanel.test.tsx
@@ -38,6 +38,21 @@ function mockRepeaterNode(id: number): MeshNode {
 
 const repeater = mockRepeaterNode(0xabc);
 
+function mockRepeaterNodeWithFavorited(id: number, favorited: boolean): MeshNode {
+  return {
+    node_id: id,
+    long_name: `Repeater ${id.toString(16)}`,
+    short_name: 'TR',
+    hw_model: 'Repeater',
+    snr: 2,
+    battery: 100,
+    last_heard: Math.floor(Date.now() / 1000),
+    latitude: null,
+    longitude: null,
+    favorited,
+  };
+}
+
 function makeBaseProps() {
   return {
     nodes: new Map([[repeater.node_id, repeater]]),
@@ -158,5 +173,34 @@ describe('RepeatersPanel', () => {
     await userEvent.click(screen.getByRole('button', { name: 'name' }));
 
     expect(onSendCliCommand).toHaveBeenCalledWith(repeater.node_id, 'name', false);
+  });
+
+  it('pins favorited repeaters above non-favorites', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const older = mockRepeaterNodeWithFavorited(0x100, false);
+    older.last_heard = now - 1000;
+    const newer = mockRepeaterNodeWithFavorited(0x200, false);
+    newer.last_heard = now;
+    const favOlder = mockRepeaterNodeWithFavorited(0x300, true);
+    favOlder.last_heard = now - 100;
+
+    const nodes = new Map([
+      [older.node_id, older],
+      [newer.node_id, newer],
+      [favOlder.node_id, favOlder],
+    ]);
+
+    render(<RepeatersPanel {...makeBaseProps()} nodes={nodes} />);
+
+    // Extract text from name buttons (the underline-decorated ones) to check sort order
+    const nameLinks = screen
+      .getAllByRole('button', { name: /Repeater/ })
+      .filter((b) => b.className.includes('underline'));
+    const names = nameLinks.map((b) => b.textContent);
+    // Favorited repeater should be first even though newer repeater was heard more recently
+    expect(names).toHaveLength(3);
+    expect(names[0]).toBe('Repeater 300'); // favorited
+    expect(names[1]).toBe('Repeater 200'); // most recent non-fav
+    expect(names[2]).toBe('Repeater 100'); // oldest non-fav
   });
 });

--- a/src/renderer/components/RepeatersPanel.test.tsx
+++ b/src/renderer/components/RepeatersPanel.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import type { MeshNode } from '../lib/types';
+import { computePathHash, usePathHistoryStore } from '../stores/pathHistoryStore';
 import RepeatersPanel from './RepeatersPanel';
 
 const mockAddToast = vi.fn();
@@ -70,6 +71,7 @@ describe('RepeatersPanel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    usePathHistoryStore.setState({ records: new Map(), lruOrder: [] });
   });
 
   afterEach(() => {
@@ -202,5 +204,79 @@ describe('RepeatersPanel', () => {
     expect(names[0]).toBe('Repeater 300'); // favorited
     expect(names[1]).toBe('Repeater 200'); // most recent non-fav
     expect(names[2]).toBe('Repeater 100'); // oldest non-fav
+  });
+
+  it('renders reliability from historical path outcomes at launch', () => {
+    usePathHistoryStore.setState({
+      records: new Map([
+        [
+          repeater.node_id,
+          [
+            {
+              nodeId: repeater.node_id,
+              pathHash: 'aa',
+              hopCount: 1,
+              pathBytes: [0xaa],
+              wasFloodDiscovery: false,
+              successCount: 2,
+              failureCount: 1,
+              tripTimeMs: 0,
+              routeWeight: 1,
+              lastSuccessTs: null,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            },
+          ],
+        ],
+      ]),
+      lruOrder: [repeater.node_id],
+    });
+
+    render(<RepeatersPanel {...makeBaseProps()} />);
+
+    expect(screen.getByText('67%')).toBeInTheDocument();
+  });
+
+  it('updates reliability after new outcome and persists outcome to DB', async () => {
+    const dbOutcomeSpy = vi.spyOn(window.electronAPI.db, 'recordMeshcorePathOutcome');
+    const pathBytes = [0x33, 0x44];
+    const pathHash = computePathHash(pathBytes);
+    usePathHistoryStore.getState().recordPathUpdated(repeater.node_id, pathBytes, 1, false);
+
+    render(<RepeatersPanel {...makeBaseProps()} />);
+
+    await act(async () => {
+      usePathHistoryStore.getState().recordOutcome(repeater.node_id, pathHash, true);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(dbOutcomeSpy).toHaveBeenCalledWith(repeater.node_id, pathHash, true, undefined);
+  });
+
+  it('loads reliability from DB via ensureBestPathLoaded fallback on mount', async () => {
+    vi.spyOn(window.electronAPI.db, 'getMeshcorePathHistory').mockResolvedValue([
+      {
+        id: 1,
+        node_id: repeater.node_id,
+        path_hash: 'bb',
+        hop_count: 1,
+        path_bytes: '[187]',
+        was_flood_discovery: 0,
+        success_count: 3,
+        failure_count: 1,
+        trip_time_ms: 0,
+        route_weight: 1,
+        last_success_ts: null,
+        created_at: 1,
+        updated_at: 2,
+      },
+    ]);
+
+    render(<RepeatersPanel {...makeBaseProps()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('75%')).toBeInTheDocument();
+    });
   });
 });

--- a/src/renderer/components/RepeatersPanel.tsx
+++ b/src/renderer/components/RepeatersPanel.tsx
@@ -17,6 +17,7 @@ import {
   meshcoreTracePathLenToHops,
 } from '../lib/meshcoreUtils';
 import { getNodeStatus, normalizeLastHeardMs } from '../lib/nodeStatus';
+import type { PathRecord } from '../lib/pathHistoryTypes';
 import { useRadioProvider } from '../lib/radio/providerFactory';
 import type { MeshNode } from '../lib/types';
 import { useCoordFormatStore } from '../stores/coordFormatStore';
@@ -53,6 +54,7 @@ interface Props {
   onClearCliHistory?: (nodeId: number) => void;
   /** MeshCore: when set (non-null), prefetches SQLite path history for visible repeaters. */
   meshcoreCanPingTrace?: (nodeId: number) => boolean;
+  onToggleFavorite?: (nodeId: number, favorited: boolean) => void;
 }
 
 function formatRelativeTime(
@@ -91,12 +93,25 @@ function formatUptime(secs: number | undefined): string {
   return `${mins}m`;
 }
 
+interface SignalPoint {
+  ts: number;
+  snr: number;
+}
+
 /** Prefer on-demand repeater status (remote query); contact list SNR/RSSI are often stale for MeshCore. */
-function displayRepeaterSnr(node: MeshNode, status: MeshCoreRepeaterStatus | undefined): string {
+function displayRepeaterSnr(
+  node: MeshNode,
+  status: MeshCoreRepeaterStatus | undefined,
+  history?: SignalPoint[],
+): string {
   if (status !== undefined && Number.isFinite(status.lastSnr)) {
     return status.lastSnr.toFixed(1);
   }
   if (node.snr != null && node.snr !== 0) return node.snr.toFixed(1);
+  const latestSignal = history && history.length > 0 ? history[history.length - 1] : undefined;
+  if (latestSignal != null && Number.isFinite(latestSignal.snr)) {
+    return latestSignal.snr.toFixed(1);
+  }
   return '—';
 }
 
@@ -108,30 +123,12 @@ function displayRepeaterRssi(node: MeshNode, status: MeshCoreRepeaterStatus | un
   return '—';
 }
 
-function SignalSparkline({ points }: { points: { ts: number; snr: number }[] }) {
-  if (points.length < 2) return <span className="text-xs text-gray-600">—</span>;
-  const W = 80,
-    H = 24;
-  const snrs = points.map((p) => p.snr);
-  const minS = Math.min(...snrs),
-    maxS = Math.max(...snrs);
-  const range = maxS - minS || 1;
-  const minT = points[0].ts,
-    maxT = points[points.length - 1].ts;
-  const timeRange = maxT - minT || 1;
-  const toX = (t: number) => ((t - minT) / timeRange) * W;
-  const toY = (s: number) => H - ((s - minS) / range) * H;
-  const d = points
-    .map((p, i) => `${i === 0 ? 'M' : 'L'}${toX(p.ts).toFixed(1)},${toY(p.snr).toFixed(1)}`)
-    .join(' ');
-  const latest = points[points.length - 1];
-  const tooltip = `${latest.snr.toFixed(1)} dB · ${formatRelativeTime(latest.ts / 1000, undefined, 'signal history')}`;
-  return (
-    <svg width={W} height={H} className="text-brand-green">
-      <title>{tooltip}</title>
-      <path d={d} fill="none" stroke="currentColor" strokeWidth="1.5" />
-    </svg>
-  );
+function displayReliability(paths: PathRecord[]): string {
+  if (!paths.length) return '—';
+  const total = paths.reduce((sum, p) => sum + p.successCount + p.failureCount, 0);
+  if (total === 0) return '—';
+  const successes = paths.reduce((sum, p) => sum + p.successCount, 0);
+  return `${((successes / total) * 100).toFixed(0)}%`;
 }
 
 export default function RepeatersPanel({
@@ -156,6 +153,7 @@ export default function RepeatersPanel({
   meshcoreCliErrors,
   onClearCliHistory,
   meshcoreCanPingTrace,
+  onToggleFavorite,
 }: Props) {
   const { addToast } = useToast();
   const { ensureConfigured, RemoteAuthModal } = useMeshcoreRepeaterRemoteAuth();
@@ -165,6 +163,7 @@ export default function RepeatersPanel({
   }, []);
   const coordinateFormat = useCoordFormatStore((s) => s.coordinateFormat);
   const signalHistory = useRepeaterSignalStore((s) => s.history);
+  const pathHistory = usePathHistoryStore((s) => s.records);
   const [statusLoadingSet, setStatusLoadingSet] = useState<Set<number>>(new Set());
   const [pingLoadingSet, setPingLoadingSet] = useState<Set<number>>(new Set());
   const [deleteLoadingSet, setDeleteLoadingSet] = useState<Set<number>>(new Set());
@@ -184,9 +183,14 @@ export default function RepeatersPanel({
 
   const repeaters = Array.from(nodes.values())
     .filter((n) => n.hw_model === 'Repeater')
-    .sort(
-      (a, b) => normalizeLastHeardMs(b.last_heard ?? 0) - normalizeLastHeardMs(a.last_heard ?? 0),
-    );
+    .sort((a, b) => {
+      // Favorites pinned above non-favorites
+      const aFav = a.favorited ? 1 : 0;
+      const bFav = b.favorited ? 1 : 0;
+      if (aFav !== bFav) return bFav - aFav;
+      // Then by last heard
+      return normalizeLastHeardMs(b.last_heard ?? 0) - normalizeLastHeardMs(a.last_heard ?? 0);
+    });
 
   useEffect(() => {
     if (nodes.size === 0) return;
@@ -203,9 +207,15 @@ export default function RepeatersPanel({
   }, [repeaters, searchQuery]);
 
   useEffect(() => {
+    for (const n of repeatersFiltered) {
+      void usePathHistoryStore.getState().ensureBestPathLoaded(n.node_id);
+    }
+  }, [repeatersFiltered]);
+
+  useEffect(() => {
     if (!isConnected || meshcoreCanPingTrace == null) return;
     for (const n of repeatersFiltered) {
-      void usePathHistoryStore.getState().loadForNode(n.node_id);
+      void usePathHistoryStore.getState().ensureBestPathLoaded(n.node_id);
     }
   }, [isConnected, repeatersFiltered, meshcoreCanPingTrace]);
 
@@ -467,7 +477,7 @@ export default function RepeatersPanel({
                   </th>
                   <th className="py-2 pr-4 font-medium">Uptime</th>
                   <th className="py-2 pr-4 font-medium">Air%</th>
-                  <th className="py-2 pr-4 font-medium">Path History</th>
+                  <th className="py-2 pr-4 font-medium">Reliability</th>
                   <th className="py-2 font-medium">Actions</th>
                 </tr>
               </thead>
@@ -481,6 +491,7 @@ export default function RepeatersPanel({
                     nodeOfflineThresholdMs,
                   );
                   const history = signalHistory.get(node.node_id) ?? [];
+                  const paths = pathHistory.get(node.node_id) ?? [];
                   const airPct =
                     status?.totalAirTimeSecs && status?.totalUpTimeSecs
                       ? ((status.totalAirTimeSecs / status.totalUpTimeSecs) * 100).toFixed(1)
@@ -551,14 +562,28 @@ export default function RepeatersPanel({
                           </span>
                         </td>
                         <td className="py-2 pr-4 font-medium text-white">
-                          <button
-                            type="button"
-                            onClick={() => onSelectRepeater?.(node)}
-                            aria-label={node.long_name}
-                            className="hover:text-brand-green hover:decoration-brand-green/70 text-left text-white underline decoration-transparent transition-colors disabled:no-underline"
-                          >
-                            {node.long_name}
-                          </button>
+                          <span className="flex items-center gap-1">
+                            {onToggleFavorite ? (
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  onToggleFavorite(node.node_id, !node.favorited);
+                                }}
+                                className="text-brand-yellow/70 hover:text-brand-yellow text-base leading-none"
+                                aria-label={node.favorited ? 'Unfavorite' : 'Favorite'}
+                              >
+                                {node.favorited ? '★' : '☆'}
+                              </button>
+                            ) : null}
+                            <button
+                              type="button"
+                              onClick={() => onSelectRepeater?.(node)}
+                              aria-label={node.long_name}
+                              className="hover:text-brand-green hover:decoration-brand-green/70 text-white underline decoration-transparent transition-colors disabled:no-underline"
+                            >
+                              {node.long_name}
+                            </button>
+                          </span>
                         </td>
                         <td className="py-2 pr-4 text-xs text-gray-400">
                           {formatRelativeTime(node.last_heard, node.node_id, node.long_name)}
@@ -571,7 +596,7 @@ export default function RepeatersPanel({
                               : 'Contact SNR — use Status for live reading'
                           }
                         >
-                          {displayRepeaterSnr(node, status)}
+                          {displayRepeaterSnr(node, status, history)}
                         </td>
                         <td
                           className="py-2 pr-4"
@@ -603,9 +628,7 @@ export default function RepeatersPanel({
                         </td>
                         <td className="py-2 pr-4">{formatUptime(status?.totalUpTimeSecs)}</td>
                         <td className="py-2 pr-4">{airPct != null ? `${airPct}%` : '—'}</td>
-                        <td className="py-2 pr-4">
-                          <SignalSparkline points={history} />
-                        </td>
+                        <td className="py-2 pr-4">{displayReliability(paths)}</td>
                         <td className="py-2">
                           <div className="flex flex-wrap gap-1">
                             {pingHardDisabled && pingBlockReason ? (

--- a/src/renderer/components/RepeatersPanel.tsx
+++ b/src/renderer/components/RepeatersPanel.tsx
@@ -61,7 +61,9 @@ const SIGNAL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function isSignalRecent(lastAdvert: number | null | undefined): boolean {
   if (lastAdvert == null) return true;
-  return Date.now() - lastAdvert < SIGNAL_MAX_AGE_MS;
+  const advertMs = normalizeLastHeardMs(lastAdvert);
+  if (!advertMs) return false;
+  return Date.now() - advertMs < SIGNAL_MAX_AGE_MS;
 }
 
 function formatRelativeTime(
@@ -260,7 +262,7 @@ export default function RepeatersPanel({
       .catch(() => {
         // catch-no-log-ok database error - contacts will show as unavailable
       });
-  }, []);
+  }, [isConnected, nodes.size]);
 
   const { nodeStaleThresholdMs, nodeOfflineThresholdMs } = useRadioProvider('meshcore');
 
@@ -293,7 +295,7 @@ export default function RepeatersPanel({
     for (const n of repeatersFiltered) {
       void usePathHistoryStore.getState().ensureBestPathLoaded(n.node_id);
     }
-  }, [repeatersFiltered]);
+  }, [pathHistory, repeatersFiltered]);
 
   useEffect(() => {
     if (!isConnected || meshcoreCanPingTrace == null) return;
@@ -575,6 +577,7 @@ export default function RepeatersPanel({
                   );
                   const history = signalHistory.get(node.node_id) ?? [];
                   const paths = pathHistory.get(node.node_id) ?? [];
+                  const reliabilityText = displayReliability(paths);
                   const airPct =
                     status?.totalAirTimeSecs && status?.totalUpTimeSecs
                       ? ((status.totalAirTimeSecs / status.totalUpTimeSecs) * 100).toFixed(1)
@@ -711,7 +714,7 @@ export default function RepeatersPanel({
                         </td>
                         <td className="py-2 pr-4">{formatUptime(status?.totalUpTimeSecs)}</td>
                         <td className="py-2 pr-4">{airPct != null ? `${airPct}%` : '—'}</td>
-                        <td className="py-2 pr-4">{displayReliability(paths)}</td>
+                        <td className="py-2 pr-4">{reliabilityText}</td>
                         <td className="py-2">
                           <div className="flex flex-wrap gap-1">
                             {pingHardDisabled && pingBlockReason ? (

--- a/src/renderer/components/RepeatersPanel.tsx
+++ b/src/renderer/components/RepeatersPanel.tsx
@@ -57,6 +57,13 @@ interface Props {
   onToggleFavorite?: (nodeId: number, favorited: boolean) => void;
 }
 
+const SIGNAL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function isSignalRecent(lastAdvert: number | null | undefined): boolean {
+  if (lastAdvert == null) return true;
+  return Date.now() - lastAdvert < SIGNAL_MAX_AGE_MS;
+}
+
 function formatRelativeTime(
   lastHeard: number | null | undefined,
   nodeId?: number,
@@ -103,21 +110,58 @@ function displayRepeaterSnr(
   node: MeshNode,
   status: MeshCoreRepeaterStatus | undefined,
   history?: SignalPoint[],
+  contacts?: Map<
+    number,
+    {
+      node_id: number;
+      last_snr: number | null;
+      last_rssi: number | null;
+      last_advert: number | null;
+    }
+  >,
 ): string {
   if (status !== undefined && Number.isFinite(status.lastSnr)) {
     return status.lastSnr.toFixed(1);
   }
-  if (node.snr != null && node.snr !== 0) return node.snr.toFixed(1);
   const latestSignal = history && history.length > 0 ? history[history.length - 1] : undefined;
   if (latestSignal != null && Number.isFinite(latestSignal.snr)) {
     return latestSignal.snr.toFixed(1);
   }
+  const contactSignal = contacts?.get(node.node_id);
+  if (
+    contactSignal?.last_snr != null &&
+    contactSignal.last_snr !== 0 &&
+    isSignalRecent(contactSignal.last_advert)
+  ) {
+    return contactSignal.last_snr.toFixed(1);
+  }
+  if (node.snr != null && node.snr !== 0) return node.snr.toFixed(1);
   return '—';
 }
 
-function displayRepeaterRssi(node: MeshNode, status: MeshCoreRepeaterStatus | undefined): string {
+function displayRepeaterRssi(
+  node: MeshNode,
+  status: MeshCoreRepeaterStatus | undefined,
+  contacts?: Map<
+    number,
+    {
+      node_id: number;
+      last_snr: number | null;
+      last_rssi: number | null;
+      last_advert: number | null;
+    }
+  >,
+): string {
   if (status !== undefined && Number.isFinite(status.lastRssi)) {
     return String(status.lastRssi);
+  }
+  const contactSignal = contacts?.get(node.node_id);
+  if (
+    contactSignal?.last_rssi != null &&
+    contactSignal.last_rssi !== 0 &&
+    isSignalRecent(contactSignal.last_advert)
+  ) {
+    return String(contactSignal.last_rssi);
   }
   if (node.rssi != null && node.rssi !== 0) return String(node.rssi);
   return '—';
@@ -178,6 +222,45 @@ export default function RepeatersPanel({
   const [cliLoadingSet, setCliLoadingSet] = useState<Set<number>>(new Set());
   const [cliUseSavedPath, setCliUseSavedPath] = useState<Map<number, boolean>>(new Map());
   const [searchQuery, setSearchQuery] = useState('');
+  const [meshcoreContactsDb, setMeshcoreContactsDb] = useState<
+    Map<
+      number,
+      {
+        node_id: number;
+        last_snr: number | null;
+        last_rssi: number | null;
+        last_advert: number | null;
+      }
+    >
+  >(new Map());
+
+  useEffect(() => {
+    void window.electronAPI.db
+      .getMeshcoreContacts()
+      .then((rows) => {
+        const m = new Map<
+          number,
+          {
+            node_id: number;
+            last_snr: number | null;
+            last_rssi: number | null;
+            last_advert: number | null;
+          }
+        >();
+        for (const row of rows as {
+          node_id: number;
+          last_snr: number | null;
+          last_rssi: number | null;
+          last_advert: number | null;
+        }[]) {
+          m.set(row.node_id, row);
+        }
+        setMeshcoreContactsDb(m);
+      })
+      .catch(() => {
+        // catch-no-log-ok database error - contacts will show as unavailable
+      });
+  }, []);
 
   const { nodeStaleThresholdMs, nodeOfflineThresholdMs } = useRadioProvider('meshcore');
 
@@ -596,7 +679,7 @@ export default function RepeatersPanel({
                               : 'Contact SNR — use Status for live reading'
                           }
                         >
-                          {displayRepeaterSnr(node, status, history)}
+                          {displayRepeaterSnr(node, status, history, meshcoreContactsDb)}
                         </td>
                         <td
                           className="py-2 pr-4"
@@ -606,7 +689,7 @@ export default function RepeatersPanel({
                               : 'Contact RSSI — use Status for live reading'
                           }
                         >
-                          {displayRepeaterRssi(node, status)}
+                          {displayRepeaterRssi(node, status, meshcoreContactsDb)}
                         </td>
                         <td className="py-2 pr-4">
                           {traceResult ? (

--- a/src/renderer/hooks/useMeshCore.import-contacts.test.tsx
+++ b/src/renderer/hooks/useMeshCore.import-contacts.test.tsx
@@ -70,6 +70,28 @@ describe('useMeshCore importContacts', () => {
     expect(node?.longitude).toBe(-122.42);
   });
 
+  it('preserves hops_away from DB when the node is not yet in the nodes map', async () => {
+    vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([
+      {
+        node_id: IMPORT_NODE_ID,
+        public_key: HEX32,
+        last_advert: null,
+        hops_away: 3,
+      },
+    ]);
+    vi.mocked(window.electronAPI.meshcore.openJsonFile).mockResolvedValue(
+      JSON.stringify([{ name: 'Known RPT', public_key: HEX32 }]),
+    );
+
+    const { result } = renderHook(() => useMeshCore());
+
+    await act(async () => {
+      await result.current.importContacts();
+    });
+
+    expect(result.current.nodes.get(IMPORT_NODE_ID)?.hops_away).toBe(3);
+  });
+
   it('preserves last_heard on re-import when the node already exists (no stale nodesRef)', async () => {
     vi.mocked(window.electronAPI.meshcore.openJsonFile).mockResolvedValue(
       JSON.stringify([

--- a/src/renderer/hooks/useMeshCore.ping-no-route-error-expiry.test.tsx
+++ b/src/renderer/hooks/useMeshCore.ping-no-route-error-expiry.test.tsx
@@ -5,7 +5,17 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { pubkeyToNodeId } from '../lib/meshcoreUtils';
-import { usePathHistoryStore } from '../stores/pathHistoryStore';
+import { computePathHash, usePathHistoryStore } from '../stores/pathHistoryStore';
+
+const { runMeshcoreTracePathMultiplexedMock } = vi.hoisted(() => ({
+  runMeshcoreTracePathMultiplexedMock: vi.fn(),
+}));
+vi.mock('../lib/meshcoreTracePathMultiplex', async (importOriginal) => {
+  const actual = await importOriginal();
+  return Object.assign({}, actual, {
+    runMeshcoreTracePathMultiplexed: runMeshcoreTracePathMultiplexedMock,
+  });
+});
 import {
   MESHCORE_PING_NO_ROUTE_ERROR_DISPLAY_MS,
   MESHCORE_PING_NO_ROUTE_ERROR_MSG,
@@ -210,9 +220,61 @@ describe('meshcorePingNoRouteErrorExpiryUpdate', () => {
   });
 });
 
+describe('useMeshCore refreshNodesFromDb hop preservation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePathHistoryStore.setState({ records: new Map(), lruOrder: [] });
+    vi.mocked(window.electronAPI.db.getMeshcoreMessages).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getNodes).mockResolvedValue([]);
+  });
+
+  it('keeps known hops_away when DB refresh row omits it', async () => {
+    const rowWithHops = {
+      node_id: REMOTE_NODE_ID,
+      public_key: REMOTE_PUBKEY_HEX,
+      adv_name: 'RemotePeer',
+      contact_type: 1,
+      last_advert: 1_700_000_000,
+      adv_lat: null,
+      adv_lon: null,
+      last_snr: null,
+      last_rssi: null,
+      favorited: 0,
+      nickname: null,
+      hops_away: 3,
+    };
+    const rowWithoutHops = {
+      ...rowWithHops,
+      hops_away: null,
+    };
+    vi.mocked(window.electronAPI.db.getMeshcoreContacts)
+      .mockResolvedValueOnce([rowWithHops])
+      .mockResolvedValueOnce([rowWithoutHops]);
+
+    const { result } = renderHook(() => useMeshCore());
+
+    await waitFor(() => {
+      expect(result.current.nodes.get(REMOTE_NODE_ID)?.hops_away).toBe(3);
+    });
+
+    await act(async () => {
+      await result.current.refreshNodesFromDb();
+    });
+
+    expect(result.current.nodes.get(REMOTE_NODE_ID)?.hops_away).toBe(3);
+  });
+});
+
 describe('useMeshCore traceRoute no-route error expiry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    runMeshcoreTracePathMultiplexedMock.mockResolvedValue({
+      pathLen: 2,
+      pathHashes: [1, 2],
+      pathSnrs: [4, 8],
+      lastSnr: 1.25,
+      tag: 7,
+    });
     usePathHistoryStore.setState({ records: new Map(), lruOrder: [] });
     getSelfInfoMock.mockResolvedValue({
       name: 'SelfRadio',
@@ -292,5 +354,123 @@ describe('useMeshCore traceRoute no-route error expiry', () => {
     });
 
     expect(result.current.meshcorePingErrors.has(REMOTE_NODE_ID)).toBe(false);
+  });
+});
+
+describe('useMeshCore traceRoute path outcome attribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runMeshcoreTracePathMultiplexedMock.mockResolvedValue({
+      pathLen: 2,
+      pathHashes: [1, 2],
+      pathSnrs: [4, 8],
+      lastSnr: 1.25,
+      tag: 7,
+    });
+    usePathHistoryStore.setState({ records: new Map(), lruOrder: [] });
+    getSelfInfoMock.mockResolvedValue({
+      name: 'SelfRadio',
+      publicKey: SELF_PUBKEY,
+      type: 1,
+      txPower: 22,
+      radioFreq: 902_000_000,
+    });
+    vi.mocked(window.electronAPI.db.getMeshcoreMessages).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getNodes).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([
+      {
+        node_id: REMOTE_NODE_ID,
+        public_key: REMOTE_PUBKEY_HEX,
+        adv_name: 'RemotePeer',
+        contact_type: 1,
+        last_advert: 1_700_000_000,
+        adv_lat: null,
+        adv_lon: null,
+        last_snr: null,
+        last_rssi: null,
+        favorited: 0,
+        nickname: null,
+        hops_away: 2,
+      },
+    ]);
+  });
+
+  it('records success outcome for traceRoute on the used path hash', async () => {
+    const dbOutcomeSpy = vi.spyOn(window.electronAPI.db, 'recordMeshcorePathOutcome');
+    const pathBytes = [0x11, 0x22];
+    const pathHash = computePathHash(pathBytes);
+    usePathHistoryStore.getState().recordPathUpdated(REMOTE_NODE_ID, pathBytes, 1, false);
+
+    const port = makeMockSerialPort();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: {
+        requestPort: vi.fn().mockResolvedValue(port),
+      },
+    });
+
+    const { result } = renderHook(() => useMeshCore());
+    await waitFor(() => {
+      expect(window.electronAPI.db.getMeshcoreContacts).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    await act(async () => {
+      await result.current.traceRoute(REMOTE_NODE_ID);
+      await Promise.resolve();
+    });
+
+    const record = usePathHistoryStore
+      .getState()
+      .records.get(REMOTE_NODE_ID)
+      ?.find((r) => r.pathHash === pathHash);
+    expect(record?.successCount).toBe(1);
+    expect(record?.failureCount).toBe(0);
+    expect(dbOutcomeSpy).toHaveBeenCalledWith(REMOTE_NODE_ID, pathHash, true, undefined);
+  });
+
+  it('records failure outcome for traceRoute errors on the used path hash', async () => {
+    runMeshcoreTracePathMultiplexedMock.mockRejectedValueOnce(new Error('trace timeout'));
+    const dbOutcomeSpy = vi.spyOn(window.electronAPI.db, 'recordMeshcorePathOutcome');
+    const pathBytes = [0x11, 0x22];
+    const pathHash = computePathHash(pathBytes);
+    usePathHistoryStore.getState().recordPathUpdated(REMOTE_NODE_ID, pathBytes, 1, false);
+
+    const port = makeMockSerialPort();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: {
+        requestPort: vi.fn().mockResolvedValue(port),
+      },
+    });
+
+    const { result } = renderHook(() => useMeshCore());
+    await waitFor(() => {
+      expect(window.electronAPI.db.getMeshcoreContacts).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    await act(async () => {
+      await result.current.traceRoute(REMOTE_NODE_ID);
+      await Promise.resolve();
+    });
+
+    const record = usePathHistoryStore
+      .getState()
+      .records.get(REMOTE_NODE_ID)
+      ?.find((r) => r.pathHash === pathHash);
+    expect(record?.successCount).toBe(0);
+    expect(record?.failureCount).toBe(1);
+    expect(dbOutcomeSpy).toHaveBeenCalledWith(REMOTE_NODE_ID, pathHash, false, undefined);
   });
 });

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -1477,11 +1477,16 @@ export function useMeshCore() {
           }
         }
         // Merge hops_away from nodes table as fallback for any nodes missing it
-        for (const n of savedNodes as { node_id: number; hops_away: number | null }[]) {
-          if (n.hops_away != null) {
+        for (const n of savedNodes as {
+          node_id: number;
+          hops_away: number | null;
+          hops: number | null;
+        }[]) {
+          const hopCount = n.hops ?? n.hops_away;
+          if (hopCount != null) {
             const existing = initial.get(n.node_id);
             if (existing && existing.hops_away === undefined) {
-              initial.set(n.node_id, { ...existing, hops_away: n.hops_away });
+              initial.set(n.node_id, { ...existing, hops_away: hopCount });
             }
           }
         }
@@ -1742,11 +1747,14 @@ export function useMeshCore() {
             });
           }
         }
-        for (const row of dbContacts) {
+        for (const row of dbContacts as (MeshcoreContactDbRow & { hops?: number | null })[]) {
           const existing = nextNodes.get(row.node_id);
           if (!existing) continue;
-          if (existing.hops_away === undefined && row.hops_away != null) {
-            nextNodes.set(row.node_id, { ...existing, hops_away: row.hops_away });
+          if (existing.hops_away === undefined) {
+            const hopCount = row.hops_away ?? row.hops;
+            if (hopCount != null) {
+              nextNodes.set(row.node_id, { ...existing, hops_away: hopCount });
+            }
           }
         }
         for (const row of dbContacts) {
@@ -4994,16 +5002,18 @@ export function useMeshCore() {
 
     if (validEntries.length > 0) {
       const importSec = Math.floor(Date.now() / 1000);
-      let dbRows: { node_id: number; last_advert: number | null }[] = [];
+      let dbRows: { node_id: number; last_advert: number | null; hops_away: number | null }[] = [];
       try {
         dbRows = (await window.electronAPI.db.getMeshcoreContacts()) as {
           node_id: number;
           last_advert: number | null;
+          hops_away: number | null;
         }[];
       } catch (e: unknown) {
         console.warn('[useMeshCore] importContacts: getMeshcoreContacts for last_advert merge', e);
       }
       const dbLastAdvertById = new Map(dbRows.map((r) => [r.node_id, r.last_advert]));
+      const dbHopsById = new Map(dbRows.map((r) => [r.node_id, r.hops_away]));
       /** Built inside `setNodes` so we read merged `last_heard` before `nodesRef` catches up. */
       const lastAdvertForDbByNodeId = new Map<number, number>();
 
@@ -5029,6 +5039,7 @@ export function useMeshCore() {
               .map((b) => b.toString(16).padStart(2, '0'))
               .join('');
             pubKeyPrefixMapRef.current.set(prefix, nodeId);
+            const dbHops = dbHopsById.get(nodeId);
             next.set(nodeId, {
               node_id: nodeId,
               long_name: name,
@@ -5041,6 +5052,7 @@ export function useMeshCore() {
               latitude: hasImportGps ? latitude : null,
               longitude: hasImportGps ? longitude : null,
               favorited: false,
+              ...(dbHops != null ? { hops_away: dbHops } : {}),
             });
           }
           const rowPrior = dbLastAdvertById.get(nodeId);

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -1491,7 +1491,8 @@ export function useMeshCore() {
           }
         }
         const mapped = mapMeshcoreDbRowsToChatMessages(dbMsgs as MeshcoreMessageDbRow[]);
-        setNodes(mergeStubNodesFromMeshcoreMessages(initial, mapped));
+        const mergedInitial = mergeStubNodesFromMeshcoreMessages(initial, mapped);
+        setNodes(mergedInitial);
         if (mapped.length > 0) {
           setMessages((prev) => mergeMeshcoreDbHydrationWithLive(prev, mapped));
         }
@@ -1760,7 +1761,36 @@ export function useMeshCore() {
         for (const row of dbContacts) {
           const existing = nextNodes.get(row.node_id);
           if (existing) {
-            nextNodes.set(row.node_id, { ...existing, favorited: row.favorited === 1 });
+            const fallbackSnr =
+              typeof row.last_snr === 'number' &&
+              Number.isFinite(row.last_snr) &&
+              row.last_snr !== 0
+                ? row.last_snr
+                : null;
+            const fallbackRssi =
+              typeof row.last_rssi === 'number' &&
+              Number.isFinite(row.last_rssi) &&
+              row.last_rssi !== 0
+                ? row.last_rssi
+                : null;
+            const nextSnr =
+              typeof existing.snr === 'number' &&
+              Number.isFinite(existing.snr) &&
+              existing.snr !== 0
+                ? existing.snr
+                : (fallbackSnr ?? existing.snr);
+            const nextRssi =
+              typeof existing.rssi === 'number' &&
+              Number.isFinite(existing.rssi) &&
+              existing.rssi !== 0
+                ? existing.rssi
+                : (fallbackRssi ?? existing.rssi);
+            nextNodes.set(row.node_id, {
+              ...existing,
+              favorited: row.favorited === 1,
+              snr: nextSnr,
+              rssi: nextRssi,
+            });
           }
         }
         for (const row of dbContacts) {
@@ -4267,16 +4297,37 @@ export function useMeshCore() {
             .getState()
             .recordPathUpdated(nodeId, tracePathBytes, tracePathHops, false);
         }
-        const result = await withTimeout(
-          runMeshcoreTracePathMultiplexed(
-            conn as unknown as MeshcoreTracePathMuxConnection,
-            outPath,
-            MESHCORE_TRACE_TIMEOUT_MS,
-            repeaterRemoteRpcRef.current,
-          ),
-          MESHCORE_TRACE_PING_TOTAL_TIMEOUT_MS,
-          'meshcoreTracePing',
-        );
+        let tracePathInUse = outPath;
+        let result;
+        try {
+          result = await withTimeout(
+            runMeshcoreTracePathMultiplexed(
+              conn as unknown as MeshcoreTracePathMuxConnection,
+              tracePathInUse,
+              MESHCORE_TRACE_TIMEOUT_MS,
+              repeaterRemoteRpcRef.current,
+            ),
+            MESHCORE_TRACE_PING_TOTAL_TIMEOUT_MS,
+            'meshcoreTracePing',
+          );
+        } catch (firstTraceError: unknown) {
+          const directRetryEligible = (hopsAway ?? 0) === 0 && tracePathInUse.length === 1;
+          if (!directRetryEligible) throw firstTraceError;
+          tracePathInUse = new Uint8Array(pubKey);
+          const retryPathBytes = Array.from(tracePathInUse);
+          tracePathHash = computePathHash(retryPathBytes);
+          usePathHistoryStore.getState().recordPathUpdated(nodeId, retryPathBytes, 0, false);
+          result = await withTimeout(
+            runMeshcoreTracePathMultiplexed(
+              conn as unknown as MeshcoreTracePathMuxConnection,
+              tracePathInUse,
+              MESHCORE_TRACE_TIMEOUT_MS,
+              repeaterRemoteRpcRef.current,
+            ),
+            MESHCORE_TRACE_PING_TOTAL_TIMEOUT_MS,
+            'meshcoreTracePingDirectRetry',
+          );
+        }
         const traceHops = meshcoreTracePathLenToHops(result.pathLen);
         const convertedSnrs = (result.pathSnrs ?? []).map((s) => s * MESHCORE_RPC_SNR_RAW_TO_DB);
         const convertedLastSnr = result.lastSnr;

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -4140,6 +4140,7 @@ export function useMeshCore() {
         return next;
       });
 
+      let tracePathHash: string | undefined;
       try {
         const conn = connRef.current;
         if (!conn) {
@@ -4255,6 +4256,17 @@ export function useMeshCore() {
         if (outPath.length === 1 && outPath[0] === 0 && pubKey[0] !== 0) {
           outPath = new Uint8Array([pubKey[0]]);
         }
+        const tracePathBytes = Array.from(outPath);
+        tracePathHash = tracePathBytes.length > 0 ? computePathHash(tracePathBytes) : undefined;
+        if (tracePathHash) {
+          const tracePathHops =
+            typeof hopsAway === 'number' && Number.isFinite(hopsAway)
+              ? Math.max(0, hopsAway)
+              : Math.max(0, tracePathBytes.length - 1);
+          usePathHistoryStore
+            .getState()
+            .recordPathUpdated(nodeId, tracePathBytes, tracePathHops, false);
+        }
         const result = await withTimeout(
           runMeshcoreTracePathMultiplexed(
             conn as unknown as MeshcoreTracePathMuxConnection,
@@ -4314,6 +4326,9 @@ export function useMeshCore() {
           });
         useRepeaterSignalStore.getState().recordSignal(nodeId, result.lastSnr);
         bumpMeshcoreNodeLastHeardFromRpc(nodeId);
+        if (tracePathHash) {
+          usePathHistoryStore.getState().recordOutcome(nodeId, tracePathHash, true);
+        }
         clearMeshcorePingNoRouteExpiryTimer(nodeId);
         setMeshcorePingErrors((prev) => {
           const next = new Map(prev);
@@ -4329,6 +4344,9 @@ export function useMeshCore() {
           ? `Request timed out (up to ~${Math.round(MESHCORE_TRACE_PING_TOTAL_TIMEOUT_MS / 1000)}s)`
           : `Failed: ${errMsg}`;
         friendlyErr = meshcoreAppendRepeaterAuthHint(friendlyErr);
+        if (tracePathHash) {
+          usePathHistoryStore.getState().recordOutcome(nodeId, tracePathHash, false);
+        }
         setMeshcorePingErrors((prev) => {
           const next = new Map(prev);
           next.set(nodeId, friendlyErr);
@@ -5490,25 +5508,37 @@ export function useMeshCore() {
         last_snr: number | null;
         last_rssi: number | null;
         favorited: number;
+        hops_away: number | null;
       }[];
       setNodes((prev) => {
         const next = new Map(prev);
         for (const row of dbContacts) {
-          if (!next.has(row.node_id)) {
-            next.set(row.node_id, {
-              node_id: row.node_id,
-              long_name: row.adv_name ?? `Node-${row.node_id.toString(16).toUpperCase()}`,
-              short_name: '',
-              hw_model: CONTACT_TYPE_LABELS[row.contact_type] ?? 'Unknown',
-              battery: 0,
-              snr: row.last_snr ?? 0,
-              rssi: row.last_rssi ?? 0,
-              last_heard: row.last_advert ?? 0,
-              latitude: row.adv_lat ?? null,
-              longitude: row.adv_lon ?? null,
-              favorited: row.favorited === 1,
-            });
+          const existing = next.get(row.node_id);
+          const mergedHopsAway =
+            row.hops_away != null
+              ? existing?.hops_away != null
+                ? Math.min(existing.hops_away, row.hops_away)
+                : row.hops_away
+              : existing?.hops_away;
+          if (existing) {
+            if (existing.hops_away === mergedHopsAway) continue;
+            next.set(row.node_id, { ...existing, hops_away: mergedHopsAway });
+            continue;
           }
+          next.set(row.node_id, {
+            node_id: row.node_id,
+            long_name: row.adv_name ?? `Node-${row.node_id.toString(16).toUpperCase()}`,
+            short_name: '',
+            hw_model: CONTACT_TYPE_LABELS[row.contact_type] ?? 'Unknown',
+            battery: 0,
+            snr: row.last_snr ?? 0,
+            rssi: row.last_rssi ?? 0,
+            last_heard: row.last_advert ?? 0,
+            latitude: row.adv_lat ?? null,
+            longitude: row.adv_lon ?? null,
+            favorited: row.favorited === 1,
+            ...(mergedHopsAway != null ? { hops_away: mergedHopsAway } : {}),
+          });
         }
         return next;
       });

--- a/src/renderer/lib/meshcoreUtils.test.ts
+++ b/src/renderer/lib/meshcoreUtils.test.ts
@@ -307,6 +307,11 @@ describe('meshcoreMergeContactHopsAwayFromPrevious', () => {
     expect(meshcoreMergeContactHopsAwayFromPrevious(2, 3, 4)).toBe(2);
   });
 
+  it('favors smaller hop count when both are defined (best known path)', () => {
+    expect(meshcoreMergeContactHopsAwayFromPrevious(3, 1, 4)).toBe(1);
+    expect(meshcoreMergeContactHopsAwayFromPrevious(1, 3, 2)).toBe(1);
+  });
+
   it('fills from previous when inferred is undefined and prev is direct', () => {
     expect(meshcoreMergeContactHopsAwayFromPrevious(undefined, 0, 1)).toBe(0);
   });

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -339,6 +339,10 @@ export function meshcoreMergeContactHopsAwayFromPrevious(
     if (inferred === undefined || (inferred === 0 && slicedPathByteLength <= 1)) {
       return prev;
     }
+    // Prefer the smaller (better) hop count if both are defined and >= 1
+    if (inferred >= 1) {
+      return Math.min(inferred, prev);
+    }
   } else if (inferred === undefined && prev !== undefined) {
     return prev;
   }

--- a/src/renderer/stores/pathHistoryStore.ts
+++ b/src/renderer/stores/pathHistoryStore.ts
@@ -291,7 +291,8 @@ export const usePathHistoryStore = create<PathHistoryState>((set, get) => ({
     const existing = get().selectBestPath(nodeId);
     if (existing != null) return existing;
     await get().loadForNode(nodeId);
-    return get().selectBestPath(nodeId);
+    const selected = get().selectBestPath(nodeId);
+    return selected;
   },
 
   async loadForNode(nodeId) {


### PR DESCRIPTION
## Summary
- restore MeshCore repeater signal fallback behavior and clean up debug traces so repeaters render consistent telemetry.
- populate MeshCore repeater reliability from trace outcomes and preserve `hops_away` during contact import to avoid regressing route data.
- add path-history/reliability plumbing in renderer + main process (DB compatibility, MQTT/logging adjustments) with accompanying tests.

## Test plan
- [ ] `pnpm run lint`
- [ ] `pnpm run typecheck`
- [ ] `pnpm run test:run`
- [ ] targeted verification of repeater panel signal/reliability in MeshCore mode