### PR TITLE
fix: harden meshcore lifecycle and bound memory-heavy reads

### DIFF
--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -299,3 +299,19 @@ describe('escapeSqlLikePattern', () => {
     expect(escapeSqlLikePattern('')).toBe('');
   });
 });
+
+describe('meshcore_path_history bounded reads', () => {
+  it('getMeshcorePathHistory uses ORDER BY updated_at DESC with a LIMIT placeholder', () => {
+    expect(DB_SOURCE).toMatch(
+      /export function getMeshcorePathHistory[\s\S]*?ORDER BY updated_at DESC LIMIT \?/,
+    );
+    expect(DB_SOURCE).toContain('MESHCORE_PATH_HISTORY_PER_NODE_ROW_LIMIT');
+  });
+
+  it('getAllMeshcorePathHistory uses ORDER BY node_id, updated_at DESC with a LIMIT placeholder', () => {
+    expect(DB_SOURCE).toMatch(
+      /export function getAllMeshcorePathHistory[\s\S]*?ORDER BY node_id, updated_at DESC LIMIT \?/,
+    );
+    expect(DB_SOURCE).toContain('MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT');
+  });
+});

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2,6 +2,10 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
+import {
+  MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT,
+  MESHCORE_PATH_HISTORY_PER_NODE_ROW_LIMIT,
+} from '../shared/meshcorePathHistoryLimits';
 import { escapeSqlLikePattern } from '../shared/sqlLikeEscape';
 import { NodeSqliteDB } from './db-compat';
 import { sanitizeLogMessage } from './log-service';
