### PR TITLE
fix: install flatpak-builder on aarch64 Flatpak CI job

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -48,6 +48,9 @@ jobs:
         with:
           platforms: arm64
 
+      - name: Install flatpak and flatpak-builder
+        run: sudo apt-get update && sudo apt-get install -y flatpak flatpak-builder
+
       - name: Generate offline pnpm sources
         run: |
           FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4840,7 +4840,7 @@ snapshots:
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4856,7 +4856,7 @@ snapshots:
       node-gyp: 11.5.0
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.7.4
+      semver: 7.8.0
       tar: 7.5.15
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -4870,7 +4870,7 @@ snapshots:
       dir-compare: 4.2.0
       fs-extra: 11.3.5
       minimatch: 9.0.9
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5165,7 +5165,7 @@ snapshots:
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   '@oxc-project/types@0.132.0': {}
 
@@ -5250,7 +5250,7 @@ snapshots:
   '@serialport/binding-mock@10.2.2':
     dependencies:
       '@serialport/bindings-interface': 1.2.2
-      debug: 4.4.0
+      debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
     transitivePeerDependencies:
       - supports-color
 
@@ -5769,8 +5769,7 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xmldom/xmldom@0.9.10':
-    optional: true
+  '@xmldom/xmldom@0.9.10': {}
 
   '@yarnpkg/lockfile@1.1.0': {}
 
@@ -8044,7 +8043,7 @@ snapshots:
 
   node-abi@4.31.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   node-addon-api@1.7.2:
     optional: true
@@ -8058,7 +8057,7 @@ snapshots:
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   node-exports-info@1.6.0:
     dependencies:
@@ -8082,7 +8081,7 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.0
       tar: 7.5.15
       tinyglobby: 0.2.16
       which: 5.0.0
@@ -8291,7 +8290,6 @@ snapshots:
       '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-    optional: true
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- Install `flatpak` and `flatpak-builder` on the aarch64 Flatpak workflow job before running `flatpak-node-generator`. The x86_64 job already gets these tools from the Flathub `flatpak-github-actions` container; the aarch64 job runs on a plain Ubuntu runner with QEMU and was missing them.
- Refresh `pnpm-lock.yaml` snapshot entries (plist, semver, debug, xmldom optional metadata) from a lockfile reconcile.

## Commits

- `757f076a` fix: install flatpak-builder on aarch64 runner before build action

## Test plan

- [ ] Trigger `Build Flatpak` workflow (workflow_dispatch) and confirm aarch64 job passes the "Generate offline pnpm sources" step
- [ ] Confirm x86_64 job is unchanged (still uses container image with flatpak tooling preinstalled)