### PR TITLE
fix: vendor Electron release archives for offline Flatpak builds

### DIFF
--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -54,7 +54,8 @@ modules:
       # Install app payload (Electron binary + app roots; zypak needs a real Chromium binary)
       - install -dm755 /app/lib/mesh-client
       - install -Dm644 package.json /app/lib/mesh-client/package.json
-      - cp -a node_modules/electron/dist /app/lib/mesh-client/electron
+      # pnpm --ignore-scripts skips electron's postinstall; unpack vendored release zips instead
+      - cp -a electron-prebuilt /app/lib/mesh-client/electron
       - cp -a dist dist-electron node_modules resources /app/lib/mesh-client/
       # Wrapper script
       - install -Dm755 flatpak/mesh-client-wrapper.sh /app/bin/mesh-client
@@ -85,4 +86,14 @@ modules:
         url: https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-arm64
         sha256: 0828e5ee23be89d22bd53cc36e93c181ce9d5c47d75f9fe9bf4bdc7a65c66322
         dest-filename: pnpm-standalone
+        only-arches: [aarch64]
+      - type: archive
+        url: https://github.com/electron/electron/releases/download/v41.7.0/electron-v41.7.0-linux-x64.zip
+        sha256: f3bf38de05ce8fafe1039251ebfaa75fd090b0a13cd861322ccd2f6db4d6bb82
+        dest: electron-prebuilt
+        only-arches: [x86_64]
+      - type: archive
+        url: https://github.com/electron/electron/releases/download/v41.7.0/electron-v41.7.0-linux-arm64.zip
+        sha256: c8d4294e052bc83b840523237538ae131d8e387243c25e763f0d14fabffa37c2
+        dest: electron-prebuilt
         only-arches: [aarch64]

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -82,12 +82,22 @@ function checkManifestAppId() {
   return violations;
 }
 
+function electronVersionFromPackage() {
+  if (!fs.existsSync(PKG)) return null;
+  const pkg = JSON.parse(fs.readFileSync(PKG, 'utf8'));
+  const spec = pkg.devDependencies?.electron ?? pkg.dependencies?.electron;
+  if (typeof spec !== 'string') return null;
+  const m = spec.match(/(\d+\.\d+\.\d+)/);
+  return m?.[1] ?? null;
+}
+
 function checkManifestBranchAndElectronPayload() {
   const violations = [];
   if (!fs.existsSync(MANIFEST)) return violations;
 
   const yaml = fs.readFileSync(MANIFEST, 'utf8');
   const rel = path.relative(ROOT, MANIFEST);
+  const electronVersion = electronVersionFromPackage();
 
   if (!/^branch:\s*stable\s*$/m.test(yaml)) {
     violations.push({
@@ -96,11 +106,31 @@ function checkManifestBranchAndElectronPayload() {
     });
   }
 
-  if (!yaml.includes('node_modules/electron/dist /app/lib/mesh-client/electron')) {
+  if (!yaml.includes('electron-prebuilt /app/lib/mesh-client/electron')) {
     violations.push({
       file: rel,
-      message: 'manifest must copy node_modules/electron/dist into the app (zypak needs Chromium)',
+      message: 'manifest must install electron-prebuilt into the app (zypak needs Chromium)',
     });
+  }
+
+  if (electronVersion) {
+    const escaped = electronVersion.replace(/\./g, '\\.');
+    const urlPattern = new RegExp(`electron/electron/releases/download/v${escaped}/`);
+    if (!urlPattern.test(yaml)) {
+      violations.push({
+        file: rel,
+        message: `manifest electron archive URLs must match package.json electron version ${electronVersion}`,
+      });
+    }
+    if (
+      !yaml.includes(`electron-v${electronVersion}-linux-x64.zip`) ||
+      !yaml.includes(`electron-v${electronVersion}-linux-arm64.zip`)
+    ) {
+      violations.push({
+        file: rel,
+        message: `manifest must vendor electron-v${electronVersion}-linux-{x64,arm64}.zip (offline; pnpm --ignore-scripts)`,
+      });
+    }
   }
 
   if (!yaml.includes('resources /app/lib/mesh-client/')) {

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -114,9 +114,8 @@ function checkManifestBranchAndElectronPayload() {
   }
 
   if (electronVersion) {
-    const escaped = electronVersion.replace(/\./g, '\\.');
-    const urlPattern = new RegExp(`electron/electron/releases/download/v${escaped}/`);
-    if (!urlPattern.test(yaml)) {
+    const releaseUrlPrefix = `electron/electron/releases/download/v${electronVersion}/`;
+    if (!yaml.includes(releaseUrlPrefix)) {
       violations.push({
         file: rel,
         message: `manifest electron archive URLs must match package.json electron version ${electronVersion}`,

--- a/src/renderer/hooks/useMeshCore.import-contacts.test.tsx
+++ b/src/renderer/hooks/useMeshCore.import-contacts.test.tsx
@@ -93,49 +93,55 @@ describe('useMeshCore importContacts', () => {
   });
 
   it('preserves last_heard on re-import when the node already exists (no stale nodesRef)', async () => {
-    vi.mocked(window.electronAPI.meshcore.openJsonFile).mockResolvedValue(
-      JSON.stringify([
-        {
-          name: 'First name',
-          public_key: HEX32,
-          latitude: 40,
-          longitude: -74,
-        },
-      ]),
-    );
+    const importMs = new Date('2026-05-20T12:00:00Z').getTime();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(importMs);
+    try {
+      vi.mocked(window.electronAPI.meshcore.openJsonFile).mockResolvedValue(
+        JSON.stringify([
+          {
+            name: 'First name',
+            public_key: HEX32,
+            latitude: 40,
+            longitude: -74,
+          },
+        ]),
+      );
 
-    const { result } = renderHook(() => useMeshCore());
+      const { result } = renderHook(() => useMeshCore());
 
-    await act(async () => {
-      await result.current.importContacts();
-    });
+      await act(async () => {
+        await result.current.importContacts();
+      });
 
-    const firstHeard = result.current.nodes.get(IMPORT_NODE_ID)?.last_heard;
-    expect(firstHeard).toBeDefined();
-    expect(firstHeard).toBeGreaterThan(1_000_000_000);
+      const firstHeard = result.current.nodes.get(IMPORT_NODE_ID)?.last_heard;
+      expect(firstHeard).toBeDefined();
+      expect(firstHeard).toBeGreaterThan(1_000_000_000);
 
-    vi.mocked(window.electronAPI.meshcore.openJsonFile).mockResolvedValue(
-      JSON.stringify([
-        {
-          name: 'Second name',
-          public_key: HEX32,
-        },
-      ]),
-    );
-    vi.mocked(window.electronAPI.db.saveMeshcoreContact).mockClear();
+      vi.mocked(window.electronAPI.meshcore.openJsonFile).mockResolvedValue(
+        JSON.stringify([
+          {
+            name: 'Second name',
+            public_key: HEX32,
+          },
+        ]),
+      );
+      vi.mocked(window.electronAPI.db.saveMeshcoreContact).mockClear();
 
-    await act(async () => {
-      await result.current.importContacts();
-    });
+      await act(async () => {
+        await result.current.importContacts();
+      });
 
-    expect(result.current.nodes.get(IMPORT_NODE_ID)?.long_name).toBe('Second name');
-    expect(result.current.nodes.get(IMPORT_NODE_ID)?.last_heard).toBe(firstHeard);
+      expect(result.current.nodes.get(IMPORT_NODE_ID)?.long_name).toBe('Second name');
+      expect(result.current.nodes.get(IMPORT_NODE_ID)?.last_heard).toBe(firstHeard);
 
-    await waitFor(() => {
-      expect(window.electronAPI.db.saveMeshcoreContact).toHaveBeenCalled();
-    });
+      await waitFor(() => {
+        expect(window.electronAPI.db.saveMeshcoreContact).toHaveBeenCalled();
+      });
 
-    const call = vi.mocked(window.electronAPI.db.saveMeshcoreContact).mock.calls[0][0];
-    expect(call.last_advert).toBe(firstHeard);
+      const call = vi.mocked(window.electronAPI.db.saveMeshcoreContact).mock.calls[0][0];
+      expect(call.last_advert).toBe(firstHeard);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes both **Flatpak (x86_64)** and **Flatpak (aarch64)** CI failures from [run #26259422863](https://github.com/Colorado-Mesh/mesh-client/actions/runs/26259422863/job/77289395308):

```
cp: cannot stat 'node_modules/electron/dist': No such file or directory
```

`pnpm install --ignore-scripts` (required for offline Flatpak builds) skips Electron's postinstall, so `node_modules/electron/dist` is never created. PR #441 tried to copy that path at install time.

**Fix:** Vendor `electron-v41.7.0-linux-{x64,arm64}.zip` as `type: archive` sources (checksums from `node_modules/electron/checksums.json`) and copy `electron-prebuilt` into `/app/lib/mesh-client/electron`.

## Test plan

- [ ] **Build Flatpak** workflow passes for both matrix arches
- [ ] `pnpm run check:flatpak` passes
- [ ] Install new `.flatpak` on ARM64 Ubuntu; `flatpak run org.coloradomesh.MeshClient` starts without zypak errors