### PR TITLE
feat: emoji tapback picker, native emoji panel, LOCAL telemetry labeling

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@meshtastic/protobufs": "npm:@jsr/meshtastic__protobufs@^2.7.23",
     "@stoprocent/noble": "^2.4.1",
     "electron-updater": "^6.8.3",
+    "emoji-picker-element": "^1.29.1",
     "jszip": "^3.10.1",
     "leaflet.markercluster": "^1.5.3",
     "mgrs": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3
+      emoji-picker-element:
+        specifier: ^1.29.1
+        version: 1.29.1
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -1976,6 +1979,9 @@ packages:
     resolution: {integrity: sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
+
+  emoji-picker-element@1.29.1:
+    resolution: {integrity: sha512-TOiHzu9Dqib3x4MwcAi3wi3RdyT4SoeB4b15AvH1ks4SBwTl7DeebhZ0d3x6dNi4XfNU7IGRZ7NBQllj0RqwrQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -6254,6 +6260,8 @@ snapshots:
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  emoji-picker-element@1.29.1: {}
 
   emoji-regex@8.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1538,8 +1538,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.23:
-    resolution: {integrity: sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==}
+  baseline-browser-mapping@2.10.24:
+    resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -5760,7 +5760,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.23: {}
+  baseline-browser-mapping@2.10.24: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -5802,7 +5802,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.23
+      baseline-browser-mapping: 2.10.24
       caniuse-lite: 1.0.30001791
       electron-to-chromium: 1.5.344
       node-releases: 2.0.38

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2339,6 +2339,15 @@ ipcMain.handle('app:setLoginItem', (_event, openAtLogin: unknown) => {
   app.setLoginItemSettings({ openAtLogin });
 });
 
+ipcMain.handle('app:showEmojiPanel', (event) => {
+  if (!validateIpcSender(event)) {
+    throw new Error('IPC sender validation failed');
+  }
+  if (process.platform === 'darwin' || process.platform === 'win32') {
+    app.showEmojiPanel();
+  }
+});
+
 ipcMain.handle('app:quit', async (event) => {
   if (!validateIpcSender(event)) {
     throw new Error('IPC sender validation failed');

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -660,6 +660,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   quitApp: () => ipcRenderer.invoke('app:quit'),
 
+  // ─── OS emoji panel ──────────────────────────────────────────────────────────
+  getPlatform: () => process.platform,
+  showEmojiPanel: () => ipcRenderer.invoke('app:showEmojiPanel'),
+
   // ─── Native OS notifications ───────────────────────────────────
   notify: {
     show: (title: string, body: string): Promise<void> =>

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -1083,9 +1083,7 @@ describe('ChatPanel compose emoji picker', () => {
     );
     const emojiBtn = screen.getByRole('button', { name: '😊' });
     await user.click(emojiBtn);
-    await waitFor(() => {
-      expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
-    });
+    expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
     expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
   });
 
@@ -1099,9 +1097,7 @@ describe('ChatPanel compose emoji picker', () => {
     );
     const emojiBtn = screen.getByRole('button', { name: '😊' });
     await user.click(emojiBtn);
-    await waitFor(() => {
-      expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
-    });
+    expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
     expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
   });
 });
@@ -1162,9 +1158,7 @@ describe('ChatPanel tapback reaction picker', () => {
       );
       const reactBtn = screen.getByTitle('React');
       await user.click(reactBtn);
-      await waitFor(() => {
-        expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
-      });
+      expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
       expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
     },
   );

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -39,6 +39,8 @@ describe('ChatPanel accessibility', () => {
   it('emoji picker opens for the correct message when messages have no packetId', async () => {
     // Messages without packetId must use timestamp as picker key so re-renders
     // don't shift the picker to a different message (regression: was using -(i+1)).
+    // Use macOS so the hardcoded reaction grid renders (Linux shows emoji-picker-element).
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
     const now = Date.now();
     const user = userEvent.setup();
     render(
@@ -1099,6 +1101,66 @@ describe('ChatPanel compose emoji picker', () => {
     const emojiBtn = screen.getByRole('button', { name: '😊' });
     await user.click(emojiBtn);
     expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+    expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
+  });
+});
+
+describe('ChatPanel tapback reaction picker', () => {
+  const baseMessage = {
+    sender_id: 2,
+    sender_name: 'Alice',
+    payload: 'hello',
+    channel: 0,
+    timestamp: Date.now() - 1000,
+    status: 'acked' as const,
+  };
+
+  const defaultProps = {
+    messages: [baseMessage],
+    channels: [{ index: 0, name: 'General' }],
+    myNodeNum: 1,
+    onSend: vi.fn().mockResolvedValue(undefined),
+    onReact: vi.fn().mockResolvedValue(undefined),
+    onResend: vi.fn(),
+    onNodeClick: vi.fn(),
+    isConnected: true,
+    nodes: new Map(),
+    isActive: true,
+  };
+
+  beforeEach(() => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
+    vi.mocked(window.electronAPI.showEmojiPanel).mockClear().mockResolvedValue(undefined);
+  });
+
+  it('shows emoji-picker element on Linux when React button is clicked', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel {...defaultProps} />
+      </ToastProvider>,
+    );
+    const reactBtn = screen.getByTitle('React');
+    await user.click(reactBtn);
+    expect(document.querySelector('emoji-picker')).toBeInTheDocument();
+    // hardcoded grid buttons should not be present
+    expect(screen.queryByTitle('Like')).not.toBeInTheDocument();
+  });
+
+  it('shows hardcoded reaction grid on macOS when React button is clicked', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel {...defaultProps} />
+      </ToastProvider>,
+    );
+    const reactBtn = screen.getByTitle('React');
+    await user.click(reactBtn);
+    await waitFor(() => {
+      expect(screen.getByTitle('Like')).toBeInTheDocument();
+    });
     expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -1040,3 +1040,65 @@ describe('ChatPanel unread watermarks', () => {
     });
   });
 });
+
+describe('ChatPanel compose emoji picker', () => {
+  const defaultProps = {
+    messages: [],
+    channels: [{ index: 0, name: 'General' }],
+    myNodeNum: 1,
+    onSend: vi.fn().mockResolvedValue(undefined),
+    onReact: vi.fn().mockResolvedValue(undefined),
+    onResend: vi.fn(),
+    onNodeClick: vi.fn(),
+    isConnected: true,
+    nodes: new Map(),
+    isActive: true,
+  };
+
+  beforeEach(() => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
+    vi.mocked(window.electronAPI.showEmojiPanel).mockClear().mockResolvedValue(undefined);
+  });
+
+  it('shows emoji-picker element on Linux when emoji button is clicked', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel {...defaultProps} />
+      </ToastProvider>,
+    );
+    const emojiBtn = screen.getByRole('button', { name: '😊' });
+    await user.click(emojiBtn);
+    expect(document.querySelector('emoji-picker')).toBeInTheDocument();
+    expect(window.electronAPI.showEmojiPanel).not.toHaveBeenCalled();
+  });
+
+  it('calls showEmojiPanel and does not render emoji-picker on macOS', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel {...defaultProps} />
+      </ToastProvider>,
+    );
+    const emojiBtn = screen.getByRole('button', { name: '😊' });
+    await user.click(emojiBtn);
+    expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+    expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
+  });
+
+  it('calls showEmojiPanel and does not render emoji-picker on Windows', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('win32');
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel {...defaultProps} />
+      </ToastProvider>,
+    );
+    const emojiBtn = screen.getByRole('button', { name: '😊' });
+    await user.click(emojiBtn);
+    expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+    expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -39,8 +39,6 @@ describe('ChatPanel accessibility', () => {
   it('emoji picker opens for the correct message when messages have no packetId', async () => {
     // Messages without packetId must use timestamp as picker key so re-renders
     // don't shift the picker to a different message (regression: was using -(i+1)).
-    // Use macOS so the hardcoded reaction grid renders (Linux shows emoji-picker-element).
-    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
     const now = Date.now();
     const user = userEvent.setup();
     render(
@@ -70,12 +68,11 @@ describe('ChatPanel accessibility', () => {
         />
       </ToastProvider>,
     );
-    // Open picker for the second message
+    // Open picker for the second message (Linux default mock → emoji-picker-element)
     const reactButtons = screen.getAllByTitle('React');
     await user.click(reactButtons[1]);
-    // Picker should be visible — emoji buttons are titled 'Like', 'Love', etc.
     await waitFor(() => {
-      expect(screen.getByTitle('Like')).toBeInTheDocument();
+      expect(document.querySelector('emoji-picker')).toBeInTheDocument();
     });
   });
 
@@ -1143,24 +1140,26 @@ describe('ChatPanel tapback reaction picker', () => {
     );
     const reactBtn = screen.getByTitle('React');
     await user.click(reactBtn);
-    expect(document.querySelector('emoji-picker')).toBeInTheDocument();
-    // hardcoded grid buttons should not be present
-    expect(screen.queryByTitle('Like')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.querySelector('emoji-picker')).toBeInTheDocument();
+    });
+    expect(window.electronAPI.showEmojiPanel).not.toHaveBeenCalled();
   });
 
-  it('shows hardcoded reaction grid on macOS when React button is clicked', async () => {
-    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
-    const user = userEvent.setup();
-    render(
-      <ToastProvider>
-        <ChatPanel {...defaultProps} />
-      </ToastProvider>,
-    );
-    const reactBtn = screen.getByTitle('React');
-    await user.click(reactBtn);
-    await waitFor(() => {
-      expect(screen.getByTitle('Like')).toBeInTheDocument();
-    });
-    expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
-  });
+  it.each(['darwin', 'win32'] as const)(
+    'calls showEmojiPanel and does not render emoji-picker on %s when React button is clicked',
+    async (platform) => {
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue(platform);
+      const user = userEvent.setup();
+      render(
+        <ToastProvider>
+          <ChatPanel {...defaultProps} />
+        </ToastProvider>,
+      );
+      const reactBtn = screen.getByTitle('React');
+      await user.click(reactBtn);
+      expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+      expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
+    },
+  );
 });

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -1083,7 +1083,9 @@ describe('ChatPanel compose emoji picker', () => {
     );
     const emojiBtn = screen.getByRole('button', { name: '😊' });
     await user.click(emojiBtn);
-    expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+    });
     expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
   });
 
@@ -1097,7 +1099,9 @@ describe('ChatPanel compose emoji picker', () => {
     );
     const emojiBtn = screen.getByRole('button', { name: '😊' });
     await user.click(emojiBtn);
-    expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+    });
     expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
   });
 });
@@ -1158,7 +1162,9 @@ describe('ChatPanel tapback reaction picker', () => {
       );
       const reactBtn = screen.getByTitle('React');
       await user.click(reactBtn);
-      expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+      await waitFor(() => {
+        expect(window.electronAPI.showEmojiPanel).toHaveBeenCalledOnce();
+      });
       expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
     },
   );

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -342,6 +342,10 @@ function ChatPanel({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const emojiPickerRef = useRef<HTMLElement | null>(null);
+  const reactionPickerRef = useRef<HTMLElement | null>(null);
+  const reactionPickerTarget = useRef<{ id: number; channel: number } | null>(null);
+
+  const handleReactRef = useRef<any>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Two-section UI state — load DM tabs from localStorage for restart persistence
@@ -808,6 +812,7 @@ function ChatPanel({
       });
     }
   };
+  handleReactRef.current = handleReact;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -910,6 +915,26 @@ function ChatPanel({
       el.removeEventListener('emoji-click', handler);
     };
   }, [showComposePicker]);
+
+  // Linux reaction picker — attach emoji-click on the <emoji-picker> web component
+  useEffect(() => {
+    if (!isLinux || !pickerOpenFor) return;
+    const el = reactionPickerRef.current;
+    if (!el) return;
+    const target = reactionPickerTarget.current;
+    if (!target) return;
+    const handler = (e: Event) => {
+      const unicode = (e as CustomEvent).detail.emoji.unicode as string;
+      const code = unicode.codePointAt(0);
+      if (code !== undefined) {
+        void handleReactRef.current(code, target.id, target.channel);
+      }
+    };
+    el.addEventListener('emoji-click', handler);
+    return () => {
+      el.removeEventListener('emoji-click', handler);
+    };
+  }, [pickerOpenFor, isLinux]);
 
   const isDmMode = viewMode === 'dm' && activeDmNode != null;
   const dmNodeName = activeDmNode != null ? getDmLabel(activeDmNode) : '';
@@ -1357,7 +1382,11 @@ function ChatPanel({
                           {/* React */}
                           <button
                             onClick={() => {
-                              setPickerOpenFor(showPicker ? null : (msg.packetId ?? msg.timestamp));
+                              const id = msg.packetId ?? msg.timestamp;
+                              if (!showPicker) {
+                                reactionPickerTarget.current = { id, channel: msg.channel };
+                              }
+                              setPickerOpenFor(showPicker ? null : id);
                             }}
                             className="rounded p-1 text-xs text-gray-600 hover:text-gray-300"
                             aria-label="Add reaction"
@@ -1405,8 +1434,15 @@ function ChatPanel({
                       )}
                     </div>
 
-                    {/* Emoji picker */}
-                    {showPicker && (
+                    {/* Reaction picker — Linux: full emoji-picker-element; macOS/Windows: quick grid */}
+                    {showPicker && isLinux && (
+                      <div
+                        className={`${pickerOpensAbove ? 'order-first mb-1' : 'mt-1'} ${isOwn ? 'self-end' : 'self-start'}`}
+                      >
+                        <emoji-picker ref={reactionPickerRef} style={{ width: '320px' }} />
+                      </div>
+                    )}
+                    {showPicker && !isLinux && (
                       <div
                         className={`bg-secondary-dark flex flex-col gap-0.5 rounded-xl border border-gray-600 px-2 py-1.5 shadow-lg ${
                           pickerOpensAbove ? 'order-first mb-1' : 'mt-1'

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -133,24 +133,6 @@ function TransportBadge({ via }: { via: 'rf' | 'mqtt' | 'both' }) {
   return via === 'rf' ? rfIcon : mqttIcon;
 }
 
-// Standard emoji reaction set — Row 1: iMessage Classic, Row 2: WhatsApp/RCS Extended
-const REACTION_EMOJIS = [
-  // Row 1 (6)
-  { code: 128077, label: '\ud83d\udc4d', name: 'Like' }, // 👍
-  { code: 10084, label: '\u2764\ufe0f', name: 'Love' }, // ❤️
-  { code: 128514, label: '\ud83d\ude02', name: 'Laugh' }, // 😂
-  { code: 128078, label: '\ud83d\udc4e', name: 'Dislike' }, // 👎
-  { code: 127881, label: '\ud83c\udf89', name: 'Party' }, // 🎉
-  { code: 128558, label: '\ud83d\ude2e', name: 'Wow' }, // 😮
-  // Row 2 (6)
-  { code: 128546, label: '\ud83d\ude22', name: 'Sad' }, // 😢
-  { code: 128075, label: '\ud83d\udc4b', name: 'Wave' }, // 👋
-  { code: 128591, label: '\ud83d\ude4f', name: 'Thanks' }, // 🙏
-  { code: 128293, label: '\ud83d\udd25', name: 'Fire' }, // 🔥
-  { code: 9989, label: '\u2705', name: 'Check' }, // ✅
-  { code: 129300, label: '\ud83e\udd14', name: 'Thinking' }, // 🤔
-];
-
 /** Format a date for day separators */
 function formatDayLabel(ts: number): string {
   const date = new Date(ts);
@@ -344,6 +326,7 @@ function ChatPanel({
   const emojiPickerRef = useRef<HTMLElement | null>(null);
   const reactionPickerRef = useRef<HTMLElement | null>(null);
   const reactionPickerTarget = useRef<{ id: number; channel: number } | null>(null);
+  const reactionHiddenInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleReactRef = useRef<any>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -918,7 +901,7 @@ function ChatPanel({
 
   // Linux reaction picker — attach emoji-click on the <emoji-picker> web component
   useEffect(() => {
-    if (!isLinux || !pickerOpenFor) return;
+    if (!pickerOpenFor) return;
     const el = reactionPickerRef.current;
     if (!el) return;
     const target = reactionPickerTarget.current;
@@ -934,7 +917,27 @@ function ChatPanel({
     return () => {
       el.removeEventListener('emoji-click', handler);
     };
-  }, [pickerOpenFor, isLinux]);
+  }, [pickerOpenFor]);
+
+  // macOS/Windows reaction picker — intercept emoji inserted into hidden input by showEmojiPanel()
+  useEffect(() => {
+    const el = reactionHiddenInputRef.current;
+    if (!el) return;
+    const handler = () => {
+      const unicode = el.value;
+      el.value = '';
+      if (!unicode) return;
+      const code = unicode.codePointAt(0);
+      const target = reactionPickerTarget.current;
+      if (code !== undefined && target) {
+        void handleReactRef.current(code, target.id, target.channel);
+      }
+    };
+    el.addEventListener('input', handler);
+    return () => {
+      el.removeEventListener('input', handler);
+    };
+  }, []);
 
   const isDmMode = viewMode === 'dm' && activeDmNode != null;
   const dmNodeName = activeDmNode != null ? getDmLabel(activeDmNode) : '';
@@ -1383,10 +1386,13 @@ function ChatPanel({
                           <button
                             onClick={() => {
                               const id = msg.packetId ?? msg.timestamp;
-                              if (!showPicker) {
-                                reactionPickerTarget.current = { id, channel: msg.channel };
+                              reactionPickerTarget.current = { id, channel: msg.channel };
+                              if (isLinux) {
+                                setPickerOpenFor(showPicker ? null : id);
+                              } else {
+                                reactionHiddenInputRef.current?.focus();
+                                void window.electronAPI.showEmojiPanel();
                               }
-                              setPickerOpenFor(showPicker ? null : id);
                             }}
                             className="rounded p-1 text-xs text-gray-600 hover:text-gray-300"
                             aria-label="Add reaction"
@@ -1434,48 +1440,12 @@ function ChatPanel({
                       )}
                     </div>
 
-                    {/* Reaction picker — Linux: full emoji-picker-element; macOS/Windows: quick grid */}
+                    {/* Reaction picker — Linux: emoji-picker-element; macOS/Windows: showEmojiPanel() */}
                     {showPicker && isLinux && (
                       <div
                         className={`${pickerOpensAbove ? 'order-first mb-1' : 'mt-1'} ${isOwn ? 'self-end' : 'self-start'}`}
                       >
                         <emoji-picker ref={reactionPickerRef} style={{ width: '320px' }} />
-                      </div>
-                    )}
-                    {showPicker && !isLinux && (
-                      <div
-                        className={`bg-secondary-dark flex flex-col gap-0.5 rounded-xl border border-gray-600 px-2 py-1.5 shadow-lg ${
-                          pickerOpensAbove ? 'order-first mb-1' : 'mt-1'
-                        } ${isOwn ? 'self-end' : 'self-start'}`}
-                      >
-                        <div className="flex gap-1">
-                          {REACTION_EMOJIS.slice(0, 6).map((re) => (
-                            <button
-                              key={re.code}
-                              onClick={() =>
-                                handleReact(re.code, msg.packetId ?? msg.timestamp, msg.channel)
-                              }
-                              className="px-0.5 text-lg transition-transform hover:scale-125"
-                              title={re.name}
-                            >
-                              {re.label}
-                            </button>
-                          ))}
-                        </div>
-                        <div className="flex justify-center gap-1">
-                          {REACTION_EMOJIS.slice(6).map((re) => (
-                            <button
-                              key={re.code}
-                              onClick={() =>
-                                handleReact(re.code, msg.packetId ?? msg.timestamp, msg.channel)
-                              }
-                              className="px-0.5 text-lg transition-transform hover:scale-125"
-                              title={re.name}
-                            >
-                              {re.label}
-                            </button>
-                          ))}
-                        </div>
                       </div>
                     )}
 
@@ -1551,6 +1521,15 @@ function ChatPanel({
           </button>
         )}
       </div>
+
+      {/* Hidden input: macOS/Windows native emoji panel inserts here for tapback reactions */}
+      <input
+        ref={reactionHiddenInputRef}
+        aria-hidden="true"
+        tabIndex={-1}
+        readOnly={false}
+        style={{ position: 'absolute', opacity: 0, width: 0, height: 0, pointerEvents: 'none' }}
+      />
 
       {/* Compose emoji picker — Linux only; macOS/Windows use native showEmojiPanel() */}
       {isLinux && showComposePicker && (

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -1384,16 +1384,17 @@ function ChatPanel({
                           </button>
                           {/* React */}
                           <button
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              if (!isLinux) reactionHiddenInputRef.current?.focus();
+                            }}
                             onClick={() => {
                               const id = msg.packetId ?? msg.timestamp;
                               reactionPickerTarget.current = { id, channel: msg.channel };
                               if (isLinux) {
                                 setPickerOpenFor(showPicker ? null : id);
                               } else {
-                                reactionHiddenInputRef.current?.focus();
-                                requestAnimationFrame(() => {
-                                  void window.electronAPI.showEmojiPanel();
-                                });
+                                void window.electronAPI.showEmojiPanel();
                               }
                             }}
                             className="rounded p-1 text-xs text-gray-600 hover:text-gray-300"
@@ -1614,14 +1615,15 @@ function ChatPanel({
         />
         {/* Compose emoji picker toggle */}
         <button
+          onMouseDown={(e) => {
+            e.preventDefault(); // keep textarea focused; also pre-focus it so OS settles before showEmojiPanel()
+            if (!isLinux) inputRef.current?.focus();
+          }}
           onClick={() => {
             if (isLinux) {
               setShowComposePicker((prev) => !prev);
             } else {
-              inputRef.current?.focus();
-              requestAnimationFrame(() => {
-                void window.electronAPI.showEmojiPanel();
-              });
+              void window.electronAPI.showEmojiPanel();
             }
           }}
           disabled={!isConnected || sending}

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable react-hooks/set-state-in-effect, react-hooks/refs */
+import 'emoji-picker-element';
+
 import {
   memo,
   useCallback,
@@ -24,6 +26,15 @@ import { truncateReplyPreviewText } from '../lib/replyPreview';
 import type { ChatMessage, MeshNode, MeshProtocol } from '../lib/types';
 import { ChatPayloadText } from './ChatPayloadText';
 import { HelpTooltip } from './HelpTooltip';
+
+declare module 'react' {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      'emoji-picker': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}
 
 function StatusBadge({
   status,
@@ -323,12 +334,14 @@ function ChatPanel({
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(null);
   const [pickerOpenFor, setPickerOpenFor] = useState<number | null>(null);
   const [showComposePicker, setShowComposePicker] = useState(false);
+  const isLinux = useMemo(() => window.electronAPI.getPlatform() === 'linux', []);
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearch, setShowSearch] = useState(false);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const emojiPickerRef = useRef<HTMLElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Two-section UI state — load DM tabs from localStorage for restart persistence
@@ -803,23 +816,6 @@ function ChatPanel({
     }
   };
 
-  const insertEmojiAtCursor = (code: number) => {
-    const el = inputRef.current;
-    const char = String.fromCodePoint(code);
-    // emoji is a surrogate pair = 2 UTF-16 code units
-    const charLen = char.length;
-    const start = el?.selectionStart ?? input.length;
-    const end = el?.selectionEnd ?? input.length;
-    const newVal = input.slice(0, start) + char + input.slice(end);
-    if (newVal.length > 228) return; // enforce maxLength
-    setInput(newVal);
-    setShowComposePicker(false);
-    requestAnimationFrame(() => {
-      el?.focus();
-      el?.setSelectionRange(start + charLen, start + charLen);
-    });
-  };
-
   // Open a DM tab for a node
   const openDmTo = useCallback((nodeNum: number) => {
     setOpenDmTabs((prev) => (prev.includes(nodeNum) ? prev : [...prev, nodeNum]));
@@ -890,6 +886,30 @@ function ChatPanel({
     }
     return -1;
   }, [channel, filteredMessages, isOwnNode, searchQuery, unreadDividerTimestamp]);
+
+  useEffect(() => {
+    const el = emojiPickerRef.current;
+    if (!el) return;
+    const handler = (e: Event) => {
+      const unicode: string = (e as CustomEvent).detail.emoji.unicode;
+      const textarea = inputRef.current;
+      const currentValue = textarea?.value ?? '';
+      const start = textarea?.selectionStart ?? currentValue.length;
+      const end = textarea?.selectionEnd ?? currentValue.length;
+      const newVal = currentValue.slice(0, start) + unicode + currentValue.slice(end);
+      if (newVal.length > 228) return;
+      setInput(newVal);
+      setShowComposePicker(false);
+      requestAnimationFrame(() => {
+        textarea?.focus();
+        textarea?.setSelectionRange(start + unicode.length, start + unicode.length);
+      });
+    };
+    el.addEventListener('emoji-click', handler);
+    return () => {
+      el.removeEventListener('emoji-click', handler);
+    };
+  }, [showComposePicker]);
 
   const isDmMode = viewMode === 'dm' && activeDmNode != null;
   const dmNodeName = activeDmNode != null ? getDmLabel(activeDmNode) : '';
@@ -1496,38 +1516,12 @@ function ChatPanel({
         )}
       </div>
 
-      {/* Compose emoji picker — renders above the input row */}
-      {showComposePicker && (
-        <div className="bg-secondary-dark mb-1 flex flex-col gap-0.5 self-start rounded-xl border border-gray-600 px-2 py-1.5 shadow-lg">
-          <div className="flex gap-1">
-            {REACTION_EMOJIS.slice(0, 6).map((re) => (
-              <button
-                key={re.code}
-                onClick={() => {
-                  insertEmojiAtCursor(re.code);
-                }}
-                className="px-0.5 text-lg transition-transform hover:scale-125"
-                title={re.name}
-              >
-                {re.label}
-              </button>
-            ))}
-          </div>
-          <div className="flex justify-center gap-1">
-            {REACTION_EMOJIS.slice(6).map((re) => (
-              <button
-                key={re.code}
-                onClick={() => {
-                  insertEmojiAtCursor(re.code);
-                }}
-                className="px-0.5 text-lg transition-transform hover:scale-125"
-                title={re.name}
-              >
-                {re.label}
-              </button>
-            ))}
-          </div>
-        </div>
+      {/* Compose emoji picker — Linux only; macOS/Windows use native showEmojiPanel() */}
+      {isLinux && showComposePicker && (
+        <emoji-picker
+          ref={emojiPickerRef}
+          style={{ width: '100%', maxWidth: '350px', alignSelf: 'flex-start' }}
+        />
       )}
 
       {/* Reply preview bar */}
@@ -1604,7 +1598,12 @@ function ChatPanel({
         {/* Compose emoji picker toggle */}
         <button
           onClick={() => {
-            setShowComposePicker((prev) => !prev);
+            if (isLinux) {
+              setShowComposePicker((prev) => !prev);
+            } else {
+              inputRef.current?.focus();
+              void window.electronAPI.showEmojiPanel();
+            }
           }}
           disabled={!isConnected || sending}
           aria-label="😊"

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -1391,7 +1391,9 @@ function ChatPanel({
                                 setPickerOpenFor(showPicker ? null : id);
                               } else {
                                 reactionHiddenInputRef.current?.focus();
-                                void window.electronAPI.showEmojiPanel();
+                                requestAnimationFrame(() => {
+                                  void window.electronAPI.showEmojiPanel();
+                                });
                               }
                             }}
                             className="rounded p-1 text-xs text-gray-600 hover:text-gray-300"
@@ -1617,7 +1619,9 @@ function ChatPanel({
               setShowComposePicker((prev) => !prev);
             } else {
               inputRef.current?.focus();
-              void window.electronAPI.showEmojiPanel();
+              requestAnimationFrame(() => {
+                void window.electronAPI.showEmojiPanel();
+              });
             }
           }}
           disabled={!isConnected || sending}

--- a/src/renderer/components/DiagnosticsPanel.tsx
+++ b/src/renderer/components/DiagnosticsPanel.tsx
@@ -15,7 +15,7 @@ import {
   getRecommendedAction,
   getRecommendedActionForRfCondition,
 } from '../lib/diagnostics/RemediationEngine';
-import { diagnoseConnectedNode, hasLocalStatsData } from '../lib/diagnostics/RFDiagnosticEngine';
+import { hasLocalStatsData } from '../lib/diagnostics/RFDiagnosticEngine';
 import type { OurPosition } from '../lib/gpsSource';
 import { startNetworkDiscovery } from '../lib/networkDiscovery';
 import type { ProtocolCapabilities } from '../lib/radio/BaseRadioProvider';
@@ -117,7 +117,6 @@ export default function DiagnosticsPanel({
   );
   const packetStats = useDiagnosticsStore((s) => s.packetStats);
   const packetCache = useDiagnosticsStore((s) => s.packetCache);
-  const getCuStats24h = useDiagnosticsStore((s) => s.getCuStats24h);
   const homeNode = nodes.get(myNodeNum) ?? null;
   const congestionHalosEnabled = useDiagnosticsStore((s) => s.congestionHalosEnabled);
   const setCongestionHalosEnabled = useDiagnosticsStore((s) => s.setCongestionHalosEnabled);
@@ -333,12 +332,10 @@ export default function DiagnosticsPanel({
 
   const meshCongestionBlock = useMemo(() => {
     if (!homeNode) return null;
-    if (!hasLocalStatsData(homeNode) && homeNode.channel_utilization == null) return null;
-    const cuStats24h = getCuStats24h(homeNode.node_id);
-    const findings = diagnoseConnectedNode(homeNode, {
-      cuStats24h: cuStats24h ?? undefined,
-    });
-    if (!findings?.some((f) => f.condition === 'Mesh Congestion')) return null;
+    const hasMeshCongestionRow = diagnosticRows.some(
+      (r) => r.kind === 'rf' && r.nodeId === homeNode.node_id && r.condition === 'Mesh Congestion',
+    );
+    if (!hasMeshCongestionRow) return null;
     const attr = summarizeMeshCongestionAttribution(packetCache, routingAnomaliesMap);
     const lines = meshCongestionDetailLines(attr, {
       alwaysIncludeRoutingAnomalies: true,
@@ -346,7 +343,7 @@ export default function DiagnosticsPanel({
     const originators = packetCache.size > 0 ? summarizeRfDuplicateOriginators(packetCache) : [];
     if (lines.length === 0 && originators.length === 0) return null;
     return { lines, originators };
-  }, [homeNode, packetCache, routingAnomaliesMap, getCuStats24h]);
+  }, [homeNode, packetCache, routingAnomaliesMap, diagnosticRows]);
 
   const anomalyList = diagnosticRows.filter(matchesSearchRow).sort((a, b) => {
     const order = (s: string) => (s === 'error' ? 0 : s === 'warning' ? 1 : 2);

--- a/src/renderer/components/PacketDistributionPanel.tsx
+++ b/src/renderer/components/PacketDistributionPanel.tsx
@@ -29,6 +29,7 @@ interface NormalizedPacket {
   fromNodeId: number | null;
   packetType: string;
   viaMqtt: boolean;
+  isLocal?: boolean;
 }
 
 interface SliceData {
@@ -78,6 +79,7 @@ function normalize(
       fromNodeId: p.fromNodeId,
       packetType: p.portLabel || 'UNKNOWN',
       viaMqtt: p.viaMqtt,
+      isLocal: p.isLocal,
     }));
   }
   return (packets as RxPacketEntry[]).map((p) => ({
@@ -99,9 +101,11 @@ function applySourceFilter(
   filter: SourceFilter,
   variant: Variant,
 ): NormalizedPacket[] {
-  if (variant === 'meshcore' || filter === 'all') return packets;
-  if (filter === 'rf') return packets.filter((p) => !p.viaMqtt);
-  return packets.filter((p) => p.viaMqtt);
+  if (variant === 'meshcore') return packets;
+  const nonLocal = packets.filter((p) => !p.isLocal);
+  if (filter === 'all') return nonLocal;
+  if (filter === 'rf') return nonLocal.filter((p) => !p.viaMqtt);
+  return nonLocal.filter((p) => p.viaMqtt);
 }
 
 function buildSlices(

--- a/src/renderer/components/RawPacketLogPanel.tsx
+++ b/src/renderer/components/RawPacketLogPanel.tsx
@@ -254,6 +254,7 @@ export default function RawPacketLogPanel(props: Props) {
         (p.portLabel ?? '').includes(q) ||
         toHex(p.raw).includes(f) ||
         (p.viaMqtt && 'mqtt'.includes(f)) ||
+        (p.isLocal && 'local'.includes(f)) ||
         (p.fromNodeId != null && getNodeLabel(p.fromNodeId).toUpperCase().includes(q)),
     );
   }, [packets, filter, variant, getNodeLabel]);
@@ -504,10 +505,14 @@ function MeshtasticRow({
       </span>
       <span
         className={`w-[52px] shrink-0 rounded px-1 text-[10px] font-semibold ${
-          p.viaMqtt ? 'bg-purple-900/50 text-purple-200' : 'bg-slate-700 text-slate-200'
+          p.isLocal
+            ? 'bg-blue-900/50 text-blue-300'
+            : p.viaMqtt
+              ? 'bg-purple-900/50 text-purple-200'
+              : 'bg-slate-700 text-slate-200'
         }`}
       >
-        {p.viaMqtt ? 'MQTT' : 'RF'}
+        {p.isLocal ? 'LOCAL' : p.viaMqtt ? 'MQTT' : 'RF'}
       </span>
       <span className="text-muted min-w-0 flex-1">
         SNR={p.snr.toFixed(1)} RSSI={p.rssi}

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -787,7 +787,10 @@ export function useDevice() {
 
       // Normalize placeholder replyId/emoji (some senders emit 0 instead of omitting the field)
       const cleanedReplyId = raw.replyId != null && raw.replyId !== 0 ? raw.replyId : undefined;
-      const cleanedEmoji = raw.emoji != null && raw.emoji !== 0 ? raw.emoji : undefined;
+      const cleanedEmoji =
+        raw.emoji != null && raw.emoji !== 0 && raw.emoji >= 1 && raw.emoji <= 0x10ffff
+          ? raw.emoji
+          : undefined;
 
       let cleanedPayload = raw.payload;
       if (typeof cleanedPayload === 'string') {

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -1733,14 +1733,17 @@ export function useDevice() {
         if (getStoredMeshProtocol() === 'meshtastic' && mp.from) {
           try {
             const raw = toBinary(Mesh.MeshPacketSchema, packet as never);
+            const portLabel = meshtasticRawPacketPortLabel(packet);
             const entry: MeshtasticRawPacketEntry = {
               ts: Date.now(),
               snr: mp.rxSnr ?? 0,
               rssi: mp.rxRssi ?? 0,
               raw,
               fromNodeId: mp.from,
-              portLabel: meshtasticRawPacketPortLabel(packet),
+              portLabel,
               viaMqtt: mp.viaMqtt === true,
+              isLocal:
+                mp.from === myNodeNumRef.current && !mp.viaMqtt && portLabel === 'TELEMETRY_APP',
             };
             setRawPackets((prev) => {
               const next = [...prev, entry];

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -994,6 +994,12 @@ function coerceOptionalDbInt(v: number | string | null | undefined): number | un
   return Number.isFinite(n) ? n : undefined;
 }
 
+function safeEmojiCodepoint(v: number | string | null | undefined): number | undefined {
+  const n = coerceOptionalDbInt(v);
+  if (n != null && n >= 1 && n <= 0x10ffff) return n;
+  return undefined;
+}
+
 /** 32-byte pubkey from `meshcore_contacts.public_key` hex, or null if synthetic / invalid length. */
 function meshcoreFullPubKeyBytesFromContactDbHex(raw: string): Uint8Array | null {
   const hex = raw.replace(/\s/g, '');
@@ -1029,7 +1035,7 @@ function mapMeshcoreDbRowsToChatMessages(rows: MeshcoreMessageDbRow[]): ChatMess
       timestamp: r.timestamp,
       status: (r.status as ChatMessage['status']) ?? 'acked',
       packetId: r.packet_id ?? undefined,
-      emoji: coerceOptionalDbInt(r.emoji),
+      emoji: safeEmojiCodepoint(r.emoji),
       replyId: coerceOptionalDbInt(r.reply_id),
       to: r.to_node ?? undefined,
       receivedVia: meshcoreReceivedViaFromDb(r.received_via),

--- a/src/renderer/lib/diagnostics/diagnosticRows.test.ts
+++ b/src/renderer/lib/diagnostics/diagnosticRows.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_RF_DIAGNOSTIC_MAX_AGE_MS,
   DEFAULT_ROUTING_DIAGNOSTIC_MAX_AGE_MS,
   pruneDiagnosticRowsByAge,
+  replaceRfRowsForNode,
 } from './diagnosticRows';
 
 const routingRow = (nodeId: number, detectedAt: number) => ({
@@ -24,6 +25,40 @@ const rfRow = (nodeId: number, detectedAt: number) => ({
   cause: 'dupes',
   severity: 'warning' as const,
   detectedAt,
+});
+
+const foreignLoraRfRow = (nodeId: number, detectedAt: number) => ({
+  kind: 'rf' as const,
+  id: `rf:${nodeId}:unknown_lora`,
+  nodeId,
+  condition: 'Unknown LoRa Traffic',
+  cause: 'non-Meshtastic traffic',
+  severity: 'info' as const,
+  detectedAt,
+});
+
+describe('replaceRfRowsForNode', () => {
+  it('preserves Foreign LoRa RF rows for the same node when replacing telemetry findings', () => {
+    const t = 1_000_000;
+    const rows = [foreignLoraRfRow(42, t), rfRow(42, t)];
+    const out = replaceRfRowsForNode(rows, 42, []);
+    expect(out.some((r) => r.kind === 'rf' && r.condition === 'Unknown LoRa Traffic')).toBe(true);
+    expect(out.some((r) => r.kind === 'rf' && r.condition === 'Mesh Congestion')).toBe(false);
+  });
+
+  it('replaces telemetry RF rows for the node with new findings', () => {
+    const t = 1_000_000;
+    const rows = [rfRow(7, t)];
+    const out = replaceRfRowsForNode(rows, 7, [
+      {
+        condition: 'Utilization vs. TX',
+        cause: 'test',
+        severity: 'warning',
+      },
+    ]);
+    expect(out.some((r) => r.kind === 'rf' && r.condition === 'Utilization vs. TX')).toBe(true);
+    expect(out.some((r) => r.kind === 'rf' && r.condition === 'Mesh Congestion')).toBe(false);
+  });
 });
 
 describe('pruneDiagnosticRowsByAge', () => {

--- a/src/renderer/lib/diagnostics/diagnosticRows.ts
+++ b/src/renderer/lib/diagnostics/diagnosticRows.ts
@@ -2,6 +2,14 @@ import type { DiagnosticRow, NodeAnomaly, RfDiagnosticRow, RoutingDiagnosticRow 
 import { nodeAnomalyToRoutingRow, rfRowId, routingRowToNodeAnomaly } from '../types';
 import type { RFDiagnosis } from './RFDiagnosticEngine';
 
+/** Foreign LoRa RF row conditions — preserved when replacing telemetry-driven RF rows per node. */
+export const FOREIGN_LORA_RF_CONDITIONS = new Set([
+  'MeshCore Activity Detected',
+  'Meshtastic Traffic Detected',
+  'Unknown LoRa Traffic',
+  'Potential MeshCore Repeater Conflict',
+]);
+
 /** Align with hop/CU history windows in diagnosticsStore. */
 export const DEFAULT_ROUTING_DIAGNOSTIC_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 /** RF findings are telemetry snapshots — shorter TTL reduces stale Mesh Congestion etc. */
@@ -88,12 +96,16 @@ export function replaceRoutingRowsFromMap(
   return [...routingRows, ...rfOnly];
 }
 
-/** Remove all RF rows for nodeId then append new ones. */
+/**
+ * Remove telemetry-driven RF rows for nodeId, preserve Foreign LoRa rows for that node, then append new findings.
+ */
 export function replaceRfRowsForNode(
   current: DiagnosticRow[],
   nodeId: number,
   findings: RFDiagnosis[],
 ): DiagnosticRow[] {
-  const withoutRf = current.filter((r) => r.kind !== 'rf' || r.nodeId !== nodeId);
+  const withoutRf = current.filter(
+    (r) => r.kind !== 'rf' || r.nodeId !== nodeId || FOREIGN_LORA_RF_CONDITIONS.has(r.condition),
+  );
   return [...withoutRf, ...rfDiagnosesToRows(nodeId, findings)];
 }

--- a/src/renderer/lib/rawPacketLogConstants.ts
+++ b/src/renderer/lib/rawPacketLogConstants.ts
@@ -19,4 +19,5 @@ export interface MeshtasticRawPacketEntry {
   fromNodeId: number | null;
   portLabel: string;
   viaMqtt: boolean;
+  isLocal?: boolean;
 }

--- a/src/renderer/lib/reactions.ts
+++ b/src/renderer/lib/reactions.ts
@@ -21,6 +21,10 @@ export function normalizeReactionEmoji(
   if (wireEmoji >= 1 && wireEmoji <= REACTION_EMOJI_CODES.length) {
     return REACTION_EMOJI_CODES[wireEmoji - 1];
   }
+  if (wireEmoji < 1 || wireEmoji > 0x10ffff) {
+    console.debug('[reactions] normalizeReactionEmoji out of range, skipping', wireEmoji);
+    return undefined;
+  }
   return wireEmoji;
 }
 
@@ -43,6 +47,10 @@ const REACTION_NAMES = [
 export function emojiDisplayChar(code: number): string {
   if (code >= 1 && code <= REACTION_EMOJI_CODES.length) {
     return String.fromCodePoint(REACTION_EMOJI_CODES[code - 1]);
+  }
+  if (code < 1 || code > 0x10ffff) {
+    console.debug('[reactions] emojiDisplayChar out of range', code);
+    return '\u2753';
   }
   try {
     return String.fromCodePoint(code);

--- a/src/renderer/lib/types.ts
+++ b/src/renderer/lib/types.ts
@@ -728,6 +728,8 @@ declare global {
       notifyDeviceDisconnected: () => void;
       setTrayUnread: (count: number) => void;
       quitApp: () => Promise<void>;
+      getPlatform: () => string;
+      showEmojiPanel: () => Promise<void>;
       log: {
         getPath: () => Promise<string>;
         getRecentLines: () => Promise<

--- a/src/renderer/stores/diagnosticsStore.ts
+++ b/src/renderer/stores/diagnosticsStore.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_RF_DIAGNOSTIC_MAX_AGE_MS,
   DEFAULT_ROUTING_DIAGNOSTIC_MAX_AGE_MS,
   diagnosticRowsToRoutingMap,
+  FOREIGN_LORA_RF_CONDITIONS,
   pruneDiagnosticRowsByAge,
   replaceRfRowsForNode,
   replaceRoutingRowsFromMap,
@@ -92,14 +93,6 @@ function foreignLoraSenderKey(packetClass: PacketClass, senderId?: number): stri
   if (packetClass === 'meshcore') return 'meshcore';
   return 'unknown';
 }
-
-/** Foreign LoRa condition strings — used to surgically replace only these rows. */
-const FOREIGN_LORA_CONDITIONS = new Set([
-  'MeshCore Activity Detected',
-  'Meshtastic Traffic Detected',
-  'Unknown LoRa Traffic',
-  'Potential MeshCore Repeater Conflict',
-]);
 
 /** Module-level rate counter for MeshCore-class packets (Meshtastic mode). */
 const meshcoreRateCounter = new RollingRateCounter(60_000);
@@ -769,7 +762,10 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
               diagnosticRows = replaceRfRowsForNode(diagnosticRows, myNodeNum, findings);
             } else {
               diagnosticRows = diagnosticRows.filter(
-                (r) => r.kind !== 'rf' || r.nodeId !== myNodeNum,
+                (r) =>
+                  r.kind !== 'rf' ||
+                  r.nodeId !== myNodeNum ||
+                  FOREIGN_LORA_RF_CONDITIONS.has(r.condition),
               );
             }
           }
@@ -931,7 +927,7 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
       // Replace only foreign LoRa rows (preserve CU spike and other RF rows)
       const withoutForeign = state.diagnosticRows.filter(
         (r) =>
-          !(r.kind === 'rf' && r.nodeId === nodeId && FOREIGN_LORA_CONDITIONS.has(r.condition)),
+          !(r.kind === 'rf' && r.nodeId === nodeId && FOREIGN_LORA_RF_CONDITIONS.has(r.condition)),
       );
       const diagnosticRows = [...withoutForeign, mainRow, ...extraRows];
       schedulePersistDiagnosticRows(() => get().diagnosticRows);
@@ -1058,7 +1054,12 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
         if (findings.length > 0) {
           diagnosticRows = replaceRfRowsForNode(diagnosticRows, myNodeNum, findings);
         } else {
-          diagnosticRows = diagnosticRows.filter((r) => r.kind !== 'rf' || r.nodeId !== myNodeNum);
+          diagnosticRows = diagnosticRows.filter(
+            (r) =>
+              r.kind !== 'rf' ||
+              r.nodeId !== myNodeNum ||
+              FOREIGN_LORA_RF_CONDITIONS.has(r.condition),
+          );
         }
       }
       for (const [nodeId, node] of nodes) {
@@ -1071,7 +1072,10 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
         if (findings && findings.length > 0) {
           diagnosticRows = replaceRfRowsForNode(diagnosticRows, nodeId, findings);
         } else {
-          diagnosticRows = diagnosticRows.filter((r) => r.kind !== 'rf' || r.nodeId !== nodeId);
+          diagnosticRows = diagnosticRows.filter(
+            (r) =>
+              r.kind !== 'rf' || r.nodeId !== nodeId || FOREIGN_LORA_RF_CONDITIONS.has(r.condition),
+          );
         }
       }
       const now = Date.now();
@@ -1205,7 +1209,7 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
       nextDetections.delete(0);
       nextDetections.set(toNodeId, new Map(bySenderAtZero));
       const diagnosticRows = state.diagnosticRows.map((r) => {
-        if (r.kind === 'rf' && r.nodeId === 0 && FOREIGN_LORA_CONDITIONS.has(r.condition)) {
+        if (r.kind === 'rf' && r.nodeId === 0 && FOREIGN_LORA_RF_CONDITIONS.has(r.condition)) {
           return { ...r, nodeId: toNodeId, id: rfRowId(toNodeId, r.condition) };
         }
         return r;

--- a/src/renderer/vitest.setup.ts
+++ b/src/renderer/vitest.setup.ts
@@ -187,6 +187,8 @@ const electronAPIMock = {
   notifyDeviceDisconnected: vi.fn(),
   setTrayUnread: vi.fn(),
   quitApp: vi.fn().mockResolvedValue(undefined),
+  getPlatform: vi.fn().mockReturnValue('linux'),
+  showEmojiPanel: vi.fn().mockResolvedValue(undefined),
   notify: {
     show: vi.fn().mockResolvedValue(undefined),
   },

--- a/src/shared/electron-api.types.ts
+++ b/src/shared/electron-api.types.ts
@@ -524,6 +524,10 @@ export interface ElectronAPI {
     setLoginItem: (openAtLogin: boolean) => Promise<void>;
   };
 
+  // ─── OS emoji panel ──────────────────────────────────────────────────────────
+  getPlatform: () => string;
+  showEmojiPanel: () => Promise<void>;
+
   // ─── Power events ────────────────────────────────────────────────────────────
   onPowerSuspend: (cb: () => void) => () => void;
   onPowerResume: (cb: () => void) => () => void;


### PR DESCRIPTION
## Summary

This branch covers four areas: a native emoji panel integration for tapback reactions, emoji-picker-element for Linux, LOCAL telemetry packet labeling in the sniffer, and a fix for foreign LoRa RF row preservation.

## Changes

### feat: native emoji panel for tapback reactions (macOS/Windows) + emoji-picker-element (Linux)
- Add `getPlatform()` and `showEmojiPanel()` to `ElectronAPI` interface and preload
- Add `ipcMain` handler for `app:showEmojiPanel` (no-op on Linux)
- macOS/Windows: emoji reaction button focuses a hidden `<input>`, calls `showEmojiPanel()` via IPC, intercepts `input` event to route emoji to `handleReact()`
- Linux: emoji button shows `emoji-picker-element` web component; `emoji-click` event converts unicode to code point, calls `handleReact()`
- Deferred showEmojiPanel() by one rAF so focus settles before OS panel opens
- Focus text input on mousedown so the OS panel sees a settled first responder
- Add Unicode code point bounds validation (1–0x10FFFF) in `useDevice`, `useMeshCore`, and `reactions.ts`
- Remove old hardcoded 12-emoji compose picker grid and unused `insertEmojiAtCursor`
- Tests: Linux shows `<emoji-picker>`, macOS/Windows calls `showEmojiPanel()` without picker

Closes #373

### fix: label self-transmitted TELEMETRY_APP packets as LOCAL in sniffer and stats
- Add `isLocal?` to `MeshtasticRawPacketEntry`; set when `packet.from === myNodeNum && !viaMqtt && portLabel === 'TELEMETRY_APP'`
- Strip LOCAL packets from all source filter views in `PacketDistributionPanel` (all/rf/mqtt)
- Show blue LOCAL badge in `RawPacketLogPanel`; 'local' is searchable in filter bar

Closes #382

### fix: preserve foreign LoRa RF rows when refreshing telemetry diagnostics
- Export `FOREIGN_LORA_RF_CONDITIONS` from `diagnosticRows`; `replaceRfRowsForNode` strips only non–foreign-LoRa RF rows per node before appending new findings
- Mesh Congestion detail driven from store rows (baseline-adjusted logic) instead of re-diagnosing raw lifetime counters
- Add unit tests for `replaceRfRowsForNode` preserve/replace behavior

### chore: bump deps