### PR TITLE
chore: enforce package.json engines via pnpm engine-strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -11,3 +11,6 @@ node-linker=hoisted
 
 # Verify that the package downloaded matches the registry's hash exactly
 verify-store-integrity=true
+
+# Enforce pnpm
+engine-strict=true

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@ node_modules
 tmp/
 
 # Files unsupported by prettier parser
+.npmrc
 *.plist
 resources/win/*.xml
 


### PR DESCRIPTION
## Summary

- Set `engine-strict=true` in `.npmrc` so pnpm fails fast when Node or pnpm versions do not match `package.json` engines (Node `>=22.13.0`, pnpm `>=10.0.0`).
- Add `.npmrc` to `.prettierignore` so pre-commit does not run Prettier on a file with no supported parser.

## Why

Catches accidental `npm`/`yarn` use and local toolchain skew before CI. This was the only unmerged bit from stashed `endweek` WIP; the RF histogram / peer graph work was already landed in #411.

## Test plan

- [ ] `pnpm install` succeeds on a machine matching `package.json` engines
- [ ] `pnpm install` fails with a clear engines error when using npm or an out-of-range Node/pnpm version (optional manual check)