### PR TITLE
fix: Meshtastic last_heard freshness and garbled TEXT_MESSAGE handling

### DIFF
--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -11,6 +11,7 @@ import { createCipheriv, createDecipheriv, createHash, randomBytes, randomInt } 
 import { EventEmitter } from 'events';
 import * as mqtt from 'mqtt';
 
+import { resolveMeshtasticTextMessagePayload } from '../renderer/lib/meshtasticBacklogUtils';
 import type { ChatMessage, MeshNode, MQTTSettings, MQTTStatus } from '../renderer/lib/types';
 import {
   MQTT_DEFAULT_RECONNECT_ATTEMPTS,
@@ -1442,19 +1443,29 @@ export class MQTTManager extends EventEmitter {
       }
     } else if (portnum === PortNum.TEXT_MESSAGE_APP && (payload?.length || data.emoji)) {
       try {
-        const text = new TextDecoder().decode(payload ?? new Uint8Array());
+        const payloadBytes = payload ?? new Uint8Array();
+        const resolved = resolveMeshtasticTextMessagePayload(payloadBytes);
+        if (!resolved) {
+          console.debug(
+            `[Meshtastic MQTT] Dropped non-readable TEXT_MESSAGE from node ${nodeId} len=${payloadBytes.length}`,
+          ); // log-filter-ok Meshtastic MQTT logs → App log panel
+          this.upsertNodeCache({ node_id: nodeId, last_heard: Date.now() });
+          this.emitMinimalNodeUpdate(nodeId, hopsAway, portnum);
+          return;
+        }
         const emoji = data.emoji || undefined;
         const replyId = data.replyId || undefined;
         const msg: Omit<ChatMessage, 'id'> & { from_mqtt: boolean } = {
           sender_id: nodeId,
           sender_name: formatMeshtasticNodeId(nodeId),
-          payload: text,
+          payload: resolved.text,
           channel: 0,
           timestamp: Date.now(),
           packetId,
           from_mqtt: true,
           emoji,
           replyId,
+          ...(resolved.viaStoreForward ? { viaStoreForward: true } : {}),
         };
         this.emit('message', msg);
         this.upsertNodeCache({ node_id: nodeId, last_heard: Date.now() });

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -64,6 +64,13 @@ import {
 import { meshtasticHwModelName } from '../lib/hardwareModels';
 import { setMeshtasticConnectedMyNodeNum } from '../lib/meshtasticConnectedNodeRef';
 import {
+  computeNodeInfoLastHeardMs,
+  mergeMeshtasticLivePacketLastHeard,
+  mergeMeshtasticUserPacketLastHeard,
+  meshtasticPacketRxTimeMs,
+  meshtasticTracerouteLastHeardNodeIds,
+} from '../lib/meshtasticLastHeard';
+import {
   findMeshtasticCrossTransportDuplicate,
   mapMeshtasticCrossTransportUpgrade,
   meshtasticPacketIdsEqual,
@@ -75,7 +82,6 @@ import {
   meshtasticTraceRouteLookupKeys,
 } from '../lib/meshtasticTraceRouteLookupKeys';
 import { consumeMqttUserDisconnect } from '../lib/mqttDisconnectIntent';
-import { LAST_HEARD_MAX_FUTURE_SKEW_SEC } from '../lib/nodeStatus';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import { MESHTASTIC_CAPABILITIES } from '../lib/radio/BaseRadioProvider';
 import {
@@ -1282,7 +1288,11 @@ export function useDevice() {
           updateNodes((prev) => {
             const existing = prev.get(meshPacket.from);
             if (!existing) return prev;
-            const now = meshPacket.rxTime ? meshPacket.rxTime * 1000 : Date.now();
+            const now = mergeMeshtasticLivePacketLastHeard(
+              existing.last_heard || 0,
+              meshtasticPacketRxTimeMs(meshPacket.rxTime),
+              false,
+            );
             if (now <= (existing.last_heard || 0)) return prev;
             const next = new Map(prev);
             const updated: MeshNode = {
@@ -1468,7 +1478,7 @@ export function useDevice() {
           hwModel?: number;
           role?: number;
         };
-        const packetRxMs = packet.rxTime instanceof Date ? packet.rxTime.getTime() : 0;
+        const packetRxMs = meshtasticPacketRxTimeMs(packet.rxTime);
         updateNodes((prev) => {
           const updated = new Map(prev);
           const existing = updated.get(packet.from) ?? emptyNode(packet.from);
@@ -1745,8 +1755,12 @@ export function useDevice() {
           latitude: lat,
           longitude: lon,
           altitude: pos.altitude ?? existing.altitude,
-          // Position replays at connect must not bump last_heard to now.
-          last_heard: existing.last_heard,
+          // Position replays at connect must not bump last_heard (configure guard).
+          last_heard: mergeMeshtasticLivePacketLastHeard(
+            existing.last_heard || 0,
+            meshtasticPacketRxTimeMs(packet.rxTime),
+            isConfiguringRef.current,
+          ),
           lastPositionWarning: undefined,
           source: 'rf',
           heard_via_mqtt_only: false,
@@ -1835,6 +1849,11 @@ export function useDevice() {
                 env_lux: env.lux ?? existing.env_lux,
                 env_wind_speed: env.windSpeed ?? existing.env_wind_speed,
                 env_wind_direction: env.windDirection ?? existing.env_wind_direction,
+                last_heard: mergeMeshtasticLivePacketLastHeard(
+                  existing.last_heard || 0,
+                  meshtasticPacketRxTimeMs(packet.rxTime),
+                  isConfiguringRef.current,
+                ),
                 source: 'rf',
                 heard_via_mqtt_only: false,
                 via_mqtt: false,
@@ -1893,6 +1912,14 @@ export function useDevice() {
             const node: MeshNode = {
               ...existing,
               battery: metrics.batteryLevel,
+              last_heard: mergeMeshtasticLivePacketLastHeard(
+                existing.last_heard || 0,
+                meshtasticPacketRxTimeMs(packet.rxTime),
+                isConfiguringRef.current,
+              ),
+              source: 'rf',
+              heard_via_mqtt_only: false,
+              via_mqtt: false,
             };
             updateNodes((prev) => {
               const updated = new Map(prev);
@@ -2145,6 +2172,7 @@ export function useDevice() {
           requestId?: number;
         },
         dataLayerSource?: number,
+        packetRxTimeMs?: number,
       ) => {
         const baseLookupKeys = meshtasticTraceRouteLookupKeys({
           from: meshFrom,
@@ -2198,6 +2226,37 @@ export function useDevice() {
             dataLayerSource,
           ),
         );
+
+        if (!isConfiguringRef.current) {
+          const bumpIds = meshtasticTracerouteLastHeardNodeIds(meshFrom, correlatedDest);
+          if (bumpIds.length > 0) {
+            updateNodes((prev) => {
+              const updated = new Map(prev);
+              let changed = false;
+              for (const nodeId of bumpIds) {
+                const existing = updated.get(nodeId);
+                if (!existing) continue;
+                const last_heard = mergeMeshtasticLivePacketLastHeard(
+                  existing.last_heard || 0,
+                  packetRxTimeMs ?? 0,
+                  false,
+                );
+                if (last_heard <= (existing.last_heard || 0)) continue;
+                const node: MeshNode = {
+                  ...existing,
+                  last_heard,
+                  source: 'rf',
+                  heard_via_mqtt_only: false,
+                  via_mqtt: false,
+                };
+                updated.set(nodeId, node);
+                void window.electronAPI.db.saveNode(node);
+                changed = true;
+              }
+              return changed ? updated : prev;
+            });
+          }
+        }
       };
 
       const unsubTraceMesh = device.events.onMeshPacket.subscribe((meshPacket) => {
@@ -2228,6 +2287,7 @@ export function useDevice() {
               requestId: typeof rawReq === 'number' && Number.isFinite(rawReq) ? rawReq : undefined,
             },
             dataLayerSource,
+            meshtasticPacketRxTimeMs(meshPacket.rxTime),
           );
         } catch {
           // catch-no-log-ok RouteDiscovery decode failed (non-traceroute payload on port)
@@ -2240,7 +2300,14 @@ export function useDevice() {
           route: readonly number[];
           routeBack: readonly number[];
         };
-        applyMeshtasticTracerouteReply(packet.from, rd, undefined, undefined, undefined);
+        applyMeshtasticTracerouteReply(
+          packet.from,
+          rd,
+          undefined,
+          undefined,
+          undefined,
+          meshtasticPacketRxTimeMs(packet.rxTime),
+        );
       });
       unsubscribesRef.current.push(unsubTraceLegacy);
 
@@ -3855,32 +3922,10 @@ export function emptyNode(nodeId: number): MeshNode {
   };
 }
 
-export function computeNodeInfoLastHeardMs(
-  infoLastHeard: number | undefined,
-  existingLastHeard: number,
-  isSelf: boolean,
-): number {
-  if ((infoLastHeard ?? 0) > 0) {
-    const ms = infoLastHeard! * 1000;
-    const maxMs = Date.now() + LAST_HEARD_MAX_FUTURE_SKEW_SEC * 1000;
-    return ms > maxMs ? Date.now() : ms;
-  }
-  return existingLastHeard || (isSelf ? Date.now() : 0);
-}
-
-/**
- * Merge last_heard from onUserPacket using packet rxTime; skip bumps during configure replay.
- */
-export function mergeMeshtasticUserPacketLastHeard(
-  existingLastHeard: number,
-  packetRxTimeMs: number,
-  isConfiguring: boolean,
-): number {
-  if (isConfiguring || !Number.isFinite(packetRxTimeMs) || packetRxTimeMs <= 0) {
-    return existingLastHeard;
-  }
-  return Math.max(existingLastHeard || 0, packetRxTimeMs);
-}
+export {
+  computeNodeInfoLastHeardMs,
+  mergeMeshtasticUserPacketLastHeard,
+} from '../lib/meshtasticLastHeard';
 
 export function createChatStubNode(nodeId: number, source: 'rf' | 'mqtt'): MeshNode {
   const base = emptyNode(nodeId);

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -14,6 +14,7 @@ import {
   parseStoreForwardHeartbeat,
   releaseStoreForwardHistoryRequest,
   reserveStoreForwardHistoryRequest,
+  resolveMeshtasticTextMessagePayload,
   shouldRequestStoreForwardHistoryOnHeartbeat,
   writeToRadioWithoutQueue,
 } from '@/renderer/lib/meshtasticBacklogUtils';
@@ -1299,7 +1300,15 @@ export function useDevice() {
 
         touchLastData();
         const isEcho = meshPacket.from === myNodeNumRef.current;
-        let payloadText = new TextDecoder().decode(dataPacket.payload);
+        const payloadBytes = dataPacket.payload ?? new Uint8Array();
+        const resolvedText = resolveMeshtasticTextMessagePayload(payloadBytes);
+        if (!resolvedText) {
+          console.debug(
+            `[useDevice] Dropped non-readable TEXT_MESSAGE from 0x${meshPacket.from.toString(16)} len=${payloadBytes.length}`,
+          );
+          return;
+        }
+        let payloadText = resolvedText.text;
         const data = dataPacket as { replyId?: number; reply_id?: number; emoji?: number };
 
         const replyId = meshtasticWireUint32NonZero(data.replyId ?? data.reply_id);
@@ -1328,6 +1337,7 @@ export function useDevice() {
           replyId,
           to: meshPacket.to && meshPacket.to !== BROADCAST_ADDR ? meshPacket.to : undefined,
           ...(incomingRxHops !== undefined ? { rxHops: incomingRxHops } : {}),
+          ...(resolvedText.viaStoreForward ? { viaStoreForward: true } : {}),
         };
         const msg = enrichMeshtasticReplyPreviews(msgBase, messagesRef.current, getNodeName);
 

--- a/src/renderer/lib/meshtasticBacklogUtils.test.ts
+++ b/src/renderer/lib/meshtasticBacklogUtils.test.ts
@@ -8,12 +8,14 @@ import {
   buildStoreForwardHistoryToRadioBytes,
   decodeStoreForwardTextPayload,
   isDuplicateHistoryMessage,
+  isLikelyReadableChatText,
   MQTT_RECONNECT_BACKLOG_MS,
   mqttMessageTreatAsHistory,
   parseStoreForwardHeartbeat,
   parseStoreForwardHistory,
   releaseStoreForwardHistoryRequest,
   reserveStoreForwardHistoryRequest,
+  resolveMeshtasticTextMessagePayload,
   shouldRequestStoreForwardHistoryOnHeartbeat,
   writeToRadioWithoutQueue,
 } from './meshtasticBacklogUtils';
@@ -233,6 +235,88 @@ describe('meshtasticBacklogUtils', () => {
     await writeToRadioWithoutQueue(device, bytes);
     expect(write).toHaveBeenCalledWith(bytes);
     expect(releaseLock).toHaveBeenCalled();
+  });
+
+  it('queues concurrent ToRadio writes when WritableStream writer is locked', async () => {
+    let locked = false;
+    const order: number[] = [];
+    const write = vi.fn().mockImplementation(async (chunk: Uint8Array) => {
+      order.push(chunk[0] ?? 0);
+      await new Promise((r) => setTimeout(r, 5));
+    });
+    const releaseLock = vi.fn().mockImplementation(() => {
+      locked = false;
+    });
+    const device = {
+      transport: {
+        toDevice: {
+          getWriter: () => {
+            if (locked) {
+              throw new Error(
+                "Failed to execute 'getWriter' on 'WritableStream': Cannot create writer when WritableStream is locked",
+              );
+            }
+            locked = true;
+            return { write, releaseLock };
+          },
+        },
+      },
+    } as unknown as MeshDevice;
+
+    await Promise.all([
+      writeToRadioWithoutQueue(device, new Uint8Array([1])),
+      writeToRadioWithoutQueue(device, new Uint8Array([2])),
+    ]);
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(order).toEqual([1, 2]);
+    expect(releaseLock).toHaveBeenCalledTimes(2);
+  });
+
+  describe('resolveMeshtasticTextMessagePayload', () => {
+    const garbledUserBytes = new Uint8Array([
+      0x16, 0x15, 0x18, 0x0d, 0x25, 0x11, 0x6a, 0x28, 0x02, 0x58, 0x04, 0x78, 0x03, 0x01, 0x0e,
+      0x01, 0x05, 0x01,
+    ]);
+
+    it('rejects garbled control-heavy payloads from the field report', () => {
+      expect(resolveMeshtasticTextMessagePayload(garbledUserBytes)).toBeNull();
+      expect(isLikelyReadableChatText(garbledUserBytes)).toBe(false);
+    });
+
+    it('rejects store-forward heartbeat protobuf on TEXT port', () => {
+      const heartbeat = sfPacket(StoreForward.StoreAndForward_RequestResponse.ROUTER_HEARTBEAT, {
+        case: 'heartbeat',
+        value: create(StoreForward.StoreAndForward_HeartbeatSchema, { period: 120, secondary: 0 }),
+      });
+      expect(resolveMeshtasticTextMessagePayload(heartbeat)).toBeNull();
+    });
+
+    it('accepts store-forward text variant with viaStoreForward flag', () => {
+      const bytes = sfPacket(StoreForward.StoreAndForward_RequestResponse.ROUTER_TEXT_BROADCAST, {
+        case: 'text',
+        value: new TextEncoder().encode('summit check-in'),
+      });
+      expect(resolveMeshtasticTextMessagePayload(bytes)).toEqual({
+        text: 'summit check-in',
+        viaStoreForward: true,
+      });
+    });
+
+    it('accepts normal UTF-8 chat text', () => {
+      const bytes = new TextEncoder().encode("Yes, I'm on the summit");
+      expect(resolveMeshtasticTextMessagePayload(bytes)).toEqual({
+        text: "Yes, I'm on the summit",
+      });
+    });
+
+    it('accepts short and emoji payloads', () => {
+      expect(resolveMeshtasticTextMessagePayload(new TextEncoder().encode('OK'))).toEqual({
+        text: 'OK',
+      });
+      expect(resolveMeshtasticTextMessagePayload(new TextEncoder().encode('🦥'))).toEqual({
+        text: '🦥',
+      });
+    });
   });
 
   it('dedupes history messages within time window', () => {

--- a/src/renderer/lib/meshtasticBacklogUtils.ts
+++ b/src/renderer/lib/meshtasticBacklogUtils.ts
@@ -174,8 +174,57 @@ export function releaseStoreForwardHistoryRequest(
   requestedServers.delete(serverNodeId);
 }
 
+/** Max share of control bytes (excluding tab/LF/CR) before payload is treated as non-chat. */
+export const MESHTASTIC_CHAT_CONTROL_BYTE_RATIO_MAX = 0.25;
+
+export interface ResolvedMeshtasticTextPayload {
+  text: string;
+  viaStoreForward?: boolean;
+}
+
+/**
+ * Returns false when payload is mostly non-printable control bytes (corrupt decrypt, mis-ported SF).
+ */
+export function isLikelyReadableChatText(bytes: Uint8Array): boolean {
+  if (!bytes.length) return true;
+  let control = 0;
+  for (const b of bytes) {
+    if (b < 0x20 && b !== 0x09 && b !== 0x0a && b !== 0x0d) control++;
+  }
+  return control / bytes.length <= MESHTASTIC_CHAT_CONTROL_BYTE_RATIO_MAX;
+}
+
+/**
+ * Resolve TEXT_MESSAGE_APP payload for chat ingest (RF and MQTT).
+ * Failure point: mis-ported StoreAndForward or corrupt binary on text port.
+ * Fallback: return null so callers skip chat insert.
+ */
+export function resolveMeshtasticTextMessagePayload(
+  data: Uint8Array,
+): ResolvedMeshtasticTextPayload | null {
+  const sfText = decodeStoreForwardTextPayload(data);
+  if (sfText != null) {
+    return { text: sfText, viaStoreForward: true };
+  }
+
+  const parsed = parseStoreForwardPacket(data);
+  if (parsed && parsed.variant.case !== 'text') {
+    return null;
+  }
+
+  if (!isLikelyReadableChatText(data)) {
+    return null;
+  }
+
+  const text = new TextDecoder().decode(data);
+  return { text };
+}
+
+let toRadioDirectWriteChain: Promise<void> = Promise.resolve();
+
 /**
  * Write ToRadio bytes directly to the transport, bypassing MeshDevice queue ack wait.
+ * Serialized so concurrent writes do not race getWriter() on a locked WritableStream.
  * Failure point: transport write rejects (BLE disconnect, backpressure).
  * Fallback: caller logs and may retry on next heartbeat.
  */
@@ -183,12 +232,20 @@ export async function writeToRadioWithoutQueue(
   device: MeshDevice,
   toRadioBytes: Uint8Array,
 ): Promise<void> {
-  const writer = device.transport.toDevice.getWriter();
-  try {
-    await writer.write(toRadioBytes);
-  } finally {
-    writer.releaseLock();
-  }
+  const run = async (): Promise<void> => {
+    const writer = device.transport.toDevice.getWriter();
+    try {
+      await writer.write(toRadioBytes);
+    } finally {
+      writer.releaseLock();
+    }
+  };
+  const next = toRadioDirectWriteChain.then(run, run);
+  toRadioDirectWriteChain = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  await next;
 }
 
 export function decodeStoreForwardTextPayload(data: Uint8Array): string | null {

--- a/src/renderer/lib/meshtasticLastHeard.test.ts
+++ b/src/renderer/lib/meshtasticLastHeard.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeNodeInfoLastHeardMs,
+  mergeMeshtasticLivePacketLastHeard,
+  mergeMeshtasticUserPacketLastHeard,
+  meshtasticPacketRxTimeMs,
+  meshtasticTracerouteLastHeardNodeIds,
+} from '@/renderer/lib/meshtasticLastHeard';
+import { getNodeStatus } from '@/renderer/lib/nodeStatus';
+
+describe('meshtasticPacketRxTimeMs', () => {
+  it('normalizes Date objects', () => {
+    const d = new Date('2024-06-01T12:00:00Z');
+    expect(meshtasticPacketRxTimeMs(d)).toBe(d.getTime());
+  });
+
+  it('normalizes Unix seconds to ms', () => {
+    expect(meshtasticPacketRxTimeMs(1_700_000_000)).toBe(1_700_000_000_000);
+  });
+
+  it('passes through epoch ms', () => {
+    expect(meshtasticPacketRxTimeMs(1_700_000_000_123)).toBe(1_700_000_000_123);
+  });
+
+  it('returns 0 for invalid values', () => {
+    expect(meshtasticPacketRxTimeMs(undefined)).toBe(0);
+    expect(meshtasticPacketRxTimeMs(0)).toBe(0);
+    expect(meshtasticPacketRxTimeMs(NaN)).toBe(0);
+  });
+});
+
+describe('mergeMeshtasticLivePacketLastHeard', () => {
+  it('does not bump during configure replay', () => {
+    const stale = 1_000_000;
+    expect(mergeMeshtasticLivePacketLastHeard(stale, Date.now(), true)).toBe(stale);
+  });
+
+  it('bumps stale last_heard on live packet without rxTime', () => {
+    const before = Date.now();
+    const bumped = mergeMeshtasticLivePacketLastHeard(1_000_000, 0, false);
+    const after = Date.now();
+    expect(bumped).toBeGreaterThanOrEqual(before);
+    expect(bumped).toBeLessThanOrEqual(after);
+  });
+
+  it('takes max of existing and packet rx when post-configure', () => {
+    const rx = 5_000_000;
+    expect(mergeMeshtasticLivePacketLastHeard(0, rx, false)).toBe(rx);
+    expect(mergeMeshtasticLivePacketLastHeard(10_000_000, rx, false)).toBe(10_000_000);
+    expect(mergeMeshtasticLivePacketLastHeard(1000, rx, false)).toBe(rx);
+  });
+});
+
+describe('mergeMeshtasticUserPacketLastHeard', () => {
+  it('does not bump during configure replay', () => {
+    expect(mergeMeshtasticUserPacketLastHeard(0, Date.now(), true)).toBe(0);
+    expect(mergeMeshtasticUserPacketLastHeard(1_000_000, Date.now(), true)).toBe(1_000_000);
+  });
+
+  it('ignores invalid rx times (no Date.now fallback)', () => {
+    expect(mergeMeshtasticUserPacketLastHeard(1000, 0, false)).toBe(1000);
+    expect(mergeMeshtasticUserPacketLastHeard(1000, NaN, false)).toBe(1000);
+  });
+
+  it('takes max of existing and packet rx when post-configure', () => {
+    const rx = 5_000_000;
+    expect(mergeMeshtasticUserPacketLastHeard(0, rx, false)).toBe(rx);
+    expect(mergeMeshtasticUserPacketLastHeard(10_000_000, rx, false)).toBe(10_000_000);
+    expect(mergeMeshtasticUserPacketLastHeard(1000, rx, false)).toBe(rx);
+  });
+});
+
+describe('computeNodeInfoLastHeardMs', () => {
+  it('preserves newer client last_heard over stale NodeDB info.lastHeard', () => {
+    const clientMs = Date.now() - 60_000;
+    const nodeDbSec = Math.floor((Date.now() - 7 * 24 * 3_600_000) / 1000);
+    const merged = computeNodeInfoLastHeardMs(nodeDbSec, clientMs, false);
+    expect(merged).toBe(clientMs);
+  });
+
+  it('uses NodeDB lastHeard when newer than client', () => {
+    const nodeDbSec = Math.floor(Date.now() / 1000);
+    const clientMs = Date.now() - 7 * 24 * 3_600_000;
+    const merged = computeNodeInfoLastHeardMs(nodeDbSec, clientMs, false);
+    expect(merged).toBe(nodeDbSec * 1000);
+  });
+
+  it('fallback to Date.now() for self when info.lastHeard and existing are both 0', () => {
+    const lastHeardMs = computeNodeInfoLastHeardMs(0, 0, true);
+    expect(getNodeStatus(lastHeardMs)).toBe('online');
+  });
+
+  it('non-self node with info.lastHeard=0 and existing=0 stays offline', () => {
+    const lastHeardMs = computeNodeInfoLastHeardMs(0, 0, false);
+    expect(getNodeStatus(lastHeardMs)).toBe('offline');
+  });
+
+  it('clamps future info.lastHeard from device RTC skew to Date.now()', () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const futureSec = nowSec + 86_400;
+    const before = Date.now();
+    const lastHeardMs = computeNodeInfoLastHeardMs(futureSec, 0, false);
+    const after = Date.now();
+    expect(lastHeardMs).toBeGreaterThanOrEqual(before);
+    expect(lastHeardMs).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('meshtasticTracerouteLastHeardNodeIds', () => {
+  it('includes reply sender and correlated target', () => {
+    expect(meshtasticTracerouteLastHeardNodeIds(0x1111, 0x2222)).toEqual([0x1111, 0x2222]);
+  });
+
+  it('deduplicates when sender equals target', () => {
+    expect(meshtasticTracerouteLastHeardNodeIds(0x1111, 0x1111)).toEqual([0x1111]);
+  });
+
+  it('includes only sender when no correlated target', () => {
+    expect(meshtasticTracerouteLastHeardNodeIds(0x1111, undefined)).toEqual([0x1111]);
+  });
+
+  it('returns empty when sender is invalid', () => {
+    expect(meshtasticTracerouteLastHeardNodeIds(0, 0x2222)).toEqual([0x2222]);
+  });
+});

--- a/src/renderer/lib/meshtasticLastHeard.ts
+++ b/src/renderer/lib/meshtasticLastHeard.ts
@@ -1,0 +1,72 @@
+import { LAST_HEARD_MAX_FUTURE_SKEW_SEC } from '@/renderer/lib/nodeStatus';
+
+/** Normalize Meshtastic packet rxTime (Date, Unix seconds, or ms) to epoch ms. */
+export function meshtasticPacketRxTimeMs(rxTime: unknown): number {
+  if (rxTime instanceof Date) {
+    const ms = rxTime.getTime();
+    return Number.isFinite(ms) && ms > 0 ? ms : 0;
+  }
+  if (typeof rxTime === 'number' && Number.isFinite(rxTime) && rxTime > 0) {
+    return rxTime < 1_000_000_000_000 ? rxTime * 1000 : rxTime;
+  }
+  return 0;
+}
+
+/**
+ * Merge last_heard from a live RF packet. Skips bumps during configure replay.
+ * Falls back to Date.now() when rxTime is missing (position/traceroute replies).
+ */
+export function mergeMeshtasticLivePacketLastHeard(
+  existingLastHeard: number,
+  packetRxTimeMs: number,
+  isConfiguring: boolean,
+): number {
+  if (isConfiguring) return existingLastHeard;
+  const rx = packetRxTimeMs > 0 ? packetRxTimeMs : Date.now();
+  return Math.max(existingLastHeard || 0, rx);
+}
+
+/**
+ * Merge last_heard from onUserPacket using packet rxTime; skip bumps during configure replay.
+ * No Date.now() fallback when rxTime is missing (NodeDB replay may lack rxTime).
+ */
+export function mergeMeshtasticUserPacketLastHeard(
+  existingLastHeard: number,
+  packetRxTimeMs: number,
+  isConfiguring: boolean,
+): number {
+  if (isConfiguring || !Number.isFinite(packetRxTimeMs) || packetRxTimeMs <= 0) {
+    return existingLastHeard;
+  }
+  return Math.max(existingLastHeard || 0, packetRxTimeMs);
+}
+
+/**
+ * Merge NodeDB info.lastHeard with client-side last_heard (max wins).
+ * Self node falls back to Date.now() when both inputs are 0 (#272).
+ */
+export function computeNodeInfoLastHeardMs(
+  infoLastHeard: number | undefined,
+  existingLastHeard: number,
+  isSelf: boolean,
+): number {
+  let fromInfo = 0;
+  if ((infoLastHeard ?? 0) > 0) {
+    const ms = infoLastHeard! * 1000;
+    const maxMs = Date.now() + LAST_HEARD_MAX_FUTURE_SKEW_SEC * 1000;
+    fromInfo = ms > maxMs ? Date.now() : ms;
+  }
+  const selfFallback = isSelf && fromInfo === 0 && (existingLastHeard ?? 0) === 0 ? Date.now() : 0;
+  return Math.max(fromInfo, existingLastHeard || 0, selfFallback);
+}
+
+/** Node IDs whose last_heard should bump on a traceroute reply. */
+export function meshtasticTracerouteLastHeardNodeIds(
+  meshFrom: number,
+  correlatedDest: number | undefined,
+): number[] {
+  const ids = new Set<number>();
+  if (meshFrom > 0) ids.add(meshFrom);
+  if (correlatedDest !== undefined && correlatedDest > 0) ids.add(correlatedDest);
+  return [...ids];
+}


### PR DESCRIPTION
## Summary

- **Last heard on live RF traffic:** Centralize `meshtasticLastHeard` helpers and bump `last_heard` on position, telemetry, traceroute replies, and text/user packets (not only chat). Traceroute replies update both the reply sender and the correlated trace target. `computeNodeInfoLastHeardMs` keeps the newer of client vs NodeDB timestamps so configure replay cannot regress freshness after live traffic.
- **Garbled TEXT_MESSAGE ingest:** `resolveMeshtasticTextMessagePayload` rejects control-heavy binary and mis-ported Store & Forward protobuf on `TEXT_MESSAGE_APP`; S&F text replays get `viaStoreForward`. Applied on RF (`useDevice`) and MQTT (`mqtt-manager`).
- **CLIENT_HISTORY races:** Serialize `writeToRadioWithoutQueue` through a promise chain to avoid `WritableStream` lock errors when history requests overlap the SDK writer.

## Commits

- `91526230` fix: drop garbled TEXT_MESSAGE payloads and serialize CLIENT_HISTORY writes
- `d522bd9a` fix: bump Meshtastic last_heard on live RF liveness packets

## Test plan

- [ ] `pnpm run test:run` — `meshtasticLastHeard.test.ts`, `meshtasticBacklogUtils` resolver/write-queue tests
- [ ] Connect Meshtastic over RF; confirm node **Last heard** updates after position/traceroute replies, not only chat
- [ ] Run traceroute to a peer; verify both the replying node and the queried target show fresh status
- [ ] Reconnect / configure replay: confirm **Last heard** does not jump backward for nodes heard live before replay
- [ ] MQTT + RF: garbled/non-text payloads on `TEXT_MESSAGE_APP` do not appear in chat; valid S&F text shows with S&F badge
- [ ] Store & Forward history request on heartbeat does not log WritableStream locked errors under load