### PR TITLE
chore: harden flatpak build pipeline and add validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,3 +46,15 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Check Flatpak
+        run: pnpm run check:flatpak
+
+      - name: Install Flatpak validation tools
+        run: sudo apt-get install -y desktop-file-utils appstream
+
+      - name: Validate desktop file
+        run: desktop-file-validate flatpak/org.coloradomesh.MeshClient.desktop
+
+      - name: Validate metainfo
+        run: appstreamcli validate --no-net flatpak/org.coloradomesh.MeshClient.metainfo.xml

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -7,8 +7,8 @@ on:
     tags: ['v*']
 
 jobs:
-  flatpak:
-    name: Flatpak
+  flatpak-x86_64:
+    name: Flatpak (x86_64)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,19 +22,47 @@ jobs:
       - name: Generate offline pnpm sources
         run: |
           pip3 install 'git+https://github.com/flatpak/flatpak-builder-tools#subdirectory=node'
-          flatpak-node-generator pnpm pnpm-lock.yaml -o flatpak/generated-sources.json
+          flatpak-node-generator pnpm pnpm-lock.yaml -a x86_64 -o flatpak/generated-sources.json
 
       # flatpak/flatpak-github-actions v6
       - uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb
         with:
-          bundle: org.coloradomesh.MeshClient.flatpak
+          bundle: org.coloradomesh.MeshClient-x86_64.flatpak
           manifest-path: org.coloradomesh.MeshClient.yml
-          cache-key: flatpak-builder-${{ github.sha }}
+          cache-key: flatpak-builder-x86_64-${{ github.sha }}
+          upload-artifact: true
+
+  flatpak-aarch64:
+    name: Flatpak (aarch64)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Generate offline pnpm sources
+        run: |
+          pip3 install 'git+https://github.com/flatpak/flatpak-builder-tools#subdirectory=node'
+          flatpak-node-generator pnpm pnpm-lock.yaml -a aarch64 -o flatpak/generated-sources.json
+
+      # flatpak/flatpak-github-actions v6
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb
+        with:
+          bundle: org.coloradomesh.MeshClient-aarch64.flatpak
+          manifest-path: org.coloradomesh.MeshClient.yml
+          arch: aarch64
+          cache-key: flatpak-builder-aarch64-${{ github.sha }}
           upload-artifact: true
 
   publish:
     name: Publish to GitHub Release
-    needs: flatpak
+    needs: [flatpak-x86_64, flatpak-aarch64]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
@@ -43,8 +71,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: org.coloradomesh.MeshClient
+          pattern: 'org.coloradomesh.MeshClient-*'
           path: flatpak-dist
+          merge-multiple: true
 
       - name: Attach Flatpak to release
         # softprops/action-gh-release v2

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Generate offline pnpm sources
         run: |
-          pip3 install 'git+https://github.com/flatpak/flatpak-builder-tools#subdirectory=node'
+          FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools
+          pip3 install "${FBTOOLS}@6f3f08759ac9859492b728f57f5163bf584c47ff#subdirectory=node"
           flatpak-node-generator pnpm pnpm-lock.yaml -a x86_64 -o flatpak/generated-sources.json
 
       # flatpak/flatpak-github-actions v6
@@ -48,7 +49,8 @@ jobs:
 
       - name: Generate offline pnpm sources
         run: |
-          pip3 install 'git+https://github.com/flatpak/flatpak-builder-tools#subdirectory=node'
+          FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools
+          pip3 install "${FBTOOLS}@6f3f08759ac9859492b728f57f5163bf584c47ff#subdirectory=node"
           flatpak-node-generator pnpm pnpm-lock.yaml -a aarch64 -o flatpak/generated-sources.json
 
       # flatpak/flatpak-github-actions v6

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -43,7 +43,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        # v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
         with:
           platforms: arm64
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules/
 release/
 test-results/
 .context-os
+flatpak/generated-sources.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Adding a cross-boundary feature:
 4. `pnpm run i18n:auto-translate`: fills missing translation keys; re-stages `src/renderer/locales/`
 5. `pnpm run lint`
 6. `pnpm run typecheck`
-7. `check:log-injection`, `check:log-service-sinks`, `check:codeql-extensions`, `check:db-migrations`, `check:ipc-contract`, `check:i18n`, `check:licenses`, `check:url-hostname-sanitization`
+7. `check:log-injection`, `check:log-service-sinks`, `check:codeql-extensions`, `check:db-migrations`, `check:ipc-contract`, `check:i18n`, `check:licenses`, `check:url-hostname-sanitization`, `check:flatpak`
 8. `pnpm audit`
 9. `actionlint`, `yamllint`
 10. `pnpm run test:run`

--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -38,7 +38,7 @@ modules:
         npm_config_cache: /run/build/mesh-client/.npm
     build-commands:
       # Install pnpm standalone binary (no network needed)
-      - install -Dm755 pnpm-linux-x64 /run/build/mesh-client/.pnpm-bin/pnpm
+      - install -Dm755 pnpm-standalone /run/build/mesh-client/.pnpm-bin/pnpm
       # Offline install using generated-sources.json.
       # --store-dir must use the sandbox-absolute path because the type:shell
       # source that writes .npmrc runs outside the sandbox, so $PWD there is
@@ -76,4 +76,10 @@ modules:
       - type: file
         url: https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-x64
         sha256: 39d7b6600239712bc9581ea219b17ffef46ba60998779cb717be2e068be029ef
-        dest-filename: pnpm-linux-x64
+        dest-filename: pnpm-standalone
+        only-arches: [x86_64]
+      - type: file
+        url: https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-arm64
+        sha256: 0828e5ee23be89d22bd53cc36e93c181ce9d5c47d75f9fe9bf4bdc7a65c66322
+        dest-filename: pnpm-standalone
+        only-arches: [aarch64]

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 
 const METAINFO = path.join(ROOT, 'flatpak', 'org.coloradomesh.MeshClient.metainfo.xml');
+const DESKTOP = path.join(ROOT, 'flatpak', 'org.coloradomesh.MeshClient.desktop');
 const MANIFEST = path.join(ROOT, 'org.coloradomesh.MeshClient.yml');
 const PKG = path.join(ROOT, 'package.json');
 const EXPECTED_APP_ID = 'org.coloradomesh.MeshClient';
@@ -78,11 +79,34 @@ function checkManifestAppId() {
   return violations;
 }
 
+function checkDesktopStartupWMClass() {
+  const violations = [];
+  if (!fs.existsSync(DESKTOP) || !fs.existsSync(PKG)) return violations;
+
+  const pkgName = JSON.parse(fs.readFileSync(PKG, 'utf8')).name;
+  const desktop = fs.readFileSync(DESKTOP, 'utf8');
+  const rel = path.relative(ROOT, DESKTOP);
+
+  const m = desktop.match(/^StartupWMClass=(.+)$/m);
+  if (!m) {
+    violations.push({ file: rel, message: 'missing StartupWMClass entry' });
+    return violations;
+  }
+  if (m[1].trim() !== pkgName) {
+    violations.push({
+      file: rel,
+      message: `StartupWMClass is "${m[1].trim()}", expected "${pkgName}" (package.json name — the WM_CLASS Electron emits under Flatpak/zypak)`,
+    });
+  }
+  return violations;
+}
+
 function main() {
   const violations = [
     ...checkMetainfoVersionMatchesPackage(),
     ...checkMetainfoAppId(),
     ...checkManifestAppId(),
+    ...checkDesktopStartupWMClass(),
   ];
 
   if (violations.length === 0) {


### PR DESCRIPTION
## Summary

Two commits on this branch:

### feat: add aarch64 flatpak build and arch-suffixed bundles
- Added a second CI job to build the Flatpak for `aarch64` in parallel with `x86_64`
- Output bundles are suffixed by arch (`org.coloradomesh.MeshClient-x86_64.flatpak`, `org.coloradomesh.MeshClient-aarch64.flatpak`)
- Updated the manifest to support both architectures

### chore: harden flatpak build pipeline and add validation
- **Supply chain:** Pin `flatpak-node-generator` to a specific commit SHA in both flatpak CI jobs (was installed from unpinned git HEAD)
- **CI enforcement:** Add `check:flatpak`, `desktop-file-validate`, and `appstreamcli validate` steps to `ci.yaml` — these now run on every PR, not just via the pre-commit hook
- **Drift detection:** Add `checkDesktopStartupWMClass()` to `check-flatpak.mjs` to catch future `StartupWMClass` mismatches in the Flatpak `.desktop` file
- **Gitignore:** Add `flatpak/generated-sources.json` (CI-generated, should never be committed)
- **Docs:** Add `check:flatpak` to the pre-commit hook order in `AGENTS.md`