@@ -1376,16 +1380,32 @@ export function recordMeshcorePathOutcome(
 }
 
 export function getMeshcorePathHistory(nodeId: number): MeshcorePathHistoryRow[] {
-  return getDatabase()
-    .prepare(`SELECT * FROM meshcore_path_history WHERE node_id = ? ORDER BY updated_at DESC`)
-    .all(nodeId) as MeshcorePathHistoryRow[];
+  const rows = getDatabase()
+    .prepare(
+      `SELECT * FROM meshcore_path_history WHERE node_id = ? ORDER BY updated_at DESC LIMIT ?`,
+    )
+    .all(nodeId, MESHCORE_PATH_HISTORY_PER_NODE_ROW_LIMIT) as MeshcorePathHistoryRow[];
+  if (rows.length >= MESHCORE_PATH_HISTORY_PER_NODE_ROW_LIMIT) {
+    console.warn(
+      '[database] getMeshcorePathHistory: row limit reached (results may be truncated)',
+      { nodeId, limit: MESHCORE_PATH_HISTORY_PER_NODE_ROW_LIMIT },
+    );
+  }
+  return rows;
 }
 
 /** All stored path variants for all nodes (for hydrating path history at app start). */
 export function getAllMeshcorePathHistory(): MeshcorePathHistoryRow[] {
-  return getDatabase()
-    .prepare(`SELECT * FROM meshcore_path_history ORDER BY node_id, updated_at DESC`)
-    .all() as MeshcorePathHistoryRow[];
+  const rows = getDatabase()
+    .prepare(`SELECT * FROM meshcore_path_history ORDER BY node_id, updated_at DESC LIMIT ?`)
+    .all(MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT) as MeshcorePathHistoryRow[];
+  if (rows.length >= MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT) {
+    console.warn(
+      '[database] getAllMeshcorePathHistory: row limit reached; path history is truncated',
+      { limit: MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT },
+    );
+  }
+  return rows;
 }
 
 export function deleteMeshcorePathHistoryForNode(nodeId: number): void {

--- a/src/main/db-compat.ts
+++ b/src/main/db-compat.ts
@@ -188,6 +188,8 @@ export class NodeSqliteDB {
       if (!ALLOWED_PRAGMAS.has(key)) {
         throw new Error(`db-compat: PRAGMA '${key}' is not on the allowed list`);
       }
+      // `val` is interpolated into SQL; `key` is allowlisted. `val` must remain a hardcoded literal
+      // or strictly internal/sanitized — never pass arbitrary user/caller-controlled strings.
       this._run(`PRAGMA ${key} = ${val}`);
       return undefined;
     }

--- a/src/main/index.contract.test.ts
+++ b/src/main/index.contract.test.ts
@@ -6,11 +6,14 @@ import { describe, expect, it } from 'vitest';
 const INDEX_SOURCE = readFileSync(join(__dirname, 'index.ts'), 'utf-8');
 
 describe('IPC payload size limits (source contract)', () => {
-  it('defines meshcore tcp-write and noble-ble limits and uses them in handlers', () => {
+  it('defines meshcore tcp-write, http:write, and noble-ble limits and uses them in handlers', () => {
     expect(INDEX_SOURCE).toContain('const MESHCORE_TCP_WRITE_MAX_BYTES = 256 * 1024');
+    expect(INDEX_SOURCE).toContain('const HTTP_WRITE_TO_RADIO_MAX_BYTES = 256 * 1024');
     expect(INDEX_SOURCE).toContain('const NOBLE_BLE_TO_RADIO_MAX_BYTES = 512');
     expect(INDEX_SOURCE).toMatch(/maxBytes: NOBLE_BLE_TO_RADIO_MAX_BYTES/);
     expect(INDEX_SOURCE).toMatch(/bytes\.length > MESHCORE_TCP_WRITE_MAX_BYTES/);
+    expect(INDEX_SOURCE).toMatch(/data\.length > HTTP_WRITE_TO_RADIO_MAX_BYTES/);
+    expect(INDEX_SOURCE).toMatch(/http:write: byte values must be integers 0-255/);
   });
 });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4160,6 +4160,8 @@ let httpDevice: {
 } | null = null;
 
 const HTTP_FETCH_INTERVAL_MS = 3000;
+/** Max Meshtastic HTTP toRadio payload (aligned with meshcore:tcp-write cap). */
+const HTTP_WRITE_TO_RADIO_MAX_BYTES = 256 * 1024;
 const MAX_HOST_LENGTH = 253;
 
 /**
@@ -4253,8 +4255,13 @@ ipcMain.handle('http:write', async (_event, data: number[]) => {
   if (!httpDevice) {
     throw new Error('http:write: no active connection');
   }
-  if (!Array.isArray(data)) {
-    throw new Error('http:write: invalid data');
+  if (!Array.isArray(data) || data.length > HTTP_WRITE_TO_RADIO_MAX_BYTES) {
+    throw new Error(
+      `http:write: invalid or oversized payload (max ${HTTP_WRITE_TO_RADIO_MAX_BYTES} bytes)`,
+    );
+  }
+  if (!data.every((b) => Number.isInteger(b) && b >= 0 && b <= 255)) {
+    throw new Error('http:write: byte values must be integers 0-255');
   }
   await httpWriteToRadio(httpDevice.host, httpDevice.tls, new Uint8Array(data));
 });

--- a/src/renderer/components/ConnectionPanel.hardware-events.test.tsx
+++ b/src/renderer/components/ConnectionPanel.hardware-events.test.tsx
@@ -36,7 +36,6 @@ const DEFAULT_PROPS = {
   onDisconnect: vi.fn().mockResolvedValue(undefined),
   mqttStatus: 'disconnected' as const,
   protocol: 'meshtastic' as const,
-  onProtocolChange: vi.fn(),
 };
 
 describe('ConnectionPanel hardware event wiring', () => {

--- a/src/renderer/components/RepeatersPanel.tsx
+++ b/src/renderer/components/RepeatersPanel.tsx
@@ -60,7 +60,7 @@ interface Props {
 const SIGNAL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function isSignalRecent(lastAdvert: number | null | undefined): boolean {
-  if (lastAdvert == null) return true;
+  if (lastAdvert == null) return false;
   const advertMs = normalizeLastHeardMs(lastAdvert);
   if (!advertMs) return false;
   return Date.now() - advertMs < SIGNAL_MAX_AGE_MS;

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -9,6 +9,7 @@ import {
   preferNonEmptyTrimmedString,
 } from '../../shared/nodeNameUtils';
 import { getAppSettingsRaw } from '../lib/appSettingsStorage';
+import { MAX_IN_MEMORY_CHAT_MESSAGES, trimChatMessagesToMax } from '../lib/chatInMemoryBuffer';
 import {
   createBleConnection,
   createConnection,
@@ -547,7 +548,7 @@ export function useDevice() {
       .getMessages(undefined, getMessageLoadLimit())
       .then((msgs) => {
         const reversed = msgs.reverse();
-        setMessages(reversed);
+        setMessages(trimChatMessagesToMax(reversed, MAX_IN_MEMORY_CHAT_MESSAGES));
         // Seed dedup map so device config-sync replays are caught immediately
         for (const m of reversed) {
           if (m.packetId) {
@@ -879,7 +880,7 @@ export function useDevice() {
             m.payload === mqttWithPreviews.payload,
         );
         if (isDup) return prev;
-        return [...prev, mqttWithPreviews];
+        return trimChatMessagesToMax([...prev, mqttWithPreviews], MAX_IN_MEMORY_CHAT_MESSAGES);
       });
       void window.electronAPI.db.saveMessage(mqttWithPreviews);
     });
@@ -1178,7 +1179,7 @@ export function useDevice() {
           if (!rfMsg.emoji && rfMsg.packetId && prev.some((m) => m.packetId === rfMsg.packetId)) {
             return prev;
           }
-          return [...prev, rfMsg];
+          return trimChatMessagesToMax([...prev, rfMsg], MAX_IN_MEMORY_CHAT_MESSAGES);
         });
         void window.electronAPI.db.saveMessage(rfMsg);
 
@@ -2677,7 +2678,7 @@ export function useDevice() {
         messagesRef.current,
         getNodeName,
       );
-      setMessages((prev) => [...prev, msg]);
+      setMessages((prev) => trimChatMessagesToMax([...prev, msg], MAX_IN_MEMORY_CHAT_MESSAGES));
       void window.electronAPI.db.saveMessage(msg);
 
       // For device path: track this tempId so the RF echo can be suppressed (avoids duplicate)
@@ -2925,7 +2926,7 @@ export function useDevice() {
       .getMessages(undefined, getMessageLoadLimit())
       .then((msgs) => {
         console.debug(`[useDevice] refreshMessagesFromDb: loaded ${msgs.length} messages`);
-        setMessages(msgs.reverse());
+        setMessages(trimChatMessagesToMax(msgs.reverse(), MAX_IN_MEMORY_CHAT_MESSAGES));
       })
       .catch((err: unknown) => {
         console.error('[useDevice] Failed to refresh messages:', err);
@@ -3111,7 +3112,7 @@ export function useDevice() {
           (m) => m.emoji === emoji && m.replyId === replyId && m.sender_id === from,
         );
         if (isDup) return prev;
-        return [...prev, msg];
+        return trimChatMessagesToMax([...prev, msg], MAX_IN_MEMORY_CHAT_MESSAGES);
       });
       void window.electronAPI.db.saveMessage(msg);
 

--- a/src/renderer/hooks/useMeshCore.listener-teardown.test.tsx
+++ b/src/renderer/hooks/useMeshCore.listener-teardown.test.tsx
@@ -1,0 +1,315 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getSelfInfoMock = vi.fn();
+const getContactsMock = vi.fn();
+const getChannelsMock = vi.fn();
+
+/** Events registered by useMeshCore setupEventListeners (persistent conn.on). */
+const MESHCORE_PERSISTENT_CONN_EVENTS = [
+  128,
+  129,
+  130,
+  138,
+  131,
+  7,
+  8,
+  136,
+  'disconnected',
+  'rx',
+] as const;
+
+/** Narrow type for the vi.mock WebSerialConnection instance (class is not visible at module scope). */
+interface MeshSerialMockConn {
+  persistentListenerCount(): number;
+  emit(event: string | number, ...args: unknown[]): undefined;
+}
+
+/** Holder avoids `this` → module binding (eslint no-this-alias) in the mock constructor. */
+const lastMeshSerialMock: { current: MeshSerialMockConn | null } = { current: null };
+
+vi.mock('@liamcottle/meshcore.js', () => {
+  class MockWebSerialConnection implements MeshSerialMockConn {
+    private listeners = new Map<string | number, Set<(...args: unknown[]) => void>>();
+
+    constructor(port: unknown) {
+      void port;
+      lastMeshSerialMock.current = this;
+    }
+    on(event: string | number, cb: (...args: unknown[]) => void) {
+      const listeners = this.listeners.get(event) ?? new Set();
+      listeners.add(cb);
+      this.listeners.set(event, listeners);
+      return undefined;
+    }
+    off(event: string | number, cb: (...args: unknown[]) => void) {
+      this.listeners.get(event)?.delete(cb);
+      return undefined;
+    }
+    once(event: string | number, cb: (...args: unknown[]) => void) {
+      const wrapped = (...args: unknown[]) => {
+        this.off(event, wrapped);
+        cb(...args);
+      };
+      this.on(event, wrapped);
+      return undefined;
+    }
+    emit(event: string | number, ...args: unknown[]) {
+      const cbs = [...(this.listeners.get(event) ?? [])];
+      for (const cb of cbs) {
+        cb(...args);
+      }
+      return undefined;
+    }
+    close = vi.fn().mockResolvedValue(undefined);
+    getSelfInfo = getSelfInfoMock;
+    getContacts = getContactsMock;
+    getChannels = getChannelsMock;
+    deviceQuery = vi.fn().mockResolvedValue({
+      firmwareVer: 1,
+      firmware_build_date: 'test',
+      manufacturerModel: 'test',
+    });
+    syncDeviceTime = vi.fn().mockResolvedValue(undefined);
+    getWaitingMessages = vi.fn().mockResolvedValue([]);
+    syncNextMessage = vi.fn().mockResolvedValue(null);
+    setOtherParams = vi.fn().mockResolvedValue(undefined);
+    setAutoAddContacts = vi.fn().mockResolvedValue(undefined);
+    setManualAddContacts = vi.fn().mockResolvedValue(undefined);
+    getBatteryVoltage = vi.fn().mockResolvedValue({ batteryMilliVolts: 4200 });
+    getStatsCore = vi.fn().mockResolvedValue({
+      type: 0,
+      raw: new Uint8Array(9),
+      data: { batteryMilliVolts: 4100, uptimeSecs: 1, queueLen: 0 },
+    });
+    getStatsRadio = vi.fn().mockResolvedValue({
+      type: 1,
+      raw: new Uint8Array([1]),
+      data: {
+        noiseFloor: -110,
+        lastRssi: -90,
+        lastSnr: 5,
+        txAirSecs: 0,
+        rxAirSecs: 0,
+      },
+    });
+    getStatsPackets = vi.fn().mockResolvedValue({
+      type: 2,
+      raw: new Uint8Array([2]),
+      data: {
+        recv: 0,
+        sent: 0,
+        nSentFlood: 0,
+        nSentDirect: 0,
+        nRecvFlood: 0,
+        nRecvDirect: 0,
+        nRecvErrors: 0,
+      },
+    });
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
+    persistentListenerCount() {
+      return MESHCORE_PERSISTENT_CONN_EVENTS.reduce(
+        (n, ev) => n + (this.listeners.get(ev)?.size ?? 0),
+        0,
+      );
+    }
+  }
+
+  class MockSerialConnection {
+    async write(bytes: Uint8Array) {
+      await Promise.resolve();
+      void bytes;
+    }
+    async onDataReceived(value: Uint8Array) {
+      await Promise.resolve();
+      void value;
+    }
+    async onConnected() {
+      await Promise.resolve();
+    }
+    onDisconnected() {
+      return undefined;
+    }
+    close = vi.fn().mockResolvedValue(undefined);
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
+  }
+
+  class MockConnection {
+    async write(bytes: Uint8Array) {
+      await Promise.resolve();
+      void bytes;
+    }
+    async sendToRadioFrame(data: Uint8Array) {
+      await Promise.resolve();
+      void data;
+    }
+    async onConnected() {
+      await Promise.resolve();
+    }
+    onDisconnected() {
+      return undefined;
+    }
+    onFrameReceived(frame: Uint8Array) {
+      void frame;
+      return undefined;
+    }
+    close = vi.fn().mockResolvedValue(undefined);
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+  }
+
+  return {
+    CayenneLpp: { parse: vi.fn().mockReturnValue([]) },
+    Connection: MockConnection,
+    SerialConnection: MockSerialConnection,
+    WebSerialConnection: MockWebSerialConnection,
+  };
+});
+
+import { useMeshCore } from './useMeshCore';
+
+const SELF_PUBKEY = new Uint8Array(32).fill(0xab);
+
+function makeMockSerialPort() {
+  return {
+    open: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    getInfo: vi.fn().mockReturnValue({ usbVendorId: 0x1234, usbProductId: 0x5678 }),
+  };
+}
+
+describe('useMeshCore connection listener teardown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastMeshSerialMock.current = null;
+    vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getMeshcoreMessages).mockResolvedValue([]);
+    getSelfInfoMock.mockResolvedValue({
+      name: 'SelfRadio',
+      publicKey: SELF_PUBKEY,
+      type: 1,
+      txPower: 22,
+      radioFreq: 902_000_000,
+    });
+    getContactsMock.mockResolvedValue([]);
+    getChannelsMock.mockResolvedValue([]);
+  });
+
+  it('removes all persistent conn.on handlers after disconnect()', async () => {
+    const port = makeMockSerialPort();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: {
+        requestPort: vi.fn().mockResolvedValue(port),
+      },
+    });
+
+    const { result } = renderHook(() => useMeshCore());
+
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    const conn = lastMeshSerialMock.current;
+    expect(conn).not.toBeNull();
+    expect(conn!.persistentListenerCount()).toBeGreaterThan(0);
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(conn!.persistentListenerCount()).toBe(0);
+  });
+
+  it('tears down listeners on the previous connection when connect replaces it', async () => {
+    const port1 = makeMockSerialPort();
+    const port2 = makeMockSerialPort();
+    const requestPort = vi.fn().mockResolvedValueOnce(port1).mockResolvedValueOnce(port2);
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: { requestPort },
+    });
+
+    const { result } = renderHook(() => useMeshCore());
+
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    const firstConn = lastMeshSerialMock.current;
+    expect(firstConn).not.toBeNull();
+    expect(firstConn!.persistentListenerCount()).toBeGreaterThan(0);
+
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    expect(firstConn!.persistentListenerCount()).toBe(0);
+    expect(lastMeshSerialMock.current).not.toBe(firstConn);
+    expect(lastMeshSerialMock.current!.persistentListenerCount()).toBeGreaterThan(0);
+  });
+
+  it('clears persistent listeners when conn emits disconnected', async () => {
+    const port = makeMockSerialPort();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: {
+        requestPort: vi.fn().mockResolvedValue(port),
+      },
+    });
+
+    const { result } = renderHook(() => useMeshCore());
+
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    const conn = lastMeshSerialMock.current!;
+    expect(conn.persistentListenerCount()).toBeGreaterThan(0);
+
+    act(() => {
+      conn.emit('disconnected');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('disconnected');
+    });
+
+    expect(conn.persistentListenerCount()).toBe(0);
+  });
+});

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -1705,7 +1705,6 @@ export function useMeshCore() {
           console.warn('[useMeshCore] saveMeshcoreContact error', e);
         });
       }
