### PR TITLE
fix: correct AES-CTR nonce construction for MQTT encrypt/decrypt

### DIFF
--- a/src/main/mqtt-manager.test.ts
+++ b/src/main/mqtt-manager.test.ts
@@ -44,7 +44,7 @@ const CUSTOM_PSK = Buffer.from([
 function makeNonce(packetId: number, fromId: number): Buffer {
   const nonce = Buffer.alloc(16, 0);
   nonce.writeUInt32LE(packetId >>> 0, 0);
-  nonce.writeUInt32LE(fromId >>> 0, 4);
+  nonce.writeUInt32LE(fromId >>> 0, 8);
   return nonce;
 }
 

--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -684,7 +684,7 @@ export class MQTTManager extends EventEmitter {
 
     const nonce = Buffer.alloc(16, 0);
     nonce.writeUInt32LE(packetId >>> 0, 0);
-    nonce.writeUInt32LE(fromId >>> 0, 4);
+    nonce.writeUInt32LE(fromId >>> 0, 8); // firmware: fromNode at byte offset 8 (after 64-bit packetId)
     const psk = this.resolvePskForChannel(channelName, explicitPsk);
     const cipher = createCipheriv(cipherForKey(psk), psk, nonce);
     const encrypted = Buffer.concat([cipher.update(Buffer.from(dataBytes)), cipher.final()]);
@@ -1855,7 +1855,7 @@ export class MQTTManager extends EventEmitter {
     try {
       const nonce = Buffer.alloc(16, 0);
       nonce.writeUInt32LE(packetId >>> 0, 0);
-      nonce.writeUInt32LE(from >>> 0, 4);
+      nonce.writeUInt32LE(from >>> 0, 8); // firmware: fromNode at byte offset 8 (after 64-bit packetId)
       const decipher = createDecipheriv(cipherForKey(key), key, nonce);
       return Buffer.concat([decipher.update(Buffer.from(encrypted)), decipher.final()]);
     } catch {


### PR DESCRIPTION
Meshtastic firmware (CryptoEngine.cpp) constructs the 16-byte nonce as:
  bytes 0-7:   packetId as uint64 little-endian (upper 32 bits zero)
  bytes 8-11:  fromNode as uint32 little-endian
  bytes 12-15: zero

mqtt-manager was writing fromNode at byte offset 4 instead of 8, causing all MQTT encryption and decryption to use the wrong nonce. Every published packet was unreadable by other clients, and all incoming encrypted packets failed to decrypt regardless of key.

Fix: move fromNode write to correct offset 8 in both publishEncryptedData and tryDecryptWithKey.

Verified against firmware source and confirmed working with live MQTT traffic on a private AES-256 channel.