### PR TITLE
chore: harden Flatpak workflow (triggers, run-name, Node.js 24) and update README

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -17,7 +17,7 @@ jobs:
       options: --privileged
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate offline pnpm sources
         run: |

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -3,10 +3,7 @@ name: Build Flatpak
 on:
   workflow_dispatch:
   push:
-    branches: [main]
     tags: ['v*']
-  pull_request:
-    branches: [main]
 
 jobs:
   flatpak:

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -1,4 +1,5 @@
 name: Build Flatpak
+run-name: Build Flatpak${{ github.event_name == 'workflow_dispatch' && ' (no release)' || '' }}
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)
 [![CI Build](https://github.com/Colorado-Mesh/mesh-client/actions/workflows/ci.yaml/badge.svg)](https://github.com/Colorado-Mesh/mesh-client/actions/workflows/ci.yaml)
 [![Build/Release Electron App](https://github.com/Colorado-Mesh/mesh-client/actions/workflows/release.yaml/badge.svg?event=push)](https://github.com/Colorado-Mesh/mesh-client/actions/workflows/release.yaml?query=event%3Apush)
+[![Flatpak Build](https://github.com/Colorado-Mesh/mesh-client/actions/workflows/flatpak.yaml/badge.svg)](https://github.com/Colorado-Mesh/mesh-client/actions/workflows/flatpak.yaml)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/Colorado-Mesh/mesh-client)
 [![Publish Docs](https://github.com/Colorado-Mesh/mesh-client/actions/workflows/docs.yml/badge.svg)](https://github.com/Colorado-Mesh/mesh-client/actions/workflows/docs.yml)
 ![Discord](https://img.shields.io/discord/1436156966648152271?label=chat&logo=discord)
@@ -278,7 +279,7 @@ MeshCore runs simultaneously alongside Meshtastic. Use the protocol switcher pil
 
 ## Quick Start
 
-**Pre-built binaries** for **macOS**, **Linux**, and **Windows** are available in the [GitHub Releases](https://github.com/Colorado-Mesh/mesh-client/releases) area. Download the installer or archive for your platform; no Node.js or build tools required.
+**Pre-built binaries** for **macOS**, **Linux**, and **Windows** are available in the [GitHub Releases](https://github.com/Colorado-Mesh/mesh-client/releases) area. Download the installer or archive for your platform; no Node.js or build tools required. A **Flatpak** (`.flatpak`) is also published to GitHub Releases on each version tag for easy installation on any Flatpak-enabled Linux distribution.
 
 **macOS (release download):** If macOS reports **"Mesh-client" is damaged and can't be opened** (or **File is damaged and cannot be opened**):
 
@@ -386,7 +387,7 @@ Enter your broker URL, topic, and optional credentials in the MQTT section of th
 | Maps         | Leaflet + OpenStreetMap                                                                                                            |
 | Charts       | Recharts                                                                                                                           |
 | Database     | SQLite (node:sqlite built-in, via db-compat.ts shim)                                                                               |
-| Build        | esbuild + Vite + electron-builder                                                                                                  |
+| Build        | esbuild + Vite + electron-builder + Flatpak (freedesktop 24.08, Electron2 BaseApp)                                                 |
 
 ### Architecture
 


### PR DESCRIPTION
## Summary

Follows up on #434 (Flatpak build support) with workflow corrections and doc updates.

## Commits

- **docs: update README for Flatpak build support** — adds Flatpak workflow badge, mentions the `.flatpak` artifact in Quick Start, and lists Flatpak in the tech stack build row.

- **chore: restrict flatpak workflow to version tags and manual dispatch** — removes `push: branches: [main]` and `pull_request` triggers so the Flatpak build only runs on `v*` tags (automatic release) and `workflow_dispatch` (manual testing).

- **chore: suffix flatpak run name with (no release) on manual dispatch** — adds `run-name` with a conditional so manual runs appear as "Build Flatpak (no release)" in the Actions UI, making it clear no artifact will be published.

- **chore: upgrade flatpak workflow to actions/checkout@v6 (Node.js 24)** — flatpak-github-actions v6.7 (the already-pinned SHA) explicitly bumped to Node.js 24, removing the prior constraint. Upgrades our `actions/checkout@v4` to `@v6` to eliminate the Node.js 20 deprecation warning before the June 2, 2026 forced cutover.