-
       try {
         const dbContacts =
           (await window.electronAPI.db.getMeshcoreContacts()) as MeshcoreContactDbRow[];

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -16,6 +16,7 @@ import {
   isMeshcoreRetryableBleErrorMessage,
   MESHCORE_SETUP_ABORT_MESSAGE,
 } from '../lib/bleConnectErrors';
+import { MAX_IN_MEMORY_CHAT_MESSAGES, trimChatMessagesToMax } from '../lib/chatInMemoryBuffer';
 import {
   classifyPayload,
   extractMeshtasticSenderId,
@@ -944,7 +945,7 @@ function mergeMeshcoreDbHydrationWithLive(
     if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp;
     return (a.id ?? 0) - (b.id ?? 0);
   });
-  return merged;
+  return trimChatMessagesToMax(merged, MAX_IN_MEMORY_CHAT_MESSAGES);
 }
 
 /** Row shape from `db:getMeshcoreMessages` — shared by initConn, mount load, refreshMessagesFromDb. */
@@ -1559,7 +1560,7 @@ export function useMeshCore() {
           return prev;
         }
         inserted = true;
-        return [...prev, msg];
+        return trimChatMessagesToMax([...prev, msg], MAX_IN_MEMORY_CHAT_MESSAGES);
       });
     });
     if (inserted) {
@@ -1867,8 +1868,24 @@ export function useMeshCore() {
     buildNodesFromContactsRef.current = buildNodesFromContacts;
   }, [buildNodesFromContacts]);
 
+  /** Returned by {@link setupEventListeners}; run before `conn.close()` or replacing the connection. */
+  const meshcoreConnEventListenersTeardownRef = useRef<(() => void) | null>(null);
+  const teardownMeshcoreConnEventListeners = useCallback(() => {
+    meshcoreConnEventListenersTeardownRef.current?.();
+    meshcoreConnEventListenersTeardownRef.current = null;
+  }, []);
+
   const setupEventListeners = useCallback(
     (conn: MeshCoreConnection) => {
+      const meshcorePersistentListenerRegs: {
+        event: string | number;
+        handler: (...args: unknown[]) => void;
+      }[] = [];
+      const onMeshcoreConn = (event: string | number, handler: (...args: unknown[]) => void) => {
+        conn.on(event, handler);
+        meshcorePersistentListenerRegs.push({ event, handler });
+      };
+
       const logTransportLineAsDevice = (line: string) => {
         const now = Date.now();
         const entry: DeviceLogEntry = {
@@ -1884,7 +1901,7 @@ export function useMeshCore() {
       };
 
       // Push: periodic advert — event 0x80 = 128 (meshcore.js emits publicKey only; lat/lastAdvert may be absent)
-      conn.on(128, (data: unknown) => {
+      onMeshcoreConn(128, (data: unknown) => {
         const d = data as {
           publicKey: Uint8Array;
           advLat?: number;
@@ -2041,7 +2058,7 @@ export function useMeshCore() {
       });
 
       // Push: path updated — event 0x81 = 129; update last_heard for that contact
-      conn.on(129, (data: unknown) => {
+      onMeshcoreConn(129, (data: unknown) => {
         const d = data as { publicKey: Uint8Array };
         if (d.publicKey?.length !== 32) {
           return;
@@ -2178,7 +2195,7 @@ export function useMeshCore() {
 
       // Push: send confirmed — event 0x82 = 130; resolve pending DM delivery
       // ackCode: 0x80 = RESP_CODE_ACK (success), 0x81 = RESP_CODE_NACK (failure)
-      conn.on(130, (data: unknown) => {
+      onMeshcoreConn(130, (data: unknown) => {
         const d = data as { ackCode: number; roundTrip?: number };
         if (typeof d.ackCode !== 'number' || !Number.isFinite(d.ackCode)) {
           console.warn('[useMeshCore] event 130: non-numeric ackCode', d.ackCode);
@@ -2254,7 +2271,7 @@ export function useMeshCore() {
       });
 
       // Push: new contact discovered — event 0x8A = 138
-      conn.on(138, (data: unknown) => {
+      onMeshcoreConn(138, (data: unknown) => {
         const d = meshcoreContactRawFromDevice(data as MeshCoreContactRaw);
         const node = meshcoreContactToMeshNode(d);
         pubKeyMapRef.current.set(node.node_id, d.publicKey);
@@ -2376,7 +2393,7 @@ export function useMeshCore() {
         }
       };
       processWaitingMessagesRef.current = processWaitingMessages;
-      conn.on(131, () => {
+      onMeshcoreConn(131, () => {
         void (async () => {
           try {
             await processWaitingMessages();
@@ -2394,7 +2411,7 @@ export function useMeshCore() {
       });
 
       // Incoming DM — event 7
-      conn.on(7, (data: unknown) => {
+      onMeshcoreConn(7, (data: unknown) => {
         const now = Date.now();
         const d = data as {
           pubKeyPrefix: Uint8Array;
@@ -2490,7 +2507,7 @@ export function useMeshCore() {
       });
 
       // Incoming channel message — event 8
-      conn.on(8, (data: unknown) => {
+      onMeshcoreConn(8, (data: unknown) => {
         const now = Date.now();
         const d = data as { channelIdx: number; text: string; senderTimestamp: number };
         if (isMeshcoreTransportStatusChatLine(d.text)) {
@@ -2586,7 +2603,7 @@ export function useMeshCore() {
 
       // Push: RF packet received — event 0x88 = 136; feed into device logs + signal telemetry.
       // Foreign LoRa fingerprinting requires d.raw (Uint8Array) from meshcore.js/device.
-      conn.on(136, (data: unknown) => {
+      onMeshcoreConn(136, (data: unknown) => {
         const d = data as { lastSnr?: number; lastRssi?: number; raw?: unknown };
         const snr = d.lastSnr ?? 0;
         const rssi = d.lastRssi ?? 0;
@@ -2852,7 +2869,12 @@ export function useMeshCore() {
         }
       });
 
-      conn.on('disconnected', () => {
+      onMeshcoreConn('disconnected', () => {
+        teardownMeshcoreConnEventListeners();
+        ipcTcpRef.current?.cleanup();
+        ipcTcpRef.current = null;
+        ipcNobleRef.current?.cleanup();
+        ipcNobleRef.current = null;
         meshcoreSessionPathUpdatedNodeIdsRef.current = new Set();
         setMeshcorePingRouteReadyEpoch((e) => e + 1);
         setState((prev) => ({ ...prev, status: 'disconnected' }));
@@ -2880,13 +2902,20 @@ export function useMeshCore() {
           }, 0);
       });
 
-      conn.on('rx', (data: unknown) => {
+      onMeshcoreConn('rx', (data: unknown) => {
         const frame = meshcoreCoerceRadioRxFrame(data);
         const parsed = frame && parseAutoaddConfigResponse(frame);
         if (parsed) setMeshcoreAutoadd(parsed);
       });
+
+      return () => {
+        for (const { event, handler } of meshcorePersistentListenerRegs) {
+          conn.off(event, handler);
+        }
+        processWaitingMessagesRef.current = null;
+      };
     },
-    [addMessage, setDeviceLogs, addCliHistoryEntry],
+    [addMessage, addCliHistoryEntry, setDeviceLogs, teardownMeshcoreConnEventListeners],
   );
 
   /** Reject promptly when `disconnect()` bumps `meshcoreSetupGenerationRef` (avoids hanging on getChannels, etc.). */
@@ -2953,7 +2982,7 @@ export function useMeshCore() {
   const initConn = useCallback(
     async (conn: MeshCoreConnection, setupGen: number) => {
       connRef.current = conn;
-      setupEventListeners(conn);
+      meshcoreConnEventListenersTeardownRef.current = setupEventListeners(conn);
 
       // meshcore.js runs deviceQuery(SupportedCompanionProtocolVersion) from onConnected() on the next
       // macrotask; register before any await so we capture that DeviceInfo (manufacturer string, build date).
@@ -3121,6 +3150,7 @@ export function useMeshCore() {
       const staleConn = connRef.current;
       connRef.current = null;
       if (staleConn) {
+        teardownMeshcoreConnEventListeners();
         void staleConn.close().catch(() => {});
       }
 
@@ -3332,6 +3362,7 @@ export function useMeshCore() {
           err.message === MESHCORE_SETUP_ABORT_MESSAGE;
         if (isSetupAbort) {
           setState({ status: 'disconnected', myNodeNum: 0, connectionType: null });
+          teardownMeshcoreConnEventListeners();
           ipcTcpRef.current?.cleanup();
           ipcTcpRef.current = null;
           ipcNobleRef.current?.cleanup();
@@ -3409,6 +3440,7 @@ export function useMeshCore() {
           })}`,
         );
         setState({ status: 'disconnected', myNodeNum: 0, connectionType: null });
+        teardownMeshcoreConnEventListeners();
         ipcTcpRef.current?.cleanup();
         ipcTcpRef.current = null;
         ipcNobleRef.current?.cleanup();
@@ -3436,7 +3468,7 @@ export function useMeshCore() {
         if (type === 'ble') bleConnectInProgressRef.current = false;
       }
     },
-    [initConn],
+    [initConn, teardownMeshcoreConnEventListeners],
   );
 
   /**
@@ -3490,6 +3522,7 @@ export function useMeshCore() {
           }
           setState({ status: 'disconnected', myNodeNum: 0, connectionType: null });
           connRef.current = null;
+          teardownMeshcoreConnEventListeners();
           // Always try both: conn.close() may throw if the read pump already errored
           if (serialConn) {
             try {
@@ -3530,7 +3563,7 @@ export function useMeshCore() {
       }
       // BLE: requires user gesture — not supported for auto-connect
     },
-    [initConn, connect],
+    [initConn, connect, teardownMeshcoreConnEventListeners],
   );
 
   const disconnect = useCallback(async () => {
@@ -3546,6 +3579,7 @@ export function useMeshCore() {
     // Clear pending CLI commands
     repeaterCommandServiceRef.current?.clear();
 
+    teardownMeshcoreConnEventListeners();
     try {
       await connRef.current?.close();
     } catch (e) {
@@ -3590,7 +3624,7 @@ export function useMeshCore() {
     }
     prevTxAirSecsRef.current = null;
     prevStatsTimestampRef.current = null;
-  }, []);
+  }, [teardownMeshcoreConnEventListeners]);
 
   const sendMessage = useCallback(
     async (text: string, channelIdx: number, destNodeId?: number, replyId?: number) => {
@@ -3630,7 +3664,9 @@ export function useMeshCore() {
           to: destNodeId,
           replyId: replyField,
         };
-        setMessages((prev) => [...prev, tempMsg]);
+        setMessages((prev) =>
+          trimChatMessagesToMax([...prev, tempMsg], MAX_IN_MEMORY_CHAT_MESSAGES),
+        );
 
         // Calculate dynamic timeout based on hop count for multi-hop paths
         const destNode = nodesRef.current.get(destNodeId);

--- a/src/renderer/lib/chatInMemoryBuffer.test.ts
+++ b/src/renderer/lib/chatInMemoryBuffer.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_IN_MEMORY_CHAT_MESSAGES, trimChatMessagesToMax } from './chatInMemoryBuffer';
+
+describe('trimChatMessagesToMax', () => {
+  it('returns the same array when under the cap', () => {
+    const a = [1, 2, 3];
+    expect(trimChatMessagesToMax(a, 10)).toBe(a);
+  });
+
+  it('keeps only the newest tail when over the cap', () => {
+    const arr = Array.from({ length: 15 }, (_, i) => i);
+    expect(trimChatMessagesToMax(arr, 10)).toEqual([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+  });
+
+  it('MAX_IN_MEMORY_CHAT_MESSAGES is a reasonable fixed bound', () => {
+    expect(MAX_IN_MEMORY_CHAT_MESSAGES).toBe(2000);
+  });
+});

--- a/src/renderer/lib/chatInMemoryBuffer.ts
+++ b/src/renderer/lib/chatInMemoryBuffer.ts
@@ -1,0 +1,12 @@
+/**
+ * Cap in-memory Meshtastic / MeshCore chat arrays so long sessions cannot grow
+ * the renderer heap unbounded. DB reads are separately limited in main IPC.
+ */
+export const MAX_IN_MEMORY_CHAT_MESSAGES = 2000;
+
+export function trimChatMessagesToMax<T>(messages: T[], maxLen: number): T[] {
+  if (messages.length <= maxLen) {
+    return messages;
+  }
+  return messages.slice(messages.length - maxLen);
+}

--- a/src/renderer/stores/pathHistoryStore.ts
+++ b/src/renderer/stores/pathHistoryStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 
+import { MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT } from '@/shared/meshcorePathHistoryLimits';
+
 import type { PathRecord, PathScore, PathSelection } from '../lib/pathHistoryTypes';
 
 const MAX_CONTACTS = 50;
@@ -319,6 +321,12 @@ export const usePathHistoryStore = create<PathHistoryState>((set, get) => ({
       if (typeof api !== 'function') return;
       const rows = (await api()) as MeshcorePathHistoryWireRow[];
       if (!rows || rows.length === 0) return;
+      if (rows.length >= MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT) {
+        console.warn(
+          '[pathHistory] loadAllFromDb: loaded row count hit global DB limit; some history may be missing',
+          MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT,
+        );
+      }
 
       const byNode = new Map<number, PathRecord[]>();
       const latestTs = new Map<number, number>();

--- a/src/shared/meshcorePathHistoryLimits.ts
+++ b/src/shared/meshcorePathHistoryLimits.ts
@@ -1,0 +1,5 @@
+/** Max rows returned by `getAllMeshcorePathHistory` (startup / full hydrate) to avoid OOM. */
+export const MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT = 10_000;
+
+/** Max rows per node from `getMeshcorePathHistory` (per-contact load). */
+export const MESHCORE_PATH_HISTORY_PER_NODE_ROW_LIMIT = 500;


### PR DESCRIPTION
## Summary
- harden MeshCore connection lifecycle cleanup to avoid stale listeners/IPC bridges across reconnects and disconnect paths
- cap memory-heavy chat/path-history reads and in-memory message growth to reduce renderer/main-process OOM risk in long sessions
- tighten payload validation for `http:write` and align tests/contracts with the new limits and guardrails

## What changed
- Added listener teardown plumbing in `useMeshCore` so event subscriptions and transport helpers are consistently cleaned up on disconnect, abort, and reconnect flows.
- Added bounded chat buffering (`MAX_IN_MEMORY_CHAT_MESSAGES`) and applied it where messages are loaded/appended in renderer hooks.
- Added shared MeshCore path-history row limits and applied SQL `LIMIT` constraints in DB accessors, with warnings when truncation thresholds are hit.
- Added HTTP write payload cap and byte-range validation in main IPC handler.
- Updated/added tests for DB SQL contracts, IPC payload limits, and in-memory chat buffer behavior.

## Why
Long-running sessions could accumulate unbounded chat/path-history data and stale connection listeners, increasing memory pressure and contributing to instability. These changes bound hot paths and make connection cleanup deterministic while preserving existing behavior.

## Test plan
- [x] Source contract tests updated for DB query limits and IPC validation
- [x] Unit test added for chat buffer trimming helper
- [ ] Run full suite locally: `pnpm run lint && pnpm run typecheck && pnpm run test:run`