### PR TITLE
fix: MeshCore/Meshtastic stability, SF history, and static GPS sync

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -469,6 +469,7 @@ export default function App() {
   }, [sidebarCollapsed]);
 
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
+  // Stable array ref from Map.get — safe for React 19 useSyncExternalStore (not latestPositionHistoryPoint).
   const selectedNodeHistoryPoints = usePositionHistoryStore(
     useCallback(
       (s) => (selectedNodeId == null ? undefined : s.history.get(selectedNodeId)),

--- a/src/renderer/components/MapPanel.tsx
+++ b/src/renderer/components/MapPanel.tsx
@@ -957,10 +957,10 @@ export default function MapPanel({
 
     return Array.from(nodes.values())
       .flatMap((n) => {
-        const displayPos = resolveNodeMapPosition(
-          n,
-          latestPositionHistoryPoint(positionHistory.get(n.node_id)),
-        );
+        const displayPos =
+          n.node_id === myNodeNum && ourPosition?.source === 'static'
+            ? { lat: ourPosition.lat, lon: ourPosition.lon }
+            : resolveNodeMapPosition(n, latestPositionHistoryPoint(positionHistory.get(n.node_id)));
         if (!displayPos) return [];
         const mapped: MeshNode = { ...n, latitude: displayPos.lat, longitude: displayPos.lon };
         if (
@@ -984,7 +984,14 @@ export default function MapPanel({
         return [mapped];
       })
       .sort((a, b) => a.node_id - b.node_id);
-  }, [nodes, myNodeNum, locationFilter, excludeMeshcoreContactTypesInMeshtastic, positionHistory]);
+  }, [
+    nodes,
+    myNodeNum,
+    locationFilter,
+    excludeMeshcoreContactTypesInMeshtastic,
+    positionHistory,
+    ourPosition,
+  ]);
   const nodesToRender = useMemo(() => {
     const idSet = new Set(nodesWithPosition.map((n) => n.node_id));
     const out: MeshNode[] = [...nodesWithPosition];

--- a/src/renderer/components/NodeDetailModal.tsx
+++ b/src/renderer/components/NodeDetailModal.tsx
@@ -218,13 +218,12 @@ export default function NodeDetailModal({
     setShareContactPending(false);
   }, [node?.node_id]);
 
-  // Detect position update after a request was sent
+  // Detect position update after a request was sent (gate on state, not ref — avoids flash on open)
   useEffect(() => {
-    if (positionRequestedAtRef.current !== null) {
-      setPositionRequestedAt(null);
-      setActionStatus(t('nodeDetailModal.positionUpdated'));
-    }
-  }, [node?.latitude, node?.longitude, t]);
+    if (positionRequestedAt === null) return;
+    setPositionRequestedAt(null);
+    setActionStatus(t('nodeDetailModal.positionUpdated'));
+  }, [node?.latitude, node?.longitude, positionRequestedAt, t]);
 
   // 30-second timeout for position request
   useEffect(() => {

--- a/src/renderer/components/NodeInfoBody.storeIntegration.test.tsx
+++ b/src/renderer/components/NodeInfoBody.storeIntegration.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MeshNode } from '../lib/types';
+import { usePositionHistoryStore } from '../stores/positionHistoryStore';
+import NodeInfoBody from './NodeInfoBody';
+
+const diagnosticsStoreState = {
+  diagnosticRows: [],
+  packetStats: new Map(),
+  hopHistory: new Map(),
+  nodeRedundancy: new Map(),
+  meshcoreHopHistory: new Map(),
+  meshcoreTraceHistory: new Map(),
+  loadMeshcorePathHistory: vi.fn(),
+  getCuStats24h: vi.fn().mockReturnValue(null),
+  packetCache: new Map(),
+  getForeignLoraDetectionsList: vi.fn().mockReturnValue([]),
+};
+
+const initialPositionHistoryState = usePositionHistoryStore.getInitialState();
+
+vi.mock('../stores/coordFormatStore', () => ({
+  useCoordFormatStore: (selector: (s: { coordinateFormat: 'decimal' | 'mgrs' }) => unknown) =>
+    selector({ coordinateFormat: 'decimal' }),
+}));
+
+vi.mock('../stores/diagnosticsStore', () => ({
+  useDiagnosticsStore: (selector: (s: typeof diagnosticsStoreState) => unknown) =>
+    selector(diagnosticsStoreState),
+}));
+
+describe('NodeInfoBody position history store integration', () => {
+  beforeEach(() => {
+    usePositionHistoryStore.setState(initialPositionHistoryState, true);
+  });
+
+  it('renders GPS node with history without infinite loop and does not auto-call onShowOnMap', () => {
+    usePositionHistoryStore.setState({
+      history: new Map([[42, [{ t: 1_000, lat: 40.12, lon: -105.12 }]]]),
+    });
+
+    const onShowOnMap = vi.fn();
+    const node: MeshNode = {
+      node_id: 42,
+      long_name: 'GPS Node',
+      short_name: 'GPS',
+      hw_model: 'T-Echo',
+      snr: 0,
+      battery: 0,
+      last_heard: Math.floor(Date.now() / 1000),
+      latitude: 40.0,
+      longitude: -105.0,
+    };
+
+    render(<NodeInfoBody node={node} protocol="meshtastic" onShowOnMap={onShowOnMap} />);
+
+    expect(screen.getByText('Position')).toBeInTheDocument();
+    expect(screen.getByText('40.00000, -105.00000')).toBeInTheDocument();
+    expect(onShowOnMap).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/NodeInfoBody.tsx
+++ b/src/renderer/components/NodeInfoBody.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from 'i18next';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useLatestTrackedPosition } from '../hooks/useLatestTrackedPosition';
 import {
   formatCoordPair,
   latestPositionHistoryPoint,
@@ -46,7 +47,6 @@ import type { HopHistoryPoint, MeshNode, MeshProtocol, NodeAnomaly } from '../li
 import { routingRowToNodeAnomaly } from '../lib/types';
 import { useCoordFormatStore } from '../stores/coordFormatStore';
 import { useDiagnosticsStore } from '../stores/diagnosticsStore';
-import { usePositionHistoryStore } from '../stores/positionHistoryStore';
 import MeshCongestionAttributionBlock from './MeshCongestionAttributionBlock';
 import SnrIndicator from './SnrIndicator';
 
@@ -185,9 +185,7 @@ export default function NodeInfoBody({
   const meshcoreTraceHistory = useDiagnosticsStore((s) => s.meshcoreTraceHistory.get(node.node_id));
   const loadMeshcorePathHistory = useDiagnosticsStore((s) => s.loadMeshcorePathHistory);
   const [pathHistoryOpen, setPathHistoryOpen] = useState(false);
-  const latestTrackedPositionFromStore = usePositionHistoryStore((s) =>
-    latestPositionHistoryPoint(s.history.get(node.node_id)),
-  );
+  const latestTrackedPositionFromStore = useLatestTrackedPosition(node.node_id);
   const latestTrackedPositionFromProps = latestPositionHistoryPoint(
     positionHistory?.get(node.node_id),
   );

--- a/src/renderer/components/RepeatersPanel.tsx
+++ b/src/renderer/components/RepeatersPanel.tsx
@@ -20,7 +20,7 @@ import {
   meshcoreIsRepeaterRemoteAuthTouched,
   meshcoreTracePathLenToHops,
 } from '../lib/meshcoreUtils';
-import { getNodeStatus, normalizeLastHeardMs } from '../lib/nodeStatus';
+import { effectiveLastHeardMs, getNodeStatus, normalizeLastHeardMs } from '../lib/nodeStatus';
 import type { PathRecord } from '../lib/pathHistoryTypes';
 import { useRadioProvider } from '../lib/radio/providerFactory';
 import type { MeshNode } from '../lib/types';
@@ -70,24 +70,12 @@ function isSignalRecent(lastAdvert: number | null | undefined): boolean {
   return Date.now() - advertMs < SIGNAL_MAX_AGE_MS;
 }
 
-function formatRelativeTime(
-  t: TFunction,
-  lastHeard: number | null | undefined,
-  nodeId?: number,
-  nodeName?: string,
-): string {
+function formatRelativeTime(t: TFunction, lastHeard: number | null | undefined): string {
   if (!lastHeard) return t('common.never');
-  const lastMs = normalizeLastHeardMs(lastHeard);
+  const lastMs = effectiveLastHeardMs(lastHeard);
   if (!lastMs) return t('common.never');
   const ageMs = Date.now() - lastMs;
   const ageSec = Math.floor(ageMs / 1000);
-  if (ageSec < 0) {
-    const timeDeltaSec = Math.abs(ageSec);
-    if (timeDeltaSec > 60)
-      console.warn(
-        `[formatRelativeTime] future timestamp detected: node=${nodeName ?? nodeId?.toString(16) ?? 'unknown'}, timeDelta=${timeDeltaSec}s, lastHeard=${lastHeard}, lastMs=${lastMs}`,
-      );
-  }
   const clampedSec = Math.max(0, ageSec);
   if (clampedSec < 60) return t('common.justNow');
   const ageMin = Math.floor(clampedSec / 60);
@@ -690,7 +678,7 @@ export default function RepeatersPanel({
                           </span>
                         </td>
                         <td className="py-2 pr-4 text-xs text-gray-400">
-                          {formatRelativeTime(t, node.last_heard, node.node_id, node.long_name)}
+                          {formatRelativeTime(t, node.last_heard)}
                         </td>
                         <td
                           className="py-2 pr-4"

--- a/src/renderer/hooks/useDevice.selfNodeLastHeard.test.ts
+++ b/src/renderer/hooks/useDevice.selfNodeLastHeard.test.ts
@@ -49,6 +49,16 @@ describe('self-node last_heard initialisation (#272)', () => {
     const lastHeardMs = computeNodeInfoLastHeardMs(0, 0, false);
     expect(getNodeStatus(lastHeardMs)).toBe('offline');
   });
+
+  it('clamps future info.lastHeard from device RTC skew to Date.now()', () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const futureSec = nowSec + 86_400;
+    const before = Date.now();
+    const lastHeardMs = computeNodeInfoLastHeardMs(futureSec, 0, false);
+    const after = Date.now();
+    expect(lastHeardMs).toBeGreaterThanOrEqual(before);
+    expect(lastHeardMs).toBeLessThanOrEqual(after);
+  });
 });
 
 describe('mergeMeshtasticUserPacketLastHeard', () => {

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -55,7 +55,11 @@ import {
   matchForeignLoraFromMeshtasticLog,
 } from '../lib/foreignLoraDetection';
 import type { OurPosition } from '../lib/gpsSource';
-import { resolveOurPosition } from '../lib/gpsSource';
+import {
+  readStoredStaticGps,
+  resolveOurPosition,
+  shouldPreserveStaticGpsForSelfNode,
+} from '../lib/gpsSource';
 import { meshtasticHwModelName } from '../lib/hardwareModels';
 import { setMeshtasticConnectedMyNodeNum } from '../lib/meshtasticConnectedNodeRef';
 import {
@@ -1539,7 +1543,11 @@ export function useDevice() {
           let newAlt = info.position?.altitude ?? existing.altitude;
           let posWarn: string | undefined = existing.lastPositionWarning;
 
-          if (info.position?.latitudeI != null && info.position?.longitudeI != null) {
+          if (
+            info.position?.latitudeI != null &&
+            info.position?.longitudeI != null &&
+            !shouldPreserveStaticGpsForSelfNode(nodeNum, myNodeNumRef.current)
+          ) {
             const lat = info.position.latitudeI / 1e7;
             const lon = info.position.longitudeI / 1e7;
             const r = validateCoords(lat, lon);
@@ -1713,6 +1721,10 @@ export function useDevice() {
             updated.set(packet.from, { ...existing, lastPositionWarning: r.warning });
             return updated;
           });
+          return;
+        }
+
+        if (shouldPreserveStaticGpsForSelfNode(packet.from, myNodeNumRef.current)) {
           return;
         }
 
@@ -3483,25 +3495,13 @@ export function useDevice() {
     setGpsLoading(true);
     try {
       const myNode = nodesRef.current.get(myNodeNumRef.current);
-      let staticLat: number | undefined;
-      let staticLon: number | undefined;
-      try {
-        const s =
-          parseStoredJson<{ staticLat?: number; staticLon?: number }>(
-            localStorage.getItem('mesh-client:gpsSettings'),
-            'useDevice refreshOurPosition gpsSettings',
-          ) ?? {};
-        if (typeof s.staticLat === 'number' && typeof s.staticLon === 'number') {
-          staticLat = s.staticLat;
-          staticLon = s.staticLon;
-        }
-      } catch {
-        // catch-no-log-ok localStorage read for GPS settings — ignore parse errors
-      }
+      const storedStatic = readStoredStaticGps();
+      const staticLat = storedStatic?.lat;
+      const staticLon = storedStatic?.lon;
       // When a static position is set, don't let device coords override it
-      const devLat = staticLat != null ? undefined : myNode?.latitude;
-      const devLon = staticLon != null ? undefined : myNode?.longitude;
-      const devAlt = staticLat != null ? undefined : myNode?.altitude;
+      const devLat = storedStatic != null ? undefined : myNode?.latitude;
+      const devLon = storedStatic != null ? undefined : myNode?.longitude;
+      const devAlt = storedStatic != null ? undefined : myNode?.altitude;
       const pos = await resolveOurPosition(devLat, devLon, staticLat, staticLon, devAlt);
       setOurPosition(pos);
       if (getStoredMeshProtocol() === 'meshtastic') {
@@ -3541,8 +3541,7 @@ export function useDevice() {
         const isClientMute = nodesRef.current.get(myNodeNumRef.current)?.role === ROLE_CLIENT_MUTE;
         const wouldSendWithoutMute =
           deviceRef.current &&
-          ((pos.source === 'static' && deviceGpsModeRef.current !== 1) ||
-            (pos.source === 'browser' && deviceGpsModeRef.current === 2));
+          (pos.source === 'static' || (pos.source === 'browser' && deviceGpsModeRef.current === 2));
         const shouldSendToDevice = !isClientMute && wouldSendWithoutMute;
 
         if (shouldSendToDevice && deviceRef.current) {

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -65,6 +65,7 @@ import {
   meshtasticTraceRouteLookupKeys,
 } from '../lib/meshtasticTraceRouteLookupKeys';
 import { consumeMqttUserDisconnect } from '../lib/mqttDisconnectIntent';
+import { LAST_HEARD_MAX_FUTURE_SKEW_SEC } from '../lib/nodeStatus';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import { MESHTASTIC_CAPABILITIES } from '../lib/radio/BaseRadioProvider';
 import {
@@ -3830,9 +3831,12 @@ export function computeNodeInfoLastHeardMs(
   existingLastHeard: number,
   isSelf: boolean,
 ): number {
-  return (infoLastHeard ?? 0) > 0
-    ? infoLastHeard! * 1000
-    : existingLastHeard || (isSelf ? Date.now() : 0);
+  if ((infoLastHeard ?? 0) > 0) {
+    const ms = infoLastHeard! * 1000;
+    const maxMs = Date.now() + LAST_HEARD_MAX_FUTURE_SKEW_SEC * 1000;
+    return ms > maxMs ? Date.now() : ms;
+  }
+  return existingLastHeard || (isSelf ? Date.now() : 0);
 }
 
 /**

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -6,11 +6,16 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import {
-  buildStoreForwardHistoryRequestBytes,
+  buildStoreForwardHistoryToRadioBytes,
   decodeStoreForwardTextPayload,
   isDuplicateHistoryMessage,
   MQTT_RECONNECT_BACKLOG_MS,
   mqttMessageTreatAsHistory,
+  parseStoreForwardHeartbeat,
+  releaseStoreForwardHistoryRequest,
+  reserveStoreForwardHistoryRequest,
+  shouldRequestStoreForwardHistoryOnHeartbeat,
+  writeToRadioWithoutQueue,
 } from '@/renderer/lib/meshtasticBacklogUtils';
 import { channelNameExists, findNextFreeChannelSlot } from '@/shared/meshtasticChannelApply';
 import { isMeshtasticDefaultPublicPsk } from '@/shared/meshtasticDefaultPublicPsk';
@@ -295,9 +300,9 @@ export function useDevice() {
   const [waypoints, setWaypoints] = useState<Map<number, MeshWaypoint>>(new Map());
   const [moduleConfigs, setModuleConfigs] = useState<Record<string, unknown>>({});
   const moduleConfigsRef = useRef(moduleConfigs);
-  const sfHistoryRequestedRef = useRef(false);
+  const sfHistoryRequestedServersRef = useRef<Set<number>>(new Set());
+  const deviceConfiguredRef = useRef(false);
   const mqttReconnectBacklogUntilRef = useRef(0);
-  const MESHTASTIC_BROADCAST_NODE_NUM = 0xffffffff;
   const [securityConfig, setSecurityConfig] = useState<{
     publicKey: Uint8Array;
     privateKey: Uint8Array;
@@ -1136,39 +1141,7 @@ export function useDevice() {
           void refreshOurPositionRef.current();
           startGpsInterval();
           setQueueStatus({ free: 16, maxlen: 16, res: 0 });
-          if (!sfHistoryRequestedRef.current && deviceRef.current) {
-            sfHistoryRequestedRef.current = true;
-            const sfCfg = moduleConfigsRef.current.storeForward as
-              | {
-                  enabled?: boolean;
-                  isServer?: boolean;
-                  historyReturnWindow?: number;
-                }
-              | undefined;
-            if (sfCfg?.enabled && !sfCfg.isServer) {
-              void (async () => {
-                try {
-                  const requestBytes = buildStoreForwardHistoryRequestBytes({
-                    windowMinutes: sfCfg.historyReturnWindow ?? 0,
-                  });
-                  // History replay arrives as async STORE_FORWARD_APP packets, not a routing reply.
-                  await deviceRef.current!.sendPacket(
-                    requestBytes,
-                    Portnums.PortNum.STORE_FORWARD_APP,
-                    MESHTASTIC_BROADCAST_NODE_NUM,
-                    0,
-                    false,
-                    false,
-                  );
-                  console.debug('[useDevice] requested Store & Forward history (CLIENT_HISTORY)');
-                } catch (e: unknown) {
-                  console.warn(
-                    '[useDevice] Store & Forward history request failed ' + errLikeToLogString(e),
-                  );
-                }
-              })();
-            }
-          }
+          deviceConfiguredRef.current = true;
           void deviceRef.current
             ?.getConfig(Admin.AdminMessage_ConfigType.LORA_CONFIG)
             .catch((e: unknown) => {
@@ -1195,7 +1168,8 @@ export function useDevice() {
           setSecurityConfig(null);
           setLoraConfig(null);
           deviceRef.current = null;
-          sfHistoryRequestedRef.current = false;
+          deviceConfiguredRef.current = false;
+          sfHistoryRequestedServersRef.current = new Set();
           setState((s) => ({
             ...s,
             status: 'disconnected',
@@ -2517,6 +2491,52 @@ export function useDevice() {
           return updated;
         });
 
+        const serverNodeId = packet.from;
+        const heartbeat = parseStoreForwardHeartbeat(packet.data);
+        if (serverNodeId && heartbeat) {
+          const sfCfg = moduleConfigsRef.current.storeForward as { isServer?: boolean } | undefined;
+          const alreadyRequested = sfHistoryRequestedServersRef.current.has(serverNodeId);
+          if (
+            shouldRequestStoreForwardHistoryOnHeartbeat({
+              heartbeatSecondary: heartbeat.secondary,
+              connectedIsStoreForwardServer: sfCfg?.isServer === true,
+              alreadyRequestedServer: alreadyRequested,
+              deviceConfigured: deviceConfiguredRef.current,
+            }) &&
+            reserveStoreForwardHistoryRequest(sfHistoryRequestedServersRef.current, serverNodeId)
+          ) {
+            const myNode = myNodeNumRef.current;
+            const activeDevice = deviceRef.current;
+            if (myNode && activeDevice) {
+              const packetId = (Math.floor(Math.random() * 0xfffffffe) + 1) >>> 0;
+              const toRadioBytes = buildStoreForwardHistoryToRadioBytes({
+                from: myNode,
+                to: serverNodeId,
+                channel: packet.channel ?? 0,
+                packetId,
+                windowMinutes: heartbeat.period > 0 ? heartbeat.period : 0,
+              });
+              void writeToRadioWithoutQueue(activeDevice, toRadioBytes)
+                .then(() => {
+                  console.debug(
+                    `[useDevice] Store & Forward CLIENT_HISTORY sent to 0x${serverNodeId.toString(16)} ch=${packet.channel ?? 0}`,
+                  );
+                })
+                .catch((e: unknown) => {
+                  releaseStoreForwardHistoryRequest(
+                    sfHistoryRequestedServersRef.current,
+                    serverNodeId,
+                  );
+                  console.warn(
+                    '[useDevice] Store & Forward history request failed ' + errLikeToLogString(e),
+                  );
+                });
+            } else {
+              releaseStoreForwardHistoryRequest(sfHistoryRequestedServersRef.current, serverNodeId);
+            }
+          }
+        }
+
         const from = packet.from;
         const payloadText = decodeStoreForwardTextPayload(packet.data);
         if (!from || !payloadText) return;
@@ -2524,7 +2544,7 @@ export function useDevice() {
           sender_id: from,
           sender_name: getNodeName(from),
           payload: payloadText,
-          channel: 0,
+          channel: packet.channel ?? 0,
           timestamp: Date.now(),
           isHistory: true,
           receivedVia: 'rf',

--- a/src/renderer/hooks/useLatestTrackedPosition.test.ts
+++ b/src/renderer/hooks/useLatestTrackedPosition.test.ts
@@ -1,0 +1,46 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { usePositionHistoryStore } from '../stores/positionHistoryStore';
+import { useLatestTrackedPosition } from './useLatestTrackedPosition';
+
+const initialPositionHistoryState = usePositionHistoryStore.getInitialState();
+
+describe('useLatestTrackedPosition', () => {
+  beforeEach(() => {
+    usePositionHistoryStore.setState(initialPositionHistoryState, true);
+  });
+
+  it('returns null when history is empty', () => {
+    const { result } = renderHook(() => useLatestTrackedPosition(42));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns newest point without re-rendering when store updates unrelated nodes', () => {
+    usePositionHistoryStore.setState({
+      history: new Map([[42, [{ t: 1_000, lat: 40.1, lon: -105.1 }]]]),
+    });
+
+    const { result, rerender } = renderHook(() => useLatestTrackedPosition(42));
+    expect(result.current).toEqual({ lat: 40.1, lon: -105.1 });
+    const firstRef = result.current;
+
+    usePositionHistoryStore.getState().recordPosition(99, 1, 2);
+    rerender();
+    expect(result.current).toBe(firstRef);
+  });
+
+  it('updates when the tracked point for this node changes', () => {
+    usePositionHistoryStore.setState({
+      history: new Map([[42, [{ t: 1_000, lat: 40.1, lon: -105.1 }]]]),
+    });
+
+    const { result } = renderHook(() => useLatestTrackedPosition(42));
+    act(() => {
+      // >10 m from prior point so recordPosition accepts the update
+      usePositionHistoryStore.getState().recordPosition(42, 41.0, -106.0);
+    });
+
+    expect(result.current).toEqual({ lat: 41.0, lon: -106.0 });
+  });
+});

--- a/src/renderer/hooks/useLatestTrackedPosition.ts
+++ b/src/renderer/hooks/useLatestTrackedPosition.ts
@@ -1,0 +1,14 @@
+import { useShallow } from 'zustand/react/shallow';
+
+import { latestPositionHistoryPoint } from '../lib/coordUtils';
+import { usePositionHistoryStore } from '../stores/positionHistoryStore';
+
+/**
+ * Latest valid tracked lat/lon for a node from position history.
+ * useShallow avoids a new object reference every getSnapshot (React 19 infinite-loop guard).
+ */
+export function useLatestTrackedPosition(nodeId: number): { lat: number; lon: number } | null {
+  return usePositionHistoryStore(
+    useShallow((s) => latestPositionHistoryPoint(s.history.get(nodeId))),
+  );
+}

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -34,6 +34,7 @@ import {
   findMeshcoreDmReplyParent,
   normalizeMeshcoreIncomingText,
 } from '../lib/meshcoreChannelText';
+import { MeshcoreCompanionTxEchoFilter } from '../lib/meshcoreCompanionTxEchoFilter';
 import {
   buildGetAutoaddConfigFrame,
   buildSetAutoaddConfigFrame,
@@ -433,6 +434,7 @@ class IpcNobleConnection {
   async connect() {
     const runConnect = async () => {
       const sessionId = this.sessionId;
+      const txEchoFilter = new MeshcoreCompanionTxEchoFilter();
       class NobleOverIpc extends MeshcoreConnectionBase {
         constructor(private readonly session: NobleBleSessionId) {
           super();
@@ -443,6 +445,7 @@ class IpcNobleConnection {
          * USB framing (0x3c/0x3e + length) used for WebSerial/TCP.
          */
         async sendToRadioFrame(data: Uint8Array) {
+          txEchoFilter.noteOutbound(data);
           this.emit('tx', data);
           await this.write(data);
         }
@@ -469,6 +472,9 @@ class IpcNobleConnection {
       const offData = window.electronAPI.onNobleBleFromRadio(({ sessionId: sid, bytes }) => {
         if (sid !== sessionId) return;
         const frame = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+        if (txEchoFilter.isEcho(frame)) {
+          return;
+        }
         instance.onFrameReceived(frame);
       });
       const offDisc = window.electronAPI.onNobleBleDisconnected((sid) => {

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -105,7 +105,11 @@ import {
 import { MeshcoreWebBluetoothConnection } from '../lib/meshcoreWebBluetoothConnection';
 import { getMeshtasticConnectedMyNodeNum } from '../lib/meshtasticConnectedNodeRef';
 import { consumeMqttUserDisconnect } from '../lib/mqttDisconnectIntent';
-import { lastHeardToUnixSeconds, mergeMeshcoreLastHeardFromAdvert } from '../lib/nodeStatus';
+import {
+  LAST_HEARD_MAX_FUTURE_SKEW_SEC,
+  lastHeardToUnixSeconds,
+  mergeMeshcoreLastHeardFromAdvert,
+} from '../lib/nodeStatus';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import { parseTcpAddress } from '../lib/parseTcpAddress';
 import { MAX_RAW_PACKET_LOG_ENTRIES } from '../lib/rawPacketLogConstants';
@@ -2060,10 +2064,20 @@ export function useMeshCore() {
             typeof d.advLat === 'number' && Number.isFinite(d.advLat) && d.advLat !== 0;
           const hasLon =
             typeof d.advLon === 'number' && Number.isFinite(d.advLon) && d.advLon !== 0;
-          const lastHeard =
+          const rawAdvertSec =
             typeof d.lastAdvert === 'number' && Number.isFinite(d.lastAdvert) && d.lastAdvert > 0
-              ? d.lastAdvert
-              : nowSec;
+              ? Math.floor(d.lastAdvert)
+              : undefined;
+          const lastHeard = mergeMeshcoreLastHeardFromAdvert(
+            rawAdvertSec,
+            existing?.last_heard ?? nowSec,
+            nowSec,
+          );
+          if (rawAdvertSec != null && rawAdvertSec > nowSec + LAST_HEARD_MAX_FUTURE_SKEW_SEC) {
+            console.debug(
+              `[useMeshCore] clamped future lastAdvert nodeId=${nodeId.toString(16)} advertSec=${rawAdvertSec} nowSec=${nowSec}`,
+            );
+          }
           persistOut.persistLastAdvert = lastHeard;
           if (!existing) {
             const built = meshcoreMinimalNodeFromAdvertEvent(d.publicKey, {

--- a/src/renderer/hooks/useMeshCore.ts
+++ b/src/renderer/hooks/useMeshCore.ts
@@ -26,7 +26,12 @@ import {
   meshtasticSenderIdForRawLogFallback,
 } from '../lib/foreignLoraDetection';
 import type { OurPosition } from '../lib/gpsSource';
-import { resolveOurPosition } from '../lib/gpsSource';
+import {
+  hasStoredStaticGps,
+  readStoredStaticGps,
+  resolveOurPosition,
+  shouldPreserveStaticGpsForSelfNode,
+} from '../lib/gpsSource';
 import { tryPersistMeshcoreIdentityFromRadioExport } from '../lib/letsMeshJwt';
 import {
   buildMeshcoreChannelIncomingMessage,
@@ -1940,14 +1945,15 @@ export function useMeshCore() {
               }
             : null;
         const fromSelfAdv = meshcoreScaledAdvLatLonToDeg(self.advLat ?? 0, self.advLon ?? 0);
+        const storedStatic = hasStoredStaticGps() ? readStoredStaticGps() : null;
         if (selfNode) {
           nextNodes.set(myNodeId, {
             ...selfNode,
             long_name: displayLongName,
             short_name: displayShortName,
             hops_away: 0,
-            latitude: fromSelfAdv.lat ?? selfNode.latitude ?? null,
-            longitude: fromSelfAdv.lon ?? selfNode.longitude ?? null,
+            latitude: storedStatic?.lat ?? fromSelfAdv.lat ?? selfNode.latitude ?? null,
+            longitude: storedStatic?.lon ?? fromSelfAdv.lon ?? selfNode.longitude ?? null,
             ...(fromSelfBattery ?? {}),
           });
         } else {
@@ -1960,8 +1966,8 @@ export function useMeshCore() {
             snr: 0,
             rssi: 0,
             last_heard: Math.floor(Date.now() / 1000),
-            latitude: fromSelfAdv.lat,
-            longitude: fromSelfAdv.lon,
+            latitude: storedStatic?.lat ?? fromSelfAdv.lat,
+            longitude: storedStatic?.lon ?? fromSelfAdv.lon,
             hops_away: 0,
             ...(fromSelfBattery?.voltage != null ? { voltage: fromSelfBattery.voltage } : {}),
           });
@@ -2109,12 +2115,18 @@ export function useMeshCore() {
           }
           persistOut.kind = 'update';
           const next = new Map(prev);
-          persistOut.persistLat = hasLat
-            ? d.advLat! / MESHCORE_COORD_SCALE
-            : (existing.latitude ?? null);
-          persistOut.persistLon = hasLon
-            ? d.advLon! / MESHCORE_COORD_SCALE
-            : (existing.longitude ?? null);
+          const skipSelfStaticCoords = shouldPreserveStaticGpsForSelfNode(
+            nodeId,
+            myNodeNumRef.current,
+          );
+          persistOut.persistLat =
+            skipSelfStaticCoords || !hasLat
+              ? (existing.latitude ?? null)
+              : d.advLat! / MESHCORE_COORD_SCALE;
+          persistOut.persistLon =
+            skipSelfStaticCoords || !hasLon
+              ? (existing.longitude ?? null)
+              : d.advLon! / MESHCORE_COORD_SCALE;
           const advNameTrim =
             typeof d.advName === 'string' && d.advName.trim() ? d.advName.trim() : '';
           const applyAdvertName = !nick && Boolean(advNameTrim);
@@ -2129,8 +2141,14 @@ export function useMeshCore() {
             ...existing,
             last_heard: lastHeard,
             hw_model: mergedHwModel,
-            latitude: hasLat ? d.advLat! / MESHCORE_COORD_SCALE : existing.latitude,
-            longitude: hasLon ? d.advLon! / MESHCORE_COORD_SCALE : existing.longitude,
+            latitude:
+              skipSelfStaticCoords || !hasLat
+                ? existing.latitude
+                : d.advLat! / MESHCORE_COORD_SCALE,
+            longitude:
+              skipSelfStaticCoords || !hasLon
+                ? existing.longitude
+                : d.advLon! / MESHCORE_COORD_SCALE,
             ...(nick
               ? { long_name: nick, short_name: '' }
               : applyAdvertName
@@ -5995,31 +6013,64 @@ export function useMeshCore() {
 
   const refreshOurPositionNoop = useCallback(async () => {
     const myNode = nodesRef.current.get(myNodeNumRef.current);
-    let staticLat: number | undefined;
-    let staticLon: number | undefined;
-    try {
-      const s = JSON.parse(localStorage.getItem('mesh-client:gpsSettings') || '{}') as {
-        staticLat?: number;
-        staticLon?: number;
-      };
-      if (typeof s.staticLat === 'number' && typeof s.staticLon === 'number') {
-        staticLat = s.staticLat;
-        staticLon = s.staticLon;
-      }
-    } catch {
-      // catch-no-log-ok localStorage read for GPS settings — ignore parse errors
-    }
+    const storedStatic = readStoredStaticGps();
+    const staticLat = storedStatic?.lat;
+    const staticLon = storedStatic?.lon;
     // Match useDevice: when a static override exists, do not let device coords win over it.
-    const devLat = staticLat != null ? undefined : myNode?.latitude;
-    const devLon = staticLon != null ? undefined : myNode?.longitude;
-    const devAlt = staticLat != null ? undefined : myNode?.altitude;
+    const devLat = storedStatic != null ? undefined : myNode?.latitude;
+    const devLon = storedStatic != null ? undefined : myNode?.longitude;
+    const devAlt = storedStatic != null ? undefined : myNode?.altitude;
     const pos = await resolveOurPosition(devLat, devLon, staticLat, staticLon, devAlt);
     setOurPosition(pos);
     if (getStoredMeshProtocol() === 'meshcore') {
       useDiagnosticsStore.getState().setOurPositionSource(pos?.source ?? null);
     }
+
+    if (pos) {
+      const selfNodeId = myNodeNumRef.current;
+      if (selfNodeId > 0) {
+        const nowSec = Math.floor(Date.now() / 1000);
+        setNodes((prev) => {
+          const next = new Map(prev);
+          const existing = next.get(selfNodeId);
+          if (existing) {
+            next.set(selfNodeId, {
+              ...existing,
+              latitude: pos.lat,
+              longitude: pos.lon,
+              last_heard: nowSec,
+              lastPositionWarning: undefined,
+            });
+          } else {
+            const trimmedName = selfInfo?.name?.trim() ?? '';
+            next.set(selfNodeId, {
+              node_id: selfNodeId,
+              long_name: trimmedName || `Node-${selfNodeId.toString(16).toUpperCase()}`,
+              short_name: '',
+              hw_model: CONTACT_TYPE_LABELS[selfInfo?.type ?? 0] ?? 'Unknown',
+              battery: 0,
+              snr: 0,
+              rssi: 0,
+              last_heard: nowSec,
+              latitude: pos.lat,
+              longitude: pos.lon,
+            });
+          }
+          return next;
+        });
+      }
+
+      if (pos.source === 'static' && connRef.current) {
+        sendPositionToDeviceMeshCore(pos.lat, pos.lon).catch((e: unknown) => {
+          console.debug(
+            '[useMeshCore] refreshOurPosition setAdvertLatLong non-fatal ' + errLikeToLogString(e),
+          );
+        });
+      }
+    }
+
     return pos;
-  }, []);
+  }, [selfInfo?.name, selfInfo?.type, sendPositionToDeviceMeshCore]);
 
   refreshOurPositionMeshCoreRef.current = refreshOurPositionNoop;
 

--- a/src/renderer/lib/coordUtils.test.ts
+++ b/src/renderer/lib/coordUtils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isDisplayableCoord,
   latestPositionHistoryPoint,
+  latestTrackedPositionEqual,
   nodeHasDisplayablePosition,
   resolveNodeMapPosition,
 } from './coordUtils';
@@ -44,6 +45,18 @@ describe('isDisplayableCoord', () => {
     expect(isDisplayableCoord(0, 0)).toBe(false);
     expect(isDisplayableCoord(Number.NaN, 1)).toBe(false);
     expect(isDisplayableCoord(39.7, -104.9)).toBe(true);
+  });
+});
+
+describe('latestTrackedPositionEqual', () => {
+  it('treats identical coordinates as equal despite different object refs', () => {
+    expect(latestTrackedPositionEqual({ lat: 40, lon: -105 }, { lat: 40, lon: -105 })).toBe(true);
+  });
+
+  it('detects coordinate changes and null transitions', () => {
+    expect(latestTrackedPositionEqual({ lat: 40, lon: -105 }, { lat: 41, lon: -105 })).toBe(false);
+    expect(latestTrackedPositionEqual(null, null)).toBe(true);
+    expect(latestTrackedPositionEqual(null, { lat: 1, lon: 2 })).toBe(false);
   });
 });
 

--- a/src/renderer/lib/coordUtils.ts
+++ b/src/renderer/lib/coordUtils.ts
@@ -32,6 +32,16 @@ export function latestPositionHistoryPoint(
   return { lat: latest.lat, lon: latest.lon };
 }
 
+/** Value equality for Zustand selectors that return latestPositionHistoryPoint results. */
+export function latestTrackedPositionEqual(
+  a: { lat: number; lon: number } | null,
+  b: { lat: number; lon: number } | null,
+): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return a === b;
+  return a.lat === b.lat && a.lon === b.lon;
+}
+
 /** NodeDB lat/lon when present, otherwise newest valid tracked point. */
 export function resolveNodeMapPosition(
   node: { latitude?: number | null; longitude?: number | null },

--- a/src/renderer/lib/formatShortRelativeAgo.ts
+++ b/src/renderer/lib/formatShortRelativeAgo.ts
@@ -1,9 +1,9 @@
-import { normalizeLastHeardMs } from './nodeStatus';
+import { effectiveLastHeardMs } from './nodeStatus';
 
 /** Short English relative time for compact UI (e.g. chat DM header). */
 export function formatShortRelativeAgo(nowMs: number, lastHeard: number): string | null {
   if (!lastHeard || !nowMs) return null;
-  const lastHeardMs = normalizeLastHeardMs(lastHeard);
+  const lastHeardMs = effectiveLastHeardMs(lastHeard, nowMs);
   if (!lastHeardMs) return null;
   const diff = nowMs - lastHeardMs;
   if (diff < 60_000) return 'just now';

--- a/src/renderer/lib/gpsSource.test.ts
+++ b/src/renderer/lib/gpsSource.test.ts
@@ -1,6 +1,49 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { resolveOurPosition } from './gpsSource';
+import {
+  GPS_SETTINGS_STORAGE_KEY,
+  hasStoredStaticGps,
+  readStoredStaticGps,
+  resolveOurPosition,
+  shouldPreserveStaticGpsForSelfNode,
+} from './gpsSource';
+
+describe('readStoredStaticGps', () => {
+  afterEach(() => {
+    localStorage.removeItem(GPS_SETTINGS_STORAGE_KEY);
+  });
+
+  it('returns null when unset or invalid', () => {
+    expect(readStoredStaticGps()).toBeNull();
+    localStorage.setItem(GPS_SETTINGS_STORAGE_KEY, JSON.stringify({ staticLat: 'bad' }));
+    expect(readStoredStaticGps()).toBeNull();
+  });
+
+  it('returns finite lat/lon when configured', () => {
+    localStorage.setItem(
+      GPS_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ staticLat: 39.7392, staticLon: -104.9903 }),
+    );
+    expect(readStoredStaticGps()).toEqual({ lat: 39.7392, lon: -104.9903 });
+    expect(hasStoredStaticGps()).toBe(true);
+  });
+});
+
+describe('shouldPreserveStaticGpsForSelfNode', () => {
+  afterEach(() => {
+    localStorage.removeItem(GPS_SETTINGS_STORAGE_KEY);
+  });
+
+  it('is false without static GPS or for remote nodes', () => {
+    expect(shouldPreserveStaticGpsForSelfNode(0xabc, 0xabc)).toBe(false);
+    expect(shouldPreserveStaticGpsForSelfNode(0xabc, 0xdef)).toBe(false);
+  });
+
+  it('is true for self node when static GPS is stored', () => {
+    localStorage.setItem(GPS_SETTINGS_STORAGE_KEY, JSON.stringify({ staticLat: 1, staticLon: 2 }));
+    expect(shouldPreserveStaticGpsForSelfNode(0x42, 0x42)).toBe(true);
+  });
+});
 
 describe('resolveOurPosition', () => {
   it('includes altitudeMeters on device branch when finite', async () => {
@@ -22,5 +65,15 @@ describe('resolveOurPosition', () => {
   it('includes sea-level altitude (0)', async () => {
     const p = await resolveOurPosition(40.1, -105.1, undefined, undefined, 0);
     expect(p?.altitudeMeters).toBe(0);
+  });
+
+  it('prefers device coords over static when device coords are provided', async () => {
+    const p = await resolveOurPosition(40.1, -105.1, 39.0, -106.0);
+    expect(p?.source).toBe('device');
+  });
+
+  it('uses static when device coords are omitted', async () => {
+    const p = await resolveOurPosition(undefined, undefined, 39.7392, -104.9903);
+    expect(p).toEqual({ lat: 39.7392, lon: -104.9903, source: 'static' });
   });
 });

--- a/src/renderer/lib/gpsSource.ts
+++ b/src/renderer/lib/gpsSource.ts
@@ -1,6 +1,43 @@
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
+import { parseStoredJson } from '@/renderer/lib/parseStoredJson';
+
+export const GPS_SETTINGS_STORAGE_KEY = 'mesh-client:gpsSettings';
 
 export type GpsSource = 'device' | 'browser' | 'ip' | 'static';
+
+interface StoredGpsSettings {
+  staticLat?: number;
+  staticLon?: number;
+}
+
+/** User-configured static coordinates from App tab GPS settings. */
+export function readStoredStaticGps(): { lat: number; lon: number } | null {
+  if (typeof localStorage === 'undefined') return null;
+  const s =
+    parseStoredJson<StoredGpsSettings>(
+      localStorage.getItem(GPS_SETTINGS_STORAGE_KEY),
+      'gpsSource readStoredStaticGps',
+    ) ?? {};
+  const { staticLat: lat, staticLon: lon } = s;
+  if (
+    typeof lat === 'number' &&
+    typeof lon === 'number' &&
+    Number.isFinite(lat) &&
+    Number.isFinite(lon)
+  ) {
+    return { lat, lon };
+  }
+  return null;
+}
+
+export function hasStoredStaticGps(): boolean {
+  return readStoredStaticGps() != null;
+}
+
+/** When true, RF/advert position for the connected self-node must not overwrite app static GPS. */
+export function shouldPreserveStaticGpsForSelfNode(nodeId: number, selfNodeId: number): boolean {
+  return selfNodeId > 0 && nodeId === selfNodeId && hasStoredStaticGps();
+}
 
 /** Sources that provide only city-level (~10–50 km) accuracy (browser WiFi/IP positioning included) */
 export const LOW_ACCURACY_SOURCES: ReadonlySet<GpsSource> = new Set(['ip', 'browser']);

--- a/src/renderer/lib/meshcoreCompanionTxEchoFilter.test.ts
+++ b/src/renderer/lib/meshcoreCompanionTxEchoFilter.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { MeshcoreCompanionTxEchoFilter } from './meshcoreCompanionTxEchoFilter';
+
+describe('MeshcoreCompanionTxEchoFilter', () => {
+  it('drops inbound frames that exactly match a recent outbound frame', () => {
+    const filter = new MeshcoreCompanionTxEchoFilter();
+    const cmd = new Uint8Array([25, 0, 0]);
+    filter.noteOutbound(cmd);
+    expect(filter.isEcho(cmd)).toBe(true);
+    expect(filter.isEcho(new Uint8Array([0]))).toBe(false);
+  });
+
+  it('does not treat similar-length frames with different bytes as echo', () => {
+    const filter = new MeshcoreCompanionTxEchoFilter();
+    filter.noteOutbound(new Uint8Array([25, 0, 0]));
+    expect(filter.isEcho(new Uint8Array([25, 0, 1]))).toBe(false);
+  });
+
+  it('expires echoed frames after the TTL', () => {
+    vi.useFakeTimers();
+    const filter = new MeshcoreCompanionTxEchoFilter();
+    const cmd = new Uint8Array([25, 0, 0]);
+    filter.noteOutbound(cmd);
+    vi.advanceTimersByTime(501);
+    expect(filter.isEcho(cmd)).toBe(false);
+    vi.useRealTimers();
+  });
+});

--- a/src/renderer/lib/meshcoreCompanionTxEchoFilter.ts
+++ b/src/renderer/lib/meshcoreCompanionTxEchoFilter.ts
@@ -1,0 +1,39 @@
+/** Drop inbound BLE frames that exactly match a recent outbound companion command (TX echo). */
+const TX_ECHO_TTL_MS = 500;
+const MAX_RECENT_TX = 16;
+
+function framesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Some BLE stacks (or firmware) reflect the last NUS RX write on the TX notify characteristic.
+ * meshcore.js treats any inbound byte[0] as a response/push code; echoed commands (e.g. 25 =
+ * CMD_SEND_RAW_DATA) log "unhandled frame" even though the real RESP_OK/ERR may follow.
+ */
+export class MeshcoreCompanionTxEchoFilter {
+  private recent: { frame: Uint8Array; at: number }[] = [];
+
+  noteOutbound(frame: Uint8Array): void {
+    const now = Date.now();
+    this.prune(now);
+    this.recent.push({ frame: frame.slice(), at: now });
+    if (this.recent.length > MAX_RECENT_TX) {
+      this.recent.shift();
+    }
+  }
+
+  isEcho(inbound: Uint8Array): boolean {
+    const now = Date.now();
+    this.prune(now);
+    return this.recent.some(({ frame }) => framesEqual(frame, inbound));
+  }
+
+  private prune(now: number): void {
+    this.recent = this.recent.filter((e) => now - e.at <= TX_ECHO_TTL_MS);
+  }
+}

--- a/src/renderer/lib/meshcoreUtils.test.ts
+++ b/src/renderer/lib/meshcoreUtils.test.ts
@@ -118,6 +118,16 @@ describe('meshcoreMinimalNodeFromAdvertEvent', () => {
     expect(r!.lastHeardSec).toBe(1_700_000_200);
   });
 
+  it('clamps future lastAdvert to nowSec', () => {
+    const nowSec = 1_700_000_000;
+    const r = meshcoreMinimalNodeFromAdvertEvent(key32, {
+      nowSec,
+      lastAdvert: nowSec + 86_400,
+    });
+    expect(r!.lastHeardSec).toBe(nowSec);
+    expect(r!.node.last_heard).toBe(nowSec);
+  });
+
   it('maps scaled lat/lon to degrees and contact type', () => {
     const r = meshcoreMinimalNodeFromAdvertEvent(key32, {
       nowSec: 1,

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -1,3 +1,4 @@
+import { mergeMeshcoreLastHeardFromAdvert } from './nodeStatus';
 import type { ConnectionType, MeshNode } from './types';
 
 /** MeshCore companion scaled coordinates: integer × degrees (same as firmware advert fields). */
@@ -438,9 +439,7 @@ export function meshcoreMinimalNodeFromAdvertEvent(
       ? Math.max(0, Math.floor(opts.contactType))
       : 0;
   const lastHeardSec =
-    typeof opts.lastAdvert === 'number' && Number.isFinite(opts.lastAdvert) && opts.lastAdvert > 0
-      ? opts.lastAdvert
-      : opts.nowSec;
+    mergeMeshcoreLastHeardFromAdvert(opts.lastAdvert, undefined, opts.nowSec) || opts.nowSec;
   const advLat = typeof opts.advLat === 'number' ? opts.advLat : 0;
   const advLon = typeof opts.advLon === 'number' ? opts.advLon : 0;
   const { lat: latDeg, lon: lonDeg } = meshcoreScaledAdvLatLonToDeg(advLat, advLon);

--- a/src/renderer/lib/meshcoreWebBluetoothConnection.ts
+++ b/src/renderer/lib/meshcoreWebBluetoothConnection.ts
@@ -2,6 +2,7 @@ import { Connection } from '@liamcottle/meshcore.js';
 import type { Types } from '@meshtastic/core';
 
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
+import { MeshcoreCompanionTxEchoFilter } from '@/renderer/lib/meshcoreCompanionTxEchoFilter';
 
 import { withTimeout } from '../../shared/withTimeout';
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- TransportWebBluetoothIpc is used as a value (new) in connect()
@@ -14,6 +15,7 @@ const WEB_BLUETOOTH_HANDSHAKE_TIMEOUT_MS = 20_000;
 
 export class MeshcoreWebBluetoothConnection extends Connection {
   private readonly transport: TransportWebBluetoothIpc;
+  private readonly txEchoFilter = new MeshcoreCompanionTxEchoFilter();
   private _fromDeviceReader: ReadableStreamDefaultReader<Types.DeviceOutput> | null = null;
 
   constructor(transport: TransportWebBluetoothIpc) {
@@ -22,6 +24,7 @@ export class MeshcoreWebBluetoothConnection extends Connection {
   }
 
   async sendToRadioFrame(data: Uint8Array): Promise<void> {
+    this.txEchoFilter.noteOutbound(data);
     this.emit('tx', data);
     const writer = this.transport.toDevice.getWriter();
     try {
@@ -80,6 +83,9 @@ export class MeshcoreWebBluetoothConnection extends Connection {
           break;
         }
         if (value.type === 'packet') {
+          if (this.txEchoFilter.isEcho(value.data)) {
+            continue;
+          }
           this.onFrameReceived(value.data);
         }
       }

--- a/src/renderer/lib/meshtasticBacklogUtils.test.ts
+++ b/src/renderer/lib/meshtasticBacklogUtils.test.ts
@@ -1,13 +1,21 @@
 import { create, fromBinary, toBinary } from '@bufbuild/protobuf';
-import { StoreForward } from '@meshtastic/protobufs';
-import { describe, expect, it } from 'vitest';
+import type { MeshDevice } from '@meshtastic/core';
+import { Mesh, Portnums, StoreForward } from '@meshtastic/protobufs';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildStoreForwardHistoryRequestBytes,
+  buildStoreForwardHistoryToRadioBytes,
   decodeStoreForwardTextPayload,
   isDuplicateHistoryMessage,
   MQTT_RECONNECT_BACKLOG_MS,
   mqttMessageTreatAsHistory,
+  parseStoreForwardHeartbeat,
+  parseStoreForwardHistory,
+  releaseStoreForwardHistoryRequest,
+  reserveStoreForwardHistoryRequest,
+  shouldRequestStoreForwardHistoryOnHeartbeat,
+  writeToRadioWithoutQueue,
 } from './meshtasticBacklogUtils';
 
 function sfPacket(rr: number, variant: { case: string; value: unknown }): Uint8Array {
@@ -34,7 +42,39 @@ describe('meshtasticBacklogUtils', () => {
     expect(decodeStoreForwardTextPayload(new Uint8Array())).toBeNull();
   });
 
-  it('returns null for non-text store-forward variants', () => {
+  it('parses ROUTER_HEARTBEAT payloads', () => {
+    const heartbeat = sfPacket(StoreForward.StoreAndForward_RequestResponse.ROUTER_HEARTBEAT, {
+      case: 'heartbeat',
+      value: create(StoreForward.StoreAndForward_HeartbeatSchema, { period: 120, secondary: 0 }),
+    });
+    expect(parseStoreForwardHeartbeat(heartbeat)).toEqual({ period: 120, secondary: 0 });
+
+    const secondary = sfPacket(StoreForward.StoreAndForward_RequestResponse.ROUTER_HEARTBEAT, {
+      case: 'heartbeat',
+      value: create(StoreForward.StoreAndForward_HeartbeatSchema, { period: 60, secondary: 1 }),
+    });
+    expect(parseStoreForwardHeartbeat(secondary)).toEqual({ period: 60, secondary: 1 });
+    expect(parseStoreForwardHeartbeat(new Uint8Array())).toBeNull();
+  });
+
+  it('parses ROUTER_HISTORY payloads', () => {
+    const history = sfPacket(StoreForward.StoreAndForward_RequestResponse.ROUTER_HISTORY, {
+      case: 'history',
+      value: create(StoreForward.StoreAndForward_HistorySchema, {
+        historyMessages: 5,
+        window: 60,
+        lastRequest: 42,
+      }),
+    });
+    expect(parseStoreForwardHistory(history)).toEqual({
+      historyMessages: 5,
+      window: 60,
+      lastRequest: 42,
+    });
+    expect(parseStoreForwardHistory(new Uint8Array())).toBeNull();
+  });
+
+  it('returns null for non-text store-forward variants in decodeStoreForwardTextPayload', () => {
     const heartbeat = sfPacket(StoreForward.StoreAndForward_RequestResponse.ROUTER_HEARTBEAT, {
       case: 'heartbeat',
       value: create(StoreForward.StoreAndForward_HeartbeatSchema, { period: 300, secondary: 0 }),
@@ -107,6 +147,92 @@ describe('meshtasticBacklogUtils', () => {
       expect(parsedCustom.variant.value.window).toBe(120);
       expect(parsedCustom.variant.value.lastRequest).toBe(42);
     }
+  });
+
+  it('builds ToRadio CLIENT_HISTORY packet with wantAck and wantResponse false', () => {
+    const bytes = buildStoreForwardHistoryToRadioBytes({
+      from: 0x11111111,
+      to: 0x22222222,
+      channel: 1,
+      packetId: 99,
+      windowMinutes: 120,
+    });
+    const toRadio = fromBinary(Mesh.ToRadioSchema, bytes) as unknown as {
+      payloadVariant: {
+        case?: string;
+        value?: {
+          from?: number;
+          to?: number;
+          channel?: number;
+          id?: number;
+          wantAck?: boolean;
+          payloadVariant?: {
+            case?: string;
+            value?: { portnum?: number; wantResponse?: boolean; payload?: Uint8Array };
+          };
+        };
+      };
+    };
+    expect(toRadio.payloadVariant.case).toBe('packet');
+    const pkt = toRadio.payloadVariant.value;
+    expect(pkt?.from).toBe(0x11111111);
+    expect(pkt?.to).toBe(0x22222222);
+    expect(pkt?.channel).toBe(1);
+    expect(pkt?.id).toBe(99);
+    expect(pkt?.wantAck).toBe(false);
+    expect(pkt?.payloadVariant?.case).toBe('decoded');
+    const decoded = pkt?.payloadVariant?.value;
+    expect(decoded?.portnum).toBe(Portnums.PortNum.STORE_FORWARD_APP);
+    expect(decoded?.wantResponse).toBe(false);
+    expect(decoded?.payload?.length).toBeGreaterThan(0);
+  });
+
+  it('gates heartbeat-triggered history requests', () => {
+    const base = {
+      heartbeatSecondary: 0,
+      connectedIsStoreForwardServer: false,
+      alreadyRequestedServer: false,
+      deviceConfigured: true,
+    };
+    expect(shouldRequestStoreForwardHistoryOnHeartbeat(base)).toBe(true);
+    expect(shouldRequestStoreForwardHistoryOnHeartbeat({ ...base, heartbeatSecondary: 1 })).toBe(
+      false,
+    );
+    expect(
+      shouldRequestStoreForwardHistoryOnHeartbeat({ ...base, connectedIsStoreForwardServer: true }),
+    ).toBe(false);
+    expect(
+      shouldRequestStoreForwardHistoryOnHeartbeat({ ...base, alreadyRequestedServer: true }),
+    ).toBe(false);
+    expect(shouldRequestStoreForwardHistoryOnHeartbeat({ ...base, deviceConfigured: false })).toBe(
+      false,
+    );
+  });
+
+  it('reserves and releases per-server history requests for one session', () => {
+    const requested = new Set<number>();
+    const server = 0xabcd1234;
+    expect(reserveStoreForwardHistoryRequest(requested, server)).toBe(true);
+    expect(reserveStoreForwardHistoryRequest(requested, server)).toBe(false);
+    releaseStoreForwardHistoryRequest(requested, server);
+    expect(reserveStoreForwardHistoryRequest(requested, server)).toBe(true);
+  });
+
+  it('writes ToRadio bytes directly to transport without queue', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const releaseLock = vi.fn();
+    const device = {
+      transport: {
+        toDevice: {
+          getWriter: () => ({ write, releaseLock }),
+        },
+      },
+    } as unknown as MeshDevice;
+
+    const bytes = new Uint8Array([1, 2, 3]);
+    await writeToRadioWithoutQueue(device, bytes);
+    expect(write).toHaveBeenCalledWith(bytes);
+    expect(releaseLock).toHaveBeenCalled();
   });
 
   it('dedupes history messages within time window', () => {

--- a/src/renderer/lib/meshtasticBacklogUtils.ts
+++ b/src/renderer/lib/meshtasticBacklogUtils.ts
@@ -1,5 +1,6 @@
 import { create, fromBinary, toBinary } from '@bufbuild/protobuf';
-import { StoreForward } from '@meshtastic/protobufs';
+import type { MeshDevice } from '@meshtastic/core';
+import { Mesh, Portnums, StoreForward } from '@meshtastic/protobufs';
 
 /** Duration after MQTT connect during which inbound messages are treated as backlog. */
 export const MQTT_RECONNECT_BACKLOG_MS = 30_000;
@@ -13,6 +14,37 @@ export interface StoreForwardHistoryRequestOptions {
   windowMinutes?: number;
   /** Index from a prior ROUTER_HISTORY response; 0 for first request. */
   lastRequest?: number;
+}
+
+export interface StoreForwardHeartbeatInfo {
+  period: number;
+  secondary: number;
+}
+
+export interface StoreForwardHistoryInfo {
+  historyMessages: number;
+  window: number;
+  lastRequest: number;
+}
+
+export interface BuildStoreForwardHistoryToRadioParams {
+  from: number;
+  to: number;
+  channel: number;
+  packetId: number;
+  windowMinutes?: number;
+  lastRequest?: number;
+}
+
+export interface ShouldRequestStoreForwardHistoryParams {
+  /** ROUTER_HEARTBEAT secondary field; primary server uses 0. */
+  heartbeatSecondary: number;
+  /** Connected radio module config: is_server. */
+  connectedIsStoreForwardServer: boolean;
+  /** Server node id already requested this session. */
+  alreadyRequestedServer: boolean;
+  /** Device must be configured before requesting. */
+  deviceConfigured: boolean;
 }
 
 /** Build CLIENT_HISTORY request bytes for STORE_FORWARD_APP port. */
@@ -35,21 +67,138 @@ export function buildStoreForwardHistoryRequestBytes(
   return toBinary(StoreForward.StoreAndForwardSchema, msg);
 }
 
-export function decodeStoreForwardTextPayload(data: Uint8Array): string | null {
+function parseStoreForwardPacket(data: Uint8Array): {
+  rr: number;
+  variant: { case?: string; value?: unknown };
+} | null {
   if (!data.length) return null;
   try {
-    const parsed = fromBinary(StoreForward.StoreAndForwardSchema, data) as unknown as {
-      variant: { case?: string; value?: Uint8Array };
+    return fromBinary(StoreForward.StoreAndForwardSchema, data) as unknown as {
+      rr: number;
+      variant: { case?: string; value?: unknown };
     };
-    if (parsed.variant.case !== 'text') return null;
-    const textBytes = parsed.variant.value;
-    if (!textBytes?.length) return null;
-    const text = new TextDecoder().decode(textBytes).trim();
-    return text || null;
   } catch {
     // catch-no-log-ok malformed StoreAndForward protobuf
     return null;
   }
+}
+
+/** Parse ROUTER_HEARTBEAT payload; null if not a heartbeat variant. */
+export function parseStoreForwardHeartbeat(data: Uint8Array): StoreForwardHeartbeatInfo | null {
+  const parsed = parseStoreForwardPacket(data);
+  if (!parsed || parsed.rr !== StoreForward.StoreAndForward_RequestResponse.ROUTER_HEARTBEAT) {
+    return null;
+  }
+  if (parsed.variant.case !== 'heartbeat' || !parsed.variant.value) return null;
+  const hb = parsed.variant.value as { period?: number; secondary?: number };
+  return {
+    period: hb.period ?? 0,
+    secondary: hb.secondary ?? 0,
+  };
+}
+
+/** Parse ROUTER_HISTORY payload; null if not a history variant. */
+export function parseStoreForwardHistory(data: Uint8Array): StoreForwardHistoryInfo | null {
+  const parsed = parseStoreForwardPacket(data);
+  if (!parsed || parsed.rr !== StoreForward.StoreAndForward_RequestResponse.ROUTER_HISTORY) {
+    return null;
+  }
+  if (parsed.variant.case !== 'history' || !parsed.variant.value) return null;
+  const hist = parsed.variant.value as {
+    historyMessages?: number;
+    window?: number;
+    lastRequest?: number;
+  };
+  return {
+    historyMessages: hist.historyMessages ?? 0,
+    window: hist.window ?? 0,
+    lastRequest: hist.lastRequest ?? 0,
+  };
+}
+
+/** Build ToRadio bytes for a direct CLIENT_HISTORY request (no SDK queue ack wait). */
+export function buildStoreForwardHistoryToRadioBytes(
+  params: BuildStoreForwardHistoryToRadioParams,
+): Uint8Array {
+  const payload = buildStoreForwardHistoryRequestBytes({
+    windowMinutes: params.windowMinutes,
+    lastRequest: params.lastRequest,
+  });
+  const meshPacket = create(Mesh.MeshPacketSchema, {
+    payloadVariant: {
+      case: 'decoded',
+      value: {
+        payload,
+        portnum: Portnums.PortNum.STORE_FORWARD_APP,
+        wantResponse: false,
+      },
+    },
+    from: params.from,
+    to: params.to,
+    id: params.packetId,
+    wantAck: false,
+    channel: params.channel,
+  });
+  const toRadio = create(Mesh.ToRadioSchema, {
+    payloadVariant: { case: 'packet', value: meshPacket },
+  });
+  return toBinary(Mesh.ToRadioSchema, toRadio);
+}
+
+/** Whether to send CLIENT_HISTORY in response to a router heartbeat. */
+export function shouldRequestStoreForwardHistoryOnHeartbeat(
+  params: ShouldRequestStoreForwardHistoryParams,
+): boolean {
+  if (!params.deviceConfigured) return false;
+  if (params.connectedIsStoreForwardServer) return false;
+  if (params.heartbeatSecondary !== 0) return false;
+  if (params.alreadyRequestedServer) return false;
+  return true;
+}
+
+/** Reserve a one-shot history request for this server per session; false if already reserved. */
+export function reserveStoreForwardHistoryRequest(
+  requestedServers: Set<number>,
+  serverNodeId: number,
+): boolean {
+  if (requestedServers.has(serverNodeId)) return false;
+  requestedServers.add(serverNodeId);
+  return true;
+}
+
+/** Undo reservation after a failed transport write so the next heartbeat can retry. */
+export function releaseStoreForwardHistoryRequest(
+  requestedServers: Set<number>,
+  serverNodeId: number,
+): void {
+  requestedServers.delete(serverNodeId);
+}
+
+/**
+ * Write ToRadio bytes directly to the transport, bypassing MeshDevice queue ack wait.
+ * Failure point: transport write rejects (BLE disconnect, backpressure).
+ * Fallback: caller logs and may retry on next heartbeat.
+ */
+export async function writeToRadioWithoutQueue(
+  device: MeshDevice,
+  toRadioBytes: Uint8Array,
+): Promise<void> {
+  const writer = device.transport.toDevice.getWriter();
+  try {
+    await writer.write(toRadioBytes);
+  } finally {
+    writer.releaseLock();
+  }
+}
+
+export function decodeStoreForwardTextPayload(data: Uint8Array): string | null {
+  const parsed = parseStoreForwardPacket(data);
+  if (!parsed) return null;
+  if (parsed.variant.case !== 'text') return null;
+  const textBytes = parsed.variant.value;
+  if (!(textBytes instanceof Uint8Array) || !textBytes.length) return null;
+  const text = new TextDecoder().decode(textBytes).trim();
+  return text || null;
 }
 
 export interface HistoryMessageDedupFields {

--- a/src/renderer/lib/nodeStatus.test.ts
+++ b/src/renderer/lib/nodeStatus.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  clampLastHeardSec,
+  effectiveLastHeardMs,
   getNodeStatus,
   lastHeardToUnixSeconds,
   mergeMeshcoreLastHeardFromAdvert,
@@ -19,6 +21,25 @@ describe('lastHeardToUnixSeconds', () => {
 
   it('treats values at or above 1e12 as epoch milliseconds', () => {
     expect(lastHeardToUnixSeconds(1_700_000_000_000)).toBe(1_700_000_000);
+  });
+});
+
+describe('clampLastHeardSec', () => {
+  const nowSec = 1_700_000_000;
+
+  it('returns 0 for invalid input', () => {
+    expect(clampLastHeardSec(0, nowSec)).toBe(0);
+    expect(clampLastHeardSec(NaN, nowSec)).toBe(0);
+  });
+
+  it('returns floored seconds when within skew tolerance', () => {
+    expect(clampLastHeardSec(1_700_000_100, nowSec)).toBe(1_700_000_100);
+    expect(clampLastHeardSec(nowSec + 300, nowSec)).toBe(nowSec + 300);
+  });
+
+  it('clamps to nowSec when unreasonably far in the future', () => {
+    expect(clampLastHeardSec(nowSec + 301, nowSec)).toBe(nowSec);
+    expect(clampLastHeardSec(nowSec + 86_400, nowSec)).toBe(nowSec);
   });
 });
 
@@ -47,6 +68,24 @@ describe('mergeMeshcoreLastHeardFromAdvert', () => {
   it('aligns with normalizeLastHeardMs for UI freshness', () => {
     const merged = mergeMeshcoreLastHeardFromAdvert(0, 1_700_000_000);
     expect(normalizeLastHeardMs(merged)).toBe(1_700_000_000_000);
+  });
+
+  it('clamps future device lastAdvert to nowSec', () => {
+    const nowSec = 1_700_000_000;
+    const futureAdvert = nowSec + 86_400;
+    expect(mergeMeshcoreLastHeardFromAdvert(futureAdvert, 0, nowSec)).toBe(nowSec);
+  });
+
+  it('preserves previous live-event last_heard when newer than stale device advert', () => {
+    const nowSec = 1_700_000_000;
+    const staleAdvert = nowSec - 3600;
+    const prevSec = nowSec - 120;
+    expect(mergeMeshcoreLastHeardFromAdvert(staleAdvert, prevSec, nowSec)).toBe(prevSec);
+  });
+
+  it('clamps previous last_heard stored in the future', () => {
+    const nowSec = 1_700_000_000;
+    expect(mergeMeshcoreLastHeardFromAdvert(0, nowSec + 86_400, nowSec)).toBe(nowSec);
   });
 });
 
@@ -101,5 +140,11 @@ describe('getNodeStatus', () => {
 
     const oneSecondOver7d = Date.now() - meshtasticOffline - 1000;
     expect(getNodeStatus(oneSecondOver7d, meshtasticStale, meshtasticOffline)).toBe('offline');
+  });
+
+  it('effectiveLastHeardMs clamps far-future timestamps to now', () => {
+    const nowMs = 1_700_000_000_000;
+    const farFutureSec = 1_700_000_000 + 86_400;
+    expect(effectiveLastHeardMs(farFutureSec, nowMs)).toBe(nowMs);
   });
 });

--- a/src/renderer/lib/nodeStatus.ts
+++ b/src/renderer/lib/nodeStatus.ts
@@ -2,6 +2,9 @@
 const STALE_MS = 2 * 3_600_000; // 2 hours
 const OFFLINE_MS = 7 * 24 * 3_600_000; // 7 days
 
+/** Max device clock lead we accept before treating timestamp as receive-time est. */
+export const LAST_HEARD_MAX_FUTURE_SKEW_SEC = 300; // 5 min
+
 export type NodeStatus = 'online' | 'stale' | 'offline';
 
 export function normalizeLastHeardMs(lastHeard: number): number {
@@ -17,6 +20,28 @@ export function lastHeardToUnixSeconds(lastHeard: number): number {
 }
 
 /**
+ * Clamp a Unix-second last_heard that is unreasonably far in the future (device RTC skew).
+ * Returns `nowSec` when the lead exceeds `maxFutureSkewSec`; otherwise returns floored seconds.
+ */
+export function clampLastHeardSec(
+  lastHeardSec: number,
+  nowSec = Math.floor(Date.now() / 1000),
+  maxFutureSkewSec = LAST_HEARD_MAX_FUTURE_SKEW_SEC,
+): number {
+  if (!lastHeardSec || !Number.isFinite(lastHeardSec)) return 0;
+  const floored = Math.floor(lastHeardSec);
+  if (floored <= nowSec + maxFutureSkewSec) return floored;
+  return nowSec;
+}
+
+/** Effective last-heard in ms for age calculations; never after `nowMs`. */
+export function effectiveLastHeardMs(lastHeard: number, nowMs = Date.now()): number {
+  const normalized = normalizeLastHeardMs(lastHeard);
+  if (!normalized) return 0;
+  return Math.min(normalized, nowMs);
+}
+
+/**
  * Return the most-recent last_heard in Unix seconds. Takes the maximum of the device's
  * `lastAdvert` and any previous `last_heard` from live events (DMs, channel messages, paths)
  * so that live-event freshness is never overwritten by a stale advert value from the radio.
@@ -24,13 +49,15 @@ export function lastHeardToUnixSeconds(lastHeard: number): number {
 export function mergeMeshcoreLastHeardFromAdvert(
   advertSec: number | null | undefined,
   previousLastHeard: number | null | undefined,
+  nowSec = Math.floor(Date.now() / 1000),
 ): number {
-  const device =
+  const deviceRaw =
     typeof advertSec === 'number' && Number.isFinite(advertSec) && advertSec > 0
       ? Math.floor(advertSec)
       : 0;
-  const prev = Math.max(lastHeardToUnixSeconds(previousLastHeard ?? 0), 0);
-  return Math.max(device, prev);
+  const device = deviceRaw > 0 ? clampLastHeardSec(deviceRaw, nowSec) : 0;
+  const prev = clampLastHeardSec(lastHeardToUnixSeconds(previousLastHeard ?? 0), nowSec);
+  return clampLastHeardSec(Math.max(device, prev), nowSec);
 }
 
 export function getNodeStatus(
@@ -39,8 +66,10 @@ export function getNodeStatus(
   offlineThresholdMs?: number,
 ): NodeStatus {
   if (!lastHeard || !Number.isFinite(lastHeard)) return 'offline';
-  const normalizedLastHeard = normalizeLastHeardMs(lastHeard);
-  const diff = Date.now() - normalizedLastHeard;
+  const nowMs = Date.now();
+  const effectiveMs = effectiveLastHeardMs(lastHeard, nowMs);
+  if (!effectiveMs) return 'offline';
+  const diff = nowMs - effectiveMs;
   const stale = staleThresholdMs ?? STALE_MS;
   const offline = offlineThresholdMs ?? OFFLINE_MS;
   if (diff <= stale) return 'online';


### PR DESCRIPTION
## Summary

This branch bundles five fixes for renderer/radio behavior:

- **Static GPS:** Saving App-tab static coordinates now updates the connected self-node in the **Node list** and **Map**, pushes position to the radio when connected (Meshtastic `setPosition`, MeshCore `setAdvertLatLong`), and prevents RF/advert ingest from reverting the override.
- **NodeInfoBody crash:** Opening a GPS node with position history no longer triggers a React 19 infinite loop (Zustand `useShallow` on latest tracked position).
- **Store & Forward history:** Requests router heartbeat history without blocking on a routing ack that never arrives; replays apply on async `STORE_FORWARD_APP` packets.
- **RTC skew:** Future `last_heard` from device clocks is clamped so online/stale status and relative times stay sane (Repeaters panel, MeshCore adverts, Meshtastic NodeInfo).
- **MeshCore BLE TX echo:** Filters companion echo of outbound NUS frames so meshcore.js does not log spurious unhandled `code=25` responses.

## Commits

- `711a5215` fix: sync static GPS to node list, map, and radio
- `541fb7a5` fix: stop NodeInfoBody infinite loop on GPS node detail open
- `8a71f61f` fix: request Store & Forward history on router heartbeat
- `df81754a` fix: clamp future last_heard timestamps from device RTC skew
- `559d88ad` fix: drop MeshCore BLE companion TX echo before frame dispatch

## Test plan

- [ ] **Static GPS (Meshtastic):** Connect radio → App tab → save static lat/lon → Node list + Map self marker move; coords stay after NodeInfo/position traffic; device receives position when connected.
- [ ] **Static GPS (MeshCore):** Same flow on MeshCore protocol; advert/contact updates do not revert coords.
- [ ] **Node detail:** Open a node with GPS + position history → no renderer crash / BLE drop; no spurious "Position updated" toast without requesting position.
- [ ] **Store & Forward:** Router with SF module → heartbeat triggers history request → backlog messages appear in chat without queue timeout errors.
- [ ] **RTC skew:** Repeater/contact with far-future `last_heard` shows sensible relative time without console spam.
- [ ] **BLE echo:** MeshCore BLE session → send raw data → no repeated `unhandled frame: code=25` for echoed TX bytes.
- [ ] `pnpm run test:run` (pre-commit already ran on latest commit)