### PR TITLE
fix remote admin response correlation and channel read hardening

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -365,7 +365,7 @@ Bare IPv6 addresses (e.g. `fe80::1`) must be wrapped in brackets when entered in
 
 ### Meshtastic remote admin: "One or more channel settings could not be loaded" / "LongFast load failed"
 
-**Cause**: Multi-hop PKI admin reads for channel 0 can be delayed, reordered, or interleaved with stale `ADMIN_APP` traffic. A fast `ADMIN_APP` shortly after `getChannelRequest` is not always the channel response. Channel 0 reads use the long-tail policy (up to 3 attempts, 120s each), while LoRa reads use a shorter essential timeout.
+**Cause**: Multi-hop PKI admin reads for channel 0 can be delayed, reordered, or interleaved with stale `ADMIN_APP` traffic. A fast `ADMIN_APP` shortly after `getChannelRequest` is not always the channel response. Firmware expects `get_channel_request` as a 1-based value on wire (channel 0 is sent as `1`). Channel 0 reads use the long-tail policy (up to 3 attempts, 120s each), while LoRa reads use a shorter essential timeout.
 
 **Fix**:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -363,6 +363,17 @@ Bare IPv6 addresses (e.g. `fe80::1`) must be wrapped in brackets when entered in
 - For first-time trust, use **Copy** public key on the Security tab and complete setup on the remote node per Meshtastic PKC docs.
 - See [README — Security (PKI)](../README.md#key-features) for the full feature list.
 
+### Meshtastic remote admin: "One or more channel settings could not be loaded" / "LongFast load failed"
+
+**Cause**: Multi-hop PKI admin reads for channel 0 can be delayed, reordered, or interleaved with stale `ADMIN_APP` traffic. A fast `ADMIN_APP` shortly after `getChannelRequest` is not always the channel response. Channel 0 reads use the long-tail policy (up to 3 attempts, 120s each), while LoRa reads use a shorter essential timeout.
+
+**Fix**:
+
+- Keep a local Meshtastic radio connected (BLE/Serial/HTTP). Remote admin does not run over MQTT-only paths.
+- Open **Log** and reproduce the load. Filter for `MeshtasticRemoteAdmin` debug lines to inspect correlation decisions (`resolve`, `ignore-stale`, `ignore-uncorrelated`, `pending-timeout`, `pending-reset`).
+- If channel 0 still fails, capture the log and verify whether the pending request was cleared by timeout/reset or by an unexpected routing/admin response.
+- Retry from the Radio tab once path quality improves (multi-hop latency and retries can be significant on congested links).
+
 ### Meshtastic MQTT: decrypt works on other clients but not mesh-client
 
 **Cause**: Older builds used an incorrect AES-CTR nonce layout for Meshtastic MQTT channel crypto. Private brokers with AES-128 or AES-256 channel PSKs need the Meshtastic packet-id nonce (fixed in recent releases).

--- a/src/renderer/lib/meshtasticRemoteAdmin.test.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.test.ts
@@ -1209,7 +1209,7 @@ describe('MeshtasticRemoteAdminClient', () => {
     }
   });
 
-  it('rejects getRemoteChannel when admin response case does not match expected channel case', async () => {
+  it('rejects getRemoteChannel when admin response case mismatches channel response', async () => {
     client.sessionStore.set(0x200, new Uint8Array(8).fill(1));
     const promise = client.getRemoteChannel(0x200, 0);
     await new Promise<void>((resolve) => {
@@ -1257,34 +1257,7 @@ describe('MeshtasticRemoteAdminClient', () => {
       }) as never,
     );
 
-    client.handleMeshPacket(
-      create(Mesh.MeshPacketSchema, {
-        from: 0x200,
-        payloadVariant: {
-          case: 'decoded',
-          value: {
-            portnum: Portnums.PortNum.ADMIN_APP,
-            payload: toBinary(
-              Admin.AdminMessageSchema,
-              create(Admin.AdminMessageSchema, {
-                payloadVariant: {
-                  case: 'getChannelResponse',
-                  value: {
-                    index: 0,
-                    role: 1,
-                    settings: { name: 'Primary', psk: new Uint8Array([1]) },
-                  } as never,
-                },
-              }),
-            ),
-            requestId: packetId,
-          },
-        },
-      }) as never,
-    );
-
-    const result = await promise;
-    expect((result as { settings?: { name?: string } }).settings?.name).toBe('Primary');
+    await expect(promise).rejects.toThrow('remoteAdmin.errors.channelResponseUnexpected');
   });
 
   it('ignores stale metadata ADMIN_APP while waiting for getChannelResponse', async () => {
@@ -1574,6 +1547,43 @@ describe('MeshtasticRemoteAdminClient', () => {
 
     const result = await promise;
     expect((result as { payloadVariant?: { case?: string } }).payloadVariant?.case).toBe('lora');
+  });
+
+  it('rejects getRemoteConfig on non-stale cross-type ADMIN_APP mismatch', async () => {
+    client.sessionStore.set(0x200, new Uint8Array(8).fill(1));
+    const promise = client.getRemoteConfig(0x200, Admin.AdminMessage_ConfigType.LORA_CONFIG);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const packetId = 555;
+
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getChannelResponse',
+                  value: {
+                    index: 0,
+                    role: 1,
+                    settings: { name: 'LongFast', psk: new Uint8Array([1]) },
+                  } as never,
+                },
+              }),
+            ),
+            requestId: packetId,
+          },
+        },
+      }) as never,
+    );
+
+    await expect(promise).rejects.toThrow('remoteAdmin.errors.configResponseUnexpected');
   });
 
   it('ensureSessionKey bootstraps via getDeviceMetadata when no passkey is cached', async () => {

--- a/src/renderer/lib/meshtasticRemoteAdmin.test.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.test.ts
@@ -163,7 +163,48 @@ describe('parseIncomingRemoteAdminPacket', () => {
     expect(parsed).toMatchObject({ kind: 'admin', requestId: 4242, from: 0x200 });
   });
 
-  it('falls back to mesh packet id when Data.requestId is zero', () => {
+  it('falls back to mesh packet id when Data.requestId is zero and sole pending matches from', () => {
+    const adminMsg = create(Admin.AdminMessageSchema, {
+      payloadVariant: { case: 'getDeviceMetadataResponse', value: {} as never },
+    });
+    const meshPacket = create(Mesh.MeshPacketSchema, {
+      id: 7777,
+      from: 0x200,
+      payloadVariant: {
+        case: 'decoded',
+        value: {
+          portnum: Portnums.PortNum.ADMIN_APP,
+          payload: toBinary(Admin.AdminMessageSchema, adminMsg),
+          requestId: 0,
+        },
+      },
+    });
+    const pending = new Map([
+      [
+        555,
+        {
+          destNodeNum: 0x200,
+          packetId: 555,
+          timeoutMs: 120_000,
+          createdAt: Date.now(),
+          resolve: () => {},
+          reject: () => {},
+          timeoutId: setTimeout(() => {}, 0),
+        },
+      ],
+    ]);
+    const firstPending = pending.values().next().value;
+    if (firstPending?.timeoutId) {
+      clearTimeout(firstPending.timeoutId);
+    }
+
+    const parsed = parseIncomingRemoteAdminPacket(meshPacket as never, {
+      pending,
+    });
+    expect(parsed).toMatchObject({ kind: 'admin', requestId: 7777, from: 0x200 });
+  });
+
+  it('does not fall back to mesh packet id without sole pending context', () => {
     const adminMsg = create(Admin.AdminMessageSchema, {
       payloadVariant: { case: 'getDeviceMetadataResponse', value: {} as never },
     });
@@ -181,7 +222,7 @@ describe('parseIncomingRemoteAdminPacket', () => {
     });
 
     const parsed = parseIncomingRemoteAdminPacket(meshPacket as never);
-    expect(parsed).toMatchObject({ kind: 'admin', requestId: 7777, from: 0x200 });
+    expect(parsed).toMatchObject({ kind: 'admin', requestId: 0, from: 0x200 });
   });
 
   it('parses ROUTING_APP errors by request id', () => {
@@ -1168,7 +1209,7 @@ describe('MeshtasticRemoteAdminClient', () => {
     }
   });
 
-  it('rejects getRemoteChannel when admin response case does not match', async () => {
+  it('rejects getRemoteChannel when admin response case does not match expected channel case', async () => {
     client.sessionStore.set(0x200, new Uint8Array(8).fill(1));
     const promise = client.getRemoteChannel(0x200, 0);
     await new Promise<void>((resolve) => {
@@ -1198,10 +1239,270 @@ describe('MeshtasticRemoteAdminClient', () => {
       }) as never,
     );
 
-    await expect(promise).rejects.toThrow('remoteAdmin.errors.channelResponseUnexpected');
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getChannelResponse',
+                  value: {
+                    index: 0,
+                    role: 1,
+                    settings: { name: 'Primary', psk: new Uint8Array([1]) },
+                  } as never,
+                },
+              }),
+            ),
+            requestId: packetId,
+          },
+        },
+      }) as never,
+    );
+
+    const result = await promise;
+    expect((result as { settings?: { name?: string } }).settings?.name).toBe('Primary');
   });
 
-  it('rejects getRemoteConfig when admin response case does not match', async () => {
+  it('ignores stale metadata ADMIN_APP while waiting for getChannelResponse', async () => {
+    client.sessionStore.set(0x200, new Uint8Array(8).fill(1));
+    const promise = client.getRemoteChannel(0x200, 0);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const channelPacketId = 555;
+
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getDeviceMetadataResponse',
+                  value: { firmwareVersion: '2.5.0' } as never,
+                },
+              }),
+            ),
+            requestId: channelPacketId,
+          },
+        },
+      }) as never,
+    );
+
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getChannelResponse',
+                  value: {
+                    index: 0,
+                    role: 1,
+                    settings: { name: 'LongFast', psk: new Uint8Array([1]) },
+                  } as never,
+                },
+              }),
+            ),
+            requestId: channelPacketId,
+          },
+        },
+      }) as never,
+    );
+
+    const result = await promise;
+    expect((result as { settings?: { name?: string } }).settings?.name).toBe('LongFast');
+  });
+
+  it('ignores tombstoned duplicate ADMIN_APP for a resolved request id', async () => {
+    client.sessionStore.set(0x200, new Uint8Array(8).fill(1));
+    const metadataPromise = client.getRemoteMetadata(0x200);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const metadataPacketId = 555;
+
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getDeviceMetadataResponse',
+                  value: { firmwareVersion: '2.5.0' } as never,
+                },
+              }),
+            ),
+            requestId: metadataPacketId,
+          },
+        },
+      }) as never,
+    );
+    await metadataPromise;
+
+    const channelPromise = client.getRemoteChannel(0x200, 0);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const channelPacketId = 556;
+
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getDeviceMetadataResponse',
+                  value: { firmwareVersion: '2.5.0' } as never,
+                },
+              }),
+            ),
+            requestId: metadataPacketId,
+          },
+        },
+      }) as never,
+    );
+
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getChannelResponse',
+                  value: {
+                    index: 0,
+                    role: 1,
+                    settings: { name: 'LongFast', psk: new Uint8Array([1]) },
+                  } as never,
+                },
+              }),
+            ),
+            requestId: channelPacketId,
+          },
+        },
+      }) as never,
+    );
+
+    const result = await channelPromise;
+    expect((result as { settings?: { name?: string } }).settings?.name).toBe('LongFast');
+  });
+
+  it('ignores mesh packet id fallback from wrong pending count', async () => {
+    client.sessionStore.set(0x200, new Uint8Array(8).fill(1));
+    const promiseLora = client.getRemoteConfig(0x200, Admin.AdminMessage_ConfigType.LORA_CONFIG);
+    const promiseDevice = client.getRemoteConfig(
+      0x200,
+      Admin.AdminMessage_ConfigType.DEVICE_CONFIG,
+    );
+    await vi.waitFor(() => {
+      expect(writeToRadioWithoutQueue).toHaveBeenCalledTimes(2);
+    });
+
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        id: 9999,
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getDeviceMetadataResponse',
+                  value: { firmwareVersion: '2.5.0' } as never,
+                },
+              }),
+            ),
+            requestId: 0,
+          },
+        },
+      }) as never,
+    );
+
+    expect(client.sessionStore.get(0x200)).toEqual(new Uint8Array(8).fill(1));
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getConfigResponse',
+                  value: {
+                    payloadVariant: { case: 'lora', value: { region: 1 } },
+                  } as never,
+                },
+              }),
+            ),
+            requestId: 555,
+          },
+        },
+      }) as never,
+    );
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getConfigResponse',
+                  value: {
+                    payloadVariant: { case: 'device', value: {} },
+                  } as never,
+                },
+              }),
+            ),
+            requestId: 556,
+          },
+        },
+      }) as never,
+    );
+    await Promise.all([promiseLora, promiseDevice]);
+  });
+
+  it('ignores stale metadata ADMIN_APP while waiting for getConfigResponse', async () => {
     client.sessionStore.set(0x200, new Uint8Array(8).fill(1));
     const promise = client.getRemoteConfig(0x200, Admin.AdminMessage_ConfigType.LORA_CONFIG);
     await new Promise<void>((resolve) => {
@@ -1231,7 +1532,30 @@ describe('MeshtasticRemoteAdminClient', () => {
       }) as never,
     );
 
-    await expect(promise).rejects.toThrow('remoteAdmin.errors.configResponseUnexpected');
+    client.handleMeshPacket(
+      create(Mesh.MeshPacketSchema, {
+        from: 0x200,
+        payloadVariant: {
+          case: 'decoded',
+          value: {
+            portnum: Portnums.PortNum.ADMIN_APP,
+            payload: toBinary(
+              Admin.AdminMessageSchema,
+              create(Admin.AdminMessageSchema, {
+                payloadVariant: {
+                  case: 'getConfigResponse',
+                  value: { payloadVariant: { case: 'lora', value: {} } } as never,
+                },
+              }),
+            ),
+            requestId: packetId,
+          },
+        },
+      }) as never,
+    );
+
+    const result = await promise;
+    expect((result as { payloadVariant?: { case?: string } }).payloadVariant?.case).toBe('lora');
   });
 
   it('ensureSessionKey bootstraps via getDeviceMetadata when no passkey is cached', async () => {

--- a/src/renderer/lib/meshtasticRemoteAdmin.test.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.test.ts
@@ -1216,6 +1216,24 @@ describe('MeshtasticRemoteAdminClient', () => {
       setImmediate(resolve);
     });
     const packetId = 555;
+    const written = vi.mocked(writeToRadioWithoutQueue).mock.calls.at(-1)?.[1];
+    const decoded = fromBinary(Mesh.ToRadioSchema, written!) as {
+      payloadVariant?: {
+        case?: string;
+        value?: {
+          payloadVariant?: {
+            case?: string;
+            value?: { payload?: Uint8Array };
+          };
+        };
+      };
+    };
+    const adminPayload = decoded.payloadVariant?.value?.payloadVariant?.value?.payload;
+    const adminMsg = fromBinary(Admin.AdminMessageSchema, adminPayload!) as {
+      payloadVariant?: { case?: string; value?: number };
+    };
+    expect(adminMsg.payloadVariant?.case).toBe('getChannelRequest');
+    expect(adminMsg.payloadVariant?.value).toBe(1);
 
     client.handleMeshPacket(
       create(Mesh.MeshPacketSchema, {

--- a/src/renderer/lib/meshtasticRemoteAdmin.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.ts
@@ -360,8 +360,16 @@ export function shouldIgnoreStaleAdminResponse(params: {
   if (!isCrossTypeAdminReadResponse(params.responseCase, params.expectedResponseCases)) {
     return false;
   }
-  void params.tombstoneResponseCase;
-  return true;
+  if (params.responseCase === 'getDeviceMetadataResponse') {
+    return true;
+  }
+  // Only ignore when the same request id was already resolved to a different response case.
+  // Otherwise, treat cross-type mismatches as active-request errors so callers fail fast.
+  return (
+    typeof params.tombstoneResponseCase === 'string' &&
+    params.tombstoneResponseCase.length > 0 &&
+    params.tombstoneResponseCase !== params.responseCase
+  );
 }
 
 export function resolveAdminRequestId(

--- a/src/renderer/lib/meshtasticRemoteAdmin.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.ts
@@ -1052,7 +1052,8 @@ export class MeshtasticRemoteAdminClient {
       destNodeNum,
       () =>
         adminMessage({
-          payloadVariant: { case: 'getChannelRequest', value: index },
+          // Meshtastic firmware/admin protobuf expects get_channel_request to be 1-based.
+          payloadVariant: { case: 'getChannelRequest', value: index + 1 },
         }),
       {
         ...REMOTE_ADMIN_READ_SEND_OPTIONS,

--- a/src/renderer/lib/meshtasticRemoteAdmin.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.ts
@@ -310,10 +310,15 @@ export function routingErrorToRemoteAdminKey(error: RemoteAdminRoutingErrorCode)
 
 export async function retryRemoteAdminOp<T>(
   operation: () => Promise<T>,
-  options?: { maxAttempts?: number; backoffMs?: number },
+  options?: {
+    maxAttempts?: number;
+    backoffMs?: number;
+    isRetryable?: (message: string) => boolean;
+  },
 ): Promise<T> {
   const maxAttempts = options?.maxAttempts ?? REMOTE_ADMIN_LORA_CONFIG_MAX_ATTEMPTS;
   const backoffMs = options?.backoffMs ?? REMOTE_ADMIN_LORA_CONFIG_RETRY_BACKOFF_MS;
+  const isRetryable = options?.isRetryable ?? isRemoteAdminRetryableError;
   let lastError: Error | undefined;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
@@ -324,7 +329,7 @@ export async function retryRemoteAdminOp<T>(
           ? e.message
           : normalizeRemoteAdminError(e);
       lastError = new Error(msg);
-      const canRetry = attempt + 1 < maxAttempts && isRemoteAdminRetryableError(msg);
+      const canRetry = attempt + 1 < maxAttempts && isRetryable(msg);
       if (!canRetry) throw lastError;
       await delayMs(backoffMs);
     }
@@ -332,7 +337,38 @@ export async function retryRemoteAdminOp<T>(
   throw lastError ?? new Error('remoteAdmin.errors.generic');
 }
 
-function resolveAdminRequestId(meshPacket: MeshPacket, dataRequestId: number): number {
+interface ResolveAdminRequestIdContext {
+  pending?: Map<number, PendingRemoteAdmin>;
+  from?: number;
+}
+
+/** Returns true when an ADMIN_APP response case cannot satisfy the pending read's expected cases. */
+export function isCrossTypeAdminReadResponse(
+  responseCase: string,
+  expectedResponseCases: readonly string[] | undefined,
+): boolean {
+  if (!expectedResponseCases?.length) return false;
+  return !expectedResponseCases.includes(responseCase);
+}
+
+/** Ignore stale cross-read ADMIN_APP instead of failing the active pending read. */
+export function shouldIgnoreStaleAdminResponse(params: {
+  responseCase: string;
+  expectedResponseCases?: readonly string[];
+  tombstoneResponseCase?: string;
+}): boolean {
+  if (!isCrossTypeAdminReadResponse(params.responseCase, params.expectedResponseCases)) {
+    return false;
+  }
+  void params.tombstoneResponseCase;
+  return true;
+}
+
+export function resolveAdminRequestId(
+  meshPacket: MeshPacket,
+  dataRequestId: number,
+  context?: ResolveAdminRequestIdContext,
+): number {
   if (dataRequestId !== 0) return dataRequestId >>> 0;
   const data = meshPacket.payloadVariant?.value;
   const replyId = data?.replyId;
@@ -340,18 +376,30 @@ function resolveAdminRequestId(meshPacket: MeshPacket, dataRequestId: number): n
   if (typeof replyId === 'number' && Number.isFinite(replyId) && replyId !== 0) {
     return replyId >>> 0;
   }
-  const packetId = meshPacket.id;
-  if (typeof packetId === 'number' && Number.isFinite(packetId) && packetId !== 0) {
-    return packetId >>> 0;
+  const pending = context?.pending;
+  const from = context?.from;
+  if (pending?.size === 1 && from != null) {
+    const solePending = pending.values().next().value!;
+    const fromNum = from >>> 0;
+    if (fromNum === solePending.destNodeNum || fromNum === 0) {
+      const packetId = meshPacket.id;
+      if (typeof packetId === 'number' && Number.isFinite(packetId) && packetId !== 0) {
+        return packetId >>> 0;
+      }
+    }
   }
   return 0;
 }
 
-export function parseIncomingRemoteAdminPacket(meshPacket: MeshPacket): ParsedAdminResponse | null {
+export function parseIncomingRemoteAdminPacket(
+  meshPacket: MeshPacket,
+  context?: ResolveAdminRequestIdContext,
+): ParsedAdminResponse | null {
   if (meshPacket.payloadVariant?.case !== 'decoded') return null;
   const data = meshPacket.payloadVariant.value;
   if (data == null || meshPacket.from == null) return null;
   const from = meshPacket.from >>> 0;
+  const resolveContext: ResolveAdminRequestIdContext = { ...context, from };
 
   if (data.portnum === Portnums.PortNum.ADMIN_APP && (data.payload?.length ?? 0) > 0) {
     try {
@@ -363,7 +411,7 @@ export function parseIncomingRemoteAdminPacket(meshPacket: MeshPacket): ParsedAd
         kind: 'admin',
         message,
         from,
-        requestId: resolveAdminRequestId(meshPacket, (data.requestId ?? 0) >>> 0),
+        requestId: resolveAdminRequestId(meshPacket, (data.requestId ?? 0) >>> 0, resolveContext),
       };
     } catch {
       // catch-no-log-ok malformed ADMIN_APP payload on unrelated mesh traffic
@@ -377,7 +425,11 @@ export function parseIncomingRemoteAdminPacket(meshPacket: MeshPacket): ParsedAd
         variant?: { case?: string; value?: number };
       };
       if (routing.variant?.case === 'errorReason') {
-        const requestId = resolveAdminRequestId(meshPacket, (data.requestId ?? 0) >>> 0);
+        const requestId = resolveAdminRequestId(
+          meshPacket,
+          (data.requestId ?? 0) >>> 0,
+          resolveContext,
+        );
         if (requestId !== 0 && routing.variant.value != null) {
           return {
             kind: 'routing_error',
@@ -443,14 +495,24 @@ interface PendingRemoteAdmin {
   packetId: number;
   adminCase?: string;
   expectedResponseCases?: readonly string[];
+  timeoutMs: number;
+  createdAt: number;
   resolve: (value: AdminMessage) => void;
   reject: (error: Error) => void;
   timeoutId: ReturnType<typeof setTimeout>;
 }
 
+interface RecentlyResolvedAdminEntry {
+  responseCase: string;
+  resolvedAt: number;
+}
+
+type PendingClearReason = 'resolve' | 'reject' | 'timeout' | 'reset';
+
 export class MeshtasticRemoteAdminClient {
   readonly sessionStore = new RemoteAdminSessionStore();
   private readonly pending = new Map<number, PendingRemoteAdmin>();
+  private readonly recentlyResolved = new Map<number, RecentlyResolvedAdminEntry>();
   private pendingEdit = false;
   private sendRawChain: Promise<unknown> = Promise.resolve();
 
@@ -467,12 +529,115 @@ export class MeshtasticRemoteAdminClient {
 
   /** Clears in-flight requests and edit state (target switch, disconnect). */
   resetEditState(reason: Error = new Error('remoteAdmin.errors.generic')): void {
-    for (const entry of this.pending.values()) {
-      clearTimeout(entry.timeoutId);
-      entry.reject(reason);
+    for (const entry of [...this.pending.values()]) {
+      this.rejectPending(entry.packetId, entry, reason, 'reset');
     }
     this.pending.clear();
     this.pendingEdit = false;
+  }
+
+  private pruneRecentlyResolved(nowMs: number = Date.now()): void {
+    const cutoff = nowMs - REMOTE_ADMIN_RESPONSE_TIMEOUT_MS;
+    for (const [id, entry] of this.recentlyResolved) {
+      if (entry.resolvedAt < cutoff) {
+        this.recentlyResolved.delete(id);
+      }
+    }
+  }
+
+  private recordResolvedRequestId(requestId: number, responseCase: string): void {
+    this.recentlyResolved.set(requestId >>> 0, {
+      responseCase,
+      resolvedAt: Date.now(),
+    });
+    this.pruneRecentlyResolved();
+  }
+
+  private getRecentlyResolved(requestId: number): RecentlyResolvedAdminEntry | undefined {
+    this.pruneRecentlyResolved();
+    return this.recentlyResolved.get(requestId >>> 0);
+  }
+
+  private adminCorrelationFields(
+    meshPacket: MeshPacket,
+    parsed: Extract<ParsedAdminResponse, { kind: 'admin' }>,
+  ): Record<string, string | number> {
+    const data = meshPacket.payloadVariant?.value;
+    return {
+      requestId: parsed.requestId,
+      dataRequestId: (data?.requestId ?? 0) >>> 0,
+      replyId: (data?.replyId ?? 0) >>> 0,
+      meshPacketId: (meshPacket.id ?? 0) >>> 0,
+      from: parsed.from,
+      responseCase: parsed.message.payloadVariant.case ?? '',
+      pendingCount: this.pending.size,
+    };
+  }
+
+  private logAdminCorrelation(
+    action: string,
+    fields: Record<string, string | number>,
+    extra?: Record<string, string | number>,
+  ): void {
+    const parts = Object.entries({ ...fields, ...extra }).map(
+      ([key, value]) => `${key}=${String(value)}`,
+    );
+    console.debug(`[MeshtasticRemoteAdmin] ${action} ${parts.join(' ')}`);
+  }
+
+  private rejectPending(
+    requestId: number,
+    pending: PendingRemoteAdmin,
+    error: Error,
+    reason: PendingClearReason,
+    logFields?: Record<string, string | number>,
+  ): void {
+    clearTimeout(pending.timeoutId);
+    this.pending.delete(requestId);
+    const elapsedMs = Date.now() - pending.createdAt;
+    if (reason === 'reject' || reason === 'timeout' || reason === 'reset') {
+      this.recordResolvedRequestId(
+        requestId,
+        pending.expectedResponseCases?.[0] ?? pending.adminCase ?? 'unknown',
+      );
+    }
+    this.logAdminCorrelation(`pending-${reason}`, {
+      requestId,
+      dest: pending.destNodeNum,
+      timeoutMs: pending.timeoutMs,
+      elapsedMs,
+      expected: pending.expectedResponseCases?.join(',') ?? '',
+      error: error.message,
+      ...logFields,
+    });
+    pending.reject(error);
+  }
+
+  private finishPendingResolve(
+    requestId: number,
+    pending: PendingRemoteAdmin,
+    message: AdminMessage,
+    meshPacket: MeshPacket,
+    parsed: Extract<ParsedAdminResponse, { kind: 'admin' }>,
+  ): void {
+    const responseCase = message.payloadVariant.case ?? '';
+    this.logAdminCorrelation('resolve', this.adminCorrelationFields(meshPacket, parsed), {
+      dest: pending.destNodeNum,
+      elapsedMs: Date.now() - pending.createdAt,
+    });
+    clearTimeout(pending.timeoutId);
+    this.pending.delete(requestId);
+    this.recordResolvedRequestId(requestId, responseCase);
+    pending.resolve(message);
+  }
+
+  private finishPendingReject(
+    requestId: number,
+    pending: PendingRemoteAdmin,
+    error: Error,
+    logFields?: Record<string, string | number>,
+  ): void {
+    this.rejectPending(requestId, pending, error, 'reject', logFields);
   }
 
   handleMeshPacket(meshPacket: MeshPacket): void {
@@ -480,7 +645,7 @@ export class MeshtasticRemoteAdminClient {
     if (variant === 'encrypted') return;
     if (variant != null && variant !== 'decoded') return;
 
-    const parsed = parseIncomingRemoteAdminPacket(meshPacket);
+    const parsed = parseIncomingRemoteAdminPacket(meshPacket, { pending: this.pending });
     if (!parsed) return;
 
     if (parsed.kind === 'routing_error') {
@@ -533,9 +698,9 @@ export class MeshtasticRemoteAdminClient {
           ' dest=0x' +
           pending.destNodeNum.toString(16),
       );
-      clearTimeout(pending.timeoutId);
-      this.pending.delete(requestId);
-      pending.reject(new Error(key));
+      this.finishPendingReject(requestId, pending, new Error(key), {
+        routingError: parsed.error,
+      });
       return;
     }
 
@@ -550,10 +715,28 @@ export class MeshtasticRemoteAdminClient {
       this.sessionStore.set(sessionNode, passkey);
     }
 
-    if (parsed.requestId === 0) return;
+    if (parsed.requestId === 0) {
+      if (this.pending.size > 0) {
+        this.logAdminCorrelation(
+          'ignore-uncorrelated',
+          this.adminCorrelationFields(meshPacket, parsed),
+        );
+      }
+      return;
+    }
 
     const pending = this.pending.get(parsed.requestId);
-    if (!pending) return;
+    if (!pending) {
+      const tombstone = this.getRecentlyResolved(parsed.requestId);
+      if (this.pending.size > 0) {
+        this.logAdminCorrelation(
+          tombstone ? 'ignore-stale-tombstone' : 'ignore-uncorrelated',
+          this.adminCorrelationFields(meshPacket, parsed),
+          tombstone ? { tombstoneCase: tombstone.responseCase } : undefined,
+        );
+      }
+      return;
+    }
 
     if (pending.destNodeNum !== parsed.from) {
       if (parsed.from === 0) {
@@ -564,6 +747,15 @@ export class MeshtasticRemoteAdminClient {
             pending.destNodeNum.toString(16),
         );
       } else {
+        if (this.pending.size > 0) {
+          this.logAdminCorrelation(
+            'ignore-wrong-from',
+            this.adminCorrelationFields(meshPacket, parsed),
+            {
+              dest: pending.destNodeNum,
+            },
+          );
+        }
         return;
       }
     }
@@ -571,27 +763,33 @@ export class MeshtasticRemoteAdminClient {
     const responseCase = parsed.message.payloadVariant.case;
     if (!responseCase) return;
     if (pending.expectedResponseCases && !pending.expectedResponseCases.includes(responseCase)) {
-      console.debug(
-        '[MeshtasticRemoteAdmin] admin response case mismatch requestId=' +
-          String(parsed.requestId) +
-          ' dest=0x' +
-          pending.destNodeNum.toString(16) +
-          ' got=' +
-          responseCase +
-          ' expected=' +
-          pending.expectedResponseCases.join(','),
-      );
-      const mismatchKey = pending.expectedResponseCases?.includes('getChannelResponse')
+      const tombstone = this.getRecentlyResolved(parsed.requestId);
+      if (
+        shouldIgnoreStaleAdminResponse({
+          responseCase,
+          expectedResponseCases: pending.expectedResponseCases,
+          tombstoneResponseCase: tombstone?.responseCase,
+        })
+      ) {
+        this.logAdminCorrelation('ignore-stale', this.adminCorrelationFields(meshPacket, parsed), {
+          dest: pending.destNodeNum,
+          expected: pending.expectedResponseCases.join(','),
+          elapsedMs: Date.now() - pending.createdAt,
+          tombstoneCase: tombstone?.responseCase ?? '',
+        });
+        return;
+      }
+      const mismatchKey = pending.expectedResponseCases.includes('getChannelResponse')
         ? 'remoteAdmin.errors.channelResponseUnexpected'
         : 'remoteAdmin.errors.configResponseUnexpected';
-      clearTimeout(pending.timeoutId);
-      this.pending.delete(parsed.requestId);
-      pending.reject(new Error(mismatchKey));
+      this.finishPendingReject(parsed.requestId, pending, new Error(mismatchKey), {
+        ...this.adminCorrelationFields(meshPacket, parsed),
+        responseCase,
+        expected: pending.expectedResponseCases.join(','),
+      });
       return;
     }
-    clearTimeout(pending.timeoutId);
-    this.pending.delete(parsed.requestId);
-    pending.resolve(parsed.message);
+    this.finishPendingResolve(parsed.requestId, pending, parsed.message, meshPacket, parsed);
   }
 
   private generatePacketId(): number {
@@ -691,10 +889,12 @@ export class MeshtasticRemoteAdminClient {
     adminCase?: string,
   ): Promise<AdminMessage> {
     const timeoutMs = options.timeoutMs ?? REMOTE_ADMIN_RESPONSE_TIMEOUT_MS;
+    const createdAt = Date.now();
     return new Promise<AdminMessage>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
-        this.pending.delete(packetId);
-        reject(new Error('remoteAdmin.errors.timeout'));
+        const pending = this.pending.get(packetId);
+        if (!pending) return;
+        this.rejectPending(packetId, pending, new Error('remoteAdmin.errors.timeout'), 'timeout');
       }, timeoutMs);
 
       this.pending.set(packetId, {
@@ -702,6 +902,8 @@ export class MeshtasticRemoteAdminClient {
         packetId,
         adminCase,
         expectedResponseCases: options.expectedResponseCases,
+        timeoutMs,
+        createdAt,
         resolve,
         reject,
         timeoutId,
@@ -731,10 +933,10 @@ export class MeshtasticRemoteAdminClient {
     } catch (e) {
       const pending = this.pending.get(packetId);
       if (pending) {
-        clearTimeout(pending.timeoutId);
-        this.pending.delete(packetId);
         const err = e instanceof Error ? e : new Error(normalizeRemoteAdminError(e));
-        pending.reject(err);
+        this.rejectPending(packetId, pending, err, 'reject', {
+          stage: 'sendRawAdmin',
+        });
       }
       // catch-no-log-ok write failure forwarded to responsePromise rejection for caller
     }
@@ -884,6 +1086,9 @@ export class MeshtasticRemoteAdminClient {
     return retryRemoteAdminOp(() => this.getRemoteChannel(destNodeNum, index, sendOptions), {
       maxAttempts: options?.maxAttempts ?? REMOTE_ADMIN_CHANNEL_MAX_ATTEMPTS,
       backoffMs: options?.backoffMs ?? REMOTE_ADMIN_CHANNEL_RETRY_BACKOFF_MS,
+      isRetryable: (message) =>
+        isRemoteAdminRetryableError(message) ||
+        message === 'remoteAdmin.errors.channelResponseUnexpected',
     });
   }
 


### PR DESCRIPTION
## Summary
- Harden Meshtastic remote-admin response correlation by improving request-id resolution, adding structured correlation logging, and tracking recently resolved request ids to ignore stale duplicate packets.
- Align channel reads to firmware wire semantics by sending `getChannelRequest` as a 1-based value while keeping client-facing channel indexing unchanged.
- Narrow cross-type mismatch handling so known stale metadata interleaving is ignored, but non-stale cross-type ADMIN_APP mismatches still fail fast with explicit config/channel mismatch errors.
- Expand remote-admin tests to cover stale interleaving, tombstoned duplicate handling, packet-id fallback guards, 1-based channel request encoding, and non-stale mismatch rejection.
- Update troubleshooting docs with guidance for diagnosing multi-hop PKI remote-admin channel load failures and interpreting `MeshtasticRemoteAdmin` correlation logs.

## Test plan
- [x] `pnpm run test:run -- src/renderer/lib/meshtasticRemoteAdmin.test.ts`
- [x] Pre-commit hook suite (format, lint, typecheck, checks, audit, and test run) passed during commit.