### PR TITLE
fix: reaction dedup on schema upgrade, MeshCore pins on map; chore: bump deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1545,8 +1545,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.25:
-    resolution: {integrity: sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==}
+  baseline-browser-mapping@2.10.27:
+    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -5780,7 +5780,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.25: {}
+  baseline-browser-mapping@2.10.27: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -5822,7 +5822,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.25
+      baseline-browser-mapping: 2.10.27
       caniuse-lite: 1.0.30001791
       electron-to-chromium: 1.5.349
       node-releases: 2.0.38

--- a/src/main/db-schema-sync.test.ts
+++ b/src/main/db-schema-sync.test.ts
@@ -46,4 +46,35 @@ describe('runSchemaUpgrade', () => {
     expect(mcCols.some((c) => c.name === 'public_key')).toBe(true);
     db.close();
   });
+
+  it('deduplicates reaction rows so idx_reaction_dedup can be created (duplicate triples)', () => {
+    dir = mkdtempSync(join(tmpdir(), 'mesh-schema-test-'));
+    const dbPath = join(dir, 'reaction-dedup.db');
+    const db = new NodeSqliteDB(dbPath);
+    runSchemaUpgrade(db);
+    db.execScript('DROP INDEX IF EXISTS idx_reaction_dedup');
+    db.prepare(
+      `INSERT INTO messages (sender_id, sender_name, payload, channel, timestamp, reply_id, emoji)
+       VALUES (1, 'a', 'x', 0, 100, 5, 10)`,
+    ).run();
+    db.prepare(
+      `INSERT INTO messages (sender_id, sender_name, payload, channel, timestamp, reply_id, emoji)
+       VALUES (1, 'a', 'x2', 0, 101, 5, 10)`,
+    ).run();
+    runSchemaUpgrade(db);
+    const n = (
+      db.prepare('SELECT COUNT(*) as c FROM messages WHERE reply_id = 5 AND emoji = 10').get() as {
+        c: number;
+      }
+    ).c;
+    expect(n).toBe(1);
+    expect(
+      db
+        .prepare(
+          `SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_reaction_dedup' LIMIT 1`,
+        )
+        .get(),
+    ).toBeDefined();
+    db.close();
+  });
 });

--- a/src/main/db-schema-sync.ts
+++ b/src/main/db-schema-sync.ts
@@ -390,6 +390,35 @@ function ensureMessagesPacketDedup(db: NodeSqliteDB): void {
   );
 }
 
+/**
+ * Remove duplicate reaction rows before idx_reaction_dedup (historical migration v4).
+ * Same failure mode as packet dedup: CREATE UNIQUE INDEX fails if duplicates exist.
+ * Idempotent when idx_reaction_dedup already exists.
+ */
+function ensureMessagesReactionDedup(db: NodeSqliteDB): void {
+  const idx = db
+    .prepare(`SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_reaction_dedup' LIMIT 1`)
+    .get();
+  if (idx !== undefined) return;
+  if (!tableExists(db, 'messages')) return;
+
+  db.prepare(
+    `DELETE FROM messages
+         WHERE id NOT IN (
+           SELECT MIN(id) FROM messages
+           WHERE emoji IS NOT NULL AND reply_id IS NOT NULL
+           GROUP BY sender_id, reply_id, emoji
+         )
+         AND emoji IS NOT NULL AND reply_id IS NOT NULL`,
+  ).run();
+
+  db.execScript(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_reaction_dedup
+        ON messages(sender_id, reply_id, emoji)
+        WHERE emoji IS NOT NULL AND reply_id IS NOT NULL`,
+  );
+}
+
 /** Rename meshcore_contact_groups → contact_groups and copy rows (historical migration v20). */
 function migrateLegacyContactGroups(db: NodeSqliteDB): void {
   const hasLegacy = db
@@ -493,6 +522,7 @@ function seedAppSettings(db: NodeSqliteDB): void {
 
 function structuralUpgrades(db: NodeSqliteDB): void {
   ensureMessagesPacketDedup(db);
+  ensureMessagesReactionDedup(db);
   ensureMeshcoreMessagesDedupIndex(db);
   migrateLegacyContactGroups(db);
   rebuildMeshcoreTraceHistoryIfNeeded(db);

--- a/src/renderer/components/MapPanel.test.tsx
+++ b/src/renderer/components/MapPanel.test.tsx
@@ -208,6 +208,58 @@ describe('MapPanel accessibility', () => {
     expect(decodedSvgs.some((svg) => svg.includes('M1 9l2 2c4.97'))).toBe(false);
   });
 
+  it('filters meshcore room contacts from meshtastic map view', () => {
+    leafletIconMock.mockClear();
+    const nowSec = Math.floor(Date.now() / 1000);
+    const nodes = new Map([
+      [
+        301,
+        {
+          node_id: 301,
+          long_name: 'MeshCore Room',
+          short_name: 'ROOM',
+          hw_model: 'Room',
+          snr: 0,
+          battery: 0,
+          last_heard: nowSec,
+          latitude: 40.22,
+          longitude: -105.12,
+        },
+      ],
+      [
+        404,
+        {
+          node_id: 404,
+          long_name: 'Meshtastic Node',
+          short_name: 'MTST',
+          hw_model: 'T-Echo',
+          snr: 0,
+          battery: 0,
+          last_heard: nowSec,
+          latitude: 40.23,
+          longitude: -105.13,
+        },
+      ],
+    ]);
+
+    render(
+      <MapPanel
+        nodes={nodes}
+        myNodeNum={404}
+        locationFilter={defaultFilter}
+        ourPosition={null}
+        onLocateMe={vi.fn().mockResolvedValue(null)}
+        protocol="meshtastic"
+      />,
+    );
+
+    const iconCalls = leafletIconMock.mock.calls.map((call) => call[0] as { iconUrl?: string });
+    const markerIcons = iconCalls.filter((call) => typeof call.iconUrl === 'string');
+    const decodedSvgs = markerIcons.map((call) => decodeURIComponent(call.iconUrl!));
+    // Room badge path fragment from NODE_BADGE_PATHS.room — must not appear when MeshCore room is filtered out.
+    expect(decodedSvgs.some((svg) => svg.includes('M8,2H16A2,2'))).toBe(false);
+  });
+
   it('renders circle overlays when enabled regardless of node count', () => {
     diagnosticsStoreState.congestionHalosEnabled = true;
     const nowSec = Math.floor(Date.now() / 1000);

--- a/src/renderer/components/MapPanel.tsx
+++ b/src/renderer/components/MapPanel.tsx
@@ -31,6 +31,7 @@ import { formatCoordPair } from '../lib/coordUtils';
 import { getRoutingRowForNode, routingAnomalyNodeIds } from '../lib/diagnostics/diagnosticRows';
 import { escapeSvgAttr } from '../lib/escapeSvg';
 import type { OurPosition } from '../lib/gpsSource';
+import { meshcoreHwModelIsContactTypeLabel } from '../lib/meshcoreUtils';
 import { NODE_BADGE_PATHS } from '../lib/nodeIcons';
 import { getNodeStatus, haversineDistanceKm } from '../lib/nodeStatus';
 import { useRadioProvider } from '../lib/radio/providerFactory';
@@ -665,7 +666,7 @@ export default function MapPanel({
   }, []);
   const homeNode = nodes.get(myNodeNum) ?? null;
   const { nodeStaleThresholdMs, nodeOfflineThresholdMs } = useRadioProvider(protocol);
-  const excludeMeshcoreRepeaterInMeshtastic = protocol === 'meshtastic';
+  const excludeMeshcoreContactTypesInMeshtastic = protocol === 'meshtastic';
 
   const congestionHalosEnabled = useDiagnosticsStore((s) => s.congestionHalosEnabled);
   const anomalyHalosEnabled = useDiagnosticsStore((s) => s.anomalyHalosEnabled);
@@ -802,10 +803,10 @@ export default function MapPanel({
         let rejectReason: string | null = null;
         if (
           rejectReason === null &&
-          excludeMeshcoreRepeaterInMeshtastic &&
-          n.hw_model === 'Repeater'
+          excludeMeshcoreContactTypesInMeshtastic &&
+          meshcoreHwModelIsContactTypeLabel(n.hw_model)
         ) {
-          rejectReason = 'meshcore_repeater_filtered_for_meshtastic';
+          rejectReason = 'meshcore_contact_type_filtered_for_meshtastic';
         }
         if (
           n.latitude == null ||
@@ -829,7 +830,7 @@ export default function MapPanel({
         return rejectReason === null;
       })
       .sort((a, b) => a.node_id - b.node_id);
-  }, [nodes, myNodeNum, locationFilter, excludeMeshcoreRepeaterInMeshtastic]);
+  }, [nodes, myNodeNum, locationFilter, excludeMeshcoreContactTypesInMeshtastic]);
   const nodesToRender = useMemo(() => {
     const idSet = new Set(nodesWithPosition.map((n) => n.node_id));
     const out: MeshNode[] = [...nodesWithPosition];
@@ -837,7 +838,8 @@ export default function MapPanel({
       if (idSet.has(nodeId)) continue;
       const node = nodes.get(nodeId);
       if (
-        (excludeMeshcoreRepeaterInMeshtastic && node?.hw_model === 'Repeater') ||
+        (excludeMeshcoreContactTypesInMeshtastic &&
+          meshcoreHwModelIsContactTypeLabel(node?.hw_model)) ||
         node?.latitude == null ||
         node.longitude == null ||
         !(Math.abs(node.latitude) > 0.0001 || Math.abs(node.longitude) > 0.0001)
@@ -847,7 +849,7 @@ export default function MapPanel({
       out.push(node);
     }
     return out.sort((a, b) => a.node_id - b.node_id);
-  }, [nodesWithPosition, routingNodeIds, nodes, excludeMeshcoreRepeaterInMeshtastic]);
+  }, [nodesWithPosition, routingNodeIds, nodes, excludeMeshcoreContactTypesInMeshtastic]);
 
   const nodesWithStatus = useMemo(
     () =>

--- a/src/renderer/lib/meshcoreUtils.test.ts
+++ b/src/renderer/lib/meshcoreUtils.test.ts
@@ -13,6 +13,7 @@ import {
   meshcoreContactTypeFromHwModel,
   meshcoreDeriveChannelKeyHexFromName,
   meshcoreGetRepeaterSessionPassword,
+  meshcoreHwModelIsContactTypeLabel,
   meshcoreInferHopsFromOutPath,
   meshcoreIsRepeaterRemoteAuthTouched,
   meshcoreManufacturerModelFromDeviceQuery,
@@ -205,6 +206,22 @@ describe('meshcoreConnectionImpliesUsbPower', () => {
     expect(meshcoreConnectionImpliesUsbPower('ble')).toBe(false);
     expect(meshcoreConnectionImpliesUsbPower('http')).toBe(false);
     expect(meshcoreConnectionImpliesUsbPower(null)).toBe(false);
+  });
+});
+
+describe('meshcoreHwModelIsContactTypeLabel', () => {
+  it('is true for MeshCore contact-type hw_model strings', () => {
+    expect(meshcoreHwModelIsContactTypeLabel('Chat')).toBe(true);
+    expect(meshcoreHwModelIsContactTypeLabel('Repeater')).toBe(true);
+    expect(meshcoreHwModelIsContactTypeLabel('Room')).toBe(true);
+    expect(meshcoreHwModelIsContactTypeLabel('Sensor')).toBe(true);
+  });
+
+  it('is false for None, unset hw_model, and Meshtastic hardware names', () => {
+    expect(meshcoreHwModelIsContactTypeLabel('None')).toBe(false);
+    expect(meshcoreHwModelIsContactTypeLabel(undefined)).toBe(false);
+    expect(meshcoreHwModelIsContactTypeLabel('')).toBe(false);
+    expect(meshcoreHwModelIsContactTypeLabel('T-Echo')).toBe(false);
   });
 });
 

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -200,6 +200,16 @@ export function meshcoreContactTypeFromHwModel(hwModel: string): number | undefi
 }
 
 /**
+ * True when `hw_model` is a MeshCore {@link CONTACT_TYPE_LABELS} string (chat/repeater/room/sensor).
+ * Those labels are not used by Meshtastic protobuf hardware names; when both stacks share the renderer
+ * node map, use this to keep MeshCore-only contacts off the Meshtastic map.
+ */
+export function meshcoreHwModelIsContactTypeLabel(hwModel: string | undefined): boolean {
+  const t = meshcoreContactTypeFromHwModel(hwModel ?? '');
+  return t !== undefined && t >= 1;
+}
+
+/**
  * Map measured cell voltage to an approximate 0–100% for UI (e.g. node list bar).
  * Uses a simple 1S LiPo-style linear range (3.5 V empty → 4.2 V full); not accurate for all chemistries or loads.
  */


### PR DESCRIPTION
## Summary

This PR includes three commits on `week` (all relative to `main`).

### `chore: bump deps` (`4459466`)
- Dependency updates (`pnpm-lock.yaml`).

### `fix: dedupe reaction rows before idx_reaction_dedup on schema upgrade` (`68d3090`)
- `CREATE UNIQUE INDEX idx_reaction_dedup` could fail when the index was missing but duplicate `(sender_id, reply_id, emoji)` rows existed.
- Adds `ensureMessagesReactionDedup` in structural upgrades: remove duplicates (keep `MIN(id)`), then create the partial unique index.
- Regression test: drop index, insert duplicate reaction rows, assert `runSchemaUpgrade` succeeds. Fixes #394 

### `fix: hide MeshCore contact pins on Meshtastic map` (`4011adc`)
- Adds `meshcoreHwModelIsContactTypeLabel()` for MeshCore `CONTACT_TYPE_LABELS` strings in `hw_model` (Chat, Repeater, Room, Sensor).
- Meshtastic `MapPanel` filters those nodes when protocol is meshtastic so dual-stack sessions do not show MeshCore room/sensor/chat stubs next to Meshtastic nodes.
- Tests extended for Room and the new helper.

## Files touched (high level)
- `src/main/db-schema-sync.ts`, `db-schema-sync.test.ts` — reaction dedup before index.
- `src/renderer/components/MapPanel.tsx`, `MapPanel.test.tsx`, `meshcoreUtils.ts`, `meshcoreUtils.test.ts` — map filtering.
- `pnpm-lock.yaml` — lockfile.