### PR TITLE
fix: remote admin PKI fallback, MQTT from guard, and snapshot hardening

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -712,8 +712,8 @@ function validateMqttPublishArgs(args: unknown): void {
   if (typeof a.text !== 'string') throw new Error('mqtt:publish: text must be a string');
   if (a.text.length > MAX_PAYLOAD_LENGTH) throw new Error('mqtt:publish: text too long');
   const from = Number(a.from);
-  if (!Number.isFinite(from) || from < 0)
-    throw new Error('mqtt:publish: from must be a non-negative integer');
+  if (!Number.isFinite(from) || from <= 0)
+    throw new Error('mqtt:publish: from must be a positive node id');
   const channel = Number(a.channel);
   if (!Number.isFinite(channel) || channel < 0)
     throw new Error('mqtt:publish: channel must be a non-negative integer');
@@ -749,8 +749,8 @@ function validateMqttPublishWaypointArgs(args: unknown): void {
     throw new Error('mqtt:publishWaypoint: publishJsonMirror must be a boolean');
   }
   const from = Number(a.from);
-  if (!Number.isFinite(from) || from < 0) {
-    throw new Error('mqtt:publishWaypoint: from must be a non-negative integer');
+  if (!Number.isFinite(from) || from <= 0) {
+    throw new Error('mqtt:publishWaypoint: from must be a positive node id');
   }
   const to = Number(a.to);
   if (!Number.isFinite(to) || to < 0) {

--- a/src/renderer/components/ConfigureNodeSelector.tsx
+++ b/src/renderer/components/ConfigureNodeSelector.tsx
@@ -231,27 +231,22 @@ export default function ConfigureNodeSelector({
             </div>
           </div>
           {configTarget.isLoading && (
-            <p className="text-muted mt-1 text-xs">{t('configureNode.loading')}</p>
+            <p className="text-muted mt-1 text-xs" role="status">
+              {remoteAdminSessionStatus === 'none'
+                ? t('configureNode.establishingSession')
+                : t('configureNode.loading')}
+            </p>
           )}
           {!configTarget.isLoading && remoteAdminSessionStatus !== 'none' && (
             <p
               className={`mt-1 text-xs ${
-                remoteAdminSessionStatus === 'active'
-                  ? 'text-green-300'
-                  : remoteAdminSessionStatus === 'stale'
-                    ? 'text-amber-300'
-                    : 'text-blue-200'
+                remoteAdminSessionStatus === 'active' ? 'text-green-300' : 'text-amber-300'
               }`}
               role="status"
             >
               {remoteAdminSessionStatus === 'active'
                 ? t('configureNode.sessionActive')
                 : t('configureNode.sessionStale')}
-            </p>
-          )}
-          {configTarget.isLoading && remoteAdminSessionStatus === 'none' && (
-            <p className="text-muted mt-1 text-xs" role="status">
-              {t('configureNode.establishingSession')}
             </p>
           )}
         </div>

--- a/src/renderer/components/NodeDetailModal.tsx
+++ b/src/renderer/components/NodeDetailModal.tsx
@@ -1313,26 +1313,23 @@ export default function NodeDetailModal({
                       {adminKeyStatus}
                     </p>
                   )}
-                  {onConfigureRemotely &&
-                    isConnected &&
-                    node.public_key_hex?.length === 64 &&
-                    hasRemoteAdminKey && (
-                      <div className="pt-1">
-                        <button
-                          type="button"
-                          aria-label={t('nodeDetailModal.configureRemotely')}
-                          className="bg-brand-green/20 text-brand-green hover:bg-brand-green/30 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
-                          onClick={() => {
-                            onConfigureRemotely(node.node_id);
-                          }}
-                        >
-                          {t('nodeDetailModal.configureRemotely')}
-                        </button>
-                        <p className="text-muted mt-1 text-xs">
-                          {t('nodeDetailModal.configureRemotelyHint')}
-                        </p>
-                      </div>
-                    )}
+                  {onConfigureRemotely && isConnected && hasRemoteAdminKey && (
+                    <div className="pt-1">
+                      <button
+                        type="button"
+                        aria-label={t('nodeDetailModal.configureRemotely')}
+                        className="bg-brand-green/20 text-brand-green hover:bg-brand-green/30 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
+                        onClick={() => {
+                          onConfigureRemotely(node.node_id);
+                        }}
+                      >
+                        {t('nodeDetailModal.configureRemotely')}
+                      </button>
+                      <p className="text-muted mt-1 text-xs">
+                        {t('nodeDetailModal.configureRemotelyHint')}
+                      </p>
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -2054,7 +2054,7 @@ export default function RadioPanel({
                     title: t('radioPanel.resetNodeDbTitle'),
                     message: t('radioPanel.resetNodeDbMessage'),
                     confirmLabel: t('radioPanel.resetNodeDbConfirm'),
-                    showPreserveFavorites: true,
+                    showPreserveFavorites: configTarget?.mode === 'remote',
                     action: () => onResetNodeDb(nodeDbPreserveFavorites),
                   });
                 }}

--- a/src/renderer/hooks/useDevice.ts
+++ b/src/renderer/hooks/useDevice.ts
@@ -111,14 +111,15 @@ import {
 } from '../lib/meshtasticMessageDedup';
 import {
   createSerialTaskQueue,
-  meshtasticNodePublicKeyBytesFromHex,
   MeshtasticRemoteAdminClient,
   normalizeRemoteAdminError,
   type RemoteAdminSessionStatus,
   remoteConfigLoadingWatchdogMsForRoute,
+  resolveMeshtasticDestPublicKeyBytes,
 } from '../lib/meshtasticRemoteAdmin';
 import {
   getMeshtasticRemoteAdminKeyForNode,
+  isValidMeshtasticAdminKeyBase64,
   MESHTASTIC_REMOTE_ADMIN_KEY_SETTING_PREFIX,
   readMeshtasticRemoteAdminKeyMap,
   setMeshtasticRemoteAdminKeyForNode,
@@ -842,7 +843,10 @@ export function useDevice() {
       () => deviceRef.current,
       () => myNodeNumRef.current,
       (nodeNum) =>
-        meshtasticNodePublicKeyBytesFromHex(nodesRef.current.get(nodeNum)?.public_key_hex),
+        resolveMeshtasticDestPublicKeyBytes({
+          publicKeyHex: nodesRef.current.get(nodeNum)?.public_key_hex,
+          adminKeyBase64: remoteAdminKeysByNodeRef.current[String(nodeNum)],
+        }),
     );
     return () => {
       remoteAdminClientRef.current?.dispose();
@@ -3584,8 +3588,8 @@ export function useDevice() {
       // Determine initial MQTT display state (TransportManager will confirm/update asynchronously)
       const chCfg = channelConfigsRef.current.find((c) => c.index === channel);
       const shouldUplink = !deviceRef.current
-        ? hasMqtt // MQTT-only: always uplink when connected
-        : !!(chCfg?.uplinkEnabled && hasMqtt && myNodeNumRef.current);
+        ? hasMqtt && from > 0 // MQTT-only: uplink when connected with a valid sender id
+        : !!(from > 0 && chCfg?.uplinkEnabled && hasMqtt);
 
       const msg: ChatMessage = enrichMeshtasticReplyPreviews(
         {
@@ -3673,16 +3677,19 @@ export function useDevice() {
         return;
       }
       const destNode = nodesRef.current.get(destNodeNum);
-      const destPubHex = destNode?.public_key_hex;
-      if ((destPubHex?.length ?? 0) !== 64) {
-        setRemoteAdminStatus('error');
-        setRemoteAdminError('remoteAdmin.errors.noRemotePublicKey');
-        return;
-      }
       const configuredAdminKey = getRemoteAdminKeyForNode(destNodeNum);
-      if (!configuredAdminKey) {
+      if (!configuredAdminKey || !isValidMeshtasticAdminKeyBase64(configuredAdminKey)) {
         setRemoteAdminStatus('error');
         setRemoteAdminError('remoteAdmin.errors.noAdminKeyConfigured');
+        return;
+      }
+      const destPublicKey = resolveMeshtasticDestPublicKeyBytes({
+        publicKeyHex: destNode?.public_key_hex,
+        adminKeyBase64: configuredAdminKey,
+      });
+      if (!destPublicKey) {
+        setRemoteAdminStatus('error');
+        setRemoteAdminError('remoteAdmin.errors.noRemotePublicKey');
         return;
       }
       if (state.status !== 'configured') return;
@@ -3718,6 +3725,7 @@ export function useDevice() {
             if (remoteAdminStatusRef.current !== 'loading') return;
             loadingWatchdogFired = true;
             remoteConfigInflightRoutesRef.current.delete(route);
+            remoteAdminClientRef.current?.resetEditState(new Error('remoteAdmin.errors.timeout'));
             if (foregroundRoute === 'modules' && modulesPartialApplied) {
               remoteConfigLoadedRoutesRef.current.add(route);
               setRemoteAdminStatus('ready');
@@ -3864,17 +3872,35 @@ export function useDevice() {
     void refreshRemoteConfigSnapshot(configureTargetNodeNum, 'radio');
   }, [configureTargetNodeNum, state.status, refreshRemoteConfigSnapshot]);
 
-  const runRemoteAdminOp = useCallback(async <T>(operation: () => Promise<T>): Promise<T> => {
-    try {
-      return await operation();
-    } catch (e) {
-      const msg = normalizeRemoteAdminError(e);
-      setRemoteAdminStatus('error');
-      setRemoteAdminError(msg);
-      console.warn('[useDevice] remote admin operation failed ' + errLikeToLogString(e));
-      throw e;
-    }
-  }, []);
+  const runRemoteAdminOp = useCallback(
+    async <T>(operation: () => Promise<T>): Promise<T> => {
+      const run = async (): Promise<T> => {
+        try {
+          return await operation();
+        } catch (e) {
+          const msg = normalizeRemoteAdminError(e);
+          setRemoteAdminStatus('error');
+          setRemoteAdminError(msg);
+          console.warn('[useDevice] remote admin operation failed ' + errLikeToLogString(e));
+          throw e;
+        }
+      };
+      if (configureTargetNodeNumRef.current != null) {
+        return new Promise<T>((resolve, reject) => {
+          void enqueueRemoteConfigFetch(async () => {
+            try {
+              resolve(await run());
+            } catch (e) {
+              // catch-no-log-ok reject propagates to caller; run() already logged the failure
+              reject(e instanceof Error ? e : new Error(String(e)));
+            }
+          });
+        });
+      }
+      return run();
+    },
+    [enqueueRemoteConfigFetch],
+  );
 
   const setConfigureTargetNodeNum = useCallback((nodeNum: number | null) => {
     const prevTarget = configureTargetNodeNumRef.current;
@@ -4245,8 +4271,13 @@ export function useDevice() {
       await deviceRef.current.sendWaypoint(waypoint, dest, channel);
 
       const chCfg = channelConfigsRef.current.find((c) => c.index === channel);
-      const fromNum = myNodeNumRef.current ?? 0;
-      if (mqttStatusRef.current === 'connected' && fromNum && chCfg?.uplinkEnabled) {
+      const fromNum = resolveMeshtasticOutboundFromNodeId({
+        hasDevice: !!deviceRef.current,
+        myNodeNum: myNodeNumRef.current,
+        lastRfSelfNodeId: lastRfSelfNodeIdRef.current,
+        virtualNodeId: virtualNodeIdRef.current,
+      });
+      if (mqttStatusRef.current === 'connected' && fromNum > 0 && chCfg?.uplinkEnabled) {
         const sendWpMqtt = resolveMeshtasticMqttPublishFieldsForChannel(
           channel,
           channelConfigsRef.current,
@@ -4288,8 +4319,13 @@ export function useDevice() {
     await deviceRef.current.sendWaypoint(waypoint, 0xffffffff, 0);
 
     const chCfg = channelConfigsRef.current.find((c) => c.index === 0);
-    const fromNum = myNodeNumRef.current ?? 0;
-    if (mqttStatusRef.current === 'connected' && fromNum && chCfg?.uplinkEnabled) {
+    const fromNum = resolveMeshtasticOutboundFromNodeId({
+      hasDevice: !!deviceRef.current,
+      myNodeNum: myNodeNumRef.current,
+      lastRfSelfNodeId: lastRfSelfNodeIdRef.current,
+      virtualNodeId: virtualNodeIdRef.current,
+    });
+    if (mqttStatusRef.current === 'connected' && fromNum > 0 && chCfg?.uplinkEnabled) {
       const delWpMqtt = resolveMeshtasticMqttPublishFieldsForChannel(
         0,
         channelConfigsRef.current,

--- a/src/renderer/lib/meshtasticRemoteAdmin.test.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.test.ts
@@ -5,21 +5,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { writeToRadioWithoutQueue } from './meshtasticBacklogUtils';
 import {
   buildRemoteAdminToRadio,
+  computeRemoteAdminRadioLoadingWatchdogMs,
   createSerialTaskQueue,
   extractAdminSessionPasskey,
   meshtasticNodePublicKeyBytesFromHex,
   MeshtasticRemoteAdminClient,
   normalizeRemoteAdminError,
   parseIncomingRemoteAdminPacket,
+  REMOTE_ADMIN_CHANNEL_MAX_ATTEMPTS,
+  REMOTE_ADMIN_CHANNEL_RETRY_BACKOFF_MS,
   REMOTE_ADMIN_MODULES_LOADING_WATCHDOG_MS,
   REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS,
+  REMOTE_ADMIN_RESPONSE_TIMEOUT_MS,
   REMOTE_ADMIN_SECURITY_LOADING_WATCHDOG_MS,
   REMOTE_ADMIN_SESSION_ACTIVE_MS,
   REMOTE_ADMIN_SESSION_TTL_MS,
   RemoteAdminSessionStore,
   remoteConfigLoadingWatchdogMsForRoute,
+  resolveMeshtasticDestPublicKeyBytes,
   routingErrorToRemoteAdminKey,
 } from './meshtasticRemoteAdmin';
+import { parseMeshtasticAdminKeyBase64 } from './meshtasticRemoteAdminKeyStorage';
 
 vi.mock('./meshtasticBacklogUtils', () => ({
   writeToRadioWithoutQueue: vi.fn(),
@@ -27,6 +33,36 @@ vi.mock('./meshtasticBacklogUtils', () => ({
 
 const TEST_DEST_PUBKEY_HEX = '4852b69364572b52efa1b6bb3e6d0abed4f389a1cbfbb60a9bba2cce649caf0e';
 const TEST_DEST_PUBKEY = meshtasticNodePublicKeyBytesFromHex(TEST_DEST_PUBKEY_HEX)!;
+
+describe('resolveMeshtasticDestPublicKeyBytes', () => {
+  const adminKeyB64 = btoa(String.fromCharCode(...TEST_DEST_PUBKEY));
+
+  it('prefers mesh NodeDB hex over stored admin key', () => {
+    const wrong = new Uint8Array(32).fill(9);
+    const wrongHex = [...wrong].map((b) => b.toString(16).padStart(2, '0')).join('');
+    expect(
+      resolveMeshtasticDestPublicKeyBytes({
+        publicKeyHex: TEST_DEST_PUBKEY_HEX,
+        adminKeyBase64: btoa(String.fromCharCode(...wrong)),
+      }),
+    ).toEqual(TEST_DEST_PUBKEY);
+    expect(
+      resolveMeshtasticDestPublicKeyBytes({
+        publicKeyHex: wrongHex,
+        adminKeyBase64: adminKeyB64,
+      }),
+    ).toEqual(wrong);
+  });
+
+  it('falls back to stored admin key when mesh hex is missing', () => {
+    expect(
+      resolveMeshtasticDestPublicKeyBytes({
+        adminKeyBase64: adminKeyB64,
+      }),
+    ).toEqual(TEST_DEST_PUBKEY);
+    expect(parseMeshtasticAdminKeyBase64(adminKeyB64)).toEqual(TEST_DEST_PUBKEY);
+  });
+});
 
 describe('meshtasticNodePublicKeyBytesFromHex', () => {
   it('parses a 32-byte hex public key', () => {
@@ -180,8 +216,47 @@ describe('parseIncomingRemoteAdminPacket', () => {
   });
 });
 
+/** Returns true when `fieldNumber` appears as a top-level field on the protobuf wire. */
+function wireHasProtoField(wire: Uint8Array, fieldNumber: number): boolean {
+  let offset = 0;
+  while (offset < wire.length) {
+    let tag = 0;
+    let shift = 0;
+    let byte: number;
+    do {
+      byte = wire[offset++];
+      tag |= (byte & 0x7f) << shift;
+      shift += 7;
+    } while (byte & 0x80);
+    const field = tag >>> 3;
+    const wireType = tag & 0x7;
+    if (field === fieldNumber) return true;
+    if (wireType === 0) {
+      do {
+        byte = wire[offset++];
+      } while (byte & 0x80);
+    } else if (wireType === 2) {
+      let len = 0;
+      shift = 0;
+      do {
+        byte = wire[offset++];
+        len |= (byte & 0x7f) << shift;
+        shift += 7;
+      } while (byte & 0x80);
+      offset += len;
+    } else if (wireType === 1) {
+      offset += 8;
+    } else if (wireType === 5) {
+      offset += 4;
+    } else {
+      break;
+    }
+  }
+  return false;
+}
+
 describe('buildRemoteAdminToRadio', () => {
-  it('sets pkiEncrypted and publicKey; omits channel (protobuf default 0) for PKI admin', () => {
+  it('sets pkiEncrypted and publicKey; omits channel field on wire for PKI admin', () => {
     const adminPayload = new Uint8Array([1, 2, 3]);
     const bytes = buildRemoteAdminToRadio({
       myNodeNum: 0x100,
@@ -208,6 +283,9 @@ describe('buildRemoteAdminToRadio', () => {
     const packet = toRadio.payloadVariant?.value;
     expect(packet?.pkiEncrypted).toBe(true);
     expect(packet?.publicKey).toEqual(TEST_DEST_PUBKEY);
+    expect(packet).toBeDefined();
+    const packetWire = toBinary(Mesh.MeshPacketSchema, packet as never);
+    expect(wireHasProtoField(packetWire, 5)).toBe(false);
     expect(packet?.channel ?? 0).toBe(0);
     expect(packet?.hopLimit).toBe(7);
     expect(packet?.hopStart).toBe(7);
@@ -1206,6 +1284,14 @@ describe('MeshtasticRemoteAdminClient', () => {
 });
 
 describe('remoteConfigLoadingWatchdogMsForRoute', () => {
+  it('radio watchdog covers channel 0 worst-case retries', () => {
+    const channel0WorstMs =
+      REMOTE_ADMIN_CHANNEL_MAX_ATTEMPTS * REMOTE_ADMIN_RESPONSE_TIMEOUT_MS +
+      (REMOTE_ADMIN_CHANNEL_MAX_ATTEMPTS - 1) * REMOTE_ADMIN_CHANNEL_RETRY_BACKOFF_MS;
+    expect(computeRemoteAdminRadioLoadingWatchdogMs()).toBe(REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS);
+    expect(remoteConfigLoadingWatchdogMsForRoute('radio')).toBeGreaterThanOrEqual(channel0WorstMs);
+  });
+
   it('uses longer watchdogs for radio, security, and modules routes', () => {
     expect(remoteConfigLoadingWatchdogMsForRoute('radio')).toBe(
       REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS,

--- a/src/renderer/lib/meshtasticRemoteAdmin.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.ts
@@ -4,6 +4,7 @@ import { Admin, Mesh, Portnums } from '@meshtastic/protobufs';
 
 import { errLikeToLogString } from './errLikeToLogString';
 import { writeToRadioWithoutQueue } from './meshtasticBacklogUtils';
+import { parseMeshtasticAdminKeyBase64 } from './meshtasticRemoteAdminKeyStorage';
 
 interface AdminMessagePayloadVariant {
   case: string;
@@ -68,9 +69,6 @@ export const REMOTE_ADMIN_ESSENTIAL_RESPONSE_TIMEOUT_MS = 25_000;
 /** Single attempt on essential reads once request/response ids are wired correctly. */
 export const REMOTE_ADMIN_ESSENTIAL_MAX_ATTEMPTS = 1;
 
-/** Wall-clock cap while UI shows loading for foreground radio snapshot fetch. */
-export const REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS = 60_000;
-
 /** Wall-clock cap for security config snapshot fetch. */
 export const REMOTE_ADMIN_SECURITY_LOADING_WATCHDOG_MS = 45_000;
 
@@ -80,9 +78,6 @@ export const REMOTE_ADMIN_MODULE_CONFIG_FETCH_COUNT = 13;
 /** Wall-clock cap for modules snapshot fetch (13 sequential multi-hop reads). */
 export const REMOTE_ADMIN_MODULES_LOADING_WATCHDOG_MS =
   REMOTE_ADMIN_MODULE_CONFIG_FETCH_COUNT * 8_000 + 30_000;
-
-/** @deprecated Use {@link remoteConfigLoadingWatchdogMsForRoute} */
-export const REMOTE_ADMIN_ESSENTIAL_LOADING_WATCHDOG_MS = REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS;
 
 export type RemoteConfigLoadingRoute = 'radio' | 'security' | 'modules';
 
@@ -138,6 +133,26 @@ export const REMOTE_ADMIN_CHANNEL_MAX_ATTEMPTS = 3;
 
 export const REMOTE_ADMIN_CHANNEL_RETRY_BACKOFF_MS = 500;
 
+/**
+ * Worst-case wall time for the radio-route foreground snapshot (session bootstrap + channel 0
+ * retries + LoRa read). Keeps UI watchdog aligned with PRIMARY_CHANNEL_FETCH_OPTIONS (3×120s).
+ */
+export function computeRemoteAdminRadioLoadingWatchdogMs(): number {
+  const sessionBootstrapMs = REMOTE_ADMIN_SESSION_KEY_TIMEOUT_MS + REMOTE_ADMIN_RESPONSE_TIMEOUT_MS;
+  const channel0Ms =
+    REMOTE_ADMIN_CHANNEL_MAX_ATTEMPTS * REMOTE_ADMIN_RESPONSE_TIMEOUT_MS +
+    (REMOTE_ADMIN_CHANNEL_MAX_ATTEMPTS - 1) * REMOTE_ADMIN_CHANNEL_RETRY_BACKOFF_MS;
+  const loraMs = REMOTE_ADMIN_ESSENTIAL_MAX_ATTEMPTS * REMOTE_ADMIN_ESSENTIAL_RESPONSE_TIMEOUT_MS;
+  const marginMs = 30_000;
+  return sessionBootstrapMs + channel0Ms + loraMs + marginMs;
+}
+
+/** Wall-clock cap while UI shows loading for foreground radio snapshot fetch. */
+export const REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS = computeRemoteAdminRadioLoadingWatchdogMs();
+
+/** @deprecated Use {@link remoteConfigLoadingWatchdogMsForRoute} */
+export const REMOTE_ADMIN_ESSENTIAL_LOADING_WATCHDOG_MS = REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS;
+
 export function delayMs(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -165,6 +180,19 @@ export type RemoteAdminRoutingErrorCode = number;
 export interface RemoteAdminSessionEntry {
   passkey: Uint8Array;
   expiresAt: number;
+}
+
+/** Dest PKI key: prefer mesh NodeDB hex; fall back to stored admin key (base64). */
+export function resolveMeshtasticDestPublicKeyBytes(params: {
+  publicKeyHex?: string;
+  adminKeyBase64?: string;
+}): Uint8Array | undefined {
+  const fromMesh = meshtasticNodePublicKeyBytesFromHex(params.publicKeyHex);
+  if (fromMesh) return fromMesh;
+  if (params.adminKeyBase64) {
+    return parseMeshtasticAdminKeyBase64(params.adminKeyBase64);
+  }
+  return undefined;
 }
 
 export function meshtasticNodePublicKeyBytesFromHex(

--- a/src/renderer/lib/meshtasticRemoteAdminSnapshot.test.ts
+++ b/src/renderer/lib/meshtasticRemoteAdminSnapshot.test.ts
@@ -157,14 +157,14 @@ describe('fetchMeshtasticRemoteConfigSnapshot', () => {
     await fetchMeshtasticRemoteConfigSnapshot(clientWithChannelRetry(client), 0x200);
 
     expect(maxInFlight).toBe(1);
-    expect(order[0]).toBe('ensureSessionKey');
-    expect(order.indexOf('ensureSessionKey')).toBeLessThan(order.indexOf('metadata'));
+    expect(order[0]).toBe('metadata');
+    expect(order.indexOf('metadata')).toBeLessThan(order.indexOf('channel:0'));
     expect(order.indexOf('metadata')).toBeLessThan(
       order.findIndex((e) => e.startsWith('configRetry:')),
     );
   });
 
-  it('calls ensureSessionKey after metadata and before config fetches', async () => {
+  it('calls ensureSessionKey before channels tail and deferred security fetch', async () => {
     const ensureSessionKey = vi.fn().mockResolvedValue(undefined);
     const client = {
       getRemoteMetadata: vi.fn().mockResolvedValue({ firmwareVersion: '2.5.0' }),
@@ -228,7 +228,7 @@ describe('fetchMeshtasticRemoteConfigSnapshot', () => {
     expect(snapshot.channelConfigs?.[0]?.name).toBe('Primary');
   });
 
-  it('continues snapshot when ensureSessionKey fails', async () => {
+  it('propagates when ensureSessionKey fails before channels tail', async () => {
     const client = {
       getRemoteMetadata: vi.fn().mockResolvedValue({ firmwareVersion: '2.5.0' }),
       ensureSessionKey: vi.fn().mockRejectedValue(new Error('remoteAdmin.errors.timeout')),
@@ -245,12 +245,9 @@ describe('fetchMeshtasticRemoteConfigSnapshot', () => {
       getRemoteOwner: vi.fn().mockResolvedValue({ longName: 'Remote', shortName: 'RM' }),
     } as unknown as MeshtasticRemoteAdminClient;
 
-    const snapshot = await fetchMeshtasticRemoteConfigSnapshot(
-      clientWithChannelRetry(client),
-      0x200,
-    );
-    expect(snapshot.loraConfig).toEqual({ region: 1 });
-    expect(snapshot.channelConfigs?.[0]?.name).toBe('Primary');
+    await expect(
+      fetchMeshtasticRemoteConfigSnapshot(clientWithChannelRetry(client), 0x200),
+    ).rejects.toThrow('remoteAdmin.errors.timeout');
   });
 
   it('continues snapshot when a channel fetch fails', async () => {
@@ -450,10 +447,10 @@ describe('fetchMeshtasticRemoteConfigSnapshotEssential', () => {
 
     await fetchMeshtasticRemoteConfigSnapshotRadio(clientWithChannelRetry(client), 0x200);
 
-    expect(order.indexOf('ensureSessionKey')).toBeGreaterThan(-1);
+    expect(order.indexOf('metadata')).toBeGreaterThan(-1);
     expect(order.indexOf('channel:0')).toBeGreaterThan(-1);
-    expect(order.indexOf('ensureSessionKey')).toBeLessThan(order.indexOf('channel:0'));
-    expect(client.getRemoteMetadata).toHaveBeenCalled();
+    expect(order.indexOf('metadata')).toBeLessThan(order.indexOf('channel:0'));
+    expect(client.getRemoteMetadata).toHaveBeenCalledTimes(1);
   });
 
   it('fetches channel 0 before essential config types', async () => {
@@ -735,6 +732,26 @@ describe('fetchMeshtasticRemoteConfigSnapshotDeferred', () => {
       0x200,
       Admin.AdminMessage_ConfigType.SECURITY_CONFIG,
     );
+    expect(partial.securityConfig?.publicKey).toHaveLength(32);
+  });
+
+  it('strips privateKey from remote security config snapshot', async () => {
+    const client = {
+      ensureSessionKey: vi.fn().mockResolvedValue(undefined),
+      getRemoteConfig: vi.fn().mockResolvedValue({
+        payloadVariant: {
+          case: 'security',
+          value: {
+            publicKey: new Uint8Array(32),
+            privateKey: new Uint8Array(32).fill(7),
+            adminKey: [],
+          },
+        },
+      }),
+    } as unknown as MeshtasticRemoteAdminClient;
+
+    const partial = await fetchMeshtasticRemoteConfigSecurity(client, 0x200);
+    expect(partial.securityConfig?.privateKey).toBeUndefined();
     expect(partial.securityConfig?.publicKey).toHaveLength(32);
   });
 });

--- a/src/renderer/lib/meshtasticRemoteAdminSnapshot.ts
+++ b/src/renderer/lib/meshtasticRemoteAdminSnapshot.ts
@@ -117,7 +117,6 @@ function parseSecurityConfig(value: unknown): MeshtasticRemoteConfigSnapshot['se
   if (!sec) return null;
   return {
     publicKey: sec.publicKey ?? new Uint8Array(),
-    ...(sec.privateKey && sec.privateKey.length > 0 ? { privateKey: sec.privateKey } : {}),
     adminKey: sec.adminKey ?? [],
     isManaged: sec.isManaged ?? false,
     serialEnabled: sec.serialEnabled ?? false,
@@ -171,15 +170,7 @@ async function ensureRemoteSessionKey(
   client: MeshtasticRemoteAdminClient,
   destNodeNum: number,
 ): Promise<void> {
-  try {
-    await client.ensureSessionKey(destNodeNum);
-  } catch (e) {
-    console.warn(
-      '[fetchMeshtasticRemoteConfigSnapshot] ensureSessionKey failed ' + errLikeToLogString(e),
-    );
-    // Failure point: session key exchange over BLE. Fallback: continue — channel/LoRa reads may
-    // still succeed with an existing passkey or establish a session on the next response.
-  }
+  await client.ensureSessionKey(destNodeNum);
 }
 
 async function fetchConfigTypes(
@@ -363,7 +354,7 @@ export async function fetchMeshtasticRemoteConfigTarget(
   client: MeshtasticRemoteAdminClient,
   destNodeNum: number,
 ): Promise<MeshtasticRemoteConfigSnapshot> {
-  await ensureRemoteSessionKey(client, destNodeNum);
+  // Single metadata read bootstraps session passkey and returns device metadata (no duplicate hop).
   const metadata = await client.getRemoteMetadata(destNodeNum);
 
   return {

--- a/src/renderer/lib/transport/TransportManager.test.ts
+++ b/src/renderer/lib/transport/TransportManager.test.ts
@@ -98,4 +98,37 @@ describe('TransportManager', () => {
       MESHTASTIC_TAPBACK_DATA_EMOJI_FLAG,
     );
   });
+
+  it('does not MQTT uplink when from is zero', async () => {
+    const publish = vi.fn().mockResolvedValue(1234);
+    window.electronAPI = {
+      mqtt: { publish },
+    } as unknown as typeof window.electronAPI;
+
+    const manager = new TransportManager({
+      deviceRef: {
+        current: { sendText: vi.fn().mockResolvedValue(1) },
+      } as never,
+      myNodeNumRef: { current: 0xdeadbeef },
+      mqttStatusRef: { current: 'connected' },
+      channelConfigsRef: {
+        current: [
+          {
+            index: 0,
+            name: 'LongFast',
+            role: MESHTASTIC_CHANNEL_ROLE.PRIMARY,
+            uplinkEnabled: true,
+            psk: new Uint8Array([1]),
+          },
+        ],
+      },
+      isDuplicate: vi.fn(),
+      onStatusUpdateRef: { current: vi.fn() },
+    });
+
+    manager.sendMessage('hello', 0, undefined, undefined, 42, 0);
+    await Promise.resolve();
+
+    expect(publish).not.toHaveBeenCalled();
+  });
 });

--- a/src/renderer/lib/transport/TransportManager.ts
+++ b/src/renderer/lib/transport/TransportManager.ts
@@ -44,14 +44,8 @@ export class TransportManager {
     from: number,
     emoji?: number,
   ): void {
-    const {
-      deviceRef,
-      myNodeNumRef,
-      mqttStatusRef,
-      channelConfigsRef,
-      isDuplicate,
-      onStatusUpdateRef,
-    } = this.deps;
+    const { deviceRef, mqttStatusRef, channelConfigsRef, isDuplicate, onStatusUpdateRef } =
+      this.deps;
 
     const chCfg = channelConfigsRef.current.find((c) => c.index === channel);
     const mqttFields = resolveMeshtasticMqttPublishFieldsForChannel(
@@ -61,14 +55,17 @@ export class TransportManager {
       deviceRef.current ? undefined : { preferManualOverRadio: true },
     );
     const shouldUplink =
+      from > 0 &&
       chCfg?.uplinkEnabled &&
       mqttStatusRef.current === 'connected' &&
-      myNodeNumRef.current &&
       mqttFields.channelName;
     // ── MQTT transport (path 1) ──────────────────────────────────────────────
     if (
       shouldUplink ||
-      (!deviceRef.current && mqttStatusRef.current === 'connected' && mqttFields.channelName)
+      (!deviceRef.current &&
+        from > 0 &&
+        mqttStatusRef.current === 'connected' &&
+        mqttFields.channelName)
     ) {
       window.electronAPI.mqtt
         .publish({


### PR DESCRIPTION
## Summary

Follow-up to #462 for changes that were left uncommitted on `main`:

- **Remote admin PKI:** `resolveMeshtasticDestPublicKeyBytes` prefers mesh NodeDB hex and falls back to the stored admin key; **Configure remotely** works when only the admin key is configured. Radio loading watchdog is derived from worst-case channel-0 retries; `ensureSessionKey` failures propagate on deferred fetch; security snapshots omit `privateKey`; remote ops serialize through the config fetch queue; loading watchdog calls `resetEditState`.
- **MQTT outbound identity:** Reject `mqtt:publish` / waypoint publish when `from <= 0`; `TransportManager` and waypoint mirrors skip uplink without a positive sender id; waypoints use `resolveMeshtasticOutboundFromNodeId`.
- **UI:** ConfigureNodeSelector session/loading copy; remote NodeDB reset offers preserve-favorites only for remote targets.

## Test plan

- [x] `pnpm run test:run` (pre-commit)
- [ ] Connect local radio, configure a remote node with admin key only (no mesh hex), open Radio panel and confirm snapshot loads
- [ ] MQTT-only session: confirm chat/waypoints do not uplink with `from=0` before NodeInfo
- [ ] Remote NodeDB reset shows preserve-favorites checkbox only in remote configure mode