### PR TITLE
feat: expose all theme colors in color scheme section

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1463,7 +1463,7 @@ export default function App() {
           onComplete={handleSignalPulseComplete}
         />
       )}
-      <div className="flex h-screen w-screen min-w-0 flex-col overflow-hidden bg-slate-950">
+      <div className="bg-app-bg flex h-screen w-screen min-w-0 flex-col overflow-hidden">
         {/* Header - full width; sidebar + main start below */}
         <div
           role="banner"
@@ -1709,7 +1709,7 @@ export default function App() {
           {/* Sidebar - collapsible width on left */}
           <nav
             aria-label={t('aria.applicationPanels')}
-            className={`flex h-full min-h-0 shrink-0 flex-col border-r border-slate-800 transition-[width] duration-300 ${
+            className={`bg-deep-black flex h-full min-h-0 shrink-0 flex-col border-r border-slate-800 transition-[width] duration-300 ${
               sidebarCollapsed ? 'w-16' : 'w-48'
             }`}
           >
@@ -1725,11 +1725,11 @@ export default function App() {
           </nav>
 
           {/* Main column: viewport + footer */}
-          <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          <main className="bg-app-bg flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {/* Main Viewport - scrollable panel area */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
               {/* Scroll container - no padding so scrollbars pin to viewport edges */}
-              <div ref={mainViewportRef} className="h-full w-full overflow-auto bg-slate-950">
+              <div ref={mainViewportRef} className="bg-app-bg h-full w-full overflow-auto">
                 {/* Content wrapper - padding lives here, not on the scroll container */}
                 <div className="h-full min-h-full min-w-0 px-8 pt-8 pb-8">
                   <ErrorBoundary>
@@ -2407,7 +2407,7 @@ export default function App() {
             )}
 
             {/* Footer - fixed height at bottom of Content Wrapper */}
-            <footer className="text-muted flex h-8 shrink-0 items-center justify-between border-t border-slate-800 bg-slate-900 px-4 text-[10px]">
+            <footer className="text-muted bg-deep-black flex h-8 shrink-0 items-center justify-between border-t border-slate-800 px-4 text-[10px]">
               <span className="min-w-0">
                 {t('app.footerSlogan')}{' '}
                 <a

--- a/src/renderer/components/AppPanel.tsx
+++ b/src/renderer/components/AppPanel.tsx
@@ -1337,10 +1337,12 @@ export default function AppPanel({
                   />
                   <div
                     id={`theme-color-heading-${meta.key}`}
-                    className="max-w-[9rem] min-w-[6.5rem] shrink-0 text-sm font-medium text-gray-200"
-                    title={meta.description}
+                    className="max-w-[9rem] min-w-[6.5rem] shrink-0"
                   >
-                    {meta.label}
+                    <div className="text-sm font-medium text-gray-200">{meta.label}</div>
+                    <div className="text-muted mt-0.5 text-[10px] leading-tight">
+                      {meta.description}
+                    </div>
                   </div>
                   <div
                     className="flex max-w-full min-w-0 flex-1 [scrollbar-width:thin] flex-nowrap gap-1 py-0.5"

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -351,7 +351,7 @@ export default function Sidebar({
                 isDisabled
                   ? 'cursor-not-allowed border-transparent text-gray-600 opacity-40'
                   : isActive
-                    ? 'border-bright-green text-bright-green bg-gray-800'
+                    ? 'border-bright-green text-bright-green bg-sidebar-active-bg'
                     : 'text-muted hover:bg-secondary-dark border-transparent hover:text-gray-200'
               }`}
             >

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -11,7 +11,7 @@
     />
     <title>Mesh Client</title>
   </head>
-  <body class="overflow-hidden bg-gray-900 text-gray-100">
+  <body class="bg-app-bg overflow-hidden text-gray-100">
     <div id="root"></div>
     <script type="module" src="./main.tsx"></script>
   </body>

--- a/src/renderer/lib/themeColors.test.ts
+++ b/src/renderer/lib/themeColors.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { DEFAULT_THEME_COLORS, isValidHex, normalizeHex, sanitizeHexDraft } from './themeColors';
+import {
+  applyThemeColors,
+  DEFAULT_THEME_COLORS,
+  isValidHex,
+  normalizeHex,
+  sanitizeHexDraft,
+} from './themeColors';
 
 describe('themeColors', () => {
   describe('normalizeHex', () => {
@@ -54,5 +60,27 @@ describe('themeColors', () => {
     for (const hex of Object.values(DEFAULT_THEME_COLORS)) {
       expect(normalizeHex(hex)).toBe(hex.toLowerCase());
     }
+  });
+
+  describe('applyThemeColors', () => {
+    it('sets chatIncomingBg as rgb() with 0.38 opacity, not bare hex', () => {
+      const setProp = vi.fn();
+      vi.spyOn(document.documentElement.style, 'setProperty').mockImplementation(setProp);
+      applyThemeColors({ ...DEFAULT_THEME_COLORS, chatIncomingBg: '#1e293b' });
+      const call = setProp.mock.calls.find(([prop]) => prop === '--color-chat-incoming-bg');
+      expect(call).toBeDefined();
+      expect(call![1]).toBe('rgb(30 41 59 / 0.38)');
+      vi.restoreAllMocks();
+    });
+
+    it('sets appBg as bare hex', () => {
+      const setProp = vi.fn();
+      vi.spyOn(document.documentElement.style, 'setProperty').mockImplementation(setProp);
+      applyThemeColors({ ...DEFAULT_THEME_COLORS, appBg: '#020617' });
+      const call = setProp.mock.calls.find(([prop]) => prop === '--color-app-bg');
+      expect(call).toBeDefined();
+      expect(call![1]).toBe('#020617');
+      vi.restoreAllMocks();
+    });
   });
 });

--- a/src/renderer/lib/themeColors.ts
+++ b/src/renderer/lib/themeColors.ts
@@ -10,31 +10,43 @@ export const THEME_COLORS_STORAGE_KEY = 'mesh-client:themeColors';
 
 /** Keys persisted in localStorage (camelCase). */
 export type ThemeColorKey =
+  | 'appBg'
+  | 'sidebarActiveBg'
   | 'brandGreen'
   | 'brightGreen'
   | 'readableGreen'
   | 'deepBlack'
   | 'secondaryDark'
-  | 'muted';
+  | 'muted'
+  | 'chatIncomingBg'
+  | 'chatIncomingBorder';
 
 /** CSS custom property name (no leading --). */
 export const THEME_CSS_VARS: Record<ThemeColorKey, string> = {
+  appBg: '--color-app-bg',
+  sidebarActiveBg: '--color-sidebar-active-bg',
   brandGreen: '--color-brand-green',
   brightGreen: '--color-bright-green',
   readableGreen: '--color-readable-green',
   deepBlack: '--color-deep-black',
   secondaryDark: '--color-secondary-dark',
   muted: '--color-muted',
+  chatIncomingBg: '--color-chat-incoming-bg',
+  chatIncomingBorder: '--color-chat-incoming-border',
 };
 
 /** Default hex values — must match src/renderer/styles.css @theme block. */
 export const DEFAULT_THEME_COLORS: Record<ThemeColorKey, string> = {
+  appBg: '#020617',
+  sidebarActiveBg: '#1e293b',
   brandGreen: '#86efac',
   brightGreen: '#86efac',
   readableGreen: '#16a34a',
   deepBlack: '#0f172a',
   secondaryDark: '#334155',
   muted: '#94a3b8',
+  chatIncomingBg: '#1e293b',
+  chatIncomingBorder: '#1e293b',
 };
 
 export interface ThemeTokenMeta {
@@ -46,7 +58,9 @@ export interface ThemeTokenMeta {
 /** Preset hex values — Tailwind palette only. */
 export const THEME_COLOR_PRESETS: { label: string; hex: string }[] = [
   { label: 'Green 300', hex: '#86efac' },
+  { label: 'Slate 950', hex: '#020617' },
   { label: 'Slate 900', hex: '#0f172a' },
+  { label: 'Slate 800', hex: '#1e293b' },
   { label: 'Slate 700', hex: '#334155' },
   { label: 'Slate 400', hex: '#94a3b8' },
   { label: 'White', hex: '#ffffff' },
@@ -66,36 +80,57 @@ export const THEME_COLOR_PRESETS: { label: string; hex: string }[] = [
 
 export const THEME_TOKEN_META: ThemeTokenMeta[] = [
   {
+    key: 'appBg',
+    label: 'Main window background',
+    description:
+      'Main content viewport and app window background — the dark canvas behind all panels.',
+  },
+  {
+    key: 'sidebarActiveBg',
+    label: 'Active sidebar tab',
+    description: 'Background of the currently selected tab in the sidebar navigation.',
+  },
+  {
     key: 'brandGreen',
-    label: 'Brand green',
+    label: 'Indicators & border highlights',
     description:
       'Accent for borders when configured, online/MQTT indicators, highlights, and progress fills.',
   },
   {
     key: 'brightGreen',
-    label: 'Bright green',
+    label: 'App title, links & node emphasis',
     description: 'App title, emphasis text, links in footer, and hop/self highlights in node list.',
   },
   {
     key: 'readableGreen',
-    label: 'Readable green',
+    label: 'Action buttons & selected pills',
     description:
       'Solid fills with white text—selected channel pills and primary action buttons for contrast.',
   },
   {
     key: 'deepBlack',
-    label: 'Deep black',
-    description: 'Header, footer, modal shells, and primary dark surfaces.',
+    label: 'Sidebar, header & modal surfaces',
+    description: 'Sidebar navigation, header, footer, modal shells, and primary dark surfaces.',
   },
   {
     key: 'secondaryDark',
-    label: 'Secondary dark',
+    label: 'Panel & input background',
     description: 'Panel backgrounds, inputs, buttons, table row hovers, and progress track.',
   },
   {
     key: 'muted',
-    label: 'Muted',
+    label: 'Secondary labels & captions',
     description: 'Secondary labels, captions, table headers, and de-emphasized text.',
+  },
+  {
+    key: 'chatIncomingBg',
+    label: 'Incoming message fill',
+    description: 'Background fill for incoming channel messages (applied at 38% opacity).',
+  },
+  {
+    key: 'chatIncomingBorder',
+    label: 'Incoming message border',
+    description: 'Border color for incoming channel messages.',
   },
 ];
 
@@ -179,7 +214,15 @@ export function applyThemeColors(colors: Record<ThemeColorKey, string>): void {
   }
   const root = document.documentElement;
   for (const key of Object.keys(THEME_CSS_VARS) as ThemeColorKey[]) {
-    root.style.setProperty(THEME_CSS_VARS[key], resolved[key]);
+    const hex = resolved[key];
+    if (key === 'chatIncomingBg') {
+      const r = parseInt(hex.slice(1, 3), 16);
+      const g = parseInt(hex.slice(3, 5), 16);
+      const b = parseInt(hex.slice(5, 7), 16);
+      root.style.setProperty(THEME_CSS_VARS[key], `rgb(${r} ${g} ${b} / 0.38)`);
+    } else {
+      root.style.setProperty(THEME_CSS_VARS[key], hex);
+    }
   }
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 
 @theme {
+  --color-app-bg: #020617;
+  --color-sidebar-active-bg: #1e293b;
   --color-brand-green: #86efac;
   --color-bright-green: #86efac;
   --color-readable-green: #16a34a;


### PR DESCRIPTION
## Summary

Exposes 4 previously hardcoded color tokens as user-configurable theme options in the Color Scheme settings panel:

- **appBg** — main content viewport and app window background (replaces hardcoded `bg-slate-950`)
- **sidebarActiveBg** — active sidebar tab highlight (replaces hardcoded `bg-gray-800`)
- **chatIncomingBg** — incoming channel message fill (previously CSS-only, now user-configurable; applied at 38% opacity)
- **chatIncomingBorder** — incoming channel message border (previously CSS-only, now user-configurable)

Also: shows token descriptions inline in the color scheme UI (was tooltip-only) and updates token labels to be more descriptive.

## Changes

- `src/renderer/lib/themeColors.ts` — adds `appBg`, `sidebarActiveBg`, `chatIncomingBg`, `chatIncomingBorder` to `ThemeColorKey`, `THEME_CSS_VARS`, `DEFAULT_THEME_COLORS`, and `THEME_TOKEN_META`; `applyThemeColors` applies `chatIncomingBg` at 38% opacity via `rgb(r g b / 0.38)`
- `src/renderer/styles.css` — adds `--color-app-bg` and `--color-sidebar-active-bg` to the `@theme` block
- `src/renderer/App.tsx` — replaces `bg-slate-950` with `bg-app-bg` on outer wrapper, main column, and scroll container; adds `bg-deep-black` to sidebar nav; replaces `bg-slate-900` with `bg-deep-black` on footer
- `src/renderer/components/Sidebar.tsx` — replaces `bg-gray-800` with `bg-sidebar-active-bg` on active tab
- `src/renderer/components/AppPanel.tsx` — shows token descriptions inline instead of as tooltip; adds `Slate 950` and `Slate 800` to color presets

## Backward Compatibility

`loadThemeColors()` merges stored keys over `DEFAULT_THEME_COLORS`, so users with existing localStorage missing the new keys get the defaults automatically — no migration required.