### PR TITLE
fix: Flatpak bundle names, vmwgfx GPU policy, and troubleshooting docs

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -22,10 +22,8 @@ jobs:
         include:
           - arch: x86_64
             runner: ubuntu-latest
-            bundle: org.coloradomesh.MeshClient-x86_64.flatpak
           - arch: aarch64
             runner: ubuntu-24.04-arm
-            bundle: org.coloradomesh.MeshClient-aarch64.flatpak
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
       options: --privileged
@@ -39,10 +37,11 @@ jobs:
           pip3 install "${FBTOOLS}@6f3f08759ac9859492b728f57f5163bf584c47ff#subdirectory=node"
           flatpak-node-generator pnpm pnpm-lock.yaml -o flatpak/generated-sources.json
 
-      # flatpak/flatpak-github-actions v6
+      # flatpak/flatpak-github-actions v6 appends -${arch} to the artifact name on upload;
+      # keep bundle arch-agnostic here to avoid org.coloradomesh.MeshClient-aarch64-aarch64.flatpak.
       - uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb
         with:
-          bundle: ${{ matrix.bundle }}
+          bundle: org.coloradomesh.MeshClient.flatpak
           manifest-path: org.coloradomesh.MeshClient.yml
           arch: ${{ matrix.arch }}
           branch: stable
@@ -62,7 +61,21 @@ jobs:
         with:
           pattern: 'org.coloradomesh.MeshClient-*'
           path: flatpak-dist
-          merge-multiple: true
+
+      - name: Flatten arch-suffixed bundles for release
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for dir in flatpak-dist/*/; do
+            name=$(basename "$dir")
+            flatpak=$(find "$dir" -maxdepth 1 -name '*.flatpak' -print -quit)
+            if [ -z "${flatpak:-}" ]; then
+              echo "no .flatpak in ${dir}" >&2
+              exit 1
+            fi
+            mv "$flatpak" "flatpak-dist/${name}"
+            rmdir "$dir"
+          done
 
       - name: Attach Flatpak to release
         # softprops/action-gh-release v2

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -195,7 +195,13 @@ flatpak install --user ./org.coloradomesh.MeshClient-aarch64.flatpak
 flatpak run org.coloradomesh.MeshClient
 ```
 
-**Flatpak GPU / `vmwgfx: driver missing` (aarch64):** On **aarch64** bundles the wrapper defaults to software rendering (`MESH_CLIENT_DISABLE_GPU=1` and Electron `--disable-gpu`) because the sandbox usually cannot see host DRM sysfs and drivers like VMware `vmwgfx` fail inside the bubble. x86_64 builds are unchanged unless you set the env vars yourself. To try hardware acceleration on ARM: `MESH_CLIENT_ENABLE_GPU=1 flatpak run org.coloradomesh.MeshClient`. To force GPU on: `MESH_CLIENT_DISABLE_GPU=0 flatpak run ...`.
+**Flatpak graphics:** **aarch64** and **x86_64** bundles use the same GPU stack (`--device=all`, Wayland/X11). Do **not** enable or rely on VMware `vmwgfx` inside the guest to “fix” the app — the Flatpak sandbox often cannot use that DRI driver (`vmwgfx: driver missing`, GPU-process crash). On **virtualized** hosts (VMware, etc.), use software rendering instead:
+
+```bash
+MESH_CLIENT_DISABLE_GPU=1 flatpak run org.coloradomesh.MeshClient
+```
+
+When `/sys/class/drm` is visible to the app, the wrapper auto-detects `vmwgfx` and sets `MESH_CLIENT_DISABLE_GPU=1` (same on both arches). If auto-detection does not run in your VM, set the variable as above. To force hardware acceleration despite vmwgfx: `MESH_CLIENT_ENABLE_GPU=1 flatpak run ...`. To skip auto-detection but keep GPU: `MESH_CLIENT_DISABLE_GPU=0 flatpak run ...`.
 
 **Lint the manifest** before submitting to Flathub:
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -1,6 +1,6 @@
 # Development Environment Setup
 
-This guide covers local development setup for Mesh Client, including cloning, prerequisites, test harness tooling, and OS-specific troubleshooting.
+This guide covers local development setup for Mesh Client, including cloning, prerequisites, and test harness tooling. For runtime errors, connection issues, and packaged-app problems, see [troubleshooting.md](troubleshooting.md).
 
 ## Shared Requirements and Tooling
 
@@ -195,13 +195,7 @@ flatpak install --user ./org.coloradomesh.MeshClient-aarch64.flatpak
 flatpak run org.coloradomesh.MeshClient
 ```
 
-**Flatpak graphics:** **aarch64** and **x86_64** bundles use the same GPU stack (`--device=all`, Wayland/X11). Do **not** enable or rely on VMware `vmwgfx` inside the guest to “fix” the app — the Flatpak sandbox often cannot use that DRI driver (`vmwgfx: driver missing`, GPU-process crash). On **virtualized** hosts (VMware, etc.), use software rendering instead:
-
-```bash
-MESH_CLIENT_DISABLE_GPU=1 flatpak run org.coloradomesh.MeshClient
-```
-
-When `/sys/class/drm` is visible to the app, the wrapper auto-detects `vmwgfx` and sets `MESH_CLIENT_DISABLE_GPU=1` (same on both arches). If auto-detection does not run in your VM, set the variable as above. To force hardware acceleration despite vmwgfx: `MESH_CLIENT_ENABLE_GPU=1 flatpak run ...`. To skip auto-detection but keep GPU: `MESH_CLIENT_DISABLE_GPU=0 flatpak run ...`.
+**Runtime issues** (GPU, VMware guests): see [Flatpak: `vmwgfx: driver missing` (VMware on macOS)](troubleshooting.md#flatpak-vmwgfx-driver-missing-vmware-on-macos).
 
 **Lint the manifest** before submitting to Flathub:
 
@@ -453,11 +447,7 @@ On first BLE connection, macOS prompts for Bluetooth access. If denied accidenta
 
 ### macOS release-download note (not required for source development)
 
-If a downloaded app reports "Mesh-client is damaged and can't be opened", remove quarantine:
-
-```bash
-xattr -r -d com.apple.quarantine /Applications/Mesh-client.app
-```
+If a downloaded app reports "Mesh-client is damaged and can't be opened", see [macOS: File is damaged and cannot be opened](troubleshooting.md#macos-file-is-damaged-and-cannot-be-opened).
 
 ## Windows
 
@@ -501,43 +491,7 @@ If serial ports do not appear, install the right USB UART driver (for example CH
 
 ### Troubleshooting
 
-#### "Could not find any Visual Studio installation to use"
-
-Cause: outdated `node-gyp` resolution or missing C++ build tools workload.
-
-Fix:
-
-1. Install/confirm Visual Studio Build Tools with Desktop C++ workload.
-2. Upgrade node-gyp:
-   ```bash
-   pnpm install node-gyp@latest -g
-   pnpm install node-gyp@latest --save-dev
-   ```
-3. Restart terminal and rerun:
-   ```bash
-   pnpm install
-   ```
-
-#### "Could not find any Python installation to use"
-
-Cause: Python missing or not on PATH for node-gyp.
-
-Fix:
-
-1. Install Python 3 and add it to PATH.
-2. Restart terminal.
-3. Retry `pnpm install` (or `pnpm run dist:win`).
-4. If still failing, set Python path with `npm config set python ...`.
-
-#### `dist:win` fails with path spaces or `EPERM`
-
-- Prefer a path without spaces (for example `C:\dev\mesh-client`)
-- Close running Electron/Node processes before rebuild
-- Run:
-  ```bash
-  pnpm run rebuild
-  pnpm run dist:win
-  ```
+See [troubleshooting.md](troubleshooting.md#windows-could-not-find-any-visual-studio-installation-to-use) (Visual Studio), [Python](troubleshooting.md#windows-could-not-find-any-python-installation-to-use), and [`dist:win` path / `EPERM`](troubleshooting.md#windows-distwin-fails-with-path-spaces-or-eperm).
 
 ## Linux
 
@@ -600,32 +554,7 @@ The app automatically enables `--enable-experimental-web-platform-features` on L
 
 There is **no portable Web Bluetooth API** for the negotiated ATT MTU ([WebBluetoothCG#383](https://github.com/WebBluetoothCG/web-bluetooth/issues/383)). When Chromium exposes `maximumWriteValueLength` on the TX characteristic, the client chunks `writeValue` accordingly; otherwise it sends each payload in one call.
 
-#### Bluetooth Pairing on Linux
-
-Web Bluetooth may invoke the **Electron pairing handler** during GATT connect. Behavior differs by protocol:
-
-- **Meshtastic:** On the first Chromium `providePin` request, the client tries the standard Meshtastic PIN `123456`. If that fails, you are prompted to enter the PIN manually.
-- **MeshCore:** The MeshCore session does **not** auto-submit `123456`. When Chromium asks for a PIN, you enter the random code shown on the radio.
-
-**MeshCore and OS-level pairing (Linux / BlueZ):** A stable GATT session usually requires a bond in BlueZ first. After you choose a device in the in-app picker, the client runs `bluetoothctl info <MAC>`. If the device is **not** paired (`Paired: no`) or not yet known to the adapter, the UI prompts for the PIN on the **radio** and runs **`bluetooth-pair`** (main-process `bluetoothctl` pairing) **before** resolving the pending Web Bluetooth selection. If `Paired: yes` already, connection continues without that step.
-
-Handshake retries reuse the **same granted Web Bluetooth device** (`navigator.bluetooth.getDevices()`) so the second attempt does not call `requestDevice()` without a user gesture.
-
-If you encounter pairing issues (e.g., "Connection attempt failed" or device was previously paired with wrong PIN):
-
-1. Use the **"Remove & Re-pair Device"** button in the app
-2. Or manually remove via `bluetoothctl`:
-   ```bash
-   bluetoothctl
-   # Inside bluetoothctl:
-   remove XX:XX:XX:XX:XX:XX # Replace with your device MAC
-   # Then re-pair from the app
-   ```
-3. If the device still won't connect, power cycle Bluetooth:
-   ```bash
-   bluetoothctl power off
-   bluetoothctl power on
-   ```
+Pairing failures and BlueZ steps: [BLE known issues](troubleshooting.md#ble-known-issues).
 
 ### Linux launch notes
 
@@ -645,50 +574,4 @@ sudo sysctl -w kernel.unprivileged_userns_clone=1
 
 ### Troubleshooting
 
-#### SIGILL during `pnpm install` (`electron exited with signal SIGILL`)
-
-Install without running Electron rebuild first:
-
-```bash
-MESHTASTIC_SKIP_ELECTRON_REBUILD=1 pnpm install
-```
-
-Then run rebuild on a host where Electron executes correctly:
-
-```bash
-pnpm run rebuild
-```
-
-#### SIGSEGV on startup (`electron exited with signal SIGSEGV`)
-
-Use:
-
-```bash
-pnpm run build && pnpm dlx electron . --disable-gpu
-```
-
-Or:
-
-```bash
-pnpm run electron:open -- --disable-gpu
-```
-
-Optional persistent mitigation:
-
-- `export MESH_CLIENT_DISABLE_GPU=1`
-- `ELECTRON_OZONE_PLATFORM_HINT=x11 pnpm run electron:open`
-
-#### `Serial: serial_io_handler.cc:147 Failed to open serial port: FILE_ERROR_ACCESS_DENIED`
-
-1. Ensure user is in `dialout`.
-2. Re-login.
-3. Verify with:
-   ```bash
-   groups
-   ```
-4. If missing, create and activate:
-   ```bash
-   sudo groupadd dialout
-   sudo usermod -a -G dialout $USER
-   newgrp dialout
-   ```
+See [Linux development: SIGILL / SIGSEGV](troubleshooting.md#linux-development-sigill-during-pnpm-install) and [Linux: serial port access denied](troubleshooting.md#linux-serial-port-access-denied).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,8 +1,10 @@
 # Troubleshooting
 
+Setup (clone, prerequisites, Flatpak build steps) is in [development-environment.md](development-environment.md). This page covers runtime failures, connections, and packaged installs.
+
 ### `pnpm install` fails on native module compilation
 
-See [development-environment.md](development-environment.md) for OS-specific prerequisite installation and troubleshooting.
+See [development-environment.md](development-environment.md) for OS-specific prerequisite installation.
 
 ### Windows: "Could not find any Visual Studio installation to use"
 
@@ -60,9 +62,90 @@ See [development-environment.md](development-environment.md#windows) for Python 
 
 See [development-environment.md](development-environment.md) for OS-specific serial setup and driver guidance.
 
-### Linux: `Serial: serial_io_handler.cc:147 Failed to open serial port: FILE_ERROR_ACCESS_DENIED`
+### Linux: serial port access denied
 
-See [development-environment.md#linux](development-environment.md#linux) for serial permission recovery steps.
+**Symptom**: `Serial: serial_io_handler.cc:147 Failed to open serial port: FILE_ERROR_ACCESS_DENIED`
+
+**Fix**:
+
+1. Ensure your user is in the `dialout` group (see [development-environment.md — Linux serial permissions](development-environment.md#serial-permissions)).
+2. Log out and back in after changing groups.
+3. Verify with `groups`.
+4. If the group is missing:
+   ```bash
+   sudo groupadd dialout
+   sudo usermod -a -G dialout $USER
+   newgrp dialout
+   ```
+
+### Flatpak: `vmwgfx: driver missing` (VMware on macOS)
+
+**Symptom**: `flatpak run org.coloradomesh.MeshClient` fails or exits after Mesa logs `vmwgfx: driver missing` (use `flatpak -v run ...` to see it). Common on **Linux guests in VMware Fusion or Workstation with a macOS host**, including **aarch64** Ubuntu/ARM VMs.
+
+**Cause**: The Flatpak uses the same GPU stack as the x86_64 bundle (`--device=all`, Wayland/X11). It expects a working virtual GPU in the guest. On macOS-hosted VMware, **3D acceleration / `vmwgfx` is often off or unsupported** unless you enable it in the VM settings — without that, Mesa cannot open the VMware DRI driver and Electron’s GPU process fails.
+
+**Fix** (preferred — hardware acceleration):
+
+1. Shut down the Linux VM.
+2. In **VMware Fusion** or **Workstation** (on the Mac host): turn on **Accelerate 3D graphics** / **3D acceleration** for this VM (exact label varies by VMware version).
+3. Boot the guest and confirm the driver is present, for example:
+   ```bash
+   grep DRIVER=vmwgfx /sys/class/drm/card*/device/uevent
+   ```
+4. Reinstall or rerun the Flatpak:
+   ```bash
+   flatpak run org.coloradomesh.MeshClient
+   ```
+
+**Workaround** (software rendering when the host cannot expose `vmwgfx`):
+
+```bash
+MESH_CLIENT_DISABLE_GPU=1 flatpak run org.coloradomesh.MeshClient
+```
+
+When `/sys/class/drm` is visible inside the sandbox, the wrapper may auto-detect `vmwgfx` and set `MESH_CLIENT_DISABLE_GPU=1` if DRI is unreliable there. Opt out of auto-detection: `MESH_CLIENT_DISABLE_GPU=0 flatpak run ...`. Force GPU despite detection: `MESH_CLIENT_ENABLE_GPU=1 flatpak run ...`.
+
+**Reinstall a release bundle** after downloading a new `.flatpak` from [GitHub Releases](https://github.com/Colorado-Mesh/mesh-client/releases):
+
+```bash
+flatpak uninstall --user org.coloradomesh.MeshClient
+flatpak install --user ./org.coloradomesh.MeshClient-aarch64.flatpak # or -x86_64
+flatpak run org.coloradomesh.MeshClient
+```
+
+### Linux development: SIGILL during `pnpm install`
+
+**Symptom**: `electron exited with signal SIGILL` during install/rebuild (common in sandboxes or VMs without instructions the prebuilt Electron binary expects).
+
+**Fix**:
+
+```bash
+MESHTASTIC_SKIP_ELECTRON_REBUILD=1 pnpm install
+pnpm run rebuild
+```
+
+Run `pnpm run rebuild` on a host where the bundled Electron binary executes correctly.
+
+### Linux development: SIGSEGV on startup
+
+**Symptom**: `electron exited with signal SIGSEGV` when running from source (GPU process; see [electron#41980](https://github.com/electron/electron/issues/41980)).
+
+**Fix**:
+
+```bash
+pnpm run build && pnpm dlx electron . --disable-gpu
+```
+
+Or:
+
+```bash
+pnpm run electron:open -- --disable-gpu
+```
+
+Optional persistent mitigation:
+
+- `export MESH_CLIENT_DISABLE_GPU=1`
+- `ELECTRON_OZONE_PLATFORM_HINT=x11 pnpm run electron:open`
 
 ### macOS: File is damaged and cannot be opened
 

--- a/flatpak/mesh-client-wrapper.sh
+++ b/flatpak/mesh-client-wrapper.sh
@@ -2,19 +2,29 @@
 # Electron2 BaseApp provides zypak-wrapper; Chromium binary comes from node_modules/electron.
 export TMPDIR="${XDG_RUNTIME_DIR:-/tmp}/app/${FLATPAK_ID:-org.coloradomesh.MeshClient}"
 
-# aarch64 Flatpak: host DRM sysfs is often invisible in the sandbox; vmwgfx and similar drivers
-# log "driver missing" and the GPU process can SIGSEGV. index.ts disables HW accel when set.
-MESH_CLIENT_GPU_ARGS=
+# VMware / virtualized guests: Mesa often cannot use vmwgfx DRI inside the Flatpak sandbox
+# ("vmwgfx: driver missing", GPU process SIGSEGV). index.ts disables HW accel when set.
+# Bare-metal aarch64 and x86_64 use full GPU acceleration by default (same finish-args).
+gpu_args=
 if [ "${MESH_CLIENT_ENABLE_GPU:-}" != "1" ] && [ "${MESH_CLIENT_DISABLE_GPU:-}" != "0" ]; then
-  case "$(uname -m)" in
-    aarch64 | arm64)
-      export MESH_CLIENT_DISABLE_GPU=1
-      MESH_CLIENT_GPU_ARGS=--disable-gpu
+  case "${MESH_CLIENT_DISABLE_GPU:-}" in
+    1) ;;
+    *)
+      if grep -rq 'DRIVER=vmwgfx' /sys/class/drm/card*/device/uevent 2> /dev/null; then
+        export MESH_CLIENT_DISABLE_GPU=1
+      fi
       ;;
   esac
 fi
+if [ "${MESH_CLIENT_DISABLE_GPU:-}" = "1" ]; then
+  gpu_args=--disable-gpu
+fi
 
 cd /app/lib/mesh-client || exit 1
+if [ -n "$gpu_args" ]; then
+  exec zypak-wrapper /app/lib/mesh-client/electron/electron \
+    "$gpu_args" \
+    /app/lib/mesh-client/dist-electron/main/index.js "$@"
+fi
 exec zypak-wrapper /app/lib/mesh-client/electron/electron \
-  ${MESH_CLIENT_GPU_ARGS} \
   /app/lib/mesh-client/dist-electron/main/index.js "$@"

--- a/flatpak/mesh-client-wrapper.sh
+++ b/flatpak/mesh-client-wrapper.sh
@@ -2,8 +2,8 @@
 # Electron2 BaseApp provides zypak-wrapper; Chromium binary comes from node_modules/electron.
 export TMPDIR="${XDG_RUNTIME_DIR:-/tmp}/app/${FLATPAK_ID:-org.coloradomesh.MeshClient}"
 
-# VMware / virtualized guests: Mesa often cannot use vmwgfx DRI inside the Flatpak sandbox
-# ("vmwgfx: driver missing", GPU process SIGSEGV). index.ts disables HW accel when set.
+# VMware guests need vmwgfx/3D enabled in the VM (especially macOS hosts); see docs/troubleshooting.md.
+# When vmwgfx is present but Mesa DRI fails in the Flatpak sandbox, auto software rendering.
 # Bare-metal aarch64 and x86_64 use full GPU acceleration by default (same finish-args).
 gpu_args=
 if [ "${MESH_CLIENT_ENABLE_GPU:-}" != "1" ] && [ "${MESH_CLIENT_DISABLE_GPU:-}" != "0" ]; then

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -185,14 +185,14 @@ function checkWrapperLaunchPaths() {
     violations.push({
       file: rel,
       message:
-        'wrapper must set MESH_CLIENT_DISABLE_GPU on aarch64 (Flatpak GPU stacks often break)',
+        'wrapper must set MESH_CLIENT_DISABLE_GPU for vmwgfx (virtualized) stacks where Mesa DRI is missing',
     });
   }
 
-  if (!sh.includes('aarch64') || !sh.includes('arm64')) {
+  if (!sh.includes('DRIVER=vmwgfx')) {
     violations.push({
       file: rel,
-      message: 'wrapper must gate default GPU disable on aarch64/arm64 (uname -m)',
+      message: 'wrapper must detect vmwgfx via /sys/class/drm card device uevent',
     });
   }
 
@@ -200,21 +200,29 @@ function checkWrapperLaunchPaths() {
     violations.push({
       file: rel,
       message:
-        'wrapper must pass --disable-gpu to Electron on aarch64 before main (Chromium startup flags)',
+        'wrapper must pass --disable-gpu to Electron when MESH_CLIENT_DISABLE_GPU=1 (Chromium startup flags)',
     });
   }
 
   if (!sh.includes('MESH_CLIENT_ENABLE_GPU')) {
     violations.push({
       file: rel,
-      message: 'wrapper must allow MESH_CLIENT_ENABLE_GPU=1 to opt out of default GPU disable',
+      message: 'wrapper must allow MESH_CLIENT_ENABLE_GPU=1 to opt out of vmwgfx GPU disable',
     });
   }
 
   if (!sh.includes('MESH_CLIENT_DISABLE_GPU:-}" != "0"')) {
     violations.push({
       file: rel,
-      message: 'wrapper must allow MESH_CLIENT_DISABLE_GPU=0 to opt out of default GPU disable',
+      message: 'wrapper must allow MESH_CLIENT_DISABLE_GPU=0 to opt out of vmwgfx auto-detection',
+    });
+  }
+
+  if (sh.includes('uname -m') && (sh.includes('aarch64') || sh.includes('arm64'))) {
+    violations.push({
+      file: rel,
+      message:
+        'wrapper must not disable GPU by CPU arch only; aarch64 and x86_64 should use the same graphics defaults',
     });
   }
 


### PR DESCRIPTION
## Summary

- **GPU policy:** Restore vmwgfx-only auto software rendering (#443) on any CPU arch; drop #444’s aarch64-wide GPU disable so bare-metal ARM matches x86.
- **CI/release:** Fix doubled arch in Flatpak artifact names (`MeshClient-aarch64-aarch64.flatpak`) via arch-agnostic bundle input and release flatten step.
- **Docs:** Move runtime guidance to [troubleshooting.md](docs/troubleshooting.md). VMware on a **macOS host** must have **3D acceleration / vmwgfx** enabled in the VM for the Flatpak GPU stack to work; `MESH_CLIENT_DISABLE_GPU=1` is the workaround when the host cannot expose it.

## Commits

- `74be7c5b` — fix: restore vmwgfx-only Flatpak GPU disable and fix bundle names
- (latest) — docs: move Flatpak GPU help to troubleshooting; fix VMware vmwgfx

## Test plan

- [ ] `pnpm run check:flatpak`
- [ ] Bare-metal aarch64: `flatpak run org.coloradomesh.MeshClient` uses GPU when vmwgfx is absent
- [ ] VMware guest with 3D enabled: Flatpak starts without `vmwgfx: driver missing` crash
- [ ] VMware guest without vmwgfx: `MESH_CLIENT_DISABLE_GPU=1 flatpak run ...` works
- [ ] Tag build: release assets `org.coloradomesh.MeshClient-{x86_64,aarch64}.flatpak` (single arch suffix)