### PR TITLE
fix: subscribe to fromNum GATT notify to receive unsolicited mesh traffic on Linux BLE

### DIFF
--- a/src/renderer/lib/webbluetooth-ble-manager.test.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.test.ts
@@ -14,6 +14,8 @@ interface ManagerTestHarness {
   fromRadioCharacteristic: BluetoothRemoteGATTCharacteristic | null;
   meshtasticFromRadioReadPump: boolean;
   gattKeepaliveTimer: ReturnType<typeof setInterval> | null;
+  fromNumNotifyHandler: (() => void) | null;
+  trySubscribeFromNum(service: BluetoothRemoteGATTService): Promise<void>;
   writeToRadio(data: Uint8Array): Promise<void>;
   setLinkHealthyCallback(callback: (() => void) | null): void;
   startGattKeepalive(): void;
@@ -187,6 +189,52 @@ describe('WebBluetoothManager writeToRadio', () => {
 
     await vi.advanceTimersByTimeAsync(45_000);
     expect(fromRadio.readValue).toHaveBeenCalled();
+  });
+
+  describe('fromNum notify', () => {
+    it('drains fromRadio when fromNum notify fires (covers unsolicited mesh traffic)', async () => {
+      const { harness } = makeManager();
+      const fromRadio = mockFromRadioChar();
+      harness.fromRadioCharacteristic = fromRadio;
+
+      let capturedHandler: (() => void) | null = null;
+      const mockFromNum = {
+        addEventListener: vi.fn((_event: string, handler: () => void) => {
+          capturedHandler = handler;
+        }),
+        removeEventListener: vi.fn(),
+        startNotifications: vi.fn().mockResolvedValue(undefined),
+      };
+      const mockService = {
+        getCharacteristic: vi.fn().mockResolvedValue(mockFromNum),
+      };
+
+      await harness.trySubscribeFromNum(mockService as unknown as BluetoothRemoteGATTService);
+      expect(mockFromNum.startNotifications).toHaveBeenCalled();
+      expect(capturedHandler).not.toBeNull();
+      expect(harness.fromNumNotifyHandler).not.toBeNull();
+
+      // Fire the handler as the BLE stack would when fromNum changes
+      capturedHandler!();
+      await Promise.resolve();
+
+      expect(fromRadio.readValue).toHaveBeenCalledTimes(1);
+    });
+
+    it('silently skips fromNum when the characteristic is not available', async () => {
+      const { harness } = makeManager();
+      const mockService = {
+        getCharacteristic: vi
+          .fn()
+          .mockRejectedValue(new DOMException('Not found', 'NotFoundError')),
+      };
+
+      await expect(
+        harness.trySubscribeFromNum(mockService as unknown as BluetoothRemoteGATTService),
+      ).resolves.toBeUndefined();
+
+      expect(harness.fromNumNotifyHandler).toBeNull();
+    });
   });
 });
 

--- a/src/renderer/lib/webbluetooth-ble-manager.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.ts
@@ -32,6 +32,12 @@ const POST_WRITE_SAFETY_READ_DELAYS_MS = [100, 500, 1500, 4000, 8000];
 const GATT_READ_VALUE_TIMEOUT_MS = 10_000;
 /** Periodic GATT read on quiet notify links — below useDevice BLE_STALE_THRESHOLD_MS (90s). */
 const GATT_KEEPALIVE_INTERVAL_MS = 45_000;
+/**
+ * Meshtastic fromNum characteristic — value increments when a new packet is queued in fromRadio.
+ * Subscribing to its NOTIFY fires a drain without waiting for the next client write.
+ * Mirrors FROMNUM_UUID in `noble-ble-manager.ts`.
+ */
+const FROMNUM_UUID = 'ed9da18c-a800-4f66-a670-aa7547e34453';
 
 /** Web Bluetooth experimental API not in all TS DOM libs (descriptor discovery). */
 type BluetoothRemoteGATTCharacteristicWithDescriptors = BluetoothRemoteGATTCharacteristic & {
@@ -107,6 +113,8 @@ export class WebBluetoothManager {
   private fromRadioDescriptorUuids: string[] = [];
   /** When true, `fromRadio` uses GATT readValue pump (Linux/BlueZ may lack CCCD for notify on 2c55…). */
   private meshtasticFromRadioReadPump = false;
+  private fromNumCharacteristic: BluetoothRemoteGATTCharacteristic | null = null;
+  private fromNumNotifyHandler: (() => void) | null = null;
   /** When set, `writeToRadio` splits payloads (Chromium `maximumWriteValueLength`); null = single writeValue. */
   private toRadioChunkLimitBytes: number | null = null;
   private _pendingDevicePromise?: Promise<BluetoothDevice>;
@@ -350,6 +358,46 @@ export class WebBluetoothManager {
     }
   }
 
+  /**
+   * Subscribe to fromNum GATT notify — fires whenever the radio queues a new packet in fromRadio.
+   * This covers unsolicited mesh traffic (messages from other nodes) without needing a client
+   * write to trigger a drain. Mirrors the fromNum subscription in `noble-ble-manager.ts`.
+   * Failure is silent; post-write safety reads remain the fallback.
+   */
+  private async trySubscribeFromNum(service: BluetoothRemoteGATTService): Promise<void> {
+    try {
+      this.fromNumCharacteristic = await withGattTimeout(
+        service.getCharacteristic(FROMNUM_UUID),
+        GATT_DISCOVERY_TIMEOUT_MS,
+        'GATT characteristic discovery (fromNum)',
+      );
+      this.fromNumNotifyHandler = () => {
+        this.notifyGattLinkHealthy();
+        void this.drainFromRadioUnchecked();
+      };
+      this.fromNumCharacteristic.addEventListener(
+        'characteristicvaluechanged',
+        this.fromNumNotifyHandler,
+      );
+      await withGattTimeout(
+        this.fromNumCharacteristic.startNotifications(),
+        GATT_NOTIFICATION_TIMEOUT_MS,
+        'GATT fromNum startNotifications',
+      );
+      console.debug(`[WebBluetooth:${this.sessionId}] fromNum notify active`);
+    } catch {
+      // catch-no-log-ok fromNum notify is optional; post-write read probes cover the fallback
+      if (this.fromNumCharacteristic && this.fromNumNotifyHandler) {
+        this.fromNumCharacteristic.removeEventListener(
+          'characteristicvaluechanged',
+          this.fromNumNotifyHandler,
+        );
+      }
+      this.fromNumCharacteristic = null;
+      this.fromNumNotifyHandler = null;
+    }
+  }
+
   private startGattKeepalive(): void {
     this.stopGattKeepalive();
     if (
@@ -506,6 +554,7 @@ export class WebBluetoothManager {
       );
       console.debug(`[WebBluetooth:${this.sessionId}] notifications started`);
       this.startGattKeepalive();
+      if (service) await this.trySubscribeFromNum(service);
     } catch (err) {
       const domErr = err as DOMException;
       const isPairing = isWebBluetoothPairingError(err);
@@ -526,6 +575,7 @@ export class WebBluetoothManager {
             `[WebBluetooth:${this.sessionId}] fromRadio: notify unavailable (no CCCD); using read pump`,
           );
           void this.drainMeshtasticFromRadioReads();
+          if (service) await this.trySubscribeFromNum(service);
           return;
         }
       }
@@ -555,6 +605,13 @@ export class WebBluetoothManager {
           this.fromRadioNotifyHandler,
         );
         await this.fromRadioCharacteristic.stopNotifications();
+      }
+      if (this.fromNumCharacteristic && this.fromNumNotifyHandler) {
+        this.fromNumCharacteristic.removeEventListener(
+          'characteristicvaluechanged',
+          this.fromNumNotifyHandler,
+        );
+        await this.fromNumCharacteristic.stopNotifications();
       }
     } catch (err) {
       console.debug(
@@ -587,6 +644,8 @@ export class WebBluetoothManager {
     this.fromRadioCharacteristic = null;
     this.fromRadioNotifyHandler = null;
     this.meshtasticFromRadioReadPump = false;
+    this.fromNumCharacteristic = null;
+    this.fromNumNotifyHandler = null;
     this.toRadioChunkLimitBytes = null;
   }
 

--- a/src/renderer/lib/webbluetooth-ble-manager.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.ts
@@ -560,7 +560,7 @@ export class WebBluetoothManager {
       const isPairing = isWebBluetoothPairingError(err);
       const isDescriptorMissingNotSupported =
         domErr?.name === 'NotSupportedError' && this.fromRadioDescriptorUuids.length === 0;
-      if (this.sessionId === 'meshtastic' && isDescriptorMissingNotSupported && service) {
+      if (this.sessionId === 'meshtastic' && isDescriptorMissingNotSupported) {
         // `ed9da18c-…` is **fromNum**, not fromRadio — see `noble-ble-manager.ts` (FROMNUM_UUID).
         // Do not subscribe there for the Meshtastic protobuf stream. When Linux exposes no CCCD on
         // canonical fromRadio (`2c55…`), fall back to GATT read pump like Noble does.

--- a/src/renderer/lib/webbluetooth-ble-manager.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.ts
@@ -554,7 +554,7 @@ export class WebBluetoothManager {
       );
       console.debug(`[WebBluetooth:${this.sessionId}] notifications started`);
       this.startGattKeepalive();
-      if (service) await this.trySubscribeFromNum(service);
+      await this.trySubscribeFromNum(service);
     } catch (err) {
       const domErr = err as DOMException;
       const isPairing = isWebBluetoothPairingError(err);
@@ -575,7 +575,7 @@ export class WebBluetoothManager {
             `[WebBluetooth:${this.sessionId}] fromRadio: notify unavailable (no CCCD); using read pump`,
           );
           void this.drainMeshtasticFromRadioReads();
-          if (service) await this.trySubscribeFromNum(service);
+          await this.trySubscribeFromNum(service);
           return;
         }
       }


### PR DESCRIPTION
## Problem

After the multi-shot probe fix (#431), ping/pong and bot commands work reliably. But messages from other nodes still don't arrive until the client sends something:

- Node A sends a message to Node B
- Nothing appears on Node B's client
- Node B sends anything — the queued messages from Node A all appear at once

## Root cause

The post-write safety reads only fire when the **client writes** something. Unsolicited incoming traffic (messages from other nodes) arrives in the `fromRadio` BLE characteristic and sits there with no scheduled probe — no read fires until the next write.

## Fix

Add `trySubscribeFromNum()`: subscribe to the Meshtastic `fromNum` GATT characteristic (`ed9da18c-a800-4f66-a670-aa7547e34453`).

The `fromNum` characteristic is designed exactly for this — its value increments whenever the radio queues a new packet in `fromRadio`. It reliably supports GATT notify even on BlueZ/Linux where `fromRadio`'s own CCCD may be absent. When the notification fires, drain `fromRadio` immediately.

This mirrors the existing `fromNum` subscription in `noble-ble-manager.ts` (macOS/Windows). Post-write safety reads from #431 remain active as a fallback.

Wire `trySubscribeFromNum()` into both the notify and read-pump paths at the end of `connect()`. Clean up in `disconnect()` (`stopNotifications`) and `cleanup()` (null fields).