### PR TITLE
fix: use npm ecosystem in dependabot.yml for pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,33 @@
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: 'weekly'
+      day: 'saturday'
     open-pull-requests-limit: 10
     versioning-strategy: lockfile-only
     groups:
       electron-framework:
         patterns:
-          - "electron"
+          - 'electron'
       all-other-deps:
         patterns:
-          - "*"
+          - '*'
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     open-pull-requests-limit: 10
     labels:
-      - "dependencies"
-      - "github-actions"
+      - 'dependencies'
+      - 'github-actions'
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: 'chore'
+      include: 'scope'
     groups:
       # Group all GitHub Actions updates into one PR to reduce noise
       all-actions:
         patterns:
-          - "*"
+          - '*'


### PR DESCRIPTION
## Summary

- Switch Dependabot `package-ecosystem` from `pnpm` to `npm` in `.github/dependabot.yml`.
- Dependabot does not support a dedicated `pnpm` ecosystem; the `npm` ecosystem reads `package.json` and respects `pnpm-lock.yaml` with `versioning-strategy: lockfile-only`.
- Normalize YAML string quoting to single quotes for consistency.

## Test plan

- [ ] Confirm Dependabot parses `.github/dependabot.yml` without config errors (check Dependabot tab after merge).
- [ ] Verify weekly npm dependency update PRs resume for this repo.