### PR TITLE
fix: Meshtastic remote admin timeout on Linux BLE

### DIFF
--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -94,6 +94,7 @@ import {
   normalizeMeshtasticPacketId,
 } from '../lib/meshtasticMessageDedup';
 import {
+  meshtasticNodePublicKeyBytesFromHex,
   MeshtasticRemoteAdminClient,
   normalizeRemoteAdminError,
 } from '../lib/meshtasticRemoteAdmin';
@@ -738,6 +739,8 @@ export function useDevice() {
     remoteAdminClientRef.current = new MeshtasticRemoteAdminClient(
       () => deviceRef.current,
       () => myNodeNumRef.current,
+      (nodeNum) =>
+        meshtasticNodePublicKeyBytesFromHex(nodesRef.current.get(nodeNum)?.public_key_hex),
     );
     return () => {
       remoteAdminClientRef.current?.dispose();
@@ -3446,6 +3449,7 @@ export function useDevice() {
       setRemoteConfigSnapshot(snapshot);
       setRemoteAdminStatus('ready');
     } catch (e) {
+      remoteAdminClientRef.current?.resetEditState();
       const msg = normalizeRemoteAdminError(e);
       setRemoteAdminStatus('error');
       setRemoteAdminError(msg);

--- a/src/renderer/lib/meshtasticRemoteAdmin.test.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.test.ts
@@ -1,10 +1,11 @@
-import { create, toBinary } from '@bufbuild/protobuf';
+import { create, fromBinary, toBinary } from '@bufbuild/protobuf';
 import { Admin, Mesh, Portnums } from '@meshtastic/protobufs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildRemoteAdminToRadio,
   extractAdminSessionPasskey,
+  meshtasticNodePublicKeyBytesFromHex,
   MeshtasticRemoteAdminClient,
   normalizeRemoteAdminError,
   parseIncomingRemoteAdminPacket,
@@ -12,6 +13,20 @@ import {
   RemoteAdminSessionStore,
   routingErrorToRemoteAdminKey,
 } from './meshtasticRemoteAdmin';
+
+const TEST_DEST_PUBKEY_HEX = '4852b69364572b52efa1b6bb3e6d0abed4f389a1cbfbb60a9bba2cce649caf0e';
+const TEST_DEST_PUBKEY = meshtasticNodePublicKeyBytesFromHex(TEST_DEST_PUBKEY_HEX)!;
+
+describe('meshtasticNodePublicKeyBytesFromHex', () => {
+  it('parses a 32-byte hex public key', () => {
+    expect(meshtasticNodePublicKeyBytesFromHex(TEST_DEST_PUBKEY_HEX)).toEqual(TEST_DEST_PUBKEY);
+  });
+
+  it('rejects invalid hex lengths', () => {
+    expect(meshtasticNodePublicKeyBytesFromHex('abcd')).toBeUndefined();
+    expect(meshtasticNodePublicKeyBytesFromHex(undefined)).toBeUndefined();
+  });
+});
 
 describe('RemoteAdminSessionStore', () => {
   it('stores and returns an 8-byte passkey before expiry', () => {
@@ -66,6 +81,27 @@ describe('parseIncomingRemoteAdminPacket', () => {
     }
   });
 
+  it('falls back to mesh packet id when Data.requestId is zero', () => {
+    const adminMsg = create(Admin.AdminMessageSchema, {
+      payloadVariant: { case: 'getDeviceMetadataResponse', value: {} as never },
+    });
+    const meshPacket = create(Mesh.MeshPacketSchema, {
+      id: 7777,
+      from: 0x200,
+      payloadVariant: {
+        case: 'decoded',
+        value: {
+          portnum: Portnums.PortNum.ADMIN_APP,
+          payload: toBinary(Admin.AdminMessageSchema, adminMsg),
+          requestId: 0,
+        },
+      },
+    });
+
+    const parsed = parseIncomingRemoteAdminPacket(meshPacket as never);
+    expect(parsed).toMatchObject({ kind: 'admin', requestId: 7777, from: 0x200 });
+  });
+
   it('parses ROUTING_APP errors by request id', () => {
     const routingPayload = toBinary(
       Mesh.RoutingSchema,
@@ -99,16 +135,28 @@ describe('parseIncomingRemoteAdminPacket', () => {
 });
 
 describe('buildRemoteAdminToRadio', () => {
-  it('sets pkiEncrypted and ADMIN_APP payload', () => {
+  it('sets pkiEncrypted, publicKey, and omits channel for PKC admin', () => {
     const adminPayload = new Uint8Array([1, 2, 3]);
     const bytes = buildRemoteAdminToRadio({
       myNodeNum: 0x100,
       destNodeNum: 0x200,
       adminPayload,
       packetId: 99,
+      publicKey: TEST_DEST_PUBKEY,
     });
     expect(bytes.length).toBeGreaterThan(0);
-    expect(bytes).toBeInstanceOf(Uint8Array);
+
+    const toRadio = fromBinary(Mesh.ToRadioSchema, bytes) as {
+      payloadVariant?: {
+        case?: string;
+        value?: { pkiEncrypted?: boolean; publicKey?: Uint8Array; channel?: number };
+      };
+    };
+    expect(toRadio.payloadVariant?.case).toBe('packet');
+    const packet = toRadio.payloadVariant?.value;
+    expect(packet?.pkiEncrypted).toBe(true);
+    expect(packet?.publicKey).toEqual(TEST_DEST_PUBKEY);
+    expect(packet?.channel).toBe(0);
   });
 });
 
@@ -163,6 +211,7 @@ describe('MeshtasticRemoteAdminClient', () => {
     client = new MeshtasticRemoteAdminClient(
       () => device as never,
       () => 0x100,
+      () => TEST_DEST_PUBKEY,
     );
   });
 
@@ -204,13 +253,39 @@ describe('MeshtasticRemoteAdminClient', () => {
     expect(client.sessionStore.get(0x200)).toEqual(new Uint8Array(8).fill(7));
   });
 
-  it('correlates concurrent getRemoteConfig responses by request id', async () => {
-    let nextId = 1000;
-    sendRaw.mockImplementation((_bytes: Uint8Array, id: number) => id);
+  it('rejects when destination public key is missing', async () => {
+    const noKeyClient = new MeshtasticRemoteAdminClient(
+      () => device as never,
+      () => 0x100,
+      () => undefined,
+    );
+    try {
+      await expect(noKeyClient.getRemoteMetadata(0x200)).rejects.toThrow(
+        'remoteAdmin.errors.pkiFailed',
+      );
+      expect(sendRaw).not.toHaveBeenCalled();
+    } finally {
+      noKeyClient.dispose();
+    }
+  });
+
+  it('serializes sendRaw so the second request waits for the first to finish sending', async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<number>((resolve) => {
+      releaseFirst = () => {
+        resolve(1001);
+      };
+    });
+    sendRaw
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- sendRaw returns Promise<number>
+      .mockImplementationOnce(() => firstGate)
+      .mockImplementation((_bytes: Uint8Array, id: number) => id);
+
+    let nextId = 2000;
     device.generateRandId = () => nextId++;
 
-    const loraPromise = client.getRemoteConfig(0x200, Admin.AdminMessage_ConfigType.LORA_CONFIG);
-    const devicePromise = client.getRemoteConfig(
+    const firstPromise = client.getRemoteConfig(0x200, Admin.AdminMessage_ConfigType.LORA_CONFIG);
+    const secondPromise = client.getRemoteConfig(
       0x200,
       Admin.AdminMessage_ConfigType.DEVICE_CONFIG,
     );
@@ -218,17 +293,17 @@ describe('MeshtasticRemoteAdminClient', () => {
       setImmediate(resolve);
     });
 
+    expect(sendRaw).toHaveBeenCalledTimes(1);
+
+    releaseFirst!();
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(sendRaw).toHaveBeenCalledTimes(2);
+
     const loraPacketId = sendRaw.mock.calls[0]?.[1] as number;
     const devicePacketId = sendRaw.mock.calls[1]?.[1] as number;
 
-    const loraResponse = create(Admin.AdminMessageSchema, {
-      payloadVariant: {
-        case: 'getConfigResponse',
-        value: {
-          payloadVariant: { case: 'lora', value: { region: 1 } },
-        } as never,
-      },
-    });
     client.handleMeshPacket(
       create(Mesh.MeshPacketSchema, {
         from: 0x200,
@@ -236,21 +311,22 @@ describe('MeshtasticRemoteAdminClient', () => {
           case: 'decoded',
           value: {
             portnum: Portnums.PortNum.ADMIN_APP,
-            payload: toBinary(Admin.AdminMessageSchema, loraResponse),
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getConfigResponse',
+                  value: {
+                    payloadVariant: { case: 'lora', value: { region: 1 } },
+                  } as never,
+                },
+              }),
+            ),
             requestId: loraPacketId,
           },
         },
       }) as never,
     );
-
-    const deviceResponse = create(Admin.AdminMessageSchema, {
-      payloadVariant: {
-        case: 'getConfigResponse',
-        value: {
-          payloadVariant: { case: 'device', value: { role: 0 } },
-        } as never,
-      },
-    });
     client.handleMeshPacket(
       create(Mesh.MeshPacketSchema, {
         from: 0x200,
@@ -258,20 +334,64 @@ describe('MeshtasticRemoteAdminClient', () => {
           case: 'decoded',
           value: {
             portnum: Portnums.PortNum.ADMIN_APP,
-            payload: toBinary(Admin.AdminMessageSchema, deviceResponse),
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getConfigResponse',
+                  value: {
+                    payloadVariant: { case: 'device', value: { role: 0 } },
+                  } as never,
+                },
+              }),
+            ),
             requestId: devicePacketId,
           },
         },
       }) as never,
     );
 
-    const [loraResult, deviceResult] = await Promise.all([loraPromise, devicePromise]);
+    const [loraResult, deviceResult] = await Promise.all([firstPromise, secondPromise]);
     expect((loraResult as { payloadVariant?: { case?: string } }).payloadVariant?.case).toBe(
       'lora',
     );
     expect((deviceResult as { payloadVariant?: { case?: string } }).payloadVariant?.case).toBe(
       'device',
     );
+  });
+
+  it('resolves admin responses correlated by mesh packet id when requestId is zero', async () => {
+    const promise = client.getRemoteMetadata(0x200);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const packetId = sendRaw.mock.calls[0]?.[1] as number;
+
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        id: packetId,
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getDeviceMetadataResponse',
+                  value: { firmwareVersion: '2.6.0' } as never,
+                },
+              }),
+            ),
+            requestId: 0,
+          },
+        },
+      }) as never,
+    );
+
+    const result = await promise;
+    expect((result as { firmwareVersion?: string }).firmwareVersion).toBe('2.6.0');
   });
 
   it('resetEditState clears pendingEdit so a new target can begin edits', async () => {

--- a/src/renderer/lib/meshtasticRemoteAdmin.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.ts
@@ -22,12 +22,17 @@ interface MeshPacketDecoded {
   portnum?: number;
   payload?: Uint8Array;
   requestId?: number;
+  replyId?: number;
 }
 
 interface MeshPacket {
+  id?: number;
   from?: number;
   payloadVariant?: { case?: string; value?: MeshPacketDecoded };
 }
+
+/** Meshtastic Android PKC sentinel; channel field is omitted on wire for PKI admin. */
+export const REMOTE_ADMIN_PKC_CHANNEL_INDEX = 8;
 
 /** Firmware session_passkey TTL (AdminModule.cpp). */
 export const REMOTE_ADMIN_SESSION_TTL_MS = 300_000;
@@ -40,6 +45,19 @@ export type RemoteAdminRoutingErrorCode = number;
 export interface RemoteAdminSessionEntry {
   passkey: Uint8Array;
   expiresAt: number;
+}
+
+export function meshtasticNodePublicKeyBytesFromHex(
+  hex: string | undefined,
+): Uint8Array | undefined {
+  if (hex?.length !== 64) return undefined;
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    const byte = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (!Number.isFinite(byte)) return undefined;
+    bytes[i] = byte;
+  }
+  return bytes;
 }
 
 export class RemoteAdminSessionStore {
@@ -127,6 +145,20 @@ export function routingErrorToRemoteAdminKey(error: RemoteAdminRoutingErrorCode)
   }
 }
 
+function resolveAdminRequestId(meshPacket: MeshPacket, dataRequestId: number): number {
+  if (dataRequestId !== 0) return dataRequestId >>> 0;
+  const packetId = meshPacket.id;
+  if (typeof packetId === 'number' && Number.isFinite(packetId) && packetId !== 0) {
+    return packetId >>> 0;
+  }
+  const data = meshPacket.payloadVariant?.value;
+  const replyId = data?.replyId;
+  if (typeof replyId === 'number' && Number.isFinite(replyId) && replyId !== 0) {
+    return replyId >>> 0;
+  }
+  return 0;
+}
+
 export function parseIncomingRemoteAdminPacket(meshPacket: MeshPacket): ParsedAdminResponse | null {
   if (meshPacket.payloadVariant?.case !== 'decoded') return null;
   const data = meshPacket.payloadVariant.value;
@@ -139,7 +171,12 @@ export function parseIncomingRemoteAdminPacket(meshPacket: MeshPacket): ParsedAd
         Admin.AdminMessageSchema,
         data.payload!,
       ) as unknown as AdminMessage;
-      return { kind: 'admin', message, from, requestId: (data.requestId ?? 0) >>> 0 };
+      return {
+        kind: 'admin',
+        message,
+        from,
+        requestId: resolveAdminRequestId(meshPacket, (data.requestId ?? 0) >>> 0),
+      };
     } catch {
       // catch-no-log-ok malformed ADMIN_APP payload on unrelated mesh traffic
       return null;
@@ -152,7 +189,7 @@ export function parseIncomingRemoteAdminPacket(meshPacket: MeshPacket): ParsedAd
         variant?: { case?: string; value?: number };
       };
       if (routing.variant?.case === 'errorReason') {
-        const requestId = (data.requestId ?? 0) >>> 0;
+        const requestId = resolveAdminRequestId(meshPacket, (data.requestId ?? 0) >>> 0);
         if (requestId !== 0 && routing.variant.value != null) {
           return {
             kind: 'routing_error',
@@ -176,17 +213,17 @@ export function buildRemoteAdminToRadio(params: {
   destNodeNum: number;
   adminPayload: Uint8Array;
   packetId: number;
+  publicKey: Uint8Array;
   wantAck?: boolean;
   wantResponse?: boolean;
-  channel?: number;
 }): Uint8Array {
   const meshPacket = create(Mesh.MeshPacketSchema, {
     from: params.myNodeNum >>> 0,
     to: params.destNodeNum >>> 0,
     id: params.packetId >>> 0,
     wantAck: params.wantAck ?? true,
-    channel: params.channel ?? 0,
     pkiEncrypted: true,
+    publicKey: params.publicKey,
     payloadVariant: {
       case: 'decoded',
       value: {
@@ -223,10 +260,12 @@ export class MeshtasticRemoteAdminClient {
   readonly sessionStore = new RemoteAdminSessionStore();
   private readonly pending = new Map<number, PendingRemoteAdmin>();
   private pendingEdit = false;
+  private sendRawChain: Promise<unknown> = Promise.resolve();
 
   constructor(
     private readonly getDevice: () => MeshDevice | null,
     private readonly getMyNodeNum: () => number,
+    private readonly getDestPublicKey: (nodeNum: number) => Uint8Array | undefined,
   ) {}
 
   dispose(): void {
@@ -266,7 +305,19 @@ export class MeshtasticRemoteAdminClient {
     if (parsed.requestId === 0) return;
 
     const pending = this.pending.get(parsed.requestId);
-    if (pending?.destNodeNum !== parsed.from) return;
+    if (!pending) return;
+
+    if (pending.destNodeNum !== parsed.from) {
+      console.debug(
+        '[MeshtasticRemoteAdmin] admin response sender mismatch expected=0x' +
+          pending.destNodeNum.toString(16) +
+          ' got=0x' +
+          parsed.from.toString(16) +
+          ' requestId=' +
+          String(parsed.requestId),
+      );
+      return;
+    }
 
     const responseCase = parsed.message.payloadVariant.case;
     if (!responseCase) return;
@@ -308,6 +359,12 @@ export class MeshtasticRemoteAdminClient {
     });
   }
 
+  private resolveDestPublicKey(destNodeNum: number): Uint8Array {
+    const publicKey = this.getDestPublicKey(destNodeNum);
+    if (publicKey?.length === 32) return publicKey;
+    throw new Error('remoteAdmin.errors.pkiFailed');
+  }
+
   private buildRawAdminPacket(
     destNodeNum: number,
     message: AdminMessage,
@@ -321,6 +378,7 @@ export class MeshtasticRemoteAdminClient {
       destNodeNum,
       adminPayload: payload,
       packetId,
+      publicKey: this.resolveDestPublicKey(destNodeNum),
       wantAck: options.wantAck ?? true,
       wantResponse: options.wantResponse ?? true,
     });
@@ -340,12 +398,22 @@ export class MeshtasticRemoteAdminClient {
 
     const id = packetId ?? this.generatePacketId();
     const toRadio = this.buildRawAdminPacket(destNodeNum, message, id, options);
-    try {
-      return await device.sendRaw(toRadio, id);
-    } catch (e) {
-      console.warn('[MeshtasticRemoteAdmin] sendRaw failed ' + errLikeToLogString(e));
-      throw new Error(normalizeRemoteAdminError(e));
-    }
+
+    const run = async (): Promise<number> => {
+      try {
+        return await device.sendRaw(toRadio, id);
+      } catch (e) {
+        console.warn('[MeshtasticRemoteAdmin] sendRaw failed ' + errLikeToLogString(e));
+        throw new Error(normalizeRemoteAdminError(e));
+      }
+    };
+
+    const next = this.sendRawChain.then(run, run);
+    this.sendRawChain = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
   }
 
   private waitForAdminResponse(

--- a/src/renderer/lib/meshtasticRemoteAdminSnapshot.test.ts
+++ b/src/renderer/lib/meshtasticRemoteAdminSnapshot.test.ts
@@ -40,4 +40,59 @@ describe('fetchMeshtasticRemoteConfigSnapshot', () => {
     expect(snapshot.channelConfigs?.[0]?.name).toBe('Primary');
     expect(snapshot.deviceOwner?.longName).toBe('Remote');
   });
+
+  it('fetches config sections sequentially without overlapping calls', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const order: string[] = [];
+
+    const track = (label: string) => {
+      order.push(label);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return () => {
+        inFlight -= 1;
+      };
+    };
+
+    const client = {
+      getRemoteMetadata: vi.fn(async () => {
+        const done = track('metadata');
+        await Promise.resolve();
+        done();
+        return { firmwareVersion: '2.5.0' };
+      }),
+      getRemoteConfig: vi.fn(async (_dest: number, type: number) => {
+        const done = track(`config:${type}`);
+        await Promise.resolve();
+        done();
+        return { payloadVariant: { case: 'device', value: {} } };
+      }),
+      getRemoteChannel: vi.fn(async (_dest: number, index: number) => {
+        const done = track(`channel:${index}`);
+        await Promise.resolve();
+        done();
+        return { index, role: 0, settings: { name: '', psk: new Uint8Array() } };
+      }),
+      getRemoteModuleConfig: vi.fn(async (_dest: number, type: number) => {
+        const done = track(`module:${type}`);
+        await Promise.resolve();
+        done();
+        return { payloadVariant: { case: 'mqtt', value: {} } };
+      }),
+      getRemoteOwner: vi.fn(async () => {
+        const done = track('owner');
+        await Promise.resolve();
+        done();
+        return { longName: 'Remote', shortName: 'RM' };
+      }),
+    } as unknown as MeshtasticRemoteAdminClient;
+
+    await fetchMeshtasticRemoteConfigSnapshot(client, 0x200);
+
+    expect(maxInFlight).toBe(1);
+    expect(order[0]).toBe('metadata');
+    expect(order.at(-1)).toBe('owner');
+    expect(order.indexOf('metadata')).toBeLessThan(order.findIndex((e) => e.startsWith('config:')));
+  });
 });

--- a/src/renderer/lib/meshtasticRemoteAdminSnapshot.ts
+++ b/src/renderer/lib/meshtasticRemoteAdminSnapshot.ts
@@ -123,30 +123,26 @@ export async function fetchMeshtasticRemoteConfigSnapshot(
     Admin.AdminMessage_ConfigType.TELEMETRY_CONFIG,
   ] as const;
 
-  const configResults = await Promise.all(
-    configTypes.map(async (type) => ({
-      type,
-      value: await client.getRemoteConfig(destNodeNum, type),
-    })),
-  );
+  const configResults: { type: (typeof configTypes)[number]; value: unknown }[] = [];
+  for (const type of configTypes) {
+    configResults.push({ type, value: await client.getRemoteConfig(destNodeNum, type) });
+  }
 
-  const channelResults = await Promise.all(
-    Array.from({ length: 8 }, (_, index) =>
-      client.getRemoteChannel(destNodeNum, index).then((value) => ({ index, value })),
-    ),
-  );
+  const channelResults: { index: number; value: unknown }[] = [];
+  for (let index = 0; index < 8; index++) {
+    channelResults.push({ index, value: await client.getRemoteChannel(destNodeNum, index) });
+  }
 
-  const moduleResults = await Promise.all(
-    MODULE_CONFIG_FETCHES.map(async ({ type, key }) => {
-      try {
-        const value = await client.getRemoteModuleConfig(destNodeNum, type);
-        return { key, value };
-      } catch {
-        // catch-no-log-ok optional module config may be unsupported on target firmware
-        return { key, value: null };
-      }
-    }),
-  );
+  const moduleResults: { key: string; value: unknown }[] = [];
+  for (const { type, key } of MODULE_CONFIG_FETCHES) {
+    try {
+      const value = await client.getRemoteModuleConfig(destNodeNum, type);
+      moduleResults.push({ key, value });
+    } catch {
+      // catch-no-log-ok optional module config may be unsupported on target firmware
+      moduleResults.push({ key, value: null });
+    }
+  }
 
   let deviceOwner: MeshtasticRemoteConfigSnapshot['deviceOwner'];
   try {


### PR DESCRIPTION
## Summary
- Serialize remote config snapshot fetches (metadata, configs, channels, modules, owner) one at a time instead of firing ~30 parallel admin requests that overloaded the radio/SDK queue.
- Build PKI admin packets with the destination node's `publicKey` from the node DB (Android PKC pattern); fail fast with `pkiFailed` when the key is missing.
- Serialize outbound `sendRaw` through a per-client promise chain and correlate responses via `meshPacket.id` when `Data.requestId` is zero.
- Clear pending admin state on snapshot fetch failure; wire public-key lookup from `nodesRef.public_key_hex` in `useDevice`.

## Context
User logs on Linux Web Bluetooth showed metadata admin succeeding (~2s) then the next parallel config batch timing out at ~60s (`sendRaw` SDK error 3). Android admin traffic is serialized and includes proper PKC fields; this aligns mesh-client with that behavior.

## Test plan
- [x] `pnpm run test:run` — remote admin unit tests (PKI packet shape, serialized sendRaw, sequential snapshot, requestId fallback)
- [ ] Linux Web Bluetooth: connect local radio, select remote configure target → snapshot reaches `ready` without 60s timeout
- [ ] Confirm sequential `ADMIN_APP` responses in logs during snapshot load
- [ ] Verify remote target has `public_key_hex` in node list (from NODEINFO); missing key should show `pkiFailed` not silent timeout
- [ ] Sanity: local configure still works; remote write/commit after snapshot loads