### PR TITLE
fix: replace single 100ms BLE safety read with multi-shot probes for LoRa latency

### DIFF
--- a/src/renderer/lib/webbluetooth-ble-manager.test.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.test.ts
@@ -144,24 +144,24 @@ describe('WebBluetoothManager writeToRadio', () => {
     expect(fromRadio.readValue).toHaveBeenCalled();
   });
 
-  it('does not schedule safety read when meshtasticFromRadioReadPump is true', async () => {
+  it('drains immediately and schedules follow-up reads in meshtasticFromRadioReadPump mode', async () => {
     const { mgr, harness } = makeManager();
     const fromRadio = mockFromRadioChar();
     harness.toRadioCharacteristic = mockToRadioChar(true);
     harness.fromRadioCharacteristic = fromRadio;
     harness.meshtasticFromRadioReadPump = true;
 
-    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
-
     await mgr.writeToRadio(new Uint8Array([1]));
 
-    expect(fromRadio.readValue).toHaveBeenCalled();
-    const safetyReadCalls = setTimeoutSpy.mock.calls.filter(
-      (args) => typeof args[1] === 'number' && args[1] === 100,
-    );
-    expect(safetyReadCalls).toHaveLength(0);
+    // Immediate drain runs synchronously with the write
+    expect(fromRadio.readValue).toHaveBeenCalledTimes(1);
 
-    setTimeoutSpy.mockRestore();
+    // Follow-up reads fire at scheduled delays to catch slow LoRa responses
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fromRadio.readValue).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(400); // 500ms total
+    expect(fromRadio.readValue).toHaveBeenCalledTimes(3);
   });
 
   it('invokes link-healthy callback after writeToRadio', async () => {

--- a/src/renderer/lib/webbluetooth-ble-manager.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.ts
@@ -23,8 +23,13 @@ const GATT_DISCOVERY_TIMEOUT_MS = 30_000;
 const GATT_NOTIFICATION_TIMEOUT_MS = 20_000;
 /** Align with `noble-ble-manager.ts` — drain burst cap for Meshtastic fromRadio read pump. */
 const BLE_READ_PUMP_MAX_ITERATIONS = 512;
-/** Mirrors `noble-ble-manager.ts` POST_WRITE_READ_PUMP_DELAY_MS — recover dropped first notify after write. */
-const POST_WRITE_SAFETY_READ_DELAY_MS = 100;
+/**
+ * Post-write safety read schedule — multiple probes cover LoRa round-trip latency (can reach
+ * several seconds). First probe matches `noble-ble-manager.ts POST_WRITE_READ_PUMP_DELAY_MS`.
+ */
+const POST_WRITE_SAFETY_READ_DELAYS_MS = [100, 500, 1500, 4000, 8000];
+/** Timeout for individual GATT readValue calls in the drain loop (shorter than discovery). */
+const GATT_READ_VALUE_TIMEOUT_MS = 10_000;
 /** Periodic GATT read on quiet notify links — below useDevice BLE_STALE_THRESHOLD_MS (90s). */
 const GATT_KEEPALIVE_INTERVAL_MS = 45_000;
 
@@ -107,7 +112,8 @@ export class WebBluetoothManager {
   private _pendingDevicePromise?: Promise<BluetoothDevice>;
   private _resolvePendingDevice?: (device: BluetoothDevice) => void;
   private _rejectPendingDevice?: (reason?: unknown) => void;
-  private postWriteSafetyReadTimer: ReturnType<typeof setTimeout> | null = null;
+  private postWriteSafetyReadTimers: ReturnType<typeof setTimeout>[] = [];
+  private isReadPumpActive = false;
   private gattKeepaliveTimer: ReturnType<typeof setInterval> | null = null;
   /** Invoked when a GATT read/write succeeds — refreshes connection watchdog on quiet meshes. */
   private onGattLinkHealthy: (() => void) | null = null;
@@ -294,39 +300,54 @@ export class WebBluetoothManager {
     await this.drainFromRadioUnchecked();
   }
 
-  /** GATT read drain without read-pump guard — post-write safety net and keepalive for notify mode. */
+  /** GATT read drain — concurrent-read guard prevents overlapping GATT reads. */
   private async drainFromRadioUnchecked(): Promise<void> {
-    if (!this.fromRadioCharacteristic) return;
+    if (!this.fromRadioCharacteristic || this.isReadPumpActive) return;
+    this.isReadPumpActive = true;
     const ch = this.fromRadioCharacteristic;
-    for (let i = 0; i < BLE_READ_PUMP_MAX_ITERATIONS; i++) {
-      if (!this.device?.gatt?.connected) return;
-      let dataView: DataView;
-      try {
-        dataView = await withGattTimeout(
-          ch.readValue(),
-          GATT_DISCOVERY_TIMEOUT_MS,
-          'GATT fromRadio readValue',
-        );
-      } catch {
-        // catch-no-log-ok read pump end — expected when characteristic is drained or stack errors
-        break;
+    try {
+      for (let i = 0; i < BLE_READ_PUMP_MAX_ITERATIONS; i++) {
+        if (!this.device?.gatt?.connected) return;
+        let dataView: DataView;
+        try {
+          dataView = await withGattTimeout(
+            ch.readValue(),
+            GATT_READ_VALUE_TIMEOUT_MS,
+            'GATT fromRadio readValue',
+          );
+        } catch {
+          // catch-no-log-ok read pump end — expected when characteristic is drained or stack errors
+          break;
+        }
+        this.notifyGattLinkHealthy();
+        if (!dataView.byteLength) break;
+        const bytes = new Uint8Array(dataView.buffer, dataView.byteOffset, dataView.byteLength);
+        this.enqueueFromRadioBytes(bytes);
+        await Promise.resolve();
       }
-      this.notifyGattLinkHealthy();
-      if (!dataView.byteLength) break;
-      const bytes = new Uint8Array(dataView.buffer, dataView.byteOffset, dataView.byteLength);
-      this.enqueueFromRadioBytes(bytes);
-      await Promise.resolve();
+    } finally {
+      this.isReadPumpActive = false;
     }
   }
 
-  private schedulePostWriteSafetyRead(): void {
-    if (this.postWriteSafetyReadTimer !== null) {
-      clearTimeout(this.postWriteSafetyReadTimer);
+  private clearPostWriteSafetyReads(): void {
+    for (const t of this.postWriteSafetyReadTimers) clearTimeout(t);
+    this.postWriteSafetyReadTimers = [];
+  }
+
+  /**
+   * Schedule multiple fromRadio reads after a write to catch responses that arrive after LoRa
+   * round-trips (can take several seconds). Cancels any pending reads from the previous write.
+   */
+  private schedulePostWriteSafetyReads(): void {
+    this.clearPostWriteSafetyReads();
+    for (const delay of POST_WRITE_SAFETY_READ_DELAYS_MS) {
+      this.postWriteSafetyReadTimers.push(
+        setTimeout(() => {
+          void this.drainFromRadioUnchecked();
+        }, delay),
+      );
     }
-    this.postWriteSafetyReadTimer = setTimeout(() => {
-      this.postWriteSafetyReadTimer = null;
-      void this.drainFromRadioUnchecked();
-    }, POST_WRITE_SAFETY_READ_DELAY_MS);
   }
 
   private startGattKeepalive(): void {
@@ -555,10 +576,8 @@ export class WebBluetoothManager {
   }
 
   private cleanup(): void {
-    if (this.postWriteSafetyReadTimer !== null) {
-      clearTimeout(this.postWriteSafetyReadTimer);
-      this.postWriteSafetyReadTimer = null;
-    }
+    this.clearPostWriteSafetyReads();
+    this.isReadPumpActive = false;
     this.stopGattKeepalive();
     this.onGattLinkHealthy = null;
     this._fromDeviceController = null;
@@ -597,8 +616,9 @@ export class WebBluetoothManager {
     if (this.sessionId === 'meshtastic') {
       if (this.meshtasticFromRadioReadPump) {
         await this.drainMeshtasticFromRadioReads();
-      } else if (this.fromRadioCharacteristic?.properties.read) {
-        this.schedulePostWriteSafetyRead();
+      }
+      if (this.fromRadioCharacteristic?.properties.read) {
+        this.schedulePostWriteSafetyReads();
       }
     }
   }


### PR DESCRIPTION
## Problem

On Linux BLE, responses to commands were displayed one command late:

- Send `cmd` → nothing appears
- Send `ping` → the `cmd` response appears
- Send `cmd` → the `pong` appears
- ...

The radio was correctly receiving and sending responses to every command (verified via LoRa node-to-node monitoring). The issue was strictly in how the client read back responses over BLE.

## Root cause

A single 100ms post-write safety read was the culprit. After writing a command:

1. The 100ms probe fires — but the radio hasn't responded yet (LoRa round-trips take seconds)
2. `readValue()` returns 0 bytes → drain exits
3. The radio's response lands in the `fromRadio` characteristic with nobody polling
4. The *next* write's drain picks up the stale response → one-command-late display

The same race existed in the `meshtasticFromRadioReadPump` path: the immediate drain after a write exits before the radio responds, then nothing reads until the next write.

## Fix

- Replace `POST_WRITE_SAFETY_READ_DELAY_MS = 100` with `POST_WRITE_SAFETY_READ_DELAYS_MS = [100, 500, 1500, 4000, 8000]` — five probes spread across 8 seconds, covering LoRa round-trip latency
- Change the `else if` in `writeToRadio` to a plain `if` so the read-pump path also gets follow-up probes (same race existed there)
- Add `isReadPumpActive` guard to `drainFromRadioUnchecked` to prevent concurrent overlapping `readValue()` calls when multiple scheduled probes fire close together
- Each write cancels the previous write's pending probes and schedules fresh ones
- Use `GATT_READ_VALUE_TIMEOUT_MS = 10_000` in the drain loop instead of the 30s `GATT_DISCOVERY_TIMEOUT_MS` (which was intended for service/characteristic discovery, not per-read timeouts)

## Testing

All 1624 tests pass. Updated the read-pump test to verify the new behavior (immediate drain + scheduled follow-ups at 100ms and 500ms).