### PR TITLE
fix: MQTT reconnect UX, Meshtastic configure awaits, MeshCore LetsMesh identity

### DIFF
--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -525,12 +525,10 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       console.warn(
         `[MeshCore MQTT] Reconnecting in ${delay}ms (attempt ${this.retryCount}/${maxRetries})`,
       );
-      this.setStatus('connecting');
       this.reconnectTimer = setTimeout(() => {
         this.reconnectTimer = null;
-        // Bug 5 fix: check status === 'connecting', not !== 'disconnected', so a manual
-        // connect() call during the window does not trigger a second _doConnect().
-        if (this.status === 'connecting' && this.lastSettings) {
+        // disconnect() clears this timer; only lastSettings guard is needed for backoff → _doConnect.
+        if (this.lastSettings) {
           this._doConnect(this.lastSettings);
         }
       }, delay);

--- a/src/main/mqtt-manager.test.ts
+++ b/src/main/mqtt-manager.test.ts
@@ -1686,3 +1686,71 @@ describe('onMessage — undecodable ServiceEnvelope signature cache', () => {
     expect(decodeSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reconnect backoff + connect watchdog
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getLastMockMqttClient(): {
+  on: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+  removeAllListeners: ReturnType<typeof vi.fn>;
+} {
+  const r = vi.mocked(mqtt.connect).mock.results;
+  if (r.length === 0) throw new Error('mqtt.connect not called');
+  return r[r.length - 1].value as {
+    on: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+    removeAllListeners: ReturnType<typeof vi.fn>;
+  };
+}
+
+function lastHandler(client: { on: ReturnType<typeof vi.fn> }, event: string): () => void {
+  const hits = client.on.mock.calls.filter((c: unknown[]) => c[0] === event);
+  const fn = hits[hits.length - 1]?.[1];
+  if (typeof fn !== 'function') throw new Error(`no ${event} handler`);
+  return fn as () => void;
+}
+
+describe('MQTTManager reconnect backoff + connect watchdog', () => {
+  const settings: MQTTSettings = {
+    server: 'localhost',
+    port: 1883,
+    username: '',
+    password: '',
+    topicPrefix: 'msh/US/',
+    autoLaunch: false,
+    maxRetries: 3,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(mqtt.connect).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs scheduled _doConnect after long backoff while UI status is disconnected', () => {
+    const manager = new MQTTManager();
+    manager.connect(settings);
+    expect(manager.getStatus()).toBe('connecting');
+    const client = getLastMockMqttClient();
+    lastHandler(client, 'close')();
+    expect(manager.getStatus()).toBe('disconnected');
+    vi.advanceTimersByTime(600_000);
+    expect(vi.mocked(mqtt.connect)).toHaveBeenCalledTimes(2);
+  });
+
+  it('connect watchdog calls end and emits error when CONNACK never arrives', () => {
+    const manager = new MQTTManager();
+    const errorSpy = vi.fn();
+    manager.on('error', errorSpy);
+    manager.connect(settings);
+    const client = getLastMockMqttClient();
+    vi.advanceTimersByTime(12_000);
+    expect(client.end).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('timed out before MQTT session'));
+  });
+});

--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -182,6 +182,8 @@ export class MQTTManager extends EventEmitter {
   private meshtasticConnectT0 = 0;
   /** After `connack timeout`, reconnect with {@link MESHTASTIC_MQTT_RECONNECT_AFTER_CONNACK_TIMEOUT_MS}. */
   private preferFastMqttReconnect = false;
+  /** Force-end client if CONNACK never arrives (mqtt.js connectTimeout alone can miss some WSS/TLS hangs). */
+  private connectAckTimer: ReturnType<typeof setTimeout> | null = null;
 
   connect(settings: MQTTSettings): void {
     // Disconnect any existing connection first
@@ -192,11 +194,28 @@ export class MQTTManager extends EventEmitter {
       .map(parsePsk)
       .filter((k): k is Buffer => k !== null);
     this.retryCount = 0;
-    this.setStatus('connecting');
     this._doConnect(settings);
   }
 
+  private clearConnectAckTimer(): void {
+    if (this.connectAckTimer) {
+      clearTimeout(this.connectAckTimer);
+      this.connectAckTimer = null;
+    }
+  }
+
   private _doConnect(settings: MQTTSettings): void {
+    this.clearConnectAckTimer();
+    this.setStatus('connecting');
+    if (this.client) {
+      try {
+        this.client.removeAllListeners();
+        this.client.end(true);
+      } catch {
+        // catch-no-log-ok tear down stale client before new connect
+      }
+      this.client = null;
+    }
     this.clientId = `meshtastic-electron-${Math.random().toString(36).slice(2, 8)}`;
     const clientId = this.clientId;
     this.meshtasticConnectT0 = Date.now();
@@ -257,7 +276,23 @@ export class MQTTManager extends EventEmitter {
       this.client = mqtt.connect(connectOpts);
     }
 
+    this.connectAckTimer = setTimeout(() => {
+      this.connectAckTimer = null;
+      if (this.status !== 'connecting' || !this.client) return;
+      const msg = `Meshtastic MQTT: timed out before MQTT session (no CONNACK within ${MESHTASTIC_MQTT_CONNECT_ACK_MS / 1000}s). Check host, port, WebSocket path /mqtt, TLS, and network (firewall, VPN, DNS).`;
+      console.error('[Meshtastic MQTT]', sanitizeLogMessage(msg)); // log-filter-ok Meshtastic MQTT logs → App log panel
+      this.emit('error', msg);
+      this.preferFastMqttReconnect = true;
+      try {
+        // Do not removeAllListeners — `close` must run so reconnect backoff still schedules.
+        this.client.end(true);
+      } catch {
+        // catch-no-log-ok forced end during stuck connect
+      }
+    }, MESHTASTIC_MQTT_CONNECT_ACK_MS);
+
     this.client.on('connect', () => {
+      this.clearConnectAckTimer();
       console.debug(
         '[Meshtastic MQTT] CONNACK received',
         `${Date.now() - this.meshtasticConnectT0}ms`,
@@ -349,6 +384,7 @@ export class MQTTManager extends EventEmitter {
     });
 
     this.client.on('close', () => {
+      this.clearConnectAckTimer();
       this.clearWssPing();
       this.clearKeepaliveReschedule();
       const skipReconnect =
@@ -381,18 +417,19 @@ export class MQTTManager extends EventEmitter {
       console.warn(
         `[Meshtastic MQTT] Reconnecting in ${delay}ms (attempt ${this.retryCount}/${maxRetries})`,
       ); // log-filter-ok Meshtastic MQTT logs → App log panel
-      this.setStatus('connecting');
+      this.setStatus('disconnected');
 
       this.reconnectTimer = setTimeout(() => {
         this.reconnectTimer = null;
-        if (this.status !== 'disconnected' && this.currentSettings) {
+        if (this.currentSettings) {
           this._doConnect(this.currentSettings);
         }
       }, delay);
     });
 
     this.client.on('offline', () => {
-      if (this.status !== 'disconnected') {
+      if (this.status === 'disconnected' || this.status === 'error') return;
+      if (this.client) {
         this.setStatus('connecting');
       }
     });
@@ -751,6 +788,7 @@ export class MQTTManager extends EventEmitter {
 
   disconnect(): void {
     this.preferFastMqttReconnect = false;
+    this.clearConnectAckTimer();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -471,3 +471,45 @@ describe("ConnectionPanel Meshtastic MQTT presets — Liam's server", () => {
     expect(screen.queryByText(/uplink-only/i)).not.toBeInTheDocument();
   });
 });
+
+describe('ConnectionPanel MQTT cancel while connecting', () => {
+  it('calls mqtt.disconnect with meshtastic when Cancel is pressed', async () => {
+    const user = userEvent.setup();
+    vi.mocked(window.electronAPI.mqtt.disconnect).mockClear();
+    render(
+      <ConnectionPanel
+        state={disconnectedState}
+        onConnect={vi.fn().mockResolvedValue(undefined)}
+        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+        onDisconnect={vi.fn().mockResolvedValue(undefined)}
+        mqttStatus="connecting"
+        protocol="meshtastic"
+      />,
+    );
+    const mqttCard = screen.getByText('MQTT Connection').closest('.bg-deep-black');
+    expect(mqttCard).toBeTruthy();
+    const cancelBtn = within(mqttCard as HTMLElement).getByRole('button', { name: /^Cancel$/i });
+    await user.click(cancelBtn);
+    expect(window.electronAPI.mqtt.disconnect).toHaveBeenCalledWith('meshtastic');
+  });
+
+  it('calls mqtt.disconnect with meshcore when Cancel is pressed', async () => {
+    const user = userEvent.setup();
+    vi.mocked(window.electronAPI.mqtt.disconnect).mockClear();
+    render(
+      <ConnectionPanel
+        state={disconnectedState}
+        onConnect={vi.fn().mockResolvedValue(undefined)}
+        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+        onDisconnect={vi.fn().mockResolvedValue(undefined)}
+        mqttStatus="connecting"
+        protocol="meshcore"
+      />,
+    );
+    const mqttCard = screen.getByText('MQTT Connection').closest('.bg-deep-black');
+    expect(mqttCard).toBeTruthy();
+    const cancelBtn = within(mqttCard as HTMLElement).getByRole('button', { name: /^Cancel$/i });
+    await user.click(cancelBtn);
+    expect(window.electronAPI.mqtt.disconnect).toHaveBeenCalledWith('meshcore');
+  });
+});

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -2346,7 +2346,23 @@ export default function ConnectionPanel({
               {t('connectionPanel.autoConnect')}
             </label>
           </div>
-          <div className="pt-1">
+          <div className={`flex pt-1 ${mqttStatus === 'connecting' ? 'gap-2' : 'flex-col'}`}>
+            {mqttStatus === 'connecting' && (
+              <button
+                type="button"
+                aria-label={t('connectionPanel.cancelMqttConnect')}
+                onClick={() =>
+                  window.electronAPI.mqtt
+                    .disconnect(protocol === 'meshcore' ? 'meshcore' : 'meshtastic')
+                    .catch((err: unknown) => {
+                      console.warn('[ConnectionPanel] mqtt.disconnect (cancel) failed:', err);
+                    })
+                }
+                className="bg-secondary-dark flex-1 rounded-lg border border-gray-600 px-4 py-2.5 text-sm font-medium text-gray-200 transition-colors hover:border-gray-500 hover:bg-gray-700"
+              >
+                {t('connectionPanel.cancelMqttConnect')}
+              </button>
+            )}
             <button
               onClick={async () => {
                 setMqttError(null);
@@ -2408,7 +2424,7 @@ export default function ConnectionPanel({
                 });
               }}
               disabled={mqttStatus === 'connecting'}
-              className="w-full rounded-lg bg-green-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-400 disabled:opacity-40"
+              className={`rounded-lg bg-green-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-400 disabled:opacity-40 ${mqttStatus === 'connecting' ? 'flex-1' : 'w-full'}`}
             >
               {t('connectionPanel.connectMqtt')}
             </button>

--- a/src/renderer/hooks/useDevice.configure-rejection.test.tsx
+++ b/src/renderer/hooks/useDevice.configure-rejection.test.tsx
@@ -1,0 +1,50 @@
+import type { MeshDevice } from '@meshtastic/core';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as connection from '../lib/connection';
+import { useDevice } from './useDevice';
+
+vi.mock('../lib/connection', () => ({
+  createBleConnection: vi.fn(),
+  createConnection: vi.fn(),
+  reconnectSerial: vi.fn(),
+  safeDisconnect: vi.fn().mockResolvedValue(undefined),
+}));
+
+function createStubDevice(configure: MeshDevice['configure']): MeshDevice {
+  const noopSub = { subscribe: () => () => {} };
+  const events = new Proxy({} as MeshDevice['events'], {
+    get: () => noopSub,
+  });
+  return { configure, events, transport: {} } as unknown as MeshDevice;
+}
+
+describe('useDevice — configure() rejection', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('rejects connect() and resets state when configure fails (no unhandled rejection)', async () => {
+    const err = new Error('Packet does not exist');
+    const device = createStubDevice(vi.fn().mockRejectedValue(err));
+    vi.mocked(connection.createConnection).mockResolvedValue(device);
+
+    const { result } = renderHook(() => useDevice());
+
+    await expect(result.current.connect('http', 'http://127.0.0.1')).rejects.toThrow(
+      'Packet does not exist',
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('disconnected');
+    });
+  });
+});

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -2556,7 +2556,7 @@ export function useDevice() {
       }
       deviceRef.current = device;
       wireSubscriptions(device, params.type);
-      void device.configure();
+      await device.configure();
 
       // Success
       console.debug(`[useDevice] Reconnect succeeded on attempt ${reconnectAttemptRef.current}`);
@@ -2616,7 +2616,7 @@ export function useDevice() {
         wireSubscriptions(device, type);
 
         // Start configuration AFTER all listeners are wired
-        void device.configure();
+        await device.configure();
       } catch (err) {
         clearConfigureTimeout();
         console.error('[Meshtastic] Connection failed:', err);
@@ -2685,7 +2685,7 @@ export function useDevice() {
         }
         deviceRef.current = device;
         wireSubscriptions(device, type);
-        void device.configure();
+        await device.configure();
       } catch (err) {
         clearConfigureTimeout();
         console.error('[Meshtastic] Auto-connect failed:', err);

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -24,6 +24,7 @@ import {
 } from '../lib/foreignLoraDetection';
 import type { OurPosition } from '../lib/gpsSource';
 import { resolveOurPosition } from '../lib/gpsSource';
+import { tryPersistMeshcoreIdentityFromRadioExport } from '../lib/letsMeshJwt';
 import {
   buildMeshcoreChannelIncomingMessage,
   buildMeshcoreDmIncomingMessage,
@@ -65,6 +66,7 @@ import {
   runMeshcoreTracePathMultiplexed,
 } from '../lib/meshcoreTracePathMultiplex';
 import {
+  coerceMeshcoreExportPrivateKeyResult,
   CONTACT_TYPE_LABELS,
   isMeshcoreTransportStatusChatLine,
   mergeHwModelOnContactUpdate,
@@ -726,7 +728,8 @@ interface MeshCoreConnection {
   ): Promise<void>;
   // Cryptographic operations
   sign(data: Uint8Array): Promise<Uint8Array>;
-  exportPrivateKey(): Promise<Uint8Array>;
+  /** Resolves to `{ privateKey: Uint8Array }` from meshcore.js (64-byte ORLP secret). */
+  exportPrivateKey(): Promise<unknown>;
   importPrivateKey(privateKey: Uint8Array): Promise<void>;
   // Waiting messages
   syncNextMessage(): Promise<unknown>;
@@ -3117,6 +3120,17 @@ export function useMeshCore() {
       setState((prev) => ({ ...prev, myNodeNum: myNodeId, status: 'configured' }));
       if (getStoredMeshProtocol() === 'meshcore') {
         useDiagnosticsStore.getState().migrateForeignLoraFromZero(myNodeId);
+      }
+
+      try {
+        const rawExport = await awaitUnlessMeshcoreSetupCancelled(
+          setupGen,
+          withTimeout(conn.exportPrivateKey(), 10_000, 'exportPrivateKey'),
+        );
+        const privBytes = coerceMeshcoreExportPrivateKeyResult(rawExport);
+        tryPersistMeshcoreIdentityFromRadioExport(info.publicKey, privBytes);
+      } catch (e) {
+        console.debug('[useMeshCore] exportPrivateKey for MQTT identity cache skipped', e);
       }
 
       try {
@@ -5613,8 +5627,8 @@ export function useMeshCore() {
     const conn = connRef.current;
     if (!conn) return null;
     try {
-      const key = await conn.exportPrivateKey();
-      return key;
+      const raw = await conn.exportPrivateKey();
+      return coerceMeshcoreExportPrivateKeyResult(raw);
     } catch (e: unknown) {
       console.warn('[useMeshCore] exportPrivateKey error', e);
       return null;

--- a/src/renderer/lib/letsMeshJwt.test.ts
+++ b/src/renderer/lib/letsMeshJwt.test.ts
@@ -8,8 +8,12 @@ import {
   LETSMESH_HOST_US,
   letsMeshJwtAudience,
   letsMeshMqttUsernameFromIdentity,
+  MESHCORE_IDENTITY_STORAGE_KEY,
   MESHMAPPER_HOST,
+  readMeshcoreIdentity,
+  tryPersistMeshcoreIdentityFromRadioExport,
 } from './letsMeshJwt';
+import { meshcoreSyntheticPlaceholderPubKeyHex } from './meshcoreUtils';
 
 // Sample key pair from @michaelhart/meshcore-decoder tests (auth-token.test.ts)
 const sampleKeyPair = {
@@ -73,5 +77,48 @@ describe('letsMeshJwt', () => {
     const verified = await verifyAuthToken(token, sampleKeyPair.publicKey);
     expect(verified).not.toBeNull();
     expect(verified?.aud).toBe(LETSMESH_HOST_EU);
+  });
+
+  it('tryPersistMeshcoreIdentityFromRadioExport stores NaCl-style seed for JWT path', () => {
+    const pub = Uint8Array.from(
+      sampleKeyPair.publicKey.match(/.{2}/g)!.map((byte) => parseInt(byte, 16)),
+    );
+    const seedHex = sampleKeyPair.privateKey.slice(0, 64);
+    const priv = Uint8Array.from(seedHex.match(/.{2}/g)!.map((byte) => parseInt(byte, 16)));
+    expect(tryPersistMeshcoreIdentityFromRadioExport(pub, priv)).toBe(true);
+    const id = readMeshcoreIdentity();
+    expect(Array.isArray(id?.public_key)).toBe(true);
+    expect((id?.public_key as number[]).length).toBe(32);
+    expect(Array.isArray(id?.private_key)).toBe(true);
+    expect((id?.private_key as number[]).length).toBe(32);
+    localStorage.removeItem(MESHCORE_IDENTITY_STORAGE_KEY);
+  });
+
+  it('tryPersistMeshcoreIdentityFromRadioExport persists full 64-byte private key', () => {
+    const pub = Uint8Array.from(
+      sampleKeyPair.publicKey.match(/.{2}/g)!.map((byte) => parseInt(byte, 16)),
+    );
+    const priv = Uint8Array.from(
+      sampleKeyPair.privateKey.match(/.{2}/g)!.map((byte) => parseInt(byte, 16)),
+    );
+    expect(tryPersistMeshcoreIdentityFromRadioExport(pub, priv)).toBe(true);
+    expect((readMeshcoreIdentity()?.private_key as number[]).length).toBe(64);
+    localStorage.removeItem(MESHCORE_IDENTITY_STORAGE_KEY);
+  });
+
+  it('tryPersistMeshcoreIdentityFromRadioExport rejects synthetic placeholder pubkey', () => {
+    const hex = meshcoreSyntheticPlaceholderPubKeyHex(0xabc);
+    const pub = Uint8Array.from(hex.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
+    const priv = new Uint8Array(32).fill(1);
+    expect(tryPersistMeshcoreIdentityFromRadioExport(pub, priv)).toBe(false);
+    expect(localStorage.getItem(MESHCORE_IDENTITY_STORAGE_KEY)).toBeNull();
+  });
+
+  it('tryPersistMeshcoreIdentityFromRadioExport rejects invalid private length', () => {
+    const pub = Uint8Array.from(
+      sampleKeyPair.publicKey.match(/.{2}/g)!.map((byte) => parseInt(byte, 16)),
+    );
+    const priv = new Uint8Array(16);
+    expect(tryPersistMeshcoreIdentityFromRadioExport(pub, priv)).toBe(false);
   });
 });

--- a/src/renderer/lib/letsMeshJwt.ts
+++ b/src/renderer/lib/letsMeshJwt.ts
@@ -1,3 +1,8 @@
+import { meshcoreIsSyntheticPlaceholderPubKeyHex } from './meshcoreUtils';
+
+/** localStorage key for MeshCore keys used by LetsMesh / device-signing MQTT JWT (Radio import or radio export). */
+export const MESHCORE_IDENTITY_STORAGE_KEY = 'mesh-client:meshcoreIdentity';
+
 /** US LetsMesh broker (WebSocket TLS on 443). */
 export const LETSMESH_HOST_US = 'mqtt-us-v1.letsmesh.net';
 /** EU LetsMesh broker (WebSocket TLS on 443). */
@@ -33,13 +38,48 @@ export function letsMeshJwtAudience(serverHost: string): string {
   return serverHost.trim();
 }
 
+function meshcorePubKeyBytesToHexLower(pub: Uint8Array): string {
+  return Array.from(pub, (b) => (b & 0xff).toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * After a MeshCore radio connects, persist identity from firmware export so LetsMesh MQTT can sign
+ * JWTs without a separate JSON import (same storage shape as RadioPanel config import).
+ * @returns true if storage was updated.
+ */
+export function tryPersistMeshcoreIdentityFromRadioExport(
+  publicKey: Uint8Array | undefined,
+  privateKeyBytes: Uint8Array | null | undefined,
+): boolean {
+  if (publicKey?.length !== 32) return false;
+  const pubHex = meshcorePubKeyBytesToHexLower(publicKey);
+  if (meshcoreIsSyntheticPlaceholderPubKeyHex(pubHex)) return false;
+  if (!privateKeyBytes || (privateKeyBytes.length !== 32 && privateKeyBytes.length !== 64)) {
+    return false;
+  }
+  try {
+    localStorage.setItem(
+      MESHCORE_IDENTITY_STORAGE_KEY,
+      JSON.stringify({
+        public_key: Array.from(publicKey),
+        private_key: Array.from(privateKeyBytes),
+      }),
+    );
+    window.dispatchEvent(new Event('meshclient:meshcoreIdentityUpdated'));
+    return true;
+  } catch {
+    // catch-no-log-ok localStorage quota or private mode — same as RadioPanel import path
+    return false;
+  }
+}
+
 // Read the identity cached by RadioPanel after a config-file import.
 export function readMeshcoreIdentity(): {
   private_key?: string | number[];
   public_key?: string | number[];
 } | null {
   try {
-    const raw = localStorage.getItem('mesh-client:meshcoreIdentity');
+    const raw = localStorage.getItem(MESHCORE_IDENTITY_STORAGE_KEY);
     if (!raw) return null;
     return JSON.parse(raw) as { private_key?: string | number[]; public_key?: string | number[] };
   } catch {

--- a/src/renderer/lib/meshcoreUtils.test.ts
+++ b/src/renderer/lib/meshcoreUtils.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  coerceMeshcoreExportPrivateKeyResult,
   isMeshcoreContactEligibleForUserGroup,
   isMeshcoreTransportStatusChatLine,
   mergeHwModelOnContactUpdate,
@@ -530,5 +531,25 @@ describe('event 128 advert hw_model merge', () => {
   it('preserves Repeater when firmware advert reports None (type 0)', () => {
     const mergedHwModel = mergeHwModelOnContactUpdate('Repeater', 'None');
     expect(mergedHwModel).toBe('Repeater');
+  });
+});
+
+describe('coerceMeshcoreExportPrivateKeyResult', () => {
+  it('unwraps meshcore.js { privateKey } payload', () => {
+    const inner = new Uint8Array(64).fill(7);
+    expect(coerceMeshcoreExportPrivateKeyResult({ privateKey: inner })).toBe(inner);
+  });
+
+  it('accepts raw non-empty Uint8Array', () => {
+    const raw = new Uint8Array(32).fill(3);
+    expect(coerceMeshcoreExportPrivateKeyResult(raw)).toBe(raw);
+  });
+
+  it('returns null for empty or invalid shapes', () => {
+    expect(coerceMeshcoreExportPrivateKeyResult(null)).toBeNull();
+    expect(coerceMeshcoreExportPrivateKeyResult(undefined)).toBeNull();
+    expect(coerceMeshcoreExportPrivateKeyResult(new Uint8Array(0))).toBeNull();
+    expect(coerceMeshcoreExportPrivateKeyResult({ privateKey: new Uint8Array(0) })).toBeNull();
+    expect(coerceMeshcoreExportPrivateKeyResult({})).toBeNull();
   });
 });

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -577,3 +577,23 @@ export function meshcoreAppendRepeaterAuthHint(message: string): string {
   if (!authish) return m;
   return `${m} ${REPEATER_AUTH_HINT}`;
 }
+
+/**
+ * Normalizes the value resolved by meshcore.js `exportPrivateKey()` — typically
+ * `{ privateKey: Uint8Array }` from `onPrivateKeyResponse`. Call sites must not assume a bare `Uint8Array`.
+ */
+export function coerceMeshcoreExportPrivateKeyResult(result: unknown): Uint8Array | null {
+  if (result instanceof Uint8Array) {
+    return result.byteLength > 0 ? result : null;
+  }
+  if (
+    result &&
+    typeof result === 'object' &&
+    'privateKey' in result &&
+    result.privateKey instanceof Uint8Array
+  ) {
+    const pk = result.privateKey;
+    return pk.byteLength > 0 ? pk : null;
+  }
+  return null;
+}

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Vypršel časový limit automatického připojení.",
       "autoConnectFailed": "Automatické připojení se nezdařilo",
       "connectionFailed": "Připojení se nezdařilo"
-    }
+    },
+    "cancelMqttConnect": "Zrušit"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Vypustit řádky směrování starší než {{hours}} hodin (1–168)",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Zeitüberschreitung bei der automatischen Verbindung.",
       "autoConnectFailed": "Automatische Verbindung fehlgeschlagen",
       "connectionFailed": "Verbindung fehlgeschlagen"
-    }
+    },
+    "cancelMqttConnect": "Stornieren"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Wirf Routingreihen, die älter als {{hours}} Stunden (1-168) sind",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -1040,6 +1040,7 @@
     "channelPsks": "Channel PSKs",
     "autoConnect": "Auto-connect on application start",
     "connectMqtt": "Connect",
+    "cancelMqttConnect": "Cancel",
     "radioConnection": "Radio Connection",
     "connectionType": "Connection Type",
     "myNode": "My Node",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Se agotó el tiempo de espera de la conexión automática.",
       "autoConnectFailed": "Falló la conexión automática",
       "connectionFailed": "La conexión falló"
-    }
+    },
+    "cancelMqttConnect": "Cancelar"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Filas de enrutamiento de más de {{hours}} horas (1–168)",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "La connexion automatique a expiré.",
       "autoConnectFailed": "Échec de la connexion automatique",
       "connectionFailed": "La connexion a échoué"
-    }
+    },
+    "cancelMqttConnect": "Annuler"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Collectez lignes de routage de plus de {{hours}} heures (1–168)",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Waktu sambungan otomatis habis.",
       "autoConnectFailed": "Sambungan otomatis gagal",
       "connectionFailed": "Koneksi gagal"
-    }
+    },
+    "cancelMqttConnect": "Membatalkan"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Hapus baris perutean yang lebih lama dari {{hours}} jam (1–168)",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Connessione automatica scaduta.",
       "autoConnectFailed": "Connessione automatica non riuscita",
       "connectionFailed": "Connessione non riuscita"
-    }
+    },
+    "cancelMqttConnect": "Cancellare"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Elimina le righe di routing più vecchie di {{hours}} ore (1–168)",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "自動接続がタイムアウトしました。",
       "autoConnectFailed": "自動接続に失敗しました",
       "connectionFailed": "接続に失敗しました"
-    }
+    },
+    "cancelMqttConnect": "キャンセル"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "{{hours}} 時間より古いルーティング行を削除 (1 ～ 168)",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "자동 연결 시간이 초과되었습니다.",
       "autoConnectFailed": "자동 연결 실패",
       "connectionFailed": "연결 실패"
-    }
+    },
+    "cancelMqttConnect": "취소"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "{{hours}}시간(1~168)보다 오래된 라우팅 행 삭제",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Er is een time-out opgetreden voor automatisch verbinden.",
       "autoConnectFailed": "Automatisch verbinden mislukt",
       "connectionFailed": "Verbinding mislukt"
-    }
+    },
+    "cancelMqttConnect": "Annuleren"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Rijen voor droprouting die ouder zijn dan {{hours}} uur (1–168)",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Upłynął limit czasu automatycznego łączenia.",
       "autoConnectFailed": "Automatyczne połączenie nie powiodło się",
       "connectionFailed": "Połączenie nie powiodło się"
-    }
+    },
+    "cancelMqttConnect": "Anulować"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Usuń wiersze routingu starsze niż {{hours}} godzin (1–168)",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "A conexão automática expirou.",
       "autoConnectFailed": "Falha na conexão automática",
       "connectionFailed": "Falha na conexão"
-    }
+    },
+    "cancelMqttConnect": "Cancelar"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Remova as linhas de roteamento com mais de {{hours}} horas (1–168)",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -1139,7 +1139,8 @@
       "autoConnectTimeout": "Время автоматического подключения истекло.",
       "autoConnectFailed": "Автоподключение не удалось",
       "connectionFailed": "Соединение не удалось"
-    }
+    },
+    "cancelMqttConnect": "Отмена"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Удалить строки маршрутизации старше {{hours}} часов (1–168).",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Otomatik bağlantı zaman aşımına uğradı.",
       "autoConnectFailed": "Otomatik bağlantı başarısız oldu",
       "connectionFailed": "Bağlantı başarısız oldu"
-    }
+    },
+    "cancelMqttConnect": "İptal etmek"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "{{hours}} saatten (1-168) daha eski olan yönlendirme satırlarını bırak",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "Час очікування автоматичного підключення минув.",
       "autoConnectFailed": "Помилка автоматичного підключення",
       "connectionFailed": "Помилка підключення"
-    }
+    },
+    "cancelMqttConnect": "Скасувати"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "Відкиньте рядки маршрутизації, старші за {{hours}} год (1–168)",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -1140,7 +1140,8 @@
       "autoConnectTimeout": "自动连接超时。",
       "autoConnectFailed": "自动连接失败",
       "connectionFailed": "连接失败"
-    }
+    },
+    "cancelMqttConnect": "取消"
   },
   "diagnosticsPanel": {
     "dropRoutingRows": "删除早于{{hours}}小时的路由行(1–168)",

--- a/src/renderer/types/meshcore.d.ts
+++ b/src/renderer/types/meshcore.d.ts
@@ -194,7 +194,8 @@ declare module '@liamcottle/meshcore.js' {
     clearFloodScope(): Promise<void>;
     // Crypto
     sign(data: Uint8Array): Promise<Uint8Array>;
-    exportPrivateKey(): Promise<Uint8Array>;
+    /** meshcore.js resolves with `{ privateKey: Uint8Array }` (not a bare Uint8Array). */
+    exportPrivateKey(): Promise<unknown>;
     importPrivateKey(privateKey: Uint8Array): Promise<void>;
     // Other
     setOtherParams(manualAddContacts: boolean): Promise<void>;


### PR DESCRIPTION
## Summary

This branch hardens MQTT connection flows for both Meshtastic and MeshCore, fixes unhandled promise rejections when Meshtastic `device.configure()` fails, and persists MeshCore identity from the radio so LetsMesh (and similar JWT brokers) work without a manual Radio JSON import when the radio was connected first.

## Commits on this branch (`origin/main`..HEAD)

1. **`17ec691` — fix: MQTT reconnect backoff, connect watchdog, and cancel while connecting**
2. **`395d876` — fix: await Meshtastic `device.configure` to avoid unhandled rejections**
3. **`732f92c` — fix: cache MeshCore identity from radio for LetsMesh MQTT**

---

### 1. MQTT reconnect, watchdog, and cancel (Meshtastic + MeshCore)

**Meshtastic (`mqtt-manager.ts`)**

- Set `connecting` only while `_doConnect` is active; avoid leaving the UI stuck in “connecting” during long reconnect backoff.
- Tear down a stale client before new connect attempts to avoid overlapping sessions.
- Add `connectAckTimer` alongside existing connect timeout so slow/failed handshakes are bounded similarly.
- Reconnect timer keys off `currentSettings` only; gate offline→connecting on an active client so state transitions stay consistent.

**MeshCore (`meshcore-mqtt-adapter.ts`)**

- Remove a pre-delay “connecting” status that could mislead the UI.
- Reconnect timer uses a `lastSettings` guard so stale timers do not fire after settings change.

**UI (`ConnectionPanel.tsx`)**

- **Cancel** is available during MQTT “connecting” (protocol-scoped disconnect).
- New i18n key: `connectionPanel.cancelMqttConnect` (English + mirrored locales).

**Tests**

- `mqtt-manager.test.ts`: backoff / watchdog behavior.
- `ConnectionPanel.test.tsx`: cancel-while-connecting behavior.

---

### 2. Meshtastic `device.configure` — await instead of fire-and-forget

**Problem:** `void device.configure()` could reject outside the surrounding `try/catch`, causing unhandled rejections and incomplete cleanup (e.g. queue errors like “Packet does not exist”).

**Change (`useDevice.ts`):** `await device.configure()` in connect, `connectAutomatic`, and `attemptReconnect` so errors flow through existing error handling; reconnect no longer marks success before configure finishes.

**Tests:** `useDevice.configure-rejection.test.tsx` — configure rejection on HTTP connect.

---

### 3. MeshCore identity for LetsMesh MQTT (no manual import when radio connects first)

**Behavior**

- After MeshCore init, `exportPrivateKey` + `tryPersistMeshcoreIdentityFromRadioExport` writes the same localStorage shape as a Radio JSON import so device-signing brokers (LetsMesh, Colorado Mesh, MeshMapper) can build JWT credentials without importing JSON first.

**`exportPrivateKey` shape**

- `coerceMeshcoreExportPrivateKeyResult`: meshcore.js resolves with `{ privateKey: Uint8Array }`, not a bare `Uint8Array`; used in init path and the Security panel export hook.

**Types / API**

- `MESHCORE_IDENTITY_STORAGE_KEY` exported from `letsMeshJwt.ts`.
- `meshcore.d.ts` / `MeshCoreConnection` typing aligned for `exportPrivateKey`.

**Tests**

- `letsMeshJwt.test.ts`, `meshcoreUtils.test.ts` for persistence and coercion.

---

## How to verify (manual)

- **MQTT:** Connect via MQTT, trigger a slow/failed broker or toggle network; confirm UI does not stall indefinitely in “connecting”, backoff behaves sensibly, and **Cancel** disconnects mid-connect.
- **Meshtastic:** Connect (e.g. HTTP) with a path that can make `configure` fail; confirm no unhandled rejection and connection state cleans up.
- **MeshCore + LetsMesh:** Connect MeshCore first (no prior Radio JSON import), then use LetsMesh MQTT; JWT/identity should be available after radio export persists.

## Automated checks

`pnpm run test:run` — includes new/updated tests in `mqtt-manager.test.ts`, `ConnectionPanel.test.tsx`, `useDevice.configure-rejection.test.tsx`, `letsMeshJwt.test.ts`, `meshcoreUtils.test.ts`.
