### PR TITLE
fix: disable GPU on Flatpak when vmwgfx DRI is missing

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -195,6 +195,8 @@ flatpak install --user ./org.coloradomesh.MeshClient-aarch64.flatpak
 flatpak run org.coloradomesh.MeshClient
 ```
 
+**VMware / `vmwgfx: driver missing`:** On VMware guests the Flatpak wrapper auto-sets `MESH_CLIENT_DISABLE_GPU=1` when the `vmwgfx` DRM driver is present (avoids GPU-process crashes). To force hardware acceleration anyway: `MESH_CLIENT_ENABLE_GPU=1 flatpak run org.coloradomesh.MeshClient`. To always disable GPU on other stacks: `MESH_CLIENT_DISABLE_GPU=1 flatpak run ...`.
+
 **Lint the manifest** before submitting to Flathub:
 
 ```bash

--- a/flatpak/mesh-client-wrapper.sh
+++ b/flatpak/mesh-client-wrapper.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 # Electron2 BaseApp provides zypak-wrapper; Chromium binary comes from node_modules/electron.
 export TMPDIR="${XDG_RUNTIME_DIR:-/tmp}/app/${FLATPAK_ID:-org.coloradomesh.MeshClient}"
+
+# VMware vmwgfx: Mesa often has no working DRI driver in the Flatpak sandbox (vmwgfx: driver missing),
+# which can SIGSEGV the GPU process. index.ts calls app.disableHardwareAcceleration() when set.
+if [ "${MESH_CLIENT_ENABLE_GPU:-}" != "1" ] && [ "${MESH_CLIENT_DISABLE_GPU:-}" != "0" ]; then
+  case "${MESH_CLIENT_DISABLE_GPU:-}" in
+    1) ;;
+    *)
+      if grep -rq 'DRIVER=vmwgfx' /sys/class/drm/card*/device/uevent 2> /dev/null; then
+        export MESH_CLIENT_DISABLE_GPU=1
+      fi
+      ;;
+  esac
+fi
+
 cd /app/lib/mesh-client || exit 1
 exec zypak-wrapper /app/lib/mesh-client/electron/electron /app/lib/mesh-client/dist-electron/main/index.js "$@"

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -181,6 +181,28 @@ function checkWrapperLaunchPaths() {
     });
   }
 
+  if (!sh.includes('MESH_CLIENT_DISABLE_GPU')) {
+    violations.push({
+      file: rel,
+      message:
+        'wrapper must set MESH_CLIENT_DISABLE_GPU for vmwgfx (VMware) stacks where Mesa DRI is missing',
+    });
+  }
+
+  if (!sh.includes('DRIVER=vmwgfx')) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must detect vmwgfx via /sys/class/drm card device uevent',
+    });
+  }
+
+  if (!sh.includes('MESH_CLIENT_ENABLE_GPU')) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must allow MESH_CLIENT_ENABLE_GPU=1 to opt out of vmwgfx GPU disable',
+    });
+  }
+
   return violations;
 }
 


### PR DESCRIPTION
## Summary

- Flatpak wrapper detects VMware `vmwgfx` via `/sys/class/drm/card*/device/uevent` and sets `MESH_CLIENT_DISABLE_GPU=1` before Electron starts (main already disables hardware acceleration for that env).
- Opt-out with `MESH_CLIENT_ENABLE_GPU=1`; explicit `MESH_CLIENT_DISABLE_GPU=0` skips auto-detection.
- `check:flatpak` guards the wrapper behavior; docs note the VMware / `vmwgfx: driver missing` case.

## Context

On Ubuntu aarch64 in a VMware guest, `flatpak run org.coloradomesh.MeshClient` logged `vmwgfx: driver missing` and could fail in the GPU process because Mesa has no working DRI driver inside the sandbox. Software rendering avoids that without affecting hosts with working GPU drivers.

## Test plan

- [ ] `pnpm run check:flatpak`
- [ ] On VMware guest with vmwgfx: install/rebuild Flatpak, `flatpak run org.coloradomesh.MeshClient` — app window opens without GPU-process crash
- [ ] On normal hardware: app still uses GPU unless `MESH_CLIENT_DISABLE_GPU=1` is set manually
- [ ] `MESH_CLIENT_ENABLE_GPU=1 flatpak run org.coloradomesh.MeshClient` still attempts hardware acceleration on vmwgfx