### PR TITLE
fix: disable Flatpak GPU on aarch64 only

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -195,7 +195,7 @@ flatpak install --user ./org.coloradomesh.MeshClient-aarch64.flatpak
 flatpak run org.coloradomesh.MeshClient
 ```
 
-**VMware / `vmwgfx: driver missing`:** On VMware guests the Flatpak wrapper auto-sets `MESH_CLIENT_DISABLE_GPU=1` when the `vmwgfx` DRM driver is present (avoids GPU-process crashes). To force hardware acceleration anyway: `MESH_CLIENT_ENABLE_GPU=1 flatpak run org.coloradomesh.MeshClient`. To always disable GPU on other stacks: `MESH_CLIENT_DISABLE_GPU=1 flatpak run ...`.
+**Flatpak GPU / `vmwgfx: driver missing` (aarch64):** On **aarch64** bundles the wrapper defaults to software rendering (`MESH_CLIENT_DISABLE_GPU=1` and Electron `--disable-gpu`) because the sandbox usually cannot see host DRM sysfs and drivers like VMware `vmwgfx` fail inside the bubble. x86_64 builds are unchanged unless you set the env vars yourself. To try hardware acceleration on ARM: `MESH_CLIENT_ENABLE_GPU=1 flatpak run org.coloradomesh.MeshClient`. To force GPU on: `MESH_CLIENT_DISABLE_GPU=0 flatpak run ...`.
 
 **Lint the manifest** before submitting to Flathub:
 

--- a/flatpak/mesh-client-wrapper.sh
+++ b/flatpak/mesh-client-wrapper.sh
@@ -2,18 +2,19 @@
 # Electron2 BaseApp provides zypak-wrapper; Chromium binary comes from node_modules/electron.
 export TMPDIR="${XDG_RUNTIME_DIR:-/tmp}/app/${FLATPAK_ID:-org.coloradomesh.MeshClient}"
 
-# VMware vmwgfx: Mesa often has no working DRI driver in the Flatpak sandbox (vmwgfx: driver missing),
-# which can SIGSEGV the GPU process. index.ts calls app.disableHardwareAcceleration() when set.
+# aarch64 Flatpak: host DRM sysfs is often invisible in the sandbox; vmwgfx and similar drivers
+# log "driver missing" and the GPU process can SIGSEGV. index.ts disables HW accel when set.
+MESH_CLIENT_GPU_ARGS=
 if [ "${MESH_CLIENT_ENABLE_GPU:-}" != "1" ] && [ "${MESH_CLIENT_DISABLE_GPU:-}" != "0" ]; then
-  case "${MESH_CLIENT_DISABLE_GPU:-}" in
-    1) ;;
-    *)
-      if grep -rq 'DRIVER=vmwgfx' /sys/class/drm/card*/device/uevent 2> /dev/null; then
-        export MESH_CLIENT_DISABLE_GPU=1
-      fi
+  case "$(uname -m)" in
+    aarch64 | arm64)
+      export MESH_CLIENT_DISABLE_GPU=1
+      MESH_CLIENT_GPU_ARGS=--disable-gpu
       ;;
   esac
 fi
 
 cd /app/lib/mesh-client || exit 1
-exec zypak-wrapper /app/lib/mesh-client/electron/electron /app/lib/mesh-client/dist-electron/main/index.js "$@"
+exec zypak-wrapper /app/lib/mesh-client/electron/electron \
+  ${MESH_CLIENT_GPU_ARGS} \
+  /app/lib/mesh-client/dist-electron/main/index.js "$@"

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -185,21 +185,36 @@ function checkWrapperLaunchPaths() {
     violations.push({
       file: rel,
       message:
-        'wrapper must set MESH_CLIENT_DISABLE_GPU for vmwgfx (VMware) stacks where Mesa DRI is missing',
+        'wrapper must set MESH_CLIENT_DISABLE_GPU on aarch64 (Flatpak GPU stacks often break)',
     });
   }
 
-  if (!sh.includes('DRIVER=vmwgfx')) {
+  if (!sh.includes('aarch64') || !sh.includes('arm64')) {
     violations.push({
       file: rel,
-      message: 'wrapper must detect vmwgfx via /sys/class/drm card device uevent',
+      message: 'wrapper must gate default GPU disable on aarch64/arm64 (uname -m)',
+    });
+  }
+
+  if (!sh.includes('--disable-gpu')) {
+    violations.push({
+      file: rel,
+      message:
+        'wrapper must pass --disable-gpu to Electron on aarch64 before main (Chromium startup flags)',
     });
   }
 
   if (!sh.includes('MESH_CLIENT_ENABLE_GPU')) {
     violations.push({
       file: rel,
-      message: 'wrapper must allow MESH_CLIENT_ENABLE_GPU=1 to opt out of vmwgfx GPU disable',
+      message: 'wrapper must allow MESH_CLIENT_ENABLE_GPU=1 to opt out of default GPU disable',
+    });
+  }
+
+  if (!sh.includes('MESH_CLIENT_DISABLE_GPU:-}" != "0"')) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must allow MESH_CLIENT_DISABLE_GPU=0 to opt out of default GPU disable',
     });
   }
 


### PR DESCRIPTION
## Summary

- On **aarch64** Flatpak runs only, the wrapper sets `MESH_CLIENT_DISABLE_GPU=1` and passes Electron `--disable-gpu` before main starts (in addition to `app.disableHardwareAcceleration()` in main).
- Removes the sysfs `vmwgfx` probe from #443 — the Flatpak sandbox often cannot read `/sys/class/drm`, so detection never fired on ARM VMware guests that logged `vmwgfx: driver missing`.
- **x86_64** Flatpak builds are unchanged; users can still force software rendering with `MESH_CLIENT_DISABLE_GPU=1` or opt out on ARM with `MESH_CLIENT_ENABLE_GPU=1` / `MESH_CLIENT_DISABLE_GPU=0`.

## Test plan

- [ ] Rebuild or install `org.coloradomesh.MeshClient-aarch64.flatpak` from CI artifact
- [ ] On aarch64 Ubuntu/VMware: `flatpak run org.coloradomesh.MeshClient` — app window opens, no GPU-process crash after `vmwgfx: driver missing`
- [ ] On aarch64: `MESH_CLIENT_ENABLE_GPU=1 flatpak run org.coloradomesh.MeshClient` still attempts HW accel
- [ ] On x86_64 Flatpak: default launch does **not** set `MESH_CLIENT_DISABLE_GPU` unless env is set manually
- [ ] `pnpm run check:flatpak` passes