### PR TITLE
fix: Windows packaged crash from GPS wifi scan and missing updater dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@bufbuild/protobuf": "^2.12.0",
     "@meshtastic/protobufs": "npm:@jsr/meshtastic__protobufs@^2.7.23",
     "@stoprocent/noble": "^2.5.3",
+    "builder-util-runtime": "9.5.1",
     "electron-updater": "^6.8.3",
     "emoji-picker-element": "^1.29.1",
     "i18next": "^26.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@stoprocent/noble':
         specifier: ^2.5.3
         version: 2.5.3
+      builder-util-runtime:
+        specifier: 9.5.1
+        version: 9.5.1
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3

--- a/src/main/gps.test.ts
+++ b/src/main/gps.test.ts
@@ -5,7 +5,7 @@ import https from 'https';
 import si from 'systeminformation';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getGpsFix, GpsHardwareError } from './gps';
+import { getGpsFix, GpsHardwareError, shouldUseWifiNetworksPreflight } from './gps';
 
 // gps.ts uses `import https from 'https'` (default import) and `import si from 'systeminformation'`
 // Mocks must export a `default` to satisfy default imports.
@@ -114,6 +114,17 @@ describe('getGpsFix', () => {
     setupHttpsSuccess(JSON.stringify({ success: true, latitude: 51.5, longitude: -0.12 }));
     const result = await getGpsFix();
     expect(result).toMatchObject({ lat: 51.5, lon: -0.12, source: 'ip' });
+  });
+
+  it('on Windows skips wifiNetworks and uses inetChecksite preflight only', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    setupHttpsSuccess(JSON.stringify({ success: true, latitude: 40.0, longitude: -105.0 }));
+    const result = await getGpsFix();
+    expect(shouldUseWifiNetworksPreflight()).toBe(false);
+    expect(si.wifiNetworks).not.toHaveBeenCalled();
+    expect(si.inetChecksite).toHaveBeenCalledWith('https://ipwho.is');
+    expect(result).toMatchObject({ lat: 40.0, lon: -105.0, source: 'ip' });
+    platformSpy.mockRestore();
   });
 
   it('returns GpsFixError for coordinates outside valid range', async () => {

--- a/src/main/gps.ts
+++ b/src/main/gps.ts
@@ -120,36 +120,40 @@ function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T
   ]);
 }
 
+/** Whether to run si.wifiNetworks() as the GPS preflight (exported for tests). */
+export function shouldUseWifiNetworksPreflight(): boolean {
+  // Windows: systeminformation wifiNetworks() uses powerShell().then() internally;
+  // parse errors reject that inner chain, not the promise returned to callers, so
+  // .catch() on wifiNetworks() cannot prevent unhandled rejections (wifi.js ~493).
+  return process.platform !== 'win32';
+}
+
+async function inetChecksitePreflight(): Promise<void> {
+  try {
+    await withTimeout(si.inetChecksite('https://ipwho.is'), GPS_SYSTEM_CHECK_TIMEOUT_MS, undefined);
+  } catch (e) {
+    const msg = sanitizeLogMessage((e as Error).message);
+    console.warn(`[gps] inetChecksite preflight failed: ${msg}`);
+  }
+}
+
+/** Lightweight connectivity check before IP geolocation (result discarded). */
+async function runGpsConnectivityPreflight(): Promise<void> {
+  if (!shouldUseWifiNetworksPreflight()) {
+    await inetChecksitePreflight();
+    return;
+  }
+
+  // WiFi scan verifies permissions / interfaces on macOS and Linux. Attach .catch()
+  // so a late rejection after the timeout race does not surface as unhandled.
+  const wifiPromise = si.wifiNetworks().catch(() => undefined);
+  await withTimeout(wifiPromise, GPS_SYSTEM_CHECK_TIMEOUT_MS, undefined);
+}
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 export async function getGpsFix(): Promise<GpsFixResult> {
-  try {
-    // Use a WiFi network scan as a lightweight system check: this verifies that
-    // the systeminformation module has required permissions and that basic
-    // network interfaces are available before attempting IP geolocation.
-    //
-    // The actual scan result is intentionally discarded: we only care that the
-    // call succeeds (proving permissions/hardware are OK) or fails fast so we
-    // can fall back to inetChecksite below. The timeout bounds the cost, so
-    // running this scan for its side effects is intentional and acceptable.
-    // Attach .catch() so that if the timeout wins the race, a later rejection
-    // from si.wifiNetworks() (e.g. systeminformation wifi.js .split() on undefined)
-    // does not become an unhandled promise rejection.
-    const wifiPromise = si.wifiNetworks().catch(() => undefined);
-    await withTimeout(wifiPromise, GPS_SYSTEM_CHECK_TIMEOUT_MS, undefined);
-  } catch {
-    // Optional: WiFi scan can fail (permissions, no adapter). Try inetChecksite as fallback.
-    try {
-      await withTimeout(
-        si.inetChecksite('https://ipwho.is'),
-        GPS_SYSTEM_CHECK_TIMEOUT_MS,
-        undefined,
-      );
-    } catch (e) {
-      const msg = sanitizeLogMessage((e as Error).message);
-      console.warn(`[gps] inetChecksite fallback failed: ${msg}`);
-    }
-  }
+  await runGpsConnectivityPreflight();
 
   try {
     const fix = await getIpFix();

--- a/src/main/updater.contract.test.ts
+++ b/src/main/updater.contract.test.ts
@@ -4,6 +4,9 @@ import { join } from 'path';
 import { describe, expect, it } from 'vitest';
 
 const UPDATER_SOURCE = readFileSync(join(__dirname, 'updater.ts'), 'utf-8');
+const PACKAGE_JSON = JSON.parse(
+  readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'),
+) as { dependencies?: Record<string, string> };
 
 describe('updater source contracts', () => {
   it('falls back to GitHub API when electron-updater is missing instead of skipping IPC handlers', () => {
@@ -16,5 +19,9 @@ describe('updater source contracts', () => {
     expect(UPDATER_SOURCE).toContain('notifyOnSettled: true');
     expect(UPDATER_SOURCE).toContain('notifyOnSettled: false');
     expect(UPDATER_SOURCE).toContain('getCheckNowFromMenu');
+  });
+
+  it('declares builder-util-runtime so electron-updater resolves in packaged Windows builds', () => {
+    expect(PACKAGE_JSON.dependencies?.['builder-util-runtime']).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Add `builder-util-runtime` as a direct production dependency so `electron-updater` loads in packaged Windows builds (pnpm hoisted layout was omitting the transitive dep from `app.asar`).
- Skip `systeminformation` `wifiNetworks()` on Windows for GPS preflight; malformed `netsh` output rejects an internal `powerShell().then()` chain that is not wired to the promise callers await, which triggered unhandled rejections and the error dialog.
- Use `inetChecksite`-only preflight on Windows, with unit and contract tests.

## Test plan

- [x] `pnpm exec vitest run src/main/gps.test.ts src/main/updater.contract.test.ts`
- [ ] Build Windows installer (`pnpm run dist:win`) and confirm `electron-updater` loads without `builder-util-runtime` error
- [ ] Launch packaged app on Windows and trigger GPS/IP lookup (map locate or connect without static GPS); confirm no unhandled rejection dialog from `wifi.js`