### PR TITLE
fix: translation issue template lint and MeshCore MQTT identity docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/translation-error.md
+++ b/.github/ISSUE_TEMPLATE/translation-error.md
@@ -4,10 +4,9 @@ about: Report a translation error
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
-Language (in English): 
+Language (in English):
 
 Bad Translation:
 

--- a/docs/letsmesh-mqtt-auth.md
+++ b/docs/letsmesh-mqtt-auth.md
@@ -28,7 +28,9 @@ Meshtastic MQTT working on the same machine does not guarantee MeshCore LetsMesh
 
 ## Manual token
 
-Import identity under **Radio**, or set **Custom** and paste username `v1_<public key>` and a token from tooling that matches your broker’s `AUTH_EXPECTED_AUDIENCE`.
+After you connect a **MeshCore** radio successfully, mesh-client persists identity from the radio (via `exportPrivateKey`) in the **same** local storage shape as a Radio-tab JSON import, so LetsMesh-style JWT credentials can be built **without** a manual import when you started from RF first.
+
+If you use MQTT **before** ever connecting a MeshCore radio, or stored identity is missing or corrupt, **import** identity under **Radio**, or set **Custom** and paste username `v1_<public key>` and a token from tooling that matches your broker’s `AUTH_EXPECTED_AUDIENCE`.
 
 ## Packet logger / Analyzer
 

--- a/docs/meshcore-meshtastic-parity.md
+++ b/docs/meshcore-meshtastic-parity.md
@@ -114,9 +114,11 @@ LetsMesh uses WebSocket (`wss`) with JWT authentication. The implementation matc
 
 The JWT audience must match the regional broker hostname (`mqtt-us-v1.letsmesh.net` or `mqtt-eu-v1.letsmesh.net`).
 
+Signing uses cached **private key** material from either a **Radio**-tab MeshCore JSON import or **automatic persistence** after a successful MeshCore radio session (same storage shape as import).
+
 ### Configuration
 
-Import a MeshCore config JSON file (Radio tab) so `public_key` and `private_key` are cached. The implementation is in [`letsMeshJwt.ts`](../src/renderer/lib/letsMeshJwt.ts).
+Import a MeshCore config JSON file (Radio tab) when you need credentials before connecting a radio, or to replace missing data; otherwise connecting the MeshCore radio first fills the same cache. The implementation is in [`letsMeshJwt.ts`](../src/renderer/lib/letsMeshJwt.ts).
 
 ### Packet logger (optional)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -212,7 +212,7 @@ Bare IPv6 addresses (e.g. `fe80::1`) must be wrapped in brackets when entered in
 
 - Check your WiFi/signal strength
 - Verify the broker is online
-- For LetsMesh/Colorado Mesh: re-import your MeshCore identity to refresh the token
+- For LetsMesh/Colorado Mesh: mesh-client refreshes JWT automatically when MeshCore identity is already cached (including after a successful MeshCore radio session). If you never imported identity and have not connected a MeshCore radio yet, import under **Radio** or use **Custom** credentials; if refresh still fails, try re-importing MeshCore config JSON to replace a corrupt cache
 - Enable debug logs to see the disconnect reason
 
 ### MQTT connected but no messages from other nodes
@@ -225,7 +225,7 @@ Bare IPv6 addresses (e.g. `fe80::1`) must be wrapped in brackets when entered in
 
 **Cause**: JWT tokens expire after 1 hour.
 
-**Fix**: Re-import your MeshCore config JSON in the Radio tab, or paste your v1\_ public key in the MQTT username field to regenerate a token.
+**Fix**: The client refreshes tokens proactively before expiry when identity is present. If you still see expiry errors, connect or re-import MeshCore so `public_key` / `private_key` are cached (Radio-tab JSON import, or automatic persistence after a successful MeshCore radio session). As a fallback, paste your `v1_<public key>` MQTT username and a manually generated token under **Custom** if your broker expects a different workflow.
 
 ### MQTT "Connection refused" or broker unreachable
 


### PR DESCRIPTION
## Summary

Aligns user-facing docs with MeshCore identity persistence after PR #401 and fixes markdownlint on the translation issue template.

## Commits on this branch (`origin/main..HEAD`)

- `b46ff9b` fix: translation issue template lint and MeshCore MQTT identity docs

## What changed

- **`.github/ISSUE_TEMPLATE/translation-error.md`**: Remove trailing whitespace after `Language (in English):` (MD009) so `pnpm run lint:md` passes.
- **`docs/letsmesh-mqtt-auth.md`**: Manual token section notes radio-export identity persistence vs Radio import / Custom when MQTT-first or cache is bad.
- **`docs/troubleshooting.md`**: MQTT disconnect and token-expiry bullets mention automatic JWT refresh when identity is cached (including after MeshCore radio connect) and when to import or use Custom.
- **`docs/meshcore-meshtastic-parity.md`**: LetsMesh JWT section documents key material from Radio JSON import or automatic persistence after successful MeshCore radio session.

## Why

PR #401 caches MeshCore identity from the radio for LetsMesh-style brokers; docs previously read as if manual Radio import was always required. The issue template had a pre-existing markdownlint failure blocking clean `lint:md` runs.