### PR TITLE
chore: pin idna>=3.15 and pymdown-extensions>=10.21.3 to fix Dependabot alerts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ tmp/
 # Files unsupported by prettier parser
 .npmrc
 *.plist
+*.txt
 resources/win/*.xml
 
 # CodeQL MaD — Prettier line-wrap breaks yamllint indentation for barrier tuples

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs
 mkdocs-material
-
+idna>=3.15
+pymdown-extensions>=10.21.3


### PR DESCRIPTION
Closes Dependabot alerts #27 and #28.

## Changes

- **`docs/requirements.txt`**: Pin `idna>=3.15` (fixes GHSA for CVE-2024-3651 bypass) and `pymdown-extensions>=10.21.3` (fixes sibling-prefix path traversal in `pymdownx.snippets`). Both are transitive deps of `mkdocs-material`; pinning forces pip to resolve safe versions.
- **`.prettierignore`**: Add `*.txt` so Prettier does not fail on `requirements.txt` (no supported parser).

## Dependabot alert status

| # | Package | Fix |
|---|---------|-----|
| 26 | `ws` (npm) | Already patched — `pnpm-lock.yaml` has `ws@8.20.1` since PR #424; alert dismissed. |
| 27 | `idna` (pip) | `idna>=3.15` added to `docs/requirements.txt` |
| 28 | `pymdown-extensions` (pip) | `pymdown-extensions>=10.21.3` added to `docs/requirements.txt` |