### PR TITLE
fix: clearer Meshtastic serial/Web Streams errors before MeshDevice

### DIFF
--- a/src/renderer/lib/connection.ble-retry.test.ts
+++ b/src/renderer/lib/connection.ble-retry.test.ts
@@ -8,7 +8,11 @@ vi.mock('@meshtastic/core', () => ({
 
 vi.mock('./transportNobleIpc', () => ({
   TransportNobleIpc: vi.fn().mockImplementation(function TransportNobleIpc(sessionId: string) {
-    return { sessionId };
+    return {
+      sessionId,
+      fromDevice: new ReadableStream<Uint8Array>(),
+      toDevice: new WritableStream<Uint8Array>(),
+    };
   }),
 }));
 

--- a/src/renderer/lib/connection.ts
+++ b/src/renderer/lib/connection.ts
@@ -3,6 +3,11 @@ import { TransportWebSerial } from '@meshtastic/transport-web-serial';
 
 import { isMainProcessBleTimeoutMessage } from './bleConnectErrors';
 import {
+  assertMeshtasticSerialWebStreamsAvailable,
+  assertTransportReadyForMeshDevice,
+  getMeshtasticStreamsDiagnostics,
+} from './connectionWebStreams';
+import {
   getPortSignature,
   persistSerialPortIdentity,
   selectGrantedSerialPort,
@@ -20,6 +25,22 @@ const BLE_CONNECT_RETRY_DELAY_MS = 1_500;
 function logMeshtasticDeviceConnection(detail: string): void {
   const fn = window.electronAPI?.log?.logDeviceConnection;
   if (typeof fn === 'function') void fn(detail);
+}
+
+/** Maps opaque `pipeTo` failures inside @meshtastic/transport-web-serial to a clearer error. */
+function rethrowIfTransportWebSerialPipeToFailed(err: unknown, phase: string): never {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (!msg.includes('pipeTo')) {
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+  console.error(
+    `[connection] Meshtastic serial ${phase}: pipeTo failure`,
+    err,
+    getMeshtasticStreamsDiagnostics(),
+  );
+  throw new Error(
+    `Meshtastic serial failed during ${phase} (Web Streams pipe). Often occurs when @meshtastic/core stream helpers are unavailable or the serial port streams are invalid. Diagnostics were logged to the console.`,
+  );
 }
 
 /**
@@ -75,6 +96,7 @@ export async function createBleConnection(
           });
         }
         console.debug('[connection] createBleConnection: connected on Linux');
+        assertTransportReadyForMeshDevice(transport, 'Meshtastic BLE (Linux Web Bluetooth)');
         return new MeshDevice(transport);
       } catch (err) {
         lastError = err;
@@ -136,6 +158,7 @@ export async function createBleConnection(
       }
       console.debug('[connection] createBleConnection connected', peripheralId);
       console.debug('[connection] createBleConnection elapsedMs', Date.now() - connectStartedAt);
+      assertTransportReadyForMeshDevice(transport, 'Meshtastic BLE (Noble)');
       return new MeshDevice(transport);
     } catch (err) {
       lastError = err;
@@ -189,6 +212,11 @@ export async function createConnection(
       if (!navigator.serial?.requestPort) {
         throw new Error('Web Serial API not available');
       }
+      assertMeshtasticSerialWebStreamsAvailable();
+      console.debug(
+        '[connection] Meshtastic serial Web Streams OK',
+        getMeshtasticStreamsDiagnostics(),
+      );
       const SERIAL_CONNECT_TIMEOUT_MS = 15_000;
       const serialApi = navigator.serial;
       const origRequestPort = serialApi.requestPort.bind(serialApi);
@@ -207,7 +235,12 @@ export async function createConnection(
             );
           }, SERIAL_CONNECT_TIMEOUT_MS),
         );
-        transport = await Promise.race([serialPromise, serialTimeoutPromise]);
+        try {
+          transport = await Promise.race([serialPromise, serialTimeoutPromise]);
+        } catch (err) {
+          console.debug('[connection] TransportWebSerial.create failed', err);
+          rethrowIfTransportWebSerialPipeToFailed(err, 'TransportWebSerial.create');
+        }
       } finally {
         serialApi.requestPort = origRequestPort;
       }
@@ -251,6 +284,7 @@ export async function createConnection(
       logMeshtasticDeviceConnection(
         `transport=http stack=meshtastic host=${host} tls=${useTls} port=${useTls ? 443 : 80}`,
       );
+      assertTransportReadyForMeshDevice(transport, 'Meshtastic HTTP');
       return new MeshDevice(transport);
     }
 
@@ -262,6 +296,7 @@ export async function createConnection(
   // event subscriptions are set up in useDevice.ts, otherwise the initial
   // node/channel/config dump is emitted before any listeners exist.
 
+  assertTransportReadyForMeshDevice(transport, 'Meshtastic serial');
   return new MeshDevice(transport as any);
 }
 
@@ -288,7 +323,15 @@ export async function reconnectSerial(lastPortId?: string | null): Promise<MeshD
     `[connection] reconnectSerial: using port portId=${(port as SerialPort & { portId?: string }).portId ?? 'none'} usbVendor=${port.getInfo?.().usbVendorId ?? 'n/a'} usbProduct=${port.getInfo?.().usbProductId ?? 'n/a'}`,
   );
 
-  const transport = await TransportWebSerial.createFromPort(port, 115200);
+  assertMeshtasticSerialWebStreamsAvailable();
+  console.debug('[connection] reconnectSerial Web Streams OK', getMeshtasticStreamsDiagnostics());
+  let transport: Awaited<ReturnType<typeof TransportWebSerial.createFromPort>>;
+  try {
+    transport = await TransportWebSerial.createFromPort(port, 115200);
+  } catch (err) {
+    console.debug('[connection] TransportWebSerial.createFromPort failed', err);
+    rethrowIfTransportWebSerialPipeToFailed(err, 'TransportWebSerial.createFromPort');
+  }
   {
     const sig = getPortSignature(port);
     const pid = (port as SerialPort & { portId?: string }).portId;
@@ -298,6 +341,7 @@ export async function reconnectSerial(lastPortId?: string | null): Promise<MeshD
     if (sig.usbProductId != null) parts.push(`usbProductId=${sig.usbProductId}`);
     logMeshtasticDeviceConnection(parts.join(' '));
   }
+  assertTransportReadyForMeshDevice(transport, 'Meshtastic serial (reconnect)');
   return new MeshDevice(transport);
 }
 

--- a/src/renderer/lib/connectionWebStreams.test.ts
+++ b/src/renderer/lib/connectionWebStreams.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  assertMeshtasticSerialWebStreamsAvailable,
+  assertTransportReadyForMeshDevice,
+  getMeshtasticStreamsDiagnostics,
+} from './connectionWebStreams';
+
+describe('connectionWebStreams', () => {
+  describe('getMeshtasticStreamsDiagnostics', () => {
+    it('reports presence of core Web Streams APIs', () => {
+      const d = getMeshtasticStreamsDiagnostics();
+      expect(typeof d.hasTransformStream).toBe('boolean');
+      expect(typeof d.hasReadablePipeTo).toBe('boolean');
+      expect(typeof d.hasWritableStream).toBe('boolean');
+      expect(typeof d.userAgentSnippet).toBe('string');
+    });
+  });
+
+  describe('assertMeshtasticSerialWebStreamsAvailable', () => {
+    let savedTransformStream: typeof TransformStream;
+
+    beforeEach(() => {
+      savedTransformStream = globalThis.TransformStream;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (savedTransformStream !== undefined) {
+        globalThis.TransformStream = savedTransformStream;
+      } else {
+        delete (globalThis as Record<string, unknown>).TransformStream;
+      }
+    });
+
+    it('throws a clear error when TransformStream is missing', () => {
+      delete (globalThis as Record<string, unknown>).TransformStream;
+
+      expect(() => {
+        assertMeshtasticSerialWebStreamsAvailable();
+      }).toThrow(/Meshtastic serial requires Web Streams/);
+    });
+  });
+
+  describe('assertTransportReadyForMeshDevice', () => {
+    it('throws when fromDevice is missing', () => {
+      const toDevice = new WritableStream<Uint8Array>();
+      expect(() => {
+        assertTransportReadyForMeshDevice({ toDevice }, 'test context');
+      }).toThrow(/test context: Meshtastic transport is missing readable\/writable streams/);
+    });
+
+    it('throws when toDevice is missing', () => {
+      const fromDevice = new ReadableStream<Uint8Array>();
+      expect(() => {
+        assertTransportReadyForMeshDevice({ fromDevice }, 'test context');
+      }).toThrow(/test context: Meshtastic transport is missing readable\/writable streams/);
+    });
+
+    it('does not throw for a minimal valid transport', () => {
+      const fromDevice = new ReadableStream<Uint8Array>();
+      const toDevice = new WritableStream<Uint8Array>();
+      expect(() => {
+        assertTransportReadyForMeshDevice({ fromDevice, toDevice }, 'ok');
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/renderer/lib/connectionWebStreams.ts
+++ b/src/renderer/lib/connectionWebStreams.ts
@@ -1,0 +1,80 @@
+/**
+ * Meshtastic stack (@meshtastic/core MeshDevice + @meshtastic/transport-web-serial) relies on
+ * Web Streams (TransformStream, ReadableStream.pipeTo, WritableStream). Fail fast with actionable
+ * errors instead of "Cannot read properties of undefined (reading 'pipeTo')".
+ */
+
+export interface MeshtasticStreamsDiagnostics {
+  hasTransformStream: boolean;
+  hasReadablePipeTo: boolean;
+  hasWritableStream: boolean;
+  /** Chromium/Electron user agent (truncated in logs if very long). */
+  userAgentSnippet: string;
+}
+
+export function getMeshtasticStreamsDiagnostics(): MeshtasticStreamsDiagnostics {
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  return {
+    hasTransformStream: typeof TransformStream !== 'undefined',
+    hasReadablePipeTo:
+      typeof ReadableStream !== 'undefined' &&
+      typeof ReadableStream.prototype.pipeTo === 'function',
+    hasWritableStream: typeof WritableStream !== 'undefined',
+    userAgentSnippet: ua.length > 160 ? `${ua.slice(0, 160)}…` : ua,
+  };
+}
+
+/**
+ * Call before `TransportWebSerial.create` / `createFromPort` so serial connect fails with a clear
+ * message if Web Streams are missing (some embedders strip them).
+ */
+export function assertMeshtasticSerialWebStreamsAvailable(): void {
+  const d = getMeshtasticStreamsDiagnostics();
+  const missing: string[] = [];
+  if (!d.hasTransformStream) missing.push('TransformStream');
+  if (!d.hasReadablePipeTo) missing.push('ReadableStream.prototype.pipeTo');
+  if (!d.hasWritableStream) missing.push('WritableStream');
+  if (missing.length === 0) return;
+
+  console.error('[connection] Meshtastic serial: Web Streams unavailable', { ...d, missing });
+  throw new Error(
+    `Meshtastic serial requires Web Streams (${missing.join(', ')}). Update the app or use another connection type if available.`,
+  );
+}
+
+function isReadableStreamWithPipeTo(x: unknown): x is ReadableStream {
+  return (
+    x != null &&
+    typeof (x as ReadableStream).pipeTo === 'function' &&
+    typeof (x as ReadableStream).getReader === 'function'
+  );
+}
+
+function isWritableStreamWithWriter(x: unknown): x is WritableStream {
+  return x != null && typeof (x as WritableStream).getWriter === 'function';
+}
+
+/**
+ * Validates transport shape before `new MeshDevice(transport)` so missing streams surface as a clear
+ * invariant error instead of failing inside `MeshDevice` on `fromDevice.pipeTo`.
+ */
+export function assertTransportReadyForMeshDevice(transport: unknown, context: string): void {
+  if (transport == null || typeof transport !== 'object') {
+    throw new Error(`${context}: transport is missing or invalid`);
+  }
+  const t = transport as { fromDevice?: unknown; toDevice?: unknown };
+  const fromOk = isReadableStreamWithPipeTo(t.fromDevice);
+  const toOk = isWritableStreamWithWriter(t.toDevice);
+  if (fromOk && toOk) return;
+
+  console.error('[connection] Transport missing streams for MeshDevice', context, {
+    ...getMeshtasticStreamsDiagnostics(),
+    hasFromDevice: t.fromDevice != null,
+    fromHasPipeTo: typeof (t.fromDevice as { pipeTo?: unknown })?.pipeTo === 'function',
+    hasToDevice: t.toDevice != null,
+    toHasGetWriter: typeof (t.toDevice as { getWriter?: unknown })?.getWriter === 'function',
+  });
+  throw new Error(
+    `${context}: Meshtastic transport is missing readable/writable streams (fromDevice/toDevice). Reconnect USB serial or try another transport; include app version if reporting.`,
+  );
+}


### PR DESCRIPTION
## Summary

Adds guards and diagnostics around Meshtastic USB serial connect so failures from `@meshtastic/core` `MeshDevice` / `@meshtastic/transport-web-serial` no longer surface only as `Cannot read properties of undefined (reading 'pipeTo')`.

## What changed

- **New** `src/renderer/lib/connectionWebStreams.ts`: runtime checks for `TransformStream`, `ReadableStream.prototype.pipeTo`, and `WritableStream`; assert `fromDevice`/`toDevice` before `new MeshDevice()`.
- **`connection.ts`**: log Web Streams diagnostics on serial paths; remap `TransportWebSerial.create` / `createFromPort` errors whose message contains `pipeTo` to a clearer error plus `console.error` with diagnostics.
- **Tests**: `connectionWebStreams.test.ts`; extend `connection.ble-retry.test.ts` mock transport with streams so pre-`MeshDevice` invariants pass.

## Commits on this branch (`origin/main..`)

```
97578c9 fix: clearer Meshtastic serial/Web Streams errors before MeshDevice
```
