### PR TITLE
feat: pulse header red on error disconnect; fix MeshCore MQTT reconnect

### DIFF
--- a/src/main/meshcore-mqtt-adapter.test.ts
+++ b/src/main/meshcore-mqtt-adapter.test.ts
@@ -200,6 +200,66 @@ describe('MeshcoreMqttAdapter — token refresh', () => {
     });
   });
 
+  describe('connack timeout during connect', () => {
+    it('schedules JWT token refresh after error then close while status is disconnected', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      const mqttMod = await import('mqtt');
+      const onToken = vi.fn();
+      adapter.on(MeshcoreMqttAdapter.EVENT_TOKEN_REFRESH_NEEDED, onToken);
+      adapter.on('error', () => {});
+
+      const v1Username = `v1_${'A'.repeat(64)}`;
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+      adapter.connect({
+        ...BASE_SETTINGS,
+        username: v1Username,
+        tokenExpiresAt: expiresAt,
+      });
+
+      const client = vi.mocked(mqttMod.connect).mock.results.at(-1)!.value as {
+        on: ReturnType<typeof vi.fn>;
+      };
+      expect(adapter.getStatus()).toBe('connecting');
+
+      const errorHits = client.on.mock.calls.filter((c: unknown[]) => c[0] === 'error');
+      const errorFn = errorHits[errorHits.length - 1]?.[1] as (err: Error) => void;
+      errorFn(new Error('connack timeout'));
+      expect(adapter.getStatus()).toBe('disconnected');
+
+      const closeHits = client.on.mock.calls.filter((c: unknown[]) => c[0] === 'close');
+      const closeFn = closeHits[closeHits.length - 1]?.[1] as () => void;
+      closeFn();
+
+      expect(onToken).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(60_000 - 1);
+      expect(onToken).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(2);
+      expect(onToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not schedule reconnect after intentional disconnect()', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      const mqttMod = await import('mqtt');
+      const onToken = vi.fn();
+      adapter.on(MeshcoreMqttAdapter.EVENT_TOKEN_REFRESH_NEEDED, onToken);
+
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+      adapter.connect({ ...BASE_SETTINGS, tokenExpiresAt: expiresAt });
+
+      const client = vi.mocked(mqttMod.connect).mock.results.at(-1)!.value as {
+        on: ReturnType<typeof vi.fn>;
+      };
+      const closeHits = client.on.mock.calls.filter((c: unknown[]) => c[0] === 'close');
+      const closeFn = closeHits[closeHits.length - 1]?.[1] as () => void;
+
+      adapter.disconnect();
+      closeFn();
+
+      vi.advanceTimersByTime(120_000);
+      expect(onToken).not.toHaveBeenCalled();
+    });
+  });
+
   describe('updateToken with pendingReconnect', () => {
     it('clears pendingReconnect and calls _doConnect', () => {
       const expiresAt = Date.now() + 60 * 60 * 1000;

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -456,8 +456,9 @@ export class MeshcoreMqttAdapter extends EventEmitter {
         `[MeshCore MQTT] connection closed after ${Math.round(sessionDuration / 1000)}s (disconnect #${this.lastConnected ? this.disconnectCount : 'first'})`,
         new Date().toISOString(),
       );
-      const skipReconnect =
-        this.status === 'disconnected' || this.status === 'error' || !this.lastSettings;
+      // Intentional disconnect() clears lastSettings; do not treat transient `disconnected`
+      // from the error handler (connack/keepalive during `connecting`) as user-initiated.
+      const skipReconnect = this.status === 'error' || !this.lastSettings;
       if (this.status === 'connected' || this.status === 'connecting') {
         this.setStatus('disconnected');
       }

--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -23,6 +23,7 @@ const {
     connectAutomatic: vi.fn(),
     disconnect: vi.fn(),
     mqttStatus: null,
+    mqttConnectionLoss: false,
     getPickerStyleNodeLabel: vi.fn((num) => `!${num.toString(16)}`),
     getFullNodeLabel: vi.fn(),
     sendText: vi.fn().mockResolvedValue(undefined),
@@ -54,6 +55,7 @@ const {
     connectAutomatic: vi.fn(),
     disconnect: vi.fn(),
     mqttStatus: null,
+    mqttConnectionLoss: false,
     getPickerStyleNodeLabel: vi.fn((num) => `!${num.toString(16)}`),
     getFullNodeLabel: vi.fn(),
     sendText: vi.fn().mockResolvedValue(undefined),
@@ -145,6 +147,8 @@ vi.mock('./hooks/useMeshCore', () => ({
 vi.mock('./hooks/useTakServer', () => ({
   useTakServer: () => ({
     status: { running: false, port: 8087 },
+    error: null,
+    takClientLoss: false,
     start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
   }),
@@ -358,6 +362,38 @@ describe('App accessibility', () => {
       'href',
       'https://coloradomesh.org/',
     );
+  });
+
+  it('shows pulsing red MQTT header when connection lost unexpectedly', async () => {
+    useDeviceMock.mockReturnValue({
+      ...createDeviceMock(),
+      mqttStatus: 'disconnected',
+      mqttConnectionLoss: true,
+    });
+
+    render(<App />);
+
+    const mqttLabel = await screen.findByLabelText('MQTT error');
+    expect(mqttLabel).toHaveClass('animate-pulse');
+    expect(mqttLabel).toHaveClass('text-red-400');
+  });
+
+  it('shows pulsing red device status when reconnecting after loss', async () => {
+    useDeviceMock.mockReturnValue({
+      ...createDeviceMock(),
+      state: {
+        status: 'reconnecting',
+        myNodeNum: 0x12345678,
+        connectionType: 'ble',
+        connectionLoss: true,
+      },
+    });
+
+    render(<App />);
+
+    const deviceLabel = await screen.findByLabelText('Reconnecting (BLE)');
+    expect(deviceLabel).toHaveClass('animate-pulse');
+    expect(deviceLabel).toHaveClass('text-red-400');
   });
 
   it('renders the queue badge in meshcore mode when queueStatus is available', async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -47,6 +47,14 @@ import {
 } from './lazyTabPanels';
 import { getAppSettingsRaw } from './lib/appSettingsStorage';
 import { playMessageNotification } from './lib/chatNotifications';
+import {
+  deviceHeaderVariant,
+  headerDotClass,
+  headerIconClass,
+  headerTextClass,
+  mqttHeaderVariant,
+  takHeaderVariant,
+} from './lib/connectionHeaderStatus';
 import { DEFAULT_APP_SETTINGS_SHARED } from './lib/defaultAppSettings';
 import {
   fetchLatestMeshCoreRelease,
@@ -77,7 +85,7 @@ import type { ProtocolCapabilities } from './lib/radio/BaseRadioProvider';
 import { useRadioProvider } from './lib/radio/providerFactory';
 import { getStoredMeshProtocol, MESH_PROTOCOL_STORAGE_KEY } from './lib/storedMeshProtocol';
 import { applyThemeColors, loadThemeColors } from './lib/themeColors';
-import type { ChatMessage, DeviceState, MeshProtocol, MQTTSettings, MQTTStatus } from './lib/types';
+import type { ChatMessage, DeviceState, MeshProtocol, MQTTSettings } from './lib/types';
 import { useDiagnosticsStore } from './stores/diagnosticsStore';
 import { usePathHistoryStore } from './stores/pathHistoryStore';
 import { usePositionHistoryStore } from './stores/positionHistoryStore';
@@ -102,15 +110,6 @@ const TAB_CAPABILITY_REQUIREMENTS: (keyof ProtocolCapabilities | undefined)[] = 
   undefined, // RF
   undefined, // Graph
 ];
-
-const STATUS_COLOR: Record<string, string> = {
-  disconnected: 'bg-red-500',
-  connecting: 'bg-yellow-500 animate-pulse',
-  connected: 'bg-blue-500',
-  configured: 'bg-green-500',
-  stale: 'bg-yellow-500 animate-pulse',
-  reconnecting: 'bg-orange-500 animate-pulse',
-};
 
 function deviceConnectionStatusLabel(
   t: ReturnType<typeof useTranslation>['t'],
@@ -271,27 +270,23 @@ function DialogLazyFallback() {
   );
 }
 
-function TakStatusIcon({ running }: { running: boolean }) {
-  const color = running ? 'text-brand-green' : 'text-gray-400';
+function TakStatusIcon({ variant }: { variant: ReturnType<typeof takHeaderVariant> }) {
   return (
-    <svg aria-hidden="true" className={`h-4 w-4 ${color}`} viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      aria-hidden="true"
+      className={`h-4 w-4 ${headerIconClass(variant)}`}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M12,8A4,4 0 0,1 16,12A4,4 0 0,1 12,16A4,4 0 0,1 8,12A4,4 0 0,1 12,8M3.05,13H1V11H3.05C3.5,6.83 6.83,3.5 11,3.05V1H13V3.05C17.17,3.5 20.5,6.83 20.95,11H23V13H20.95C20.5,17.17 17.17,20.5 13,20.95V23H11V20.95C6.83,20.5 3.5,17.17 3.05,13M12,5A7,7 0 0,0 5,12A7,7 0 0,0 12,19A7,7 0 0,0 19,12A7,7 0 0,0 12,5Z" />
     </svg>
   );
 }
 
-function MqttGlobeIcon({ status }: { status: MQTTStatus }) {
-  const color =
-    status === 'connected'
-      ? 'text-brand-green'
-      : status === 'connecting'
-        ? 'text-yellow-400'
-        : status === 'error'
-          ? 'text-red-400'
-          : 'text-gray-400';
+function MqttGlobeIcon({ variant }: { variant: ReturnType<typeof mqttHeaderVariant> }) {
   return (
     <svg
-      className={`h-4 w-4 ${color}`}
+      className={`h-4 w-4 ${headerIconClass(variant)}`}
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -594,7 +589,7 @@ export default function App() {
 
   const meshtasticDevice = useDevice();
   const meshcoreDevice = useMeshCore();
-  const { status: takStatus } = useTakServer();
+  const { status: takStatus, error: takError, takClientLoss } = useTakServer();
   const contactGroupsSelfId =
     protocol === 'meshcore'
       ? meshcoreDevice.selfNodeId
@@ -1427,8 +1422,12 @@ export default function App() {
     setChatCompactMode(compact);
   }, []);
 
-  const statusColor = STATUS_COLOR[device.state.status] ?? 'bg-gray-500';
-
+  const mqttLoss = device.mqttConnectionLoss ?? false;
+  const mqttVariant = mqttHeaderVariant(device.mqttStatus ?? 'disconnected', mqttLoss);
+  const deviceLoss = device.state.connectionLoss ?? false;
+  const deviceVariant = deviceHeaderVariant(device.state.status, deviceLoss);
+  const takServerError = !takStatus.running && !!(takStatus.error || takError);
+  const takVariant = takHeaderVariant(takStatus.running, takServerError, takClientLoss);
   const queueUsed = device.queueStatus ? device.queueStatus.maxlen - device.queueStatus.free : 0;
   const queueShowBadge = device.queueStatus != null;
   const queueColorClass =
@@ -1574,66 +1573,58 @@ export default function App() {
           <div className="ml-auto flex min-w-0 shrink-0 items-center justify-end gap-2">
             {capabilities.hasTakPanel && (
               <div className="mr-3 flex items-center gap-1.5 border-r border-gray-700 pr-3">
-                <TakStatusIcon running={takStatus.running} />
+                <TakStatusIcon variant={takVariant} />
                 <span
                   aria-label={
-                    takStatus.running ? t('app.takServerRunning') : t('app.takServerStopped')
+                    takClientLoss && takStatus.running
+                      ? t('app.takClientLost')
+                      : takStatus.running
+                        ? t('app.takServerRunning')
+                        : t('app.takServerStopped')
                   }
-                  className={`text-xs ${takStatus.running ? 'text-brand-green' : 'text-gray-400'}`}
+                  className={`text-xs ${headerTextClass(takVariant)}`}
                 >
-                  {takStatus.running ? t('app.takRunning') : t('app.takStopped')}
+                  {takClientLoss && takStatus.running
+                    ? t('app.takClientLost')
+                    : takStatus.running
+                      ? t('app.takRunning')
+                      : t('app.takStopped')}
                 </span>
               </div>
             )}
             <div className="mr-3 flex items-center gap-1.5 border-r border-gray-700 pr-3">
-              <MqttGlobeIcon status={device.mqttStatus ?? 'disconnected'} />
+              <MqttGlobeIcon variant={mqttVariant} />
               <span
                 aria-label={
                   device.mqttStatus === 'connected'
                     ? t('app.mqttConnected')
                     : device.mqttStatus === 'connecting'
                       ? t('app.mqttConnecting')
-                      : device.mqttStatus === 'error'
+                      : device.mqttStatus === 'error' || mqttLoss
                         ? t('app.mqttError')
                         : t('app.mqttDisconnected')
                 }
-                className={`text-xs ${
-                  device.mqttStatus === 'connected'
-                    ? 'text-brand-green'
-                    : device.mqttStatus === 'connecting'
-                      ? 'animate-pulse text-yellow-400'
-                      : device.mqttStatus === 'error'
-                        ? 'text-red-400'
-                        : 'text-gray-400'
-                }`}
+                className={`text-xs ${headerTextClass(mqttVariant)}`}
               >
                 {device.mqttStatus === 'connected'
                   ? t('app.mqttConnected')
                   : device.mqttStatus === 'connecting'
                     ? t('app.mqttConnecting')
-                    : device.mqttStatus === 'error'
+                    : device.mqttStatus === 'error' || mqttLoss
                       ? t('app.mqttError')
                       : t('app.mqttDisconnected')}
               </span>
             </div>
             {isConnectedOrOperational && <LinkIcon className="h-4 w-4" aria-hidden="true" />}
             <div
-              className={`h-2.5 w-2.5 rounded-full ${statusColor}`}
+              className={`h-2.5 w-2.5 rounded-full ${headerDotClass(deviceVariant)}`}
               aria-hidden="true"
               title={deviceConnectionStatusLabel(t, device.state.status)}
             />
             <div role="status" aria-live="polite" aria-atomic="true">
               <span
                 aria-label={`${deviceConnectionStatusLabel(t, device.state.status)}${device.state.connectionType ? ` (${device.state.connectionType.toUpperCase()})` : ''}`}
-                className={`text-xs ${
-                  device.state.status === 'connecting'
-                    ? 'animate-pulse text-yellow-400'
-                    : device.state.status === 'stale'
-                      ? 'animate-pulse text-yellow-400'
-                      : device.state.status === 'reconnecting'
-                        ? 'animate-pulse text-orange-400'
-                        : 'text-muted'
-                }`}
+                className={`text-xs ${headerTextClass(deviceVariant)}`}
               >
                 {deviceConnectionStatusLabel(t, device.state.status)}
                 {device.state.connectionType

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
+import { markMqttUserDisconnect } from '@/renderer/lib/mqttDisconnectIntent';
 import { parseTcpAddress } from '@/renderer/lib/parseTcpAddress';
 import {
   MQTT_DEFAULT_RECONNECT_ATTEMPTS,
@@ -1937,15 +1938,16 @@ export default function ConnectionPanel({
             />
           </div>
           <button
-            onClick={() =>
+            onClick={() => {
+              markMqttUserDisconnect();
               window.electronAPI.mqtt
                 .disconnect(protocol === 'meshcore' ? 'meshcore' : 'meshtastic')
                 .catch((err: unknown) => {
                   console.warn(
                     '[ConnectionPanel] mqtt.disconnect failed: ' + errLikeToLogString(err),
                   );
-                })
-            }
+                });
+            }}
             className="w-full rounded-lg bg-red-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-red-500"
           >
             {t('connectionPanel.disconnectMqtt')}
@@ -2415,7 +2417,8 @@ export default function ConnectionPanel({
               <button
                 type="button"
                 aria-label={t('connectionPanel.cancelMqttConnect')}
-                onClick={() =>
+                onClick={() => {
+                  markMqttUserDisconnect();
                   window.electronAPI.mqtt
                     .disconnect(protocol === 'meshcore' ? 'meshcore' : 'meshtastic')
                     .catch((err: unknown) => {
@@ -2423,8 +2426,8 @@ export default function ConnectionPanel({
                         '[ConnectionPanel] mqtt.disconnect (cancel) failed: ' +
                           errLikeToLogString(err),
                       );
-                    })
-                }
+                    });
+                }}
                 className="bg-secondary-dark flex-1 rounded-lg border border-gray-600 px-4 py-2.5 text-sm font-medium text-gray-200 transition-colors hover:border-gray-500 hover:bg-gray-700"
               >
                 {t('connectionPanel.cancelMqttConnect')}
@@ -2514,6 +2517,7 @@ export default function ConnectionPanel({
               onDisconnect(),
               new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
             ]);
+            markMqttUserDisconnect();
             void window.electronAPI.mqtt.disconnect();
             await window.electronAPI.quitApp();
           }}
@@ -2646,6 +2650,7 @@ export default function ConnectionPanel({
         <button
           type="button"
           onClick={() => {
+            markMqttUserDisconnect();
             void window.electronAPI.mqtt.disconnect();
             void window.electronAPI.quitApp();
           }}

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -50,6 +50,7 @@ import {
   mergeMeshtasticTraceRouteIntoResultsMap,
   meshtasticTraceRouteLookupKeys,
 } from '../lib/meshtasticTraceRouteLookupKeys';
+import { consumeMqttUserDisconnect } from '../lib/mqttDisconnectIntent';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import { MESHTASTIC_CAPABILITIES } from '../lib/radio/BaseRadioProvider';
 import {
@@ -218,6 +219,7 @@ export function useDevice() {
   const lastNodeInfoRequestAtRef = useRef<Map<number, number>>(new Map());
 
   const [mqttStatus, setMqttStatus] = useState<MQTTStatus>('disconnected');
+  const [mqttConnectionLoss, setMqttConnectionLoss] = useState(false);
   const [ourPosition, setOurPosition] = useState<OurPosition | null>(null);
   const [gpsLoading, setGpsLoading] = useState(false);
   const [deviceGpsMode, setDeviceGpsMode] = useState<number>(0);
@@ -629,8 +631,16 @@ export function useDevice() {
   useEffect(() => {
     const unsubStatus = window.electronAPI.mqtt.onStatus(({ status: s, protocol }) => {
       if (protocol !== 'meshtastic') return;
+      const prev = mqttStatusRef.current;
       mqttStatusRef.current = s;
       setMqttStatus(s);
+      if (s === 'connected') {
+        setMqttConnectionLoss(false);
+      } else if (consumeMqttUserDisconnect()) {
+        setMqttConnectionLoss(false);
+      } else if (prev === 'connected') {
+        setMqttConnectionLoss(true);
+      }
       if (s !== 'connected') {
         setMessages((prev) =>
           prev.map((m) =>
@@ -1050,7 +1060,11 @@ export function useDevice() {
           7: 'configured', // DeviceConfigured
         };
         const mapped = statusMap[status] ?? 'connected';
-        setState((s) => ({ ...s, status: mapped }));
+        setState((s) => ({
+          ...s,
+          status: mapped,
+          ...(mapped === 'configured' || mapped === 'connected' ? { connectionLoss: false } : {}),
+        }));
 
         // Track configuring phase so packet replays are marked as historical
         if (status === 3 || status === 5 || status === 6) {
@@ -2615,6 +2629,7 @@ export function useDevice() {
         ...s,
         status: 'disconnected',
         connectionType: null,
+        connectionLoss: false,
         batteryPercent: undefined,
         batteryCharging: undefined,
       }));
@@ -2628,6 +2643,7 @@ export function useDevice() {
         ...s,
         status: 'disconnected',
         connectionType: null,
+        connectionLoss: true,
         batteryPercent: undefined,
         batteryCharging: undefined,
       }));
@@ -2641,6 +2657,7 @@ export function useDevice() {
     setState((s) => ({
       ...s,
       status: 'reconnecting',
+      connectionLoss: true,
       reconnectAttempt: reconnectAttemptRef.current,
     }));
 
@@ -2708,6 +2725,7 @@ export function useDevice() {
         ...s,
         status: 'connecting',
         connectionType: type,
+        connectionLoss: false,
         batteryPercent: undefined,
         batteryCharging: undefined,
       }));
@@ -2781,6 +2799,7 @@ export function useDevice() {
         ...s,
         status: 'connecting',
         connectionType: type,
+        connectionLoss: false,
         batteryPercent: undefined,
         batteryCharging: undefined,
       }));
@@ -2838,6 +2857,7 @@ export function useDevice() {
       status: 'disconnected',
       myNodeNum: 0,
       connectionType: null,
+      connectionLoss: false,
       batteryPercent: undefined,
       batteryCharging: undefined,
     });
@@ -3526,6 +3546,7 @@ export function useDevice() {
   return {
     state,
     mqttStatus,
+    mqttConnectionLoss,
     messages,
     nodes,
     telemetry,

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -103,6 +103,7 @@ import {
 } from '../lib/meshcoreUtils';
 import { MeshcoreWebBluetoothConnection } from '../lib/meshcoreWebBluetoothConnection';
 import { getMeshtasticConnectedMyNodeNum } from '../lib/meshtasticConnectedNodeRef';
+import { consumeMqttUserDisconnect } from '../lib/mqttDisconnectIntent';
 import { lastHeardToUnixSeconds, mergeMeshcoreLastHeardFromAdvert } from '../lib/nodeStatus';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import { parseTcpAddress } from '../lib/parseTcpAddress';
@@ -1162,6 +1163,7 @@ export function useMeshCore() {
   });
   const [environmentTelemetry, setEnvironmentTelemetry] = useState<EnvironmentTelemetryPoint[]>([]);
   const [mqttStatus, setMqttStatus] = useState<MQTTStatus>('disconnected');
+  const [mqttConnectionLoss, setMqttConnectionLoss] = useState(false);
   const mqttStatusRef = useRef<MQTTStatus>('disconnected');
 
   const connRef = useRef<MeshCoreConnection | null>(null);
@@ -1462,9 +1464,17 @@ export function useMeshCore() {
   useEffect(() => {
     return window.electronAPI.mqtt.onStatus(({ status: s, protocol }) => {
       if (protocol !== 'meshcore') return;
+      const prev = mqttStatusRef.current;
       const st = s;
       mqttStatusRef.current = st;
       setMqttStatus(st);
+      if (st === 'connected') {
+        setMqttConnectionLoss(false);
+      } else if (consumeMqttUserDisconnect()) {
+        setMqttConnectionLoss(false);
+      } else if (prev === 'connected') {
+        setMqttConnectionLoss(true);
+      }
     });
   }, []);
 
@@ -3154,7 +3164,15 @@ export function useMeshCore() {
         ipcNobleRef.current = null;
         meshcoreSessionPathUpdatedNodeIdsRef.current = new Set();
         setMeshcorePingRouteReadyEpoch((e) => e + 1);
-        setState((prev) => ({ ...prev, status: 'disconnected' }));
+        setState((prev) => {
+          const wasOperational =
+            prev.status === 'connected' || prev.status === 'configured' || prev.status === 'stale';
+          return {
+            ...prev,
+            status: 'disconnected',
+            connectionLoss: wasOperational,
+          };
+        });
         setQueueStatus(null);
         // Clear pending contacts refresh timer
         if (meshcoreContactsRefreshTimerRef.current) {
@@ -3305,7 +3323,12 @@ export function useMeshCore() {
       setState((prev) => ({ ...prev, status: 'connected' }));
 
       const myNodeId = pubkeyToNodeId(info.publicKey);
-      setState((prev) => ({ ...prev, myNodeNum: myNodeId, status: 'configured' }));
+      setState((prev) => ({
+        ...prev,
+        myNodeNum: myNodeId,
+        status: 'configured',
+        connectionLoss: false,
+      }));
       if (getStoredMeshProtocol() === 'meshcore') {
         useDiagnosticsStore.getState().migrateForeignLoraFromZero(myNodeId);
       }
@@ -3475,6 +3498,7 @@ export function useMeshCore() {
         status: 'connecting',
         myNodeNum: 0,
         connectionType: type === 'tcp' ? 'http' : type,
+        connectionLoss: false,
       });
 
       if (type === 'ble') bleConnectInProgressRef.current = true;
@@ -3819,7 +3843,12 @@ export function useMeshCore() {
       lastSerialPortId?: string | null,
     ) => {
       if (type === 'serial') {
-        setState({ status: 'connecting', myNodeNum: 0, connectionType: 'serial' });
+        setState({
+          status: 'connecting',
+          myNodeNum: 0,
+          connectionType: 'serial',
+          connectionLoss: false,
+        });
         let serialPort: SerialPort | null = null;
         let serialConn: MeshCoreConnection | null = null;
         try {
@@ -6114,6 +6143,7 @@ export function useMeshCore() {
       clearCliHistory,
       manualAddContacts,
       mqttStatus,
+      mqttConnectionLoss,
       selfNodeId: state.myNodeNum,
       getNodes,
       getFullNodeLabel,
@@ -6234,6 +6264,7 @@ export function useMeshCore() {
       clearCliHistory,
       manualAddContacts,
       mqttStatus,
+      mqttConnectionLoss,
       queueStatus,
       telemetry,
       signalTelemetry,

--- a/src/renderer/hooks/useTakServer.ts
+++ b/src/renderer/hooks/useTakServer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { TAKClientInfo, TAKServerStatus, TAKSettings } from '@/shared/tak-types';
 
@@ -16,6 +16,7 @@ interface UseTakServerResult {
   settings: TAKSettings;
   isLoading: boolean;
   error: string | null;
+  takClientLoss: boolean;
   setSettings: (s: TAKSettings) => void;
   start: (s: TAKSettings) => Promise<void>;
   stop: () => Promise<void>;
@@ -33,6 +34,12 @@ export function useTakServer(): UseTakServerResult {
   const [settings, setSettings] = useState<TAKSettings>(DEFAULT_SETTINGS);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [takClientLoss, setTakClientLoss] = useState(false);
+  const statusRef = useRef(status);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
   useEffect(() => {
     void window.electronAPI.tak
@@ -52,12 +59,15 @@ export function useTakServer(): UseTakServerResult {
       setStatus(s);
       if (s.error) setError(s.error);
       else setError(null);
+      if (!s.running) setTakClientLoss(false);
     });
     const unsubConnected = window.electronAPI.tak.onClientConnected((client) => {
       setClients((prev) => [...prev, client]);
+      setTakClientLoss(false);
     });
     const unsubDisconnected = window.electronAPI.tak.onClientDisconnected((id) => {
       setClients((prev) => prev.filter((c) => c.id !== id));
+      if (statusRef.current.running) setTakClientLoss(true);
     });
 
     return () => {
@@ -70,6 +80,7 @@ export function useTakServer(): UseTakServerResult {
   const start = async (s: TAKSettings) => {
     setIsLoading(true);
     setError(null);
+    setTakClientLoss(false);
     try {
       await window.electronAPI.tak.start(s);
       setSettings(s);
@@ -84,6 +95,7 @@ export function useTakServer(): UseTakServerResult {
   const stop = async () => {
     setIsLoading(true);
     setError(null);
+    setTakClientLoss(false);
     try {
       await window.electronAPI.tak.stop();
     } catch (err) {
@@ -118,7 +130,7 @@ export function useTakServer(): UseTakServerResult {
     } catch (err) {
       console.debug(
         '[TakServer] regenerateCertificates error:',
-        err instanceof Error ? err.message : err,
+        err instanceof Error ? err.message : String(err),
       );
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -132,6 +144,7 @@ export function useTakServer(): UseTakServerResult {
     settings,
     isLoading,
     error,
+    takClientLoss,
     setSettings,
     start,
     stop,

--- a/src/renderer/lib/connectionHeaderStatus.test.ts
+++ b/src/renderer/lib/connectionHeaderStatus.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONNECTION_HEADER_PULSE_RED_DOT,
+  CONNECTION_HEADER_PULSE_RED_TEXT,
+  deviceHeaderVariant,
+  headerDotClass,
+  headerIconClass,
+  headerTextClass,
+  isDeviceErrorDisconnect,
+  isMqttErrorDisconnect,
+  isTakErrorDisconnect,
+  mqttHeaderVariant,
+  takHeaderVariant,
+} from './connectionHeaderStatus';
+
+describe('connectionHeaderStatus', () => {
+  describe('isMqttErrorDisconnect', () => {
+    it('is true for error status', () => {
+      expect(isMqttErrorDisconnect('error', false)).toBe(true);
+    });
+
+    it('is true when connection loss flag is set', () => {
+      expect(isMqttErrorDisconnect('disconnected', true)).toBe(true);
+    });
+
+    it('is false for manual disconnect', () => {
+      expect(isMqttErrorDisconnect('disconnected', false)).toBe(false);
+    });
+  });
+
+  describe('isDeviceErrorDisconnect', () => {
+    it('is true when reconnecting', () => {
+      expect(isDeviceErrorDisconnect('reconnecting', false)).toBe(true);
+    });
+
+    it('is true when connection loss flag is set', () => {
+      expect(isDeviceErrorDisconnect('disconnected', true)).toBe(true);
+    });
+
+    it('is false for manual disconnect', () => {
+      expect(isDeviceErrorDisconnect('disconnected', false)).toBe(false);
+    });
+  });
+
+  describe('isTakErrorDisconnect', () => {
+    it('is true when server stopped with error', () => {
+      expect(isTakErrorDisconnect(false, true, false)).toBe(true);
+    });
+
+    it('is true when client lost while server running', () => {
+      expect(isTakErrorDisconnect(true, false, true)).toBe(true);
+    });
+
+    it('is false when manually stopped', () => {
+      expect(isTakErrorDisconnect(false, false, false)).toBe(false);
+    });
+  });
+
+  describe('variants and classes', () => {
+    it('mqtt error uses pulsing red text', () => {
+      expect(mqttHeaderVariant('error', false)).toBe('error');
+      expect(headerTextClass('error')).toBe(CONNECTION_HEADER_PULSE_RED_TEXT);
+      expect(headerIconClass('error')).toBe(CONNECTION_HEADER_PULSE_RED_TEXT);
+    });
+
+    it('mqtt connecting uses yellow pulse', () => {
+      expect(mqttHeaderVariant('connecting', false)).toBe('warn');
+      expect(headerTextClass('warn')).toContain('text-yellow-400');
+    });
+
+    it('device error uses pulsing red dot', () => {
+      expect(deviceHeaderVariant('reconnecting', false)).toBe('error');
+      expect(headerDotClass('error')).toBe(CONNECTION_HEADER_PULSE_RED_DOT);
+    });
+
+    it('device manual disconnect is idle', () => {
+      expect(deviceHeaderVariant('disconnected', false)).toBe('idle');
+      expect(headerDotClass('idle')).not.toContain('animate-pulse');
+    });
+
+    it('tak running ok is green', () => {
+      expect(takHeaderVariant(true, false, false)).toBe('ok');
+      expect(headerTextClass('ok')).toContain('text-brand-green');
+    });
+  });
+});

--- a/src/renderer/lib/connectionHeaderStatus.ts
+++ b/src/renderer/lib/connectionHeaderStatus.ts
@@ -1,0 +1,102 @@
+import type { DeviceState, MQTTStatus } from './types';
+
+export const CONNECTION_HEADER_PULSE_RED_TEXT = 'animate-pulse text-red-400';
+export const CONNECTION_HEADER_PULSE_RED_DOT = 'bg-red-500 animate-pulse';
+export const CONNECTION_HEADER_IDLE_TEXT = 'text-gray-400';
+export const CONNECTION_HEADER_IDLE_DOT = 'bg-gray-500';
+export const CONNECTION_HEADER_WARN_TEXT = 'animate-pulse text-yellow-400';
+export const CONNECTION_HEADER_WARN_DOT = 'bg-yellow-500 animate-pulse';
+export const CONNECTION_HEADER_OK_TEXT = 'text-brand-green';
+export const CONNECTION_HEADER_OK_DOT = 'bg-green-500';
+export const CONNECTION_HEADER_CONNECTED_DOT = 'bg-blue-500';
+export const CONNECTION_HEADER_MUTED_TEXT = 'text-muted';
+
+export function isMqttErrorDisconnect(status: MQTTStatus, connectionLoss: boolean): boolean {
+  return status === 'error' || connectionLoss;
+}
+
+export function isDeviceErrorDisconnect(
+  status: DeviceState['status'],
+  connectionLoss: boolean,
+): boolean {
+  return connectionLoss || status === 'reconnecting';
+}
+
+export function isTakErrorDisconnect(
+  running: boolean,
+  serverError: boolean,
+  clientLoss: boolean,
+): boolean {
+  return (!running && serverError) || (running && clientLoss);
+}
+
+export type ConnectionHeaderVariant = 'ok' | 'warn' | 'error' | 'idle' | 'connected' | 'muted';
+
+export function mqttHeaderVariant(
+  status: MQTTStatus,
+  connectionLoss: boolean,
+): ConnectionHeaderVariant {
+  if (isMqttErrorDisconnect(status, connectionLoss)) return 'error';
+  if (status === 'connected') return 'ok';
+  if (status === 'connecting') return 'warn';
+  return 'idle';
+}
+
+export function deviceHeaderVariant(
+  status: DeviceState['status'],
+  connectionLoss: boolean,
+): ConnectionHeaderVariant {
+  if (isDeviceErrorDisconnect(status, connectionLoss)) return 'error';
+  if (status === 'connecting' || status === 'stale') return 'warn';
+  if (status === 'configured') return 'ok';
+  if (status === 'connected') return 'connected';
+  return 'idle';
+}
+
+export function takHeaderVariant(
+  running: boolean,
+  serverError: boolean,
+  clientLoss: boolean,
+): ConnectionHeaderVariant {
+  if (isTakErrorDisconnect(running, serverError, clientLoss)) return 'error';
+  if (running) return 'ok';
+  return 'idle';
+}
+
+export function headerTextClass(variant: ConnectionHeaderVariant): string {
+  switch (variant) {
+    case 'ok':
+      return CONNECTION_HEADER_OK_TEXT;
+    case 'warn':
+      return CONNECTION_HEADER_WARN_TEXT;
+    case 'error':
+      return CONNECTION_HEADER_PULSE_RED_TEXT;
+    case 'connected':
+      return CONNECTION_HEADER_MUTED_TEXT;
+    case 'muted':
+      return CONNECTION_HEADER_MUTED_TEXT;
+    default:
+      return CONNECTION_HEADER_IDLE_TEXT;
+  }
+}
+
+export function headerIconClass(variant: ConnectionHeaderVariant): string {
+  return headerTextClass(variant);
+}
+
+export function headerDotClass(variant: ConnectionHeaderVariant): string {
+  switch (variant) {
+    case 'ok':
+      return CONNECTION_HEADER_OK_DOT;
+    case 'warn':
+      return CONNECTION_HEADER_WARN_DOT;
+    case 'error':
+      return CONNECTION_HEADER_PULSE_RED_DOT;
+    case 'connected':
+      return CONNECTION_HEADER_CONNECTED_DOT;
+    case 'muted':
+      return CONNECTION_HEADER_MUTED_TEXT;
+    default:
+      return CONNECTION_HEADER_IDLE_DOT;
+  }
+}

--- a/src/renderer/lib/mqttDisconnectIntent.ts
+++ b/src/renderer/lib/mqttDisconnectIntent.ts
@@ -1,0 +1,13 @@
+let userRequestedDisconnect = false;
+
+/** Call immediately before `electronAPI.mqtt.disconnect()` from the UI. */
+export function markMqttUserDisconnect(): void {
+  userRequestedDisconnect = true;
+}
+
+/** Returns true once if the last disconnect was user-initiated. */
+export function consumeMqttUserDisconnect(): boolean {
+  const v = userRequestedDisconnect;
+  userRequestedDisconnect = false;
+  return v;
+}

--- a/src/renderer/lib/types.ts
+++ b/src/renderer/lib/types.ts
@@ -323,6 +323,8 @@ export interface EnvironmentTelemetryPoint {
 
 export interface DeviceState {
   status: 'disconnected' | 'connecting' | 'connected' | 'configured' | 'stale' | 'reconnecting';
+  /** True when the last drop was unexpected (not manual disconnect). */
+  connectionLoss?: boolean;
   myNodeNum: number;
   connectionType: ConnectionType | null;
   reconnectAttempt?: number;

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -151,7 +151,8 @@
       "stale": "Zatuchlý",
       "reconnecting": "Opětovné připojení"
     },
-    "nodeLabel": "Uzel: {{name}}"
+    "nodeLabel": "Uzel: {{name}}",
+    "takClientLost": "Ztráta klienta TAK"
   },
   "toasts": {
     "firmwareAvailable": "Dostupná aktualizace firmwaru: v{{version}}",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -150,7 +150,8 @@
       "stale": "a",
       "reconnecting": "Ankommen"
     },
-    "nodeLabel": "Knoten: {{name}}"
+    "nodeLabel": "Knoten: {{name}}",
+    "takClientLost": "TAK-CLIENT VERLOREN"
   },
   "toasts": {
     "firmwareAvailable": "Firmware-Update verfügbar: v{{version}}",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -140,6 +140,7 @@
     "meshtasticQueueTooltip": "Transmit queue: packets waiting to be sent. Green = low, amber = filling up, red = congested.",
     "meshcoreQueueTooltip": "Because MeshCore sends messages rapidly, and we poll every 30 seconds, this should always be 0. If not 0, there is congestion.",
     "takRunning": "TAK running",
+    "takClientLost": "TAK client lost",
     "takStopped": "TAK stopped",
     "takServerRunning": "TAK server running",
     "takServerStopped": "TAK server stopped",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -151,7 +151,8 @@
       "stale": "(Rancio)",
       "reconnecting": "Reconectando"
     },
-    "nodeLabel": "Nodo: {{name}}"
+    "nodeLabel": "Nodo: {{name}}",
+    "takClientLost": "Cliente TAK PERDIDO"
   },
   "toasts": {
     "firmwareAvailable": "Actualización de firmware disponible: v{{version}}",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -151,7 +151,8 @@
       "stale": "goût de vieux",
       "reconnecting": "Reconnexion"
     },
-    "nodeLabel": "Nœud : {{name}}"
+    "nodeLabel": "Nœud : {{name}}",
+    "takClientLost": "TAK client perdu"
   },
   "toasts": {
     "firmwareAvailable": "Mise à jour du micrologiciel disponible : v{{version}}",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -151,7 +151,8 @@
       "stale": "Basi",
       "reconnecting": "Menghubungkan kembali"
     },
-    "nodeLabel": "Simpul: {{name}}"
+    "nodeLabel": "Simpul: {{name}}",
+    "takClientLost": "Klien TAK HILANG"
   },
   "toasts": {
     "firmwareAvailable": "Pembaruan firmware tersedia: v{{version}}",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -151,7 +151,8 @@
       "stale": "Rafferma",
       "reconnecting": "La riconnessione"
     },
-    "nodeLabel": "Nodo: {{name}}"
+    "nodeLabel": "Nodo: {{name}}",
+    "takClientLost": "Cliente TAK PERSO"
   },
   "toasts": {
     "firmwareAvailable": "Aggiornamento firmware disponibile: v{{version}}",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -151,7 +151,8 @@
       "stale": "古い",
       "reconnecting": "再接続中"
     },
-    "nodeLabel": "ノード: {{name}}"
+    "nodeLabel": "ノード: {{name}}",
+    "takClientLost": "TAKクライアントを失いました"
   },
   "toasts": {
     "firmwareAvailable": "利用可能なファームウェアアップデート: v{{version}}",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -151,7 +151,8 @@
       "stale": "탁한",
       "reconnecting": "다시 연결하는 중"
     },
-    "nodeLabel": "노드: {{name}}"
+    "nodeLabel": "노드: {{name}}",
+    "takClientLost": "TAK 클라이언트 연결 끊김"
   },
   "toasts": {
     "firmwareAvailable": "사용 가능한 펌웨어 업데이트: v{{version}}",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -151,7 +151,8 @@
       "stale": "Muf",
       "reconnecting": "Opnieuw verbinding maken"
     },
-    "nodeLabel": "Knooppunt: {{name}}"
+    "nodeLabel": "Knooppunt: {{name}}",
+    "takClientLost": "TAK client verloren"
   },
   "toasts": {
     "firmwareAvailable": "Firmware-update beschikbaar: v{{version}}",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -151,7 +151,8 @@
       "stale": "Nadpsute",
       "reconnecting": "Ponowne podłączenie"
     },
-    "nodeLabel": "Węzeł: {{name}}"
+    "nodeLabel": "Węzeł: {{name}}",
+    "takClientLost": "Klient TAK UTRACONY"
   },
   "toasts": {
     "firmwareAvailable": "Dostępna aktualizacja oprogramowania sprzętowego: v{{version}}",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -151,7 +151,8 @@
       "stale": "Rançoso",
       "reconnecting": "A restabelecer ligação"
     },
-    "nodeLabel": "Nó: {{name}}"
+    "nodeLabel": "Nó: {{name}}",
+    "takClientLost": "Cliente TAK PERDIDO"
   },
   "toasts": {
     "firmwareAvailable": "Atualização de firmware disponível: v{{version}}",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -151,7 +151,8 @@
       "stale": "Несвежий",
       "reconnecting": "Повторное подключение"
     },
-    "nodeLabel": "Узел: {{name}}"
+    "nodeLabel": "Узел: {{name}}",
+    "takClientLost": "TAK клиент потерян"
   },
   "toasts": {
     "firmwareAvailable": "Доступно обновление прошивки: v{{version}}",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -151,7 +151,8 @@
       "stale": "Bayat",
       "reconnecting": "Yeniden bağlanılıyor"
     },
-    "nodeLabel": "Düğüm: {{name}}"
+    "nodeLabel": "Düğüm: {{name}}",
+    "takClientLost": "TAK müşterisi kaybetti"
   },
   "toasts": {
     "firmwareAvailable": "Ürün yazılımı güncellemesi mevcut: v{{version}}",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -151,7 +151,8 @@
       "stale": "Несвіжий",
       "reconnecting": "Повторне під’єднання"
     },
-    "nodeLabel": "Вузол: {{name}}"
+    "nodeLabel": "Вузол: {{name}}",
+    "takClientLost": "Клієнт TAK втрачений"
   },
   "toasts": {
     "firmwareAvailable": "Доступне оновлення прошивки: v{{version}}",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -150,7 +150,8 @@
       "stale": "陈旧",
       "reconnecting": "重新连接"
     },
-    "nodeLabel": "节点： {{name}}"
+    "nodeLabel": "节点： {{name}}",
+    "takClientLost": "TAK客户丢失"
   },
   "toasts": {
     "firmwareAvailable": "固件更新可用： v {{version}}",


### PR DESCRIPTION
## Summary

- **Header status (MQTT, TAK, device):** When a connection drops due to an error (not a manual disconnect/stop), the top-right indicator pulses red (`animate-pulse text-red-400`). Manual disconnect/stop stays gray; in-progress connect keeps yellow pulse.
- **Signals:** `mqttConnectionLoss` (with `markMqttUserDisconnect` before UI disconnect), `DeviceState.connectionLoss`, and `takClientLoss` for TAK client drops while the server is still running.
- **MeshCore MQTT:** Resume reconnect scheduling after connack timeout instead of leaving the adapter stuck without retries.

## Test plan

- [ ] Connect MQTT, kill broker → header pulses red during retry and on terminal error; Disconnect → gray, no pulse
- [ ] Meshtastic: connect radio, unplug → red pulse while reconnecting; Stop → gray
- [ ] MeshCore: connect, drop link → red pulse on disconnected
- [ ] TAK: start server, disconnect ATAK client → red pulse with "TAK client lost"; manual Stop → gray
- [ ] `pnpm run test:run -- connectionHeaderStatus App.test.tsx`