### PR TITLE
fix: stop mesh flooding from auto-traceroute and position broadcast poll

### DIFF
--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -68,8 +68,6 @@ function getMessageLoadLimit(): number {
 }
 
 const MAX_TELEMETRY_POINTS = 50;
-const POLL_INTERVAL_MS = 30_000; // 30 seconds (BLE/serial)
-const HTTP_POLL_INTERVAL_MS = 60_000; // 60 seconds for WiFi — less contention with user sends
 const BROADCAST_ADDR = 0xffffffff;
 
 /** Portnums.TRACEROUTE_APP — use Number() so protobuf enums compare reliably */
@@ -141,8 +139,6 @@ export function useDevice() {
   const myNodeNumRef = useRef<number>(0);
   // Use a ref for nodes so event callbacks always see the latest value
   const nodesRef = useRef<Map<number, MeshNode>>(new Map());
-  // Track polling interval for node refresh
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // Track event unsubscribe functions for cleanup
   const unsubscribesRef = useRef<(() => void)[]>([]);
 
@@ -422,25 +418,6 @@ export function useDevice() {
     const charging = batteryLevel > 100;
     const pct = Math.min(100, batteryLevel);
     setState((s) => ({ ...s, batteryPercent: pct, batteryCharging: charging }));
-  }, []);
-
-  // ─── Helper: start polling for node updates ─────────────────────
-  const startPolling = useCallback((connectionType?: ConnectionType | null) => {
-    if (pollRef.current) return; // Already polling
-    const intervalMs = connectionType === 'http' ? HTTP_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
-    pollRef.current = setInterval(() => {
-      if (nodesRef.current.get(myNodeNumRef.current)?.role === ROLE_CLIENT_MUTE) return;
-      deviceRef.current?.requestPosition(0xffffffff).catch((e: unknown) => {
-        console.debug('[useDevice] requestPosition poll', e);
-      });
-    }, intervalMs);
-  }, []);
-
-  const stopPolling = useCallback(() => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
   }, []);
 
   // ─── Helper: clean up all event subscriptions ───────────────────
@@ -933,7 +910,6 @@ export function useDevice() {
     return () => {
       cleanupSubscriptions();
       clearConfigureTimeout();
-      stopPolling();
       stopWatchdog();
       stopGpsInterval();
       isReconnectingRef.current = false;
@@ -945,7 +921,7 @@ export function useDevice() {
         });
       }
     };
-  }, [cleanupSubscriptions, clearConfigureTimeout, stopPolling, stopWatchdog, stopGpsInterval]);
+  }, [cleanupSubscriptions, clearConfigureTimeout, stopWatchdog, stopGpsInterval]);
 
   // ─── Wire up all event subscriptions for a device ─────────────
   const wireSubscriptions = useCallback(
@@ -979,7 +955,6 @@ export function useDevice() {
                 });
               }
               cleanupSubscriptions();
-              stopPolling();
               stopWatchdog();
               stopGpsInterval();
               setState({
@@ -994,12 +969,11 @@ export function useDevice() {
           }
         }
 
-        // Start polling + watchdog when configured
+        // Start watchdog when configured
         if (status === 7) {
           clearConfigureTimeout();
           isConfiguringRef.current = false;
           lastDataReceivedRef.current = Date.now();
-          startPolling(type);
           startWatchdog();
           void refreshOurPositionRef.current();
           startGpsInterval();
@@ -1014,7 +988,6 @@ export function useDevice() {
           stopWatchdog();
           stopGpsInterval();
           cleanupSubscriptions();
-          stopPolling();
           setTraceRouteResults(new Map());
           setQueueStatus(null);
           setDeviceLogs([]);
@@ -2349,8 +2322,6 @@ export function useDevice() {
       applyOwnNodeBatteryFromDeviceMetrics,
       getNodeName,
       updateNodes,
-      startPolling,
-      stopPolling,
       startWatchdog,
       stopWatchdog,
       cleanupSubscriptions,
@@ -2371,7 +2342,6 @@ export function useDevice() {
     // Clean up existing connection
     clearConfigureTimeout();
     cleanupSubscriptions();
-    stopPolling();
     stopWatchdog();
     stopGpsInterval();
     const oldDevice = deviceRef.current;
@@ -2383,7 +2353,7 @@ export function useDevice() {
 
     // Begin reconnection
     void attemptReconnectRef.current();
-  }, [clearConfigureTimeout, cleanupSubscriptions, stopPolling, stopWatchdog, stopGpsInterval]);
+  }, [clearConfigureTimeout, cleanupSubscriptions, stopWatchdog, stopGpsInterval]);
 
   // Keep the ref in sync
   handleConnectionLostRef.current = handleConnectionLost;
@@ -2468,7 +2438,6 @@ export function useDevice() {
       clearConfigureTimeout();
       if (deviceRef.current) {
         cleanupSubscriptions();
-        stopPolling();
         stopWatchdog();
         const oldDevice = deviceRef.current;
         deviceRef.current = null;
@@ -2511,7 +2480,6 @@ export function useDevice() {
         clearConfigureTimeout();
         console.error('[Meshtastic] Connection failed:', err);
         cleanupSubscriptions();
-        stopPolling();
         stopWatchdog();
         deviceRef.current = null;
         setState({
@@ -2524,7 +2492,7 @@ export function useDevice() {
         throw err;
       }
     },
-    [wireSubscriptions, cleanupSubscriptions, stopPolling, stopWatchdog, clearConfigureTimeout],
+    [wireSubscriptions, cleanupSubscriptions, stopWatchdog, clearConfigureTimeout],
   );
 
   /**
@@ -2542,7 +2510,6 @@ export function useDevice() {
       clearConfigureTimeout();
       if (deviceRef.current) {
         cleanupSubscriptions();
-        stopPolling();
         stopWatchdog();
         const oldDevice = deviceRef.current;
         deviceRef.current = null;
@@ -2582,7 +2549,6 @@ export function useDevice() {
         clearConfigureTimeout();
         console.error('[Meshtastic] Auto-connect failed:', err);
         cleanupSubscriptions();
-        stopPolling();
         stopWatchdog();
         deviceRef.current = null;
         setState({
@@ -2595,14 +2561,13 @@ export function useDevice() {
         throw err;
       }
     },
-    [wireSubscriptions, cleanupSubscriptions, stopPolling, stopWatchdog, clearConfigureTimeout],
+    [wireSubscriptions, cleanupSubscriptions, stopWatchdog, clearConfigureTimeout],
   );
 
   const disconnect = useCallback(async () => {
     // Stop all monitoring and reconnection
     clearConfigureTimeout();
     cleanupSubscriptions();
-    stopPolling();
     stopWatchdog();
     stopGpsInterval();
     isReconnectingRef.current = false;
@@ -2622,7 +2587,7 @@ export function useDevice() {
       batteryPercent: undefined,
       batteryCharging: undefined,
     });
-  }, [cleanupSubscriptions, stopPolling, stopWatchdog, stopGpsInterval, clearConfigureTimeout]);
+  }, [cleanupSubscriptions, stopWatchdog, stopGpsInterval, clearConfigureTimeout]);
 
   // ─── TransportManager status handler ─────────────────────────────────────
   // Defined as useCallback so it's stable; stored in a ref so TransportManager

--- a/src/renderer/lib/networkDiscovery.test.ts
+++ b/src/renderer/lib/networkDiscovery.test.ts
@@ -20,9 +20,9 @@ describe('startNetworkDiscovery', () => {
       },
       () => [1, 2, 3],
       60_000,
+      0,
     );
 
-    // Flush the immediate sweep (no timers involved when interNodeDelayMs=0)
     await vi.advanceTimersByTimeAsync(0);
     stop();
 
@@ -38,6 +38,7 @@ describe('startNetworkDiscovery', () => {
       },
       () => [10, 20],
       60_000,
+      0,
     );
 
     stop();
@@ -55,6 +56,7 @@ describe('startNetworkDiscovery', () => {
       },
       () => [5],
       10_000,
+      0,
     );
 
     // First sweep (immediate)
@@ -77,6 +79,7 @@ describe('startNetworkDiscovery', () => {
       },
       () => [7],
       5_000,
+      0,
     );
 
     await vi.advanceTimersByTimeAsync(0);
@@ -100,6 +103,7 @@ describe('startNetworkDiscovery', () => {
       },
       () => [1, 2, 3],
       60_000,
+      0,
     );
 
     await vi.advanceTimersByTimeAsync(0);
@@ -113,5 +117,51 @@ describe('startNetworkDiscovery', () => {
     );
 
     warnSpy.mockRestore();
+  });
+
+  it('staggers node trace starts by interNodeStaggerMs', async () => {
+    const startTimes: Record<number, number> = {};
+    const stop = startNetworkDiscovery(
+      (id) => {
+        startTimes[id] = Date.now();
+        return Promise.resolve();
+      },
+      () => [1, 2, 3],
+      60_000,
+      500,
+    );
+
+    // Advance past initial yield then through all stagger timers
+    await vi.advanceTimersByTimeAsync(0); // yield for index 0
+    await vi.advanceTimersByTimeAsync(500); // stagger for index 1
+    await vi.advanceTimersByTimeAsync(500); // stagger delta for index 2
+    stop();
+
+    expect(startTimes[1]).toBeDefined();
+    expect(startTimes[2]).toBeDefined();
+    expect(startTimes[3]).toBeDefined();
+    // Each node starts after the previous stagger window
+    expect(startTimes[2]).toBeGreaterThanOrEqual(startTimes[1] + 500);
+    expect(startTimes[3]).toBeGreaterThanOrEqual(startTimes[1] + 1_000);
+  });
+
+  it('stops staggered traces mid-sweep when stop() is called', async () => {
+    const traced: number[] = [];
+    const stop = startNetworkDiscovery(
+      (id) => {
+        traced.push(id);
+        return Promise.resolve();
+      },
+      () => [1, 2, 3],
+      60_000,
+      500,
+    );
+
+    // Let node 1 (index 0) trace, then stop before node 2's stagger fires
+    await vi.advanceTimersByTimeAsync(0);
+    stop();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(traced).toEqual([1]);
   });
 });

--- a/src/renderer/lib/networkDiscovery.ts
+++ b/src/renderer/lib/networkDiscovery.ts
@@ -1,19 +1,23 @@
 import { sanitizeLogMessage } from '@/main/sanitize-log-message';
 
 const AUTO_TRACEROUTE_INTERVAL_MS = 30 * 60 * 1_000; // 30 minutes
+const INTER_NODE_STAGGER_MS = 1_500; // stagger trace starts to avoid simultaneous mesh flood
 
 /**
  * Starts a periodic network discovery loop that traceroutes all known nodes.
  *
- * @param traceRouteFn    Async function to run traceroute to a single node.
- * @param getNodeIds      Returns the current list of node IDs to probe (excluding our own node).
- * @param intervalMs      How often to run a full sweep (default: 30 minutes).
- * @returns               A stop function — call it to cancel the scheduler.
+ * @param traceRouteFn       Async function to run traceroute to a single node.
+ * @param getNodeIds         Returns the current list of node IDs to probe (excluding our own node).
+ * @param intervalMs         How often to run a full sweep (default: 30 minutes).
+ * @param interNodeStaggerMs Delay between each node's trace start within a sweep (default: 1.5 s).
+ *                           Pass 0 in tests to avoid slow fake-timer advances.
+ * @returns                  A stop function — call it to cancel the scheduler.
  */
 export function startNetworkDiscovery(
   traceRouteFn: (nodeId: number) => Promise<void>,
   getNodeIds: () => number[],
   intervalMs: number = AUTO_TRACEROUTE_INTERVAL_MS,
+  interNodeStaggerMs: number = INTER_NODE_STAGGER_MS,
 ): () => void {
   let stopped = false;
   let sweepTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -22,10 +26,14 @@ export function startNetworkDiscovery(
     if (stopped) return;
     const nodeIds = getNodeIds();
     await Promise.all(
-      nodeIds.map(async (nodeId) => {
+      nodeIds.map(async (nodeId, index) => {
         if (stopped) return;
         await Promise.resolve();
         if (stopped) return;
+        if (interNodeStaggerMs > 0 && index > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, index * interNodeStaggerMs));
+          if (stopped) return;
+        }
         try {
           await traceRouteFn(nodeId);
         } catch (e) {


### PR DESCRIPTION
## Summary

Two separate sources of mesh flooding:

### 1. Auto-traceroute simultaneous blast (fixes #369)

Commit `55960af` switched `networkDiscovery.ts` from sequential iteration (with a 2 s inter-node delay) to `Promise.all` with no delay. When the 30-minute auto-traceroute sweep fires, it sent traceroute packets to **all known nodes at once**, spiking mesh utilization 3–5×.

**Fix:** Add a 1.5 s per-node stagger (`index × interNodeStaggerMs`) inside the `Promise.all` map. Nodes still run concurrently (packet correlation preserved), but trace starts are spread over ~1.5 s × N nodes instead of all firing at t=0. Tests updated to pass `interNodeStaggerMs: 0` to keep fake-timer tests fast; two new tests verify stagger ordering and mid-sweep cancellation.

### 2. Position broadcast poll flooding mesh (fixes #369)

`useDevice.ts` had a `setInterval` (30 s for BLE/serial, 60 s for HTTP) that called `requestPosition(0xFFFFFFFF)` — a broadcast with `wantResponse: true`. This caused **every node on the mesh to reply with its position on every tick**, regardless of the node's own telemetry interval setting. Reported symptoms:
- Telemetry/position packets appearing every 60 s despite a 1800 s node setting
- On a large northern mesh: "spammed position packets and caused all nodes to reply back with their position"

**Fix:** Remove `startPolling`/`stopPolling` and all call sites entirely. Nodes already broadcast positions on their own configured schedule; the NodeDB sync on connect provides initial positions for the UI. Per-node unicast `requestPosition` remains available from the UI (unaffected).

## Files changed

| File | Change |
|------|--------|
| `src/renderer/lib/networkDiscovery.ts` | Add `INTER_NODE_STAGGER_MS = 1_500`, stagger loop in `runSweep` |
| `src/renderer/lib/networkDiscovery.test.ts` | Pass `0` stagger in existing tests; add 2 new stagger tests |
| `src/renderer/hooks/useDevice.ts` | Remove `POLL_INTERVAL_MS`, `HTTP_POLL_INTERVAL_MS`, `pollRef`, `startPolling`, `stopPolling`, and all call sites |

## Testing

- `pnpm run test:run` — 1071 tests pass
- `pnpm run typecheck` — no errors
- Manual: verify traceroutes arrive spaced ~1.5 s apart in Raw Packet Log; verify position packets appear only on nodes' own schedule after connect