### PR TITLE
fix: hoist readable-stream for Linux asar MQTT packaging

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -112,6 +112,14 @@ Node deprecates `spawn(..., { shell: true })` with an args array. This project c
 
 npm's JSON tree lists hoisted packages with many duplicate refs (one per edge). That's expected and not something you need to fix. The patched packaging dependency path keeps that summary at **debug** only so normal `dist:*` runs stay quiet. To see it: `DEBUG=electron-builder pnpm dlx electron-builder --mac` (or your usual dist command).
 
+### Linux packaged app: `Cannot find module 'readable-stream'`
+
+**Symptom**: On Linux, the installed or AppImage build shows a main-process error when loading MQTT (`bl` → `mqtt-packet` → `mqtt` require stack).
+
+**Cause**: pnpm 10.29.3+ marks some `pnpm list --json` nodes as deduped; electron-builder can omit those transitive packages from `app.asar` unless a full copy exists at a predictable path. `mqtt` is loaded from `node_modules` at runtime (not bundled into the main esbuild output).
+
+**Fix in this repo**: `readable-stream@^4.7.0` is a **direct** production dependency (with the existing `patches/readable-stream@4.7.0.patch` for Windows `process/` resolution). Do not remove it when bumping `mqtt` or pnpm. After `pnpm run dist:linux`, verify the asar contains `node_modules/readable-stream`, `node_modules/bl`, and `node_modules/mqtt`. See [electron-builder#9603](https://github.com/electron-userland/electron-builder/issues/9603) and [pnpm#10601](https://github.com/pnpm/pnpm/issues/10601).
+
 ### `[DEP0169]` / `url.parse()` deprecation warning
 
 The app uses npm package overrides to force `follow-redirects` and `cacheable-request` onto versions that use the WHATWG URL API, which removes this warning. To trace the source of any deprecation, run:

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "mgrs": "^2.1.0",
     "mqtt": "^5.15.1",
     "node-forge": "^1.4.0",
+    "readable-stream": "^4.7.0",
     "react-i18next": "^17.0.8",
     "react-leaflet-cluster": "^4.1.3",
     "systeminformation": "^5.31.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       react-leaflet-cluster:
         specifier: ^4.1.3
         version: 4.1.3(@react-leaflet/core@3.0.0(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      readable-stream:
+        specifier: ^4.7.0
+        version: 4.7.0(patch_hash=96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1)
       systeminformation:
         specifier: ^5.31.6
         version: 5.31.6

--- a/src/main/windows-long-path-manifest.contract.test.ts
+++ b/src/main/windows-long-path-manifest.contract.test.ts
@@ -26,6 +26,17 @@ describe('Windows long-path application manifest (packaging contract)', () => {
     expect(manifest).toMatch(/ws2:longPathAware>true</);
   });
 
+  it('declares readable-stream as a direct production dep with pnpm patch for asar packaging', () => {
+    const packageJson = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8')) as {
+      dependencies?: Record<string, string>;
+      pnpm?: { patchedDependencies?: Record<string, string> };
+    };
+    expect(packageJson.dependencies?.['readable-stream']).toMatch(/^[\^~]?4\./);
+    expect(packageJson.pnpm?.patchedDependencies?.['readable-stream@4.7.0']).toBe(
+      'patches/readable-stream@4.7.0.patch',
+    );
+  });
+
   it('keeps the @electron/asar pnpm override on v4 or newer for Windows packaging', () => {
     const packageJson = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8')) as {
       pnpm?: { overrides?: Record<string, string> };


### PR DESCRIPTION
## Summary

- Add `readable-stream@^4.7.0` as a direct production dependency so the patched v4 package is hoisted to top-level `node_modules` and included in `app.asar`.
- Fixes Linux packaged builds crashing on startup with `Cannot find module 'readable-stream'` when loading MQTT (`bl` → `mqtt-packet` → `mqtt`).
- Extend the packaging contract test and document the pnpm deduped-deps / electron-builder interaction in troubleshooting.

## Why

pnpm 10.29.3+ marks some `pnpm list --json` nodes as deduped; electron-builder can omit those transitive packages from the asar. `mqtt` is externalized from the main bundle and loaded from `node_modules` at runtime, so a missing `readable-stream` breaks immediately on launch.

## Test plan

- [x] `pnpm exec vitest run src/main/windows-long-path-manifest.contract.test.ts`
- [x] Linux unpacked build: `app.asar` contains `node_modules/readable-stream` (v4.7.0), `node_modules/bl`, and `node_modules/mqtt`
- [x] Extracted asar layout: `bl` successfully `require('readable-stream')`
- [ ] CI `ubuntu-latest` release/build job passes
- [ ] Installed Linux build launches without main-process error