### PR TITLE
fix: prioritize publish-time MQTT PSKs for broker echo decrypt

### DIFF
--- a/src/main/mqtt-manager.test.ts
+++ b/src/main/mqtt-manager.test.ts
@@ -1388,7 +1388,7 @@ describe('publish — decrypt round-trip (explicit PSK)', () => {
     const protoPayload = publish.mock.calls[0][1] as Buffer;
     const envelope = fromBinary(ServiceEnvelopeSchema, protoPayload);
     const packetId = envelope.packet?.id ?? 0;
-    if (packetId) (manager as any).seenPacketIds.delete(packetId);
+    (manager as any).seenPacketIds.delete(packetId);
 
     const messages: unknown[] = [];
     manager.on('message', (m) => messages.push(m));
@@ -1397,6 +1397,39 @@ describe('publish — decrypt round-trip (explicit PSK)', () => {
     expect(messages).toHaveLength(1);
     expect((messages[0] as { payload: string }).payload).toBe('echo test');
     expect((messages[0] as { channel: number }).channel).toBe(2);
+  });
+
+  it('tries publish-time PSKs before radio channel keys in allDecryptKeys', () => {
+    const manager = new MQTTManager();
+    (manager as any)._doConnect = () => {};
+    manager.connect({
+      server: 'localhost',
+      port: 1883,
+      username: '',
+      password: '',
+      topicPrefix: 'msh/US/',
+      autoLaunch: false,
+    });
+    const radioKey = Buffer.alloc(32, 0x22);
+    const publishKey = Buffer.alloc(32, 0xab);
+    manager.updateChannelKeys([
+      { name: 'Garber', pskBase64: radioKey.toString('base64'), index: 2 },
+    ]);
+    wireConnected(manager);
+    manager.publish({
+      text: 'order probe',
+      from: 0x11223344,
+      channel: 2,
+      channelName: 'Garber',
+      pskBase64: publishKey.toString('base64'),
+      publishJsonMirror: false,
+    });
+    const keys: Buffer[] = (manager as any).allDecryptKeys;
+    const publishIdx = keys.findIndex((k) => k.equals(publishKey));
+    const radioIdx = keys.findIndex((k) => k.equals(radioKey));
+    expect(publishIdx).toBeGreaterThan(-1);
+    expect(radioIdx).toBeGreaterThan(-1);
+    expect(publishIdx).toBeLessThan(radioIdx);
   });
 });
 

--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -357,9 +357,11 @@ export class MQTTManager extends EventEmitter {
       keys.push(k);
     };
     add(DEFAULT_PSK);
+    // Publish-time PSKs before radio/manual channel map so broker echo decrypts with the
+    // same key used to encrypt when pskBase64 was passed only on publish IPC.
+    for (const k of this.extraDecryptPsks) add(k);
     for (const k of this.channelKeysByName.values()) add(k);
     for (const k of this.decryptOnlyPsks) add(k);
-    for (const k of this.extraDecryptPsks) add(k);
     this.allDecryptKeys = keys;
   }
 


### PR DESCRIPTION
## Summary

- Reorder `rebuildAllDecryptKeys()` so publish-time PSKs (`extraDecryptPsks`) are tried before radio-synced channel keys, matching encrypt when `pskBase64` is passed only on publish IPC.
- Harden the flaky `mqtt-manager` echo round-trip test and add coverage for decrypt key ordering.

Fixes intermittent CI failure in `decrypts broker echo of publish when pskBase64 is only passed on publish IPC` ([run 26428091250](https://github.com/Colorado-Mesh/mesh-client/actions/runs/26428091250/job/77795624214)): a random `packetId` could let a stale Garber radio key decrypt to valid protobuf first, so no `message` event was emitted.

## Commits

- `5c0b172b` fix: prioritize publish-time MQTT PSKs for broker echo decrypt

## Test plan

- [x] `pnpm exec vitest run src/main/mqtt-manager.test.ts`
- [x] Stress: echo round-trip test 100× locally
- [ ] CI Unit Tests green