### PR TITLE
fix: unify Flatpak CI on privileged container and ARM runners

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -7,11 +7,25 @@ on:
     tags: ['v*']
 
 jobs:
-  flatpak-x86_64:
-    name: Flatpak (x86_64)
-    runs-on: ubuntu-latest
+  # Both arches use the flathub-infra container (Flathub remote, flatpak-builder, privileged
+  # system installs). aarch64 uses GitHub's native ARM runners — do not build on bare
+  # ubuntu-latest with apt flatpak; that lacks --privileged and fails with
+  # "Flatpak system operation Deploy not allowed for user".
+  flatpak:
+    name: Flatpak (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+            bundle: org.coloradomesh.MeshClient-x86_64.flatpak
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            bundle: org.coloradomesh.MeshClient-aarch64.flatpak
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
       options: --privileged
@@ -28,54 +42,15 @@ jobs:
       # flatpak/flatpak-github-actions v6
       - uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb
         with:
-          bundle: org.coloradomesh.MeshClient-x86_64.flatpak
+          bundle: ${{ matrix.bundle }}
           manifest-path: org.coloradomesh.MeshClient.yml
-          cache-key: flatpak-builder-x86_64-${{ github.sha }}
-          upload-artifact: true
-
-  flatpak-aarch64:
-    name: Flatpak (aarch64)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        # v3
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
-        with:
-          platforms: arm64
-
-      - name: Install flatpak and flatpak-builder
-        run: sudo apt-get update && sudo apt-get install -y flatpak flatpak-builder
-
-      # flatpak-github-actions only runs remote-add when repository-url is non-default;
-      # the x86_64 job's container image already has flathub configured.
-      - name: Add Flathub remote (system)
-        run: |
-          sudo flatpak remote-add --if-not-exists --system flathub \
-            https://flathub.org/repo/flathub.flatpakrepo
-
-      - name: Generate offline pnpm sources
-        run: |
-          FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools
-          pip3 install "${FBTOOLS}@6f3f08759ac9859492b728f57f5163bf584c47ff#subdirectory=node"
-          flatpak-node-generator pnpm pnpm-lock.yaml -o flatpak/generated-sources.json
-
-      # flatpak/flatpak-github-actions v6
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb
-        with:
-          bundle: org.coloradomesh.MeshClient-aarch64.flatpak
-          manifest-path: org.coloradomesh.MeshClient.yml
-          arch: aarch64
-          cache-key: flatpak-builder-aarch64-${{ github.sha }}
+          arch: ${{ matrix.arch }}
+          cache-key: flatpak-builder-${{ matrix.arch }}-${{ github.sha }}
           upload-artifact: true
 
   publish:
     name: Publish to GitHub Release
-    needs: [flatpak-x86_64, flatpak-aarch64]
+    needs: flatpak
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -66,18 +66,17 @@ See [Release Process](release-process.md) for the maintainer workflow.
 
 ## Flatpak (`flatpak.yaml`)
 
-Builds a Flatpak bundle using [`flatpak/flatpak-github-actions`](https://github.com/flatpak/flatpak-github-actions).
+Builds Flatpak bundles using [`flatpak/flatpak-github-actions`](https://github.com/flatpak/flatpak-github-actions).
 
-**Triggers:** push or PR to `main`, all version tags (`v*`), and manual `workflow_dispatch`.
+**Triggers:** version tags (`v*`) and manual `workflow_dispatch`.
 
-The job runs inside a privileged `ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08` container, which provides the Freedesktop 24.08 SDK and can fetch Flathub runtimes:
+A matrix builds **x86_64** and **aarch64** in parallel. Both use the same privileged `ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08` container (Flathub remote, `flatpak-builder`, and system-scope runtime installs). **x86_64** runs on `ubuntu-latest`; **aarch64** runs on `ubuntu-24.04-arm` (native ARM runners — not QEMU on bare Ubuntu).
 
-1. Reads `org.coloradomesh.MeshClient.yml` as the manifest
-2. Installs runtimes (`org.freedesktop.Platform//24.08`, `org.electronjs.Electron2.BaseApp//24.08`, `org.freedesktop.Sdk.Extension.node22//24.08`)
-3. Builds the app offline using `flatpak/generated-sources.json` for pnpm dependencies
-4. Uploads `org.coloradomesh.MeshClient.flatpak` as a workflow artifact
+1. Generates `flatpak/generated-sources.json` via `flatpak-node-generator`
+2. Builds from `org.coloradomesh.MeshClient.yml` with offline pnpm sources
+3. Uploads `org.coloradomesh.MeshClient-{x86_64,aarch64}.flatpak` artifacts
 
-On **version tag pushes**, a second `publish` job downloads the artifact and attaches it to the GitHub Release alongside the AppImage/deb/rpm.
+On **version tag pushes**, a `publish` job attaches both bundles to the GitHub Release. aarch64 is the primary ARM Linux install path (release `build.yaml` only produces x86_64 AppImage/deb/rpm).
 
 `flatpak/generated-sources.json` is generated automatically in CI by `flatpak-node-generator` before each build — it does not need to be committed to the repo. For local builds, generate it manually; see [development-environment.md](development-environment.md) for steps. If submitting to Flathub's dedicated submission repo, the file must be committed there.
 


### PR DESCRIPTION
## Summary

Fixes recurring **Flatpak (aarch64)** failures ([run #26255960862](https://github.com/Colorado-Mesh/mesh-client/actions/runs/26255960862/job/77278574839)) by aligning aarch64 with the proven x86_64 build path instead of patching a one-off host setup.

**Root cause chain (failure-by-failure):**
1. Missing `flatpak-builder` on bare Ubuntu → apt install (#438)
2. Missing Flathub remote on bare Ubuntu → manual `remote-add` (#439)
3. **`Flatpak system operation Deploy not allowed for user`** — `flatpak-builder` uses `--system install`, which requires a **privileged** environment. The x86_64 job had this via `flathub-infra` container + `--privileged`; aarch64 did not.

**Fix:** Single matrix job — both arches use `ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08` with `--privileged`. aarch64 runs on **`ubuntu-24.04-arm`** (native ARM, no QEMU hackery), per [flatpak-github-actions multi-arch docs](https://github.com/flatpak/flatpak-github-actions#building-for-multiple-cpu-architectures).

## Is aarch64 worth it?

**Yes.** Release `build.yaml` only ships x86_64 AppImage/deb/rpm. The aarch64 Flatpak is the main ARM Linux distribution path for this project. The build is maintainable once it uses the same container pattern as x86_64.

## Test plan

- [ ] Re-run **Build Flatpak** (`workflow_dispatch`) — both **Flatpak (x86_64)** and **Flatpak (aarch64)** should pass SDK install and complete builds.
- [ ] On tag push, `publish` attaches both `org.coloradomesh.MeshClient-{x86_64,aarch64}.flatpak` to the release.