### PR TITLE
fix: address GitHub Code Quality AI findings

### DIFF
--- a/src/main/mqtt-manager.test.ts
+++ b/src/main/mqtt-manager.test.ts
@@ -8,11 +8,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MQTTSettings } from '../renderer/lib/types';
 import {
+  BAD_ENVELOPE_SIGNATURE_MAX,
+  bufferListIncludesKey,
   cipherForKey,
+  enforceBadEnvelopeSignatureCap,
   MQTTManager,
   parseChannelPskLine,
   parseMeshtasticMqttEncryptedTopicChannelName,
   parsePsk,
+  portNumEnumToProtoName,
   prepareMqttProtobufBytes,
 } from './mqtt-manager';
 
@@ -2498,5 +2502,52 @@ describe('handleJsonText — packetId coercion and dedup', () => {
     );
 
     expect(messages).toHaveLength(2);
+  });
+});
+
+describe('portNumEnumToProtoName', () => {
+  it('maps known PortNum values without scanning Object.entries each call', () => {
+    expect(portNumEnumToProtoName(PortNum.TEXT_MESSAGE_APP)).toBe('TEXT_MESSAGE_APP');
+    expect(portNumEnumToProtoName(PortNum.NODEINFO_APP)).toBe('NODEINFO_APP');
+  });
+
+  it('returns UNKNOWN_APP for unmapped port numbers', () => {
+    expect(portNumEnumToProtoName(999_999)).toBe('UNKNOWN_APP');
+  });
+});
+
+describe('bufferListIncludesKey', () => {
+  it('matches buffers by contents, not base64 string identity', () => {
+    const a = Buffer.from([1, 2, 3]);
+    const b = Buffer.from([1, 2, 3]);
+    const c = Buffer.from([9, 9, 9]);
+    expect(bufferListIncludesKey([c], a)).toBe(false);
+    expect(bufferListIncludesKey([c, b], a)).toBe(true);
+  });
+});
+
+describe('enforceBadEnvelopeSignatureCap', () => {
+  it('evicts expired signatures first', () => {
+    const now = 1_000_000;
+    const map = new Map<string, number>([
+      ['a', now - 1],
+      ['b', now + 60_000],
+      ['c', now + 120_000],
+    ]);
+    enforceBadEnvelopeSignatureCap(map, now, 2);
+    expect(map.has('a')).toBe(false);
+    expect(map.size).toBeLessThanOrEqual(2);
+  });
+
+  it('evicts soonest-expiry entries when none are expired', () => {
+    const now = 1_000_000;
+    const map = new Map<string, number>();
+    for (let i = 0; i < BAD_ENVELOPE_SIGNATURE_MAX + 5; i++) {
+      map.set(`sig-${i}`, now + 60_000 + i);
+    }
+    enforceBadEnvelopeSignatureCap(map, now);
+    expect(map.size).toBe(BAD_ENVELOPE_SIGNATURE_MAX);
+    expect(map.has('sig-0')).toBe(false);
+    expect(map.has(`sig-${BAD_ENVELOPE_SIGNATURE_MAX + 4}`)).toBe(true);
   });
 });

--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -42,6 +42,13 @@ const {
 } = Mesh;
 const { PortNum } = Portnums;
 
+/** Static PortNum enum name lookup (built once; used for JSON mirror publishes). */
+const PORT_NUM_TO_PROTO_NAME = new Map<number, string>(
+  (Object.entries(PortNum).filter(([, v]) => typeof v === 'number') as [string, number][]).map(
+    ([name, value]) => [value, name],
+  ),
+);
+
 // Extended schema constants for additional portnum decoding
 const TelemetrySchema =
   (Telemetry as unknown as { TelemetrySchema?: unknown }).TelemetrySchema ?? null;
@@ -111,15 +118,42 @@ export function parseMeshtasticMqttEncryptedTopicChannelName(topic: string): str
 }
 
 /** Map numeric PortNum to protobuf enum name string (e.g. TEXT_MESSAGE_APP). */
-function portNumEnumToProtoName(portnum: number): string {
-  const entries = Object.entries(PortNum).filter(([, v]) => typeof v === 'number') as [
-    string,
-    number,
-  ][];
-  for (const [name, value] of entries) {
-    if (value === portnum) return name;
+export function portNumEnumToProtoName(portnum: number): string {
+  return PORT_NUM_TO_PROTO_NAME.get(portnum) ?? 'UNKNOWN_APP';
+}
+
+/** True when `keys` already contains `key` (constant-time Buffer compare). */
+export function bufferListIncludesKey(keys: readonly Buffer[], key: Buffer): boolean {
+  return keys.some((k) => k.equals(key));
+}
+
+export const BAD_ENVELOPE_SIGNATURE_MAX = 1000;
+
+/**
+ * Enforce {@link BAD_ENVELOPE_SIGNATURE_MAX}: drop expired entries, then evict soonest-expiry
+ * entries until the map is within the cap (handles bursts of distinct bad envelopes).
+ */
+export function enforceBadEnvelopeSignatureCap(
+  signatures: Map<string, number>,
+  now: number,
+  maxSize: number = BAD_ENVELOPE_SIGNATURE_MAX,
+): void {
+  if (signatures.size <= maxSize) return;
+  for (const [sig, expiry] of signatures) {
+    if (expiry <= now) signatures.delete(sig);
   }
-  return 'UNKNOWN_APP';
+  while (signatures.size > maxSize) {
+    let evictKey: string | undefined;
+    let evictExpiry = Infinity;
+    for (const [sig, expiry] of signatures) {
+      if (expiry < evictExpiry) {
+        evictExpiry = expiry;
+        evictKey = sig;
+      }
+    }
+    if (evictKey === undefined) break;
+    signatures.delete(evictKey);
+  }
 }
 
 /**
@@ -339,10 +373,7 @@ export class MQTTManager extends EventEmitter {
 
   /** Register a publish-time PSK so broker echo decrypt uses the same key as encrypt. */
   private ensureDecryptKey(psk: Buffer): void {
-    const sig = psk.toString('base64');
-    for (const k of this.allDecryptKeys) {
-      if (k.toString('base64') === sig) return;
-    }
+    if (bufferListIncludesKey(this.allDecryptKeys, psk)) return;
     this.extraDecryptPsks.push(psk);
     this.rebuildAllDecryptKeys();
   }
@@ -1111,11 +1142,7 @@ export class MQTTManager extends EventEmitter {
     const now = Date.now();
     const key = this.signatureFromPayload(topic, bytes);
     this.badEnvelopeSignatures.set(key, now + BAD_ENVELOPE_SIGNATURE_TTL_MS);
-    if (this.badEnvelopeSignatures.size > 1000) {
-      for (const [sig, expiry] of this.badEnvelopeSignatures) {
-        if (expiry <= now) this.badEnvelopeSignatures.delete(sig);
-      }
-    }
+    enforceBadEnvelopeSignatureCap(this.badEnvelopeSignatures, now);
   }
 
   private upsertNodeCache(update: Partial<CachedNode> & { node_id: number }): void {

--- a/src/renderer/lib/meshtasticLastHeard.test.ts
+++ b/src/renderer/lib/meshtasticLastHeard.test.ts
@@ -120,7 +120,12 @@ describe('meshtasticTracerouteLastHeardNodeIds', () => {
     expect(meshtasticTracerouteLastHeardNodeIds(0x1111, undefined)).toEqual([0x1111]);
   });
 
-  it('returns empty when sender is invalid', () => {
+  it('includes correlated target when sender is invalid (0)', () => {
     expect(meshtasticTracerouteLastHeardNodeIds(0, 0x2222)).toEqual([0x2222]);
+  });
+
+  it('returns empty when sender and correlated target are both invalid', () => {
+    expect(meshtasticTracerouteLastHeardNodeIds(0, 0)).toEqual([]);
+    expect(meshtasticTracerouteLastHeardNodeIds(0, undefined)).toEqual([]);
   });
 });

--- a/src/renderer/lib/meshtasticRemoteAdmin.test.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.test.ts
@@ -73,6 +73,10 @@ describe('meshtasticNodePublicKeyBytesFromHex', () => {
     expect(meshtasticNodePublicKeyBytesFromHex('abcd')).toBeUndefined();
     expect(meshtasticNodePublicKeyBytesFromHex(undefined)).toBeUndefined();
   });
+
+  it('rejects non-hex characters in a 64-character string', () => {
+    expect(meshtasticNodePublicKeyBytesFromHex('gg'.repeat(32))).toBeUndefined();
+  });
 });
 
 describe('RemoteAdminSessionStore', () => {

--- a/src/renderer/lib/meshtasticRemoteAdmin.ts
+++ b/src/renderer/lib/meshtasticRemoteAdmin.ts
@@ -79,19 +79,6 @@ export const REMOTE_ADMIN_MODULE_CONFIG_FETCH_COUNT = 13;
 export const REMOTE_ADMIN_MODULES_LOADING_WATCHDOG_MS =
   REMOTE_ADMIN_MODULE_CONFIG_FETCH_COUNT * 8_000 + 30_000;
 
-export type RemoteConfigLoadingRoute = 'radio' | 'security' | 'modules';
-
-export function remoteConfigLoadingWatchdogMsForRoute(route: RemoteConfigLoadingRoute): number {
-  switch (route) {
-    case 'radio':
-      return REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS;
-    case 'security':
-      return REMOTE_ADMIN_SECURITY_LOADING_WATCHDOG_MS;
-    case 'modules':
-      return REMOTE_ADMIN_MODULES_LOADING_WATCHDOG_MS;
-  }
-}
-
 /** Serializes remote config snapshot fetches so admin reads do not overlap on one client. */
 export function createSerialTaskQueue(): {
   enqueue: (task: () => Promise<void>) => Promise<void>;
@@ -150,6 +137,19 @@ export function computeRemoteAdminRadioLoadingWatchdogMs(): number {
 /** Wall-clock cap while UI shows loading for foreground radio snapshot fetch. */
 export const REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS = computeRemoteAdminRadioLoadingWatchdogMs();
 
+export type RemoteConfigLoadingRoute = 'radio' | 'security' | 'modules';
+
+export function remoteConfigLoadingWatchdogMsForRoute(route: RemoteConfigLoadingRoute): number {
+  switch (route) {
+    case 'radio':
+      return REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS;
+    case 'security':
+      return REMOTE_ADMIN_SECURITY_LOADING_WATCHDOG_MS;
+    case 'modules':
+      return REMOTE_ADMIN_MODULES_LOADING_WATCHDOG_MS;
+  }
+}
+
 /** @deprecated Use {@link remoteConfigLoadingWatchdogMsForRoute} */
 export const REMOTE_ADMIN_ESSENTIAL_LOADING_WATCHDOG_MS = REMOTE_ADMIN_RADIO_LOADING_WATCHDOG_MS;
 
@@ -202,7 +202,7 @@ export function meshtasticNodePublicKeyBytesFromHex(
   const bytes = new Uint8Array(32);
   for (let i = 0; i < 32; i++) {
     const byte = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
-    if (!Number.isFinite(byte)) return undefined;
+    if (!Number.isFinite(byte) || byte < 0 || byte > 255) return undefined;
     bytes[i] = byte;
   }
   return bytes;

--- a/src/renderer/lib/transport/TransportManager.test.ts
+++ b/src/renderer/lib/transport/TransportManager.test.ts
@@ -79,7 +79,7 @@ describe('TransportManager', () => {
       onStatusUpdateRef: { current: vi.fn() },
     });
 
-    manager.sendMessage('👍', 0, undefined, 99, 1, 0x11111111, 0x1f44d);
+    manager.sendMessage('👍', 0, undefined, 99, 1, 0x11111111, true);
     await Promise.resolve();
 
     expect(publish).toHaveBeenCalledWith(
@@ -130,5 +130,41 @@ describe('TransportManager', () => {
     await Promise.resolve();
 
     expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('MQTT-only publish when connected without radio uplink enabled', async () => {
+    const publish = vi.fn().mockResolvedValue(1234);
+    window.electronAPI = {
+      mqtt: { publish },
+    } as unknown as typeof window.electronAPI;
+
+    const manager = new TransportManager({
+      deviceRef: { current: null },
+      myNodeNumRef: { current: 0x11111111 },
+      mqttStatusRef: { current: 'connected' },
+      channelConfigsRef: {
+        current: [
+          {
+            index: 0,
+            name: 'LongFast',
+            role: MESHTASTIC_CHANNEL_ROLE.PRIMARY,
+            uplinkEnabled: false,
+            psk: new Uint8Array([1]),
+          },
+        ],
+      },
+      isDuplicate: vi.fn(),
+      onStatusUpdateRef: { current: vi.fn() },
+    });
+
+    manager.sendMessage('mqtt only', 0, undefined, undefined, 7, 0x11111111);
+    await Promise.resolve();
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'mqtt only',
+        from: 0x11111111,
+      }),
+    );
   });
 });

--- a/src/renderer/lib/transport/TransportManager.ts
+++ b/src/renderer/lib/transport/TransportManager.ts
@@ -42,7 +42,8 @@ export class TransportManager {
     replyId: number | undefined,
     tempId: number,
     from: number,
-    emoji?: number,
+    /** When true, sets Meshtastic tapback flag on wire (glyph is UTF-8 in `text`). */
+    tapback?: boolean,
   ): void {
     const { deviceRef, mqttStatusRef, channelConfigsRef, isDuplicate, onStatusUpdateRef } =
       this.deps;
@@ -54,19 +55,11 @@ export class TransportManager {
       loadMeshtasticMqttManualChannelPsks(),
       deviceRef.current ? undefined : { preferManualOverRadio: true },
     );
-    const shouldUplink =
-      from > 0 &&
-      chCfg?.uplinkEnabled &&
-      mqttStatusRef.current === 'connected' &&
-      mqttFields.channelName;
+    const mqttReady =
+      from > 0 && mqttStatusRef.current === 'connected' && Boolean(mqttFields.channelName);
+    const shouldMqtt = mqttReady && (Boolean(chCfg?.uplinkEnabled) || !deviceRef.current);
     // ── MQTT transport (path 1) ──────────────────────────────────────────────
-    if (
-      shouldUplink ||
-      (!deviceRef.current &&
-        from > 0 &&
-        mqttStatusRef.current === 'connected' &&
-        mqttFields.channelName)
-    ) {
+    if (shouldMqtt) {
       window.electronAPI.mqtt
         .publish({
           text,
@@ -76,7 +69,7 @@ export class TransportManager {
           channelName: mqttFields.channelName,
           pskBase64: mqttFields.pskBase64,
           publishJsonMirror: mqttFields.publishJsonMirror,
-          ...(emoji != null ? { emoji: MESHTASTIC_TAPBACK_DATA_EMOJI_FLAG } : {}),
+          ...(tapback ? { emoji: MESHTASTIC_TAPBACK_DATA_EMOJI_FLAG } : {}),
           ...(replyId != null ? { replyId } : {}),
         })
         .then((mqttPacketId: number) => {
@@ -107,7 +100,7 @@ export class TransportManager {
           true,
           channel,
           replyId,
-          emoji != null ? MESHTASTIC_TAPBACK_DATA_EMOJI_FLAG : undefined,
+          tapback ? MESHTASTIC_TAPBACK_DATA_EMOJI_FLAG : undefined,
         )
         .then((packetId: number) => {
           onStatusUpdateRef.current({

--- a/src/shared/electron-api.types.ts
+++ b/src/shared/electron-api.types.ts
@@ -440,7 +440,7 @@ export interface ElectronAPI {
       emoji?: number;
       replyId?: number;
       publishJsonMirror: boolean;
-    }) => Promise<void>;
+    }) => Promise<number>;
     publishNodeInfo: (args: {
       from: number;
       longName: string;
@@ -449,7 +449,7 @@ export interface ElectronAPI {
       hwModel?: number;
       pskBase64?: string;
       publishJsonMirror: boolean;
-    }) => Promise<void>;
+    }) => Promise<number>;
     publishPosition: (args: {
       from: number;
       channel: number;
@@ -459,7 +459,7 @@ export interface ElectronAPI {
       altitude?: number;
       pskBase64?: string;
       publishJsonMirror: boolean;
-    }) => Promise<void>;
+    }) => Promise<number>;
     publishWaypoint: (args: {
       from: number;
       to: number;
@@ -477,7 +477,7 @@ export interface ElectronAPI {
         lockedTo?: number;
         expire?: number;
       };
-    }) => Promise<void>;
+    }) => Promise<number>;
     publishMeshcore: (args: {
       text: string;
       channelIdx: number;


### PR DESCRIPTION
## Summary

- **mqtt-manager:** Static `PortNum` → name map (O(1) JSON mirror publishes); `Buffer.equals` for publish-time PSK dedup; bounded bad-envelope signature cache with TTL cleanup and oldest-expiry eviction when over cap.
- **meshtasticLastHeard:** Correct traceroute test description; add case when both sender and correlated target are invalid.
- **meshtasticRemoteAdmin:** Move radio loading watchdog constants above `remoteConfigLoadingWatchdogMsForRoute`; tighten hex byte parsing to 0–255.
- **TransportManager:** Consolidate MQTT publish gating into `shouldMqtt`; rename tapback param to `boolean` (wire still uses `MESHTASTIC_TAPBACK_DATA_EMOJI_FLAG`).
- **electron-api.types:** `mqtt.publish` / `publishNodeInfo` / `publishPosition` / `publishWaypoint` return `Promise<number>` to match main IPC and dedup usage.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test:run` (2022 tests)
- [x] New unit tests: `portNumEnumToProtoName`, `bufferListIncludesKey`, `enforceBadEnvelopeSignatureCap`, traceroute last-heard, remote admin hex guard, TransportManager MQTT-only path