### PR TITLE
fix: add 3-second background fromRadio poll to catch responses between write cycles

### DIFF
--- a/src/renderer/lib/webbluetooth-ble-manager.test.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.test.ts
@@ -15,7 +15,9 @@ interface ManagerTestHarness {
   meshtasticFromRadioReadPump: boolean;
   gattKeepaliveTimer: ReturnType<typeof setInterval> | null;
   fromNumNotifyHandler: (() => void) | null;
+  backgroundPollTimer: ReturnType<typeof setInterval> | null;
   trySubscribeFromNum(service: BluetoothRemoteGATTService): Promise<void>;
+  startBackgroundPoll(): void;
   writeToRadio(data: Uint8Array): Promise<void>;
   setLinkHealthyCallback(callback: (() => void) | null): void;
   startGattKeepalive(): void;
@@ -189,6 +191,30 @@ describe('WebBluetoothManager writeToRadio', () => {
 
     await vi.advanceTimersByTimeAsync(45_000);
     expect(fromRadio.readValue).toHaveBeenCalled();
+  });
+
+  describe('background poll', () => {
+    it('polls fromRadio at 3-second intervals to catch slow responses', async () => {
+      const { harness } = makeManager();
+      const fromRadio = mockFromRadioChar();
+      harness.fromRadioCharacteristic = fromRadio;
+      harness.device = { gatt: { connected: true } } as unknown as BluetoothDevice;
+
+      harness.startBackgroundPoll();
+      expect(harness.backgroundPollTimer).not.toBeNull();
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(fromRadio.readValue).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(fromRadio.readValue).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not start background poll for non-meshtastic sessions', () => {
+      const { harness } = makeManager('meshcore');
+      harness.startBackgroundPoll();
+      expect(harness.backgroundPollTimer).toBeNull();
+    });
   });
 
   describe('fromNum notify', () => {

--- a/src/renderer/lib/webbluetooth-ble-manager.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.ts
@@ -33,6 +33,12 @@ const GATT_READ_VALUE_TIMEOUT_MS = 10_000;
 /** Periodic GATT read on quiet notify links — below useDevice BLE_STALE_THRESHOLD_MS (90s). */
 const GATT_KEEPALIVE_INTERVAL_MS = 45_000;
 /**
+ * Background fromRadio poll interval — catches responses that arrive after the post-write
+ * safety-read window (8 s) when fromNum / fromRadio notify don't fire (BlueZ on Linux).
+ * Runs continuously on Meshtastic sessions regardless of notify state.
+ */
+const FROMRADIO_POLL_INTERVAL_MS = 3_000;
+/**
  * Meshtastic fromNum characteristic — value increments when a new packet is queued in fromRadio.
  * Subscribing to its NOTIFY fires a drain without waiting for the next client write.
  * Mirrors FROMNUM_UUID in `noble-ble-manager.ts`.
@@ -123,6 +129,7 @@ export class WebBluetoothManager {
   private postWriteSafetyReadTimers: ReturnType<typeof setTimeout>[] = [];
   private isReadPumpActive = false;
   private gattKeepaliveTimer: ReturnType<typeof setInterval> | null = null;
+  private backgroundPollTimer: ReturnType<typeof setInterval> | null = null;
   /** Invoked when a GATT read/write succeeds — refreshes connection watchdog on quiet meshes. */
   private onGattLinkHealthy: (() => void) | null = null;
 
@@ -420,6 +427,21 @@ export class WebBluetoothManager {
     }
   }
 
+  private startBackgroundPoll(): void {
+    if (this.sessionId !== 'meshtastic' || this.backgroundPollTimer !== null) return;
+    this.backgroundPollTimer = setInterval(() => {
+      if (!this.device?.gatt?.connected) return;
+      void this.drainFromRadioUnchecked();
+    }, FROMRADIO_POLL_INTERVAL_MS);
+  }
+
+  private stopBackgroundPoll(): void {
+    if (this.backgroundPollTimer !== null) {
+      clearInterval(this.backgroundPollTimer);
+      this.backgroundPollTimer = null;
+    }
+  }
+
   async connect(): Promise<void> {
     if (!this.device) {
       throw new Error('No device selected. Call requestDevice() first.');
@@ -555,6 +577,7 @@ export class WebBluetoothManager {
       console.debug(`[WebBluetooth:${this.sessionId}] notifications started`);
       this.startGattKeepalive();
       await this.trySubscribeFromNum(service);
+      this.startBackgroundPoll();
     } catch (err) {
       const domErr = err as DOMException;
       const isPairing = isWebBluetoothPairingError(err);
@@ -576,6 +599,7 @@ export class WebBluetoothManager {
           );
           void this.drainMeshtasticFromRadioReads();
           await this.trySubscribeFromNum(service);
+          this.startBackgroundPoll();
           return;
         }
       }
@@ -636,6 +660,7 @@ export class WebBluetoothManager {
     this.clearPostWriteSafetyReads();
     this.isReadPumpActive = false;
     this.stopGattKeepalive();
+    this.stopBackgroundPoll();
     this.onGattLinkHealthy = null;
     this._fromDeviceController = null;
     this.device = null;


### PR DESCRIPTION
## Problem

After the previous fixes, simple ping/pong and bot commands work, but responses from other nodes still get stuck for up to ~60 seconds:

- Send ping at 18:58:18 → no response appears
- Heartbeat fires at 18:58:49 → buffered response finally appears

Post-write safety reads cover up to 8s after each write. When fromNum and fromRadio GATT notify don't fire (BlueZ on Linux — a known issue where `startNotifications()` succeeds but events are never delivered), responses that arrive after that 8s window sit in `fromRadio` unread until the next client write.

## Fix

Add `FROMRADIO_POLL_INTERVAL_MS = 3_000` — a continuous `setInterval` that calls `drainFromRadioUnchecked()` every 3 seconds on Meshtastic sessions. Worst-case response latency for stuck packets drops from ~60s to ~3s.

- Runs regardless of notify state or read-pump mode (covers both paths)
- The existing `isReadPumpActive` guard prevents concurrent reads if a safety read or fromNum drain is already in progress
- Does not replace fromNum notify or post-write safety reads — those still fire when they work, this is the backstop
- No-op for MeshCore sessions (`sessionId !== 'meshtastic'` guard)