### PR TITLE
fix: bundle Electron binary and correct Flatpak launch paths

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -45,6 +45,7 @@ jobs:
           bundle: ${{ matrix.bundle }}
           manifest-path: org.coloradomesh.MeshClient.yml
           arch: ${{ matrix.arch }}
+          branch: stable
           cache-key: flatpak-builder-${{ matrix.arch }}-${{ github.sha }}
           upload-artifact: true
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -182,7 +182,17 @@ flatpak run org.coloradomesh.MeshClient
 ```bash
 flatpak build-bundle ~/.local/share/flatpak/repo \
   org.coloradomesh.MeshClient.flatpak \
-  org.coloradomesh.MeshClient
+  org.coloradomesh.MeshClient stable
+```
+
+Installing a `.flatpak` file creates a one-off remote named like `meshclient-origin` (not `flathub`); that is expected. The ref branch is `stable` (release CI sets this; older artifacts used `master`). Version is shown in MetaInfo / `flatpak info`, not in the remote name.
+
+**Reinstall after downloading a new bundle**
+
+```bash
+flatpak uninstall --user org.coloradomesh.MeshClient
+flatpak install --user ./org.coloradomesh.MeshClient-aarch64.flatpak
+flatpak run org.coloradomesh.MeshClient
 ```
 
 **Lint the manifest** before submitting to Flathub:

--- a/flatpak/mesh-client-wrapper.sh
+++ b/flatpak/mesh-client-wrapper.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-exec zypak-wrapper /app/electron/electron /app/lib/mesh-client/dist-electron/main.js "$@"
+# Electron2 BaseApp provides zypak-wrapper; Chromium binary comes from node_modules/electron.
+export TMPDIR="${XDG_RUNTIME_DIR:-/tmp}/app/${FLATPAK_ID:-org.coloradomesh.MeshClient}"
+cd /app/lib/mesh-client || exit 1
+exec zypak-wrapper /app/lib/mesh-client/electron/electron /app/lib/mesh-client/dist-electron/main/index.js "$@"

--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -1,4 +1,5 @@
 app-id: org.coloradomesh.MeshClient
+branch: stable
 runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
@@ -50,9 +51,11 @@ modules:
       - pnpm run build
       # Rebuild native addons (noble BLE, sqlite) against the bundled Electron ABI
       - pnpm run rebuild
-      # Install app payload
+      # Install app payload (Electron binary + app roots; zypak needs a real Chromium binary)
       - install -dm755 /app/lib/mesh-client
-      - cp -r dist dist-electron node_modules /app/lib/mesh-client/
+      - install -Dm644 package.json /app/lib/mesh-client/package.json
+      - cp -a node_modules/electron/dist /app/lib/mesh-client/electron
+      - cp -a dist dist-electron node_modules resources /app/lib/mesh-client/
       # Wrapper script
       - install -Dm755 flatpak/mesh-client-wrapper.sh /app/bin/mesh-client
       # Icons

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -9,8 +9,11 @@ const ROOT = path.resolve(__dirname, '..');
 const METAINFO = path.join(ROOT, 'flatpak', 'org.coloradomesh.MeshClient.metainfo.xml');
 const DESKTOP = path.join(ROOT, 'flatpak', 'org.coloradomesh.MeshClient.desktop');
 const MANIFEST = path.join(ROOT, 'org.coloradomesh.MeshClient.yml');
+const WRAPPER = path.join(ROOT, 'flatpak', 'mesh-client-wrapper.sh');
 const PKG = path.join(ROOT, 'package.json');
 const EXPECTED_APP_ID = 'org.coloradomesh.MeshClient';
+const EXPECTED_MAIN = 'dist-electron/main/index.js';
+const EXPECTED_ELECTRON = '/app/lib/mesh-client/electron/electron';
 
 function checkMetainfoVersionMatchesPackage() {
   const violations = [];
@@ -79,6 +82,79 @@ function checkManifestAppId() {
   return violations;
 }
 
+function checkManifestBranchAndElectronPayload() {
+  const violations = [];
+  if (!fs.existsSync(MANIFEST)) return violations;
+
+  const yaml = fs.readFileSync(MANIFEST, 'utf8');
+  const rel = path.relative(ROOT, MANIFEST);
+
+  if (!/^branch:\s*stable\s*$/m.test(yaml)) {
+    violations.push({
+      file: rel,
+      message: 'expected branch: stable (CI bundles should not publish master refs)',
+    });
+  }
+
+  if (!yaml.includes('node_modules/electron/dist /app/lib/mesh-client/electron')) {
+    violations.push({
+      file: rel,
+      message: 'manifest must copy node_modules/electron/dist into the app (zypak needs Chromium)',
+    });
+  }
+
+  if (!yaml.includes('resources /app/lib/mesh-client/')) {
+    violations.push({
+      file: rel,
+      message: 'manifest must install resources/ for runtime icon paths',
+    });
+  }
+
+  return violations;
+}
+
+function checkWrapperLaunchPaths() {
+  const violations = [];
+  if (!fs.existsSync(WRAPPER)) {
+    violations.push({ file: path.relative(ROOT, WRAPPER), message: 'wrapper script missing' });
+    return violations;
+  }
+
+  const sh = fs.readFileSync(WRAPPER, 'utf8');
+  const rel = path.relative(ROOT, WRAPPER);
+
+  if (!sh.includes(EXPECTED_MAIN)) {
+    violations.push({
+      file: rel,
+      message: `wrapper must launch ${EXPECTED_MAIN} (package.json "main")`,
+    });
+  }
+
+  if (!sh.includes(EXPECTED_ELECTRON)) {
+    violations.push({
+      file: rel,
+      message: `wrapper must invoke bundled Chromium at ${EXPECTED_ELECTRON}`,
+    });
+  }
+
+  if (sh.includes('dist-electron/main.js')) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must not reference dist-electron/main.js (file does not exist)',
+    });
+  }
+
+  if (sh.includes('/app/electron/electron')) {
+    violations.push({
+      file: rel,
+      message:
+        'wrapper must not reference /app/electron/electron (Electron is under lib/mesh-client)',
+    });
+  }
+
+  return violations;
+}
+
 function checkDesktopStartupWMClass() {
   const violations = [];
   if (!fs.existsSync(DESKTOP) || !fs.existsSync(PKG)) return violations;
@@ -106,6 +182,8 @@ function main() {
     ...checkMetainfoVersionMatchesPackage(),
     ...checkMetainfoAppId(),
     ...checkManifestAppId(),
+    ...checkManifestBranchAndElectronPayload(),
+    ...checkWrapperLaunchPaths(),
     ...checkDesktopStartupWMClass(),
   ];
 


### PR DESCRIPTION
## Summary

Fixes Flatpak installs that list `master` / `meshclient-origin` but fail at runtime with zypak errors (`/app/electron/electron` not found, `dist-electron/main.js` missing).

**Runtime root cause:** The manifest never copied the Electron Chromium binary from `node_modules/electron/dist`, and the wrapper pointed at wrong paths (`/app/electron/electron`, `main.js` instead of `main/index.js`).

**Changes:**
- Bundle `node_modules/electron/dist` → `/app/lib/mesh-client/electron/`
- Copy `package.json` and `resources/` for runtime paths used by main process
- Fix `mesh-client-wrapper.sh` to call zypak on the real binary + correct main entry
- Build/publish on branch `stable` (manifest + CI) instead of `master`
- `check:flatpak` guards for these invariants
- Docs: explain `meshclient-origin` remote (normal for `.flatpak` file installs) and reinstall steps

## User reinstall (after new CI artifact)

```bash
flatpak uninstall --user org.coloradomesh.MeshClient
flatpak install --user ./org.coloradomesh.MeshClient-aarch64.flatpak
flatpak run org.coloradomesh.MeshClient
```

`flatpak list` should show branch **stable** (not `master`). Version comes from `flatpak info`, not the remote name.

## Test plan

- [ ] CI **Build Flatpak** produces new aarch64/x86_64 artifacts
- [ ] Install bundle on ARM64 Ubuntu, `flatpak run org.coloradomesh.MeshClient` starts without zypak-helper errors
- [ ] `pnpm run check:flatpak` passes