### PR TITLE
fix: add Flathub system remote for aarch64 Flatpak CI

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -51,6 +51,13 @@ jobs:
       - name: Install flatpak and flatpak-builder
         run: sudo apt-get update && sudo apt-get install -y flatpak flatpak-builder
 
+      # flatpak-github-actions only runs remote-add when repository-url is non-default;
+      # the x86_64 job's container image already has flathub configured.
+      - name: Add Flathub remote (system)
+        run: |
+          sudo flatpak remote-add --if-not-exists --system flathub \
+            https://flathub.org/repo/flathub.flatpakrepo
+
       - name: Generate offline pnpm sources
         run: |
           FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools


### PR DESCRIPTION
## Summary

- Fixes **Flatpak (aarch64)** CI failure (`No remote refs found for 'flathub'`) from [run #26255178165](https://github.com/Colorado-Mesh/mesh-client/actions/runs/26255178165/job/77276023417).
- Registers the Flathub **system** remote on the bare Ubuntu aarch64 job before `flatpak-builder` runs.
- The x86_64 job uses `ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08`, which already has flathub configured; `flatpak-github-actions` only runs `remote-add` when `repository-url` is non-default, so the aarch64 path (apt-installed flatpak on the host) never got a remote.

## Commits

- `fa1b590e` fix: add Flathub system remote for aarch64 Flatpak CI

## Test plan

- [ ] Re-run **Build Flatpak** workflow (`workflow_dispatch`) and confirm **Flatpak (aarch64)** passes SDK install and completes the build.
- [ ] Confirm **Flatpak (x86_64)** still succeeds (unchanged job).