### PR TITLE
chore(deps): bump electron, i18next, and Flatpak workflow actions

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -57,7 +57,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: 'org.coloradomesh.MeshClient-*'
           path: flatpak-dist
@@ -80,7 +80,7 @@ jobs:
           done
 
       - name: Attach Flatpak to release
-        # softprops/action-gh-release v2
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        # softprops/action-gh-release v3 (Node 24)
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           files: flatpak-dist/*.flatpak

--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -88,12 +88,12 @@ modules:
         dest-filename: pnpm-standalone
         only-arches: [aarch64]
       - type: archive
-        url: https://github.com/electron/electron/releases/download/v41.7.0/electron-v41.7.0-linux-x64.zip
-        sha256: f3bf38de05ce8fafe1039251ebfaa75fd090b0a13cd861322ccd2f6db4d6bb82
+        url: https://github.com/electron/electron/releases/download/v41.7.1/electron-v41.7.1-linux-x64.zip
+        sha256: 0165fc68656f49ad7ae0c4254b1ff3af1718c114b6007a2aeef5211e0562f174
         dest: electron-prebuilt
         only-arches: [x86_64]
       - type: archive
-        url: https://github.com/electron/electron/releases/download/v41.7.0/electron-v41.7.0-linux-arm64.zip
-        sha256: c8d4294e052bc83b840523237538ae131d8e387243c25e763f0d14fabffa37c2
+        url: https://github.com/electron/electron/releases/download/v41.7.1/electron-v41.7.1-linux-arm64.zip
+        sha256: 8a8bc763406ad19954432922347ca7c3c8db130f966871687cfb8b4ddccfa28e
         dest: electron-prebuilt
         only-arches: [aarch64]

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@stoprocent/noble": "^2.5.3",
     "electron-updater": "^6.8.3",
     "emoji-picker-element": "^1.29.1",
-    "i18next": "^26.2.0",
+    "i18next": "^26.3.0",
     "jszip": "^3.10.1",
     "leaflet.markercluster": "^1.5.3",
     "mgrs": "^2.1.0",
@@ -121,7 +121,7 @@
     "@typescript-eslint/parser": "^8.60.0",
     "@vitejs/plugin-react": "^6.0.2",
     "concurrently": "^9.2.1",
-    "electron": "^41.7.0",
+    "electron": "^41.7.1",
     "electron-builder": "^26.11.1",
     "esbuild": "^0.28.0",
     "eslint": "^10.4.0",
@@ -182,6 +182,7 @@
       "@electron/asar": "^4.0.1",
       "@meshtastic/core": "npm:@jsr/meshtastic__core@^2.6.6",
       "cacheable-request": "^10.0.0",
+      "tmp": "^0.2.6",
       "yauzl": "^3.2.1"
     },
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@electron/asar': ^4.0.1
   '@meshtastic/core': npm:@jsr/meshtastic__core@^2.6.6
   cacheable-request: ^10.0.0
+  tmp: ^0.2.6
   yauzl: ^3.2.1
 
 patchedDependencies:
@@ -44,8 +45,8 @@ importers:
         specifier: ^1.29.1
         version: 1.29.1
       i18next:
-        specifier: ^26.2.0
-        version: 26.2.0(typescript@6.0.3)
+        specifier: ^26.3.0
+        version: 26.3.0(typescript@6.0.3)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -63,7 +64,7 @@ importers:
         version: 1.4.0
       react-i18next:
         specifier: ^17.0.8
-        version: 17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        version: 17.0.8(i18next@26.3.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       react-leaflet-cluster:
         specifier: ^4.1.3
         version: 4.1.3(@react-leaflet/core@3.0.0(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -138,8 +139,8 @@ importers:
         specifier: ^9.2.1
         version: 9.2.1
       electron:
-        specifier: ^41.7.0
-        version: 41.7.0
+        specifier: ^41.7.1
+        version: 41.7.1
       electron-builder:
         specifier: ^26.11.1
         version: 26.11.1(electron-builder-squirrel-windows@26.11.1)
@@ -2039,8 +2040,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.7.0:
-    resolution: {integrity: sha512-U6KAKivjk6YQ0Z5+eloJBjwhbHRE206gvy1UBMw2bSluWtMh5waeXMvX6AT/Ujm5ymYXVJOp7g9N7vOFw16wBQ==}
+  electron@41.7.1:
+    resolution: {integrity: sha512-pdRvNNP99Qfvs1lyIxo/sfIGAwJP0CrJFNCE3goFKc7/fV+kjK3EPxx5Nt6sLTkzqTyeRYylpwPUfpeGojiyyw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -2557,8 +2558,8 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  i18next@26.2.0:
-    resolution: {integrity: sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==}
+  i18next@26.3.0:
+    resolution: {integrity: sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==}
     peerDependencies:
       typescript: ^5 || ^6
     peerDependenciesMeta:
@@ -4213,8 +4214,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -6519,7 +6520,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.7.0:
+  electron@41.7.1:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.12.4
@@ -7228,7 +7229,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  i18next@26.2.0(typescript@6.0.3):
+  i18next@26.3.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 
@@ -8259,7 +8260,7 @@ snapshots:
       open: 7.4.2
       semver: 7.8.1
       slash: 2.0.0
-      tmp: 0.2.5
+      tmp: 0.2.6
       yaml: 2.9.0
 
   path-exists@4.0.0: {}
@@ -8388,11 +8389,11 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-i18next@17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
+  react-i18next@17.0.8(i18next@26.3.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.7
       html-parse-stringify: 3.0.1
-      i18next: 26.2.0(typescript@6.0.3)
+      i18next: 26.3.0(typescript@6.0.3)
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
@@ -9058,9 +9059,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.6
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Consolidates open Dependabot PRs [#471](https://github.com/Colorado-Mesh/mesh-client/pull/471), [#472](https://github.com/Colorado-Mesh/mesh-client/pull/472), and [#473](https://github.com/Colorado-Mesh/mesh-client/pull/473):

- **electron** 41.7.0 → 41.7.1 — macOS `webContents.print()` crash/prefill fixes ([#471](https://github.com/Colorado-Mesh/mesh-client/pull/471))
- **i18next** 26.2.0 → 26.3.0 — `ResourceNamespaceMap` typing only; backwards-compatible ([#473](https://github.com/Colorado-Mesh/mesh-client/pull/473))
- **Flatpak publish workflow** — `actions/download-artifact@v8`, `softprops/action-gh-release@v3` (Node 24) ([#472](https://github.com/Colorado-Mesh/mesh-client/pull/472))
- **Flatpak manifest** — vendored `electron-v41.7.1` linux archives (required by `check:flatpak`)
- **pnpm override** `tmp@^0.2.6` — clears GHSA-ph9p-34f9-6g65 (transitive via `electron-builder`; unblocks pre-commit audit)

Also created the missing `github-actions` repo label referenced in `dependabot.yml` (Dependabot warned on [#472](https://github.com/Colorado-Mesh/mesh-client/pull/472)).

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test:run`
- [x] `pnpm run lint`
- [x] `pnpm run check:flatpak`
- [x] `pnpm audit --audit-level=high`