### PR TITLE
docs: sync README and AGENTS with recent chat and tooling changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ Panels: `src/renderer/components/`. New tabs: `lazyTabPanels.ts` / `lazyAppPanel
 ### i18n / Localization
 
 - **Framework:** i18next + react-i18next; static JSON bundles loaded at startup; `fallbackLng: 'en'`.
-- **Locale files:** `src/renderer/locales/{en,es,uk,de,zh,pt-BR,fr,it,pl,cs,ja,ru,nl,ko,tr,id}/translation.json` — English is source of truth (314 keys).
+- **Locale files:** `src/renderer/locales/{en,es,uk,de,zh,pt-BR,fr,it,pl,cs,ja,ru,nl,ko,tr,id}/translation.json` — English is source of truth (`pnpm run check:i18n` reports key count).
 - **Locale persistence:** `locale` key in `app_settings` SQLite table (canonical) and `mesh-client:appSettings` localStorage (fast startup read); reconciled in `App.tsx` on mount.
 - **Adding strings:** add to `src/renderer/locales/en/translation.json`, use `t('your.key')` in components; `check:i18n` enforces all call sites resolve to English keys.
 - **Auto-translate:** `pnpm run i18n:auto-translate` uses MyMemory (default) or LibreTranslate (`LIBRETRANSLATE_URL`). With git, the default run **only** fills keys that are **new in English vs `HEAD`** and still missing from each locale (pre-commit uses this). Use **`pnpm run i18n:auto-translate --all`** or **`I18N_TRANSLATE_ALL=1`** to machine-translate **every** key missing from a locale vs English (large runs). Existing entries in a locale file are never overwritten. MyMemory sends contact `info@coloradomesh.org` by default for the 50 k words/day quota; override with `MYMEMORY_EMAIL` if needed.
@@ -142,9 +142,11 @@ Panels: `src/renderer/components/`. New tabs: `lazyTabPanels.ts` / `lazyAppPanel
 
 ### Chat Panel
 
-- **Component:** `src/renderer/components/ChatPanel.tsx` — sender filter, draft persistence, jump-to-date, sound notifications, @mention autocomplete, copy, export.
-- **Storage helpers:** `src/renderer/lib/chatPanelProtocolStorage.ts` — localStorage keys for drafts (`mesh-client:drafts:<protocol>`), open DM tabs, last-read timestamps.
-- **Notifications:** `src/renderer/lib/chatNotifications.ts` — `playMessageNotification()` (AudioContext beep); mute preference stored in `mesh-client:notifMuted`.
+- **Component:** `src/renderer/components/ChatPanel.tsx` — sender filter, draft persistence, DM info header, jump-to-date, sound notifications, per-conversation mute, starring, @mention autocomplete, copy, export.
+- **Payload / links:** `ChatPayloadText.tsx` — mention highlighting, search marks, URL linkification; link previews via `chat:fetchLinkPreview` (`src/main/fetchLinkPreview.ts`, blocks localhost/private IPs, 10s timeout, 64 KiB HTML cap).
+- **Storage helpers:** `src/renderer/lib/chatPanelProtocolStorage.ts` — drafts (`mesh-client:drafts:<protocol>`), open DM tabs, last-read, per-view mute (`mesh-client:mutedViews:<protocol>`), starred (`mesh-client:starred:<protocol>`, cap 200).
+- **Notifications:** `src/renderer/lib/chatNotifications.ts` — `playMessageNotification()` (AudioContext beep); global mute `mesh-client:notifMuted`; per-view mute in `mutedViews`.
+- **Meshtastic dedup:** `src/renderer/lib/meshtasticMessageDedup.ts` — merges delayed RF/MQTT duplicates (10-minute content window) in `useDevice.ts`.
 - **Mention segments:** `src/renderer/lib/chatMentionSegments.ts` — parse/build `@[Name]` tokens; `MentionAutocomplete.tsx` renders the dropdown.
 - **Export IPC:** `chat:export` — renderer calls `window.electronAPI.chat.export(messages)`; main opens a Save dialog and writes a `.txt` file.
 
@@ -163,6 +165,8 @@ Panels: `src/renderer/components/`. New tabs: `lazyTabPanels.ts` / `lazyAppPanel
 | Chat export fails      | `chat:export` handler in `src/main/index.ts`        |
 | Draft not restored     | `chatPanelProtocolStorage.ts`, `viewKey` logic      |
 | Mention picker missing | `MentionAutocomplete.tsx`, `buildMentionCandidates` |
+| Link preview missing   | `fetchLinkPreview.ts`, `chat:fetchLinkPreview` IPC  |
+| Duplicate RF+MQTT msg  | `meshtasticMessageDedup.ts`, `useDevice.ts` ingest  |
 
 ## 9. Cursor / Claude indexing
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ From real-time diagnostics to permanent message archives, Mesh-Client delivers t
 
 **MQTT**
 
-- Subscribe to a broker to receive mesh traffic over the internet; AES-128-CTR decryption, automatic RF deduplication, **10-minute reconnect delay after failed attempts** (recovers faster on connack timeout), and an **active node cache** that periodically refreshes presence information so MQTT-only and RF+MQTT nodes stay visible even when your radio is offline
+- Subscribe to a broker to receive mesh traffic over the internet; AES-128-CTR decryption, automatic RF deduplication, **cross-transport chat dedup** (when the same message arrives on MQTT and RF within ~10 minutes, one bubble is kept and the transport badge upgrades to **both**), **10-minute reconnect delay after failed attempts** (recovers faster on connack timeout), and an **active node cache** that periodically refreshes presence information so MQTT-only and RF+MQTT nodes stay visible even when your radio is offline
 - Transport indicator (RF / MQTT / both) on received messages; MQTT messages are shown in chat but not rebroadcast over RF
 - Enter your broker URL, topic, and optional credentials in the MQTT section of the Connection tab; settings persist across sessions
 
@@ -137,11 +137,15 @@ From real-time diagnostics to permanent message archives, Mesh-Client delivers t
 - Emoji reactions (11 emojis with compose picker) and reply-to-message (quoted preview in bubble)
 - **`@[Display Name]` tokens** (Meshtastic / MeshCore reply, tapback, path, and inline-reference syntax) render as compact inline labels in the bubble instead of raw brackets; see [docs/meshcore-meshtastic-parity.md](docs/meshcore-meshtastic-parity.md#chat-mention-tokens)
 - Unread message divider that persists across restarts; auto-scrolls on tab switch
-- Direct messages (DMs) to individual nodes
+- Direct messages (DMs) to individual nodes; **DM info header** shows battery, last heard, and SNR for the peer
 - **Draft persistence**: unsent message is saved per channel/DM and restored when you return
+- **Copy message**: hover action copies message text to the clipboard
 - **Sender filter**: click any message sender to filter the view to that sender; Escape clears
 - **Jump to date**: scroll the chat to a specific calendar date
-- **Sound notifications**: audio ping for new messages in non-active channels/DMs; mute toggle in the toolbar
+- **Link previews**: `http`/`https` URLs in message text fetch Open Graph metadata (title, description, image) via main-process IPC; localhost and private IPs are blocked
+- **Sound notifications**: audio ping for new messages in non-active channels/DMs; global mute in the toolbar; **per-conversation mute** (bell on channel/DM tabs) stored per protocol
+- **Message starring**: star messages from the hover row; **Starred** view lists bookmarks across conversations (newest first, cap 200)
+- **Timestamp tooltip**: hover the short time label for full date and time
 - **@mention autocomplete**: type `@` to open a node-name picker; Tab or Enter to insert; arrow keys to navigate
 - **Export chat**: save the current channel or DM history as a `.txt` file via Save dialog
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -9,8 +9,8 @@ These requirements apply to all platforms.
 ### 1) Required software
 
 - Git
-- Node.js **22.13.0+** (`package.json` `engines.node`; [CI](https://github.com/Colorado-Mesh/mesh-client/blob/main/.github/workflows/ci.yaml) uses Node 22)
-- pnpm **10+**
+- Node.js **22.13.0+** and pnpm **10+** (`package.json` `engines`; `.npmrc` sets `engine-strict=true` so `pnpm install` fails on version mismatch)
+- [CI](https://github.com/Colorado-Mesh/mesh-client/blob/main/.github/workflows/ci.yaml) uses Node 22
 - Python 3 + `pip` (needed for MkDocs documentation build and yamllint)
 
 Verify:


### PR DESCRIPTION
## Summary

- **README**: Document chat features shipped in #413–#415 (DM info header, copy message, link previews, per-conversation mute, message starring, timestamp tooltip) and Meshtastic **cross-transport chat dedup** (RF + MQTT → single bubble with **both** badge).
- **AGENTS.md**: Expand Chat Panel quick reference (`ChatPayloadText`, link preview IPC, storage keys, `meshtasticMessageDedup`); replace stale “314 keys” i18n count with `check:i18n`; add troubleshooting rows for link previews and duplicate RF+MQTT messages.
- **docs/development-environment.md**: Document `package.json` `engines` and `.npmrc` `engine-strict=true` (#416).

Reviewed commits from the last three days; `docs/diagnostics.md` and `ARCHITECTURE.md` were already current from #411–#412.

## Test plan

- [x] `pnpm run format` (no changes needed)
- [x] Pre-commit hook passed on commit (lint, typecheck, tests)
- [ ] Docs render correctly on GitHub preview