### PR TITLE
fix: MeshCore reply previews and tapback echo dedup

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -97,6 +97,7 @@ import {
   letsMeshMqttUsernameFromIdentity,
   readMeshcoreIdentityAsync,
 } from './lib/letsMeshJwt';
+import { meshcoreChatMessagesForDisplay } from './lib/meshcoreChannelText';
 import { pubkeyToNodeId } from './lib/meshcoreUtils';
 import { meshNodeStubForDetailModal } from './lib/meshNodeStubForDetail';
 import { MESHTASTIC_OFFICIAL_PRESET_DEFAULTS } from './lib/meshtasticMqttTlsMigration';
@@ -670,7 +671,7 @@ function AppContent({
     [meshtasticStoreMessages],
   );
   const meshcoreUiMessages = useMemo(
-    () => messageRecordsToChatMessages(meshcoreStoreMessages),
+    () => meshcoreChatMessagesForDisplay(messageRecordsToChatMessages(meshcoreStoreMessages)),
     [meshcoreStoreMessages],
   );
   const meshtasticUiNodes = useMemo(() => {

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -994,6 +994,31 @@ describe('ChatPanel StatusBadge', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders quoted preview from replyPreviewSender without replyId (MeshCore unresolved parent)', () => {
+    render(
+      <ToastProvider>
+        <ChatPanel
+          {...baseProps}
+          protocol="meshcore"
+          messages={[
+            {
+              sender_id: 2,
+              sender_name: 'TB-Dek',
+              payload: 'agreed, coffee',
+              channel: 0,
+              timestamp: Date.now(),
+              replyPreviewSender: '🛩️ W0STR mobl',
+              status: 'acked',
+            },
+          ]}
+        />
+      </ToastProvider>,
+    );
+    expect(screen.getByText(/W0STR mobl/)).toBeInTheDocument();
+    expect(screen.getByText('agreed, coffee')).toBeInTheDocument();
+    expect(screen.queryByText('@[')).not.toBeInTheDocument();
+  });
+
   it('renders quoted preview from stored replyPreview fields when parent is not in messages', () => {
     render(
       <ToastProvider>
@@ -1015,9 +1040,8 @@ describe('ChatPanel StatusBadge', () => {
         />
       </ToastProvider>,
     );
-    expect(
-      screen.getByRole('button', { name: /Jump to quoted message from Alice/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Jump to quoted message from Alice/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Jump to quoted message from Alice/i })).toBeNull();
     expect(screen.getByText('Saved parent snippet')).toBeInTheDocument();
   });
 

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -50,6 +50,7 @@ import {
   type StarredMessage,
 } from '../lib/chatPanelProtocolStorage';
 import { computeChannelUnreadCounts, computeDmUnreadCounts } from '../lib/chatUnreadCounts';
+import { meshcoreChatMessagesForDisplay } from '../lib/meshcoreChannelText';
 import { nodeDisplayName } from '../lib/nodeLongNameOrHex';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import { emojiDisplayLabel, reactionDisplayGlyph, reactionGlyphFromPicker } from '../lib/reactions';
@@ -657,6 +658,11 @@ function ChatPanel({
     }
   }, [initialDmTarget, onDmTargetConsumed]);
 
+  const displayMessages = useMemo(
+    () => (protocol === 'meshcore' ? meshcoreChatMessagesForDisplay(messages) : messages),
+    [messages, protocol],
+  );
+
   // Separate regular messages from reaction messages
   const { regularMessages, reactionsByReplyId } = useMemo(() => {
     const regular: ChatMessage[] = [];
@@ -665,7 +671,7 @@ function ChatPanel({
       { emoji: number; payload: string; sender_id: number; sender_name: string; id?: number }[]
     >();
 
-    for (const msg of messages) {
+    for (const msg of displayMessages) {
       if (protocol === 'meshcore' && isMeshcoreRoomChatMessage(msg)) {
         continue;
       }
@@ -684,7 +690,7 @@ function ChatPanel({
       }
     }
     return { regularMessages: regular, reactionsByReplyId: reactions };
-  }, [messages, protocol]);
+  }, [displayMessages, protocol]);
 
   const inferredDmTabs = useMemo(() => {
     const peers = new Map<number, number>();
@@ -2120,10 +2126,13 @@ function ChatPanel({
                         )}
 
                         {/* Quoted reply preview */}
-                        {msg.replyId &&
+                        {(msg.replyId != null ||
+                          msg.replyPreviewSender != null ||
+                          msg.replyPreviewText != null) &&
                           !msg.emoji &&
                           (() => {
-                            const orig = messageByReplyKey.get(msg.replyId);
+                            const orig =
+                              msg.replyId != null ? messageByReplyKey.get(msg.replyId) : undefined;
                             const quoteSnippet = orig
                               ? truncateReplyPreviewText(orig.payload)
                               : msg.replyPreviewText;
@@ -2131,28 +2140,52 @@ function ChatPanel({
                               ? nodeDisplayName(nodes.get(orig.sender_id), protocol) ||
                                 orig.sender_name
                               : msg.replyPreviewSender;
+                            const canJumpToParent = msg.replyId != null && !!orig;
                             if (!quoteSnippet && !quotedLabel) return null;
-                            return (
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  scrollToQuotedParent(msg.replyId!);
-                                }}
-                                className="bg-secondary-dark/50 hover:bg-secondary-dark/80 mb-1.5 flex w-full gap-1.5 rounded-lg border border-gray-600/50 px-2 py-1.5 text-left transition-colors"
-                                aria-label={t('chatPanel.jumpToQuotedMessage', {
-                                  sender: quotedLabel ?? '',
-                                })}
-                              >
+                            const quoteClassName =
+                              'bg-secondary-dark/50 mb-1.5 flex w-full gap-1.5 rounded-lg border border-gray-600/50 px-2 py-1.5 text-left';
+                            const quoteBody = (
+                              <>
                                 <div className="min-h-[2rem] w-0.5 shrink-0 self-stretch rounded-full bg-gray-500" />
                                 <div className="min-w-0 flex-1">
                                   <span className="block text-[10px] font-semibold text-gray-400">
                                     {quotedLabel}
                                   </span>
-                                  <span className="line-clamp-2 block text-[11px] break-words text-gray-500">
-                                    {quoteSnippet}
-                                  </span>
+                                  {quoteSnippet ? (
+                                    <span className="line-clamp-2 block text-[11px] break-words text-gray-500">
+                                      {quoteSnippet}
+                                    </span>
+                                  ) : null}
                                 </div>
-                              </button>
+                              </>
+                            );
+                            if (canJumpToParent) {
+                              return (
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    scrollToQuotedParent(msg.replyId!);
+                                  }}
+                                  className={`${quoteClassName} hover:bg-secondary-dark/80 transition-colors`}
+                                  aria-label={t('chatPanel.jumpToQuotedMessage', {
+                                    sender: quotedLabel ?? '',
+                                  })}
+                                >
+                                  {quoteBody}
+                                </button>
+                              );
+                            }
+                            return (
+                              <div
+                                className={quoteClassName}
+                                aria-label={
+                                  quotedLabel
+                                    ? t('chatPanel.jumpToQuotedMessage', { sender: quotedLabel })
+                                    : undefined
+                                }
+                              >
+                                {quoteBody}
+                              </div>
                             );
                           })()}
 

--- a/src/renderer/components/ChatPayloadText.tsx
+++ b/src/renderer/components/ChatPayloadText.tsx
@@ -123,18 +123,16 @@ export function ChatPayloadText({ text, query }: ChatPayloadTextProps) {
       <div>
         {segments.map((seg, i) =>
           seg.kind === 'mention' ? (
-            <span
-              key={`m-${i}`}
-              className="mx-0.5 inline-flex max-w-full rounded-md border border-cyan-500/35 bg-cyan-500/15 px-1 py-px align-baseline text-[0.92em] leading-snug font-medium text-cyan-100/95 first:ml-0"
-              title={seg.label ? `@${seg.label}` : 'Mention'}
-              aria-label={
-                seg.label
-                  ? t('chatPayload.mention', { label: seg.label })
-                  : t('chatPayload.emptyMention')
-              }
-            >
-              @{highlightCaseInsensitive(seg.label, query)}
-            </span>
+            seg.label ? (
+              <span
+                key={`m-${i}`}
+                className="mx-0.5 inline-flex max-w-full rounded-md border border-cyan-500/35 bg-cyan-500/15 px-1 py-px align-baseline text-[0.92em] leading-snug font-medium text-cyan-100/95 first:ml-0"
+                title={`@${seg.label}`}
+                aria-label={t('chatPayload.mention', { label: seg.label })}
+              >
+                @{highlightCaseInsensitive(seg.label, query)}
+              </span>
+            ) : null
           ) : seg.kind === 'url' ? (
             <a
               key={`u-${i}`}

--- a/src/renderer/hooks/meshcore/meshcoreHookPreamble.crossTransport.test.ts
+++ b/src/renderer/hooks/meshcore/meshcoreHookPreamble.crossTransport.test.ts
@@ -4,9 +4,11 @@ import { meshcoreChatStubNodeIdFromDisplayName } from '../../lib/meshcoreUtils';
 import type { ChatMessage } from '../../lib/types';
 import {
   findMeshcoreCrossTransportDuplicate,
+  findMeshcoreTapbackEchoDuplicate,
   mapMeshcoreCrossTransportUpgrade,
   MESHCORE_CROSS_TRANSPORT_DEDUP_WINDOW_MS,
   meshcoreCrossTransportMatch,
+  meshcoreTapbackEchoMatch,
 } from './meshcoreHookPreamble';
 
 function baseMsg(overrides: Partial<ChatMessage> = {}): ChatMessage {
@@ -68,6 +70,26 @@ describe('meshcoreCrossTransportMatch', () => {
       timestamp: mqtt.timestamp + 1_000,
     });
     expect(meshcoreCrossTransportMatch(mqtt, rf)).toBe(true);
+  });
+
+  it('matches tapback echo on same transport within window', () => {
+    const local = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 99,
+      payload: '👍',
+      timestamp: 1_700_000_000_000,
+      receivedVia: 'rf',
+    });
+    const echo = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 99,
+      payload: '👍',
+      meshcoreDedupeKey: 'Me: @[Bob] 👍',
+      timestamp: local.timestamp + 2_000,
+      receivedVia: 'rf',
+    });
+    expect(meshcoreTapbackEchoMatch(local, echo)).toBe(true);
+    expect(findMeshcoreTapbackEchoDuplicate([local], echo)).toBe(local);
   });
 
   it('matches reaction duplicates across transports', () => {

--- a/src/renderer/hooks/meshcore/meshcoreHookPreamble.ts
+++ b/src/renderer/hooks/meshcore/meshcoreHookPreamble.ts
@@ -6,7 +6,10 @@ import type {
   MeshcoreContactDbRow,
   MeshCoreContactRaw,
 } from '../../lib/meshcore/meshcoreHookTypes';
-import { normalizeMeshcoreIncomingText } from '../../lib/meshcoreChannelText';
+import {
+  meshcoreChatMessagesForDisplay,
+  normalizeMeshcoreIncomingText,
+} from '../../lib/meshcoreChannelText';
 import {
   CONTACT_TYPE_LABELS,
   isMeshcoreTransportStatusChatLine,
@@ -361,6 +364,39 @@ export function findMeshcoreRoomPostDuplicate(
   for (let i = messages.length - 1; i >= start; i--) {
     const existing = messages[i];
     if (meshcoreRoomPostMatch(existing, incoming, windowMs)) {
+      return existing;
+    }
+  }
+  return undefined;
+}
+
+export const MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS = 30_000;
+
+/** Outbound tapback (local optimistic) vs RF/MQTT echo of `@[Name] emoji` — same transport allowed. */
+export function meshcoreTapbackEchoMatch(
+  existing: ChatMessage,
+  incoming: ChatMessage,
+  windowMs: number = MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS,
+): boolean {
+  if (existing.emoji == null || incoming.emoji == null) return false;
+  if ((existing.replyId ?? undefined) !== (incoming.replyId ?? undefined)) return false;
+  if (existing.channel !== incoming.channel) return false;
+  if ((existing.to ?? undefined) !== (incoming.to ?? undefined)) return false;
+  if (existing.emoji !== incoming.emoji) return false;
+  if (!meshcoreSenderMatchesForDedup(existing, incoming)) return false;
+  if (Math.abs(existing.timestamp - incoming.timestamp) > windowMs) return false;
+  return true;
+}
+
+export function findMeshcoreTapbackEchoDuplicate(
+  messages: readonly ChatMessage[],
+  incoming: ChatMessage,
+  windowMs: number = MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS,
+): ChatMessage | undefined {
+  const start = Math.max(0, messages.length - MESHCORE_CROSS_TRANSPORT_SCAN_LIMIT);
+  for (let i = messages.length - 1; i >= start; i--) {
+    const existing = messages[i];
+    if (meshcoreTapbackEchoMatch(existing, incoming, windowMs)) {
       return existing;
     }
   }
@@ -731,7 +767,7 @@ export function mapMeshcoreDbRowsToChatMessages(rows: MeshcoreMessageDbRow[]): C
       roomServerId: coerceOptionalDbInt(r.room_server_id),
     });
   }
-  return meshcoreReconcileChannelSenderIds(mapped);
+  return meshcoreChatMessagesForDisplay(meshcoreReconcileChannelSenderIds(mapped));
 }
 
 /** Persist sender_id/name repairs after {@link mapMeshcoreDbRowsToChatMessages} reconciliation. */

--- a/src/renderer/lib/meshcoreChannelText.test.ts
+++ b/src/renderer/lib/meshcoreChannelText.test.ts
@@ -4,8 +4,12 @@ import {
   buildMeshcoreChannelIncomingMessage,
   buildMeshcoreDmIncomingMessage,
   findMeshcoreDmReplyParent,
+  meshcoreBracketDisplayNamesMatch,
+  meshcoreChannelRepairRawText,
+  meshcoreChatMessagesForDisplay,
   meshcorePayloadIsTapbackEmojiOnly,
   normalizeMeshcoreIncomingText,
+  parseMeshcoreBracketPrefix,
   parseMeshcorePlainBracketLine,
   resolveMeshcoreBracketParentKey,
   resolveMeshcoreBracketParentKeyDm,
@@ -53,6 +57,7 @@ describe('normalizeMeshcoreIncomingText', () => {
       senderName: 'NVON 01',
       payload: '👍',
       bracketTargetName: 'NVON 02',
+      hadBracketReplyPrefix: true,
     });
   });
 
@@ -61,6 +66,7 @@ describe('normalizeMeshcoreIncomingText', () => {
       senderName: 'A',
       payload: 'hello there',
       bracketTargetName: 'Bob',
+      hadBracketReplyPrefix: true,
     });
   });
 
@@ -85,6 +91,7 @@ describe('parseMeshcorePlainBracketLine', () => {
     expect(parseMeshcorePlainBracketLine('@[Alice] 👍')).toEqual({
       bracketTargetName: 'Alice',
       payload: '👍',
+      hadBracketReplyPrefix: true,
     });
   });
 
@@ -261,6 +268,21 @@ describe('meshcorePayloadIsTapbackEmojiOnly', () => {
   });
 });
 
+describe('meshcoreBracketDisplayNamesMatch', () => {
+  it('matches case and surrounding whitespace', () => {
+    expect(meshcoreBracketDisplayNamesMatch('  Bob ', 'bob')).toBe(true);
+  });
+
+  it('matches when one name contains the other', () => {
+    expect(meshcoreBracketDisplayNamesMatch('W0STR mobl', 'W0STR')).toBe(true);
+  });
+
+  it('matches mobile alias to station name via callsign token', () => {
+    expect(meshcoreBracketDisplayNamesMatch('🛩️ W0STR mobl', '🛩️ W0STR 01')).toBe(true);
+    expect(meshcoreBracketDisplayNamesMatch('W0STR mobl', '🛩️ W0STR 01')).toBe(true);
+  });
+});
+
 describe('resolveMeshcoreBracketParentKey', () => {
   const baseTime = 1_000_000;
   const parents: ChatMessage[] = [
@@ -365,6 +387,95 @@ describe('buildMeshcoreChannelIncomingMessage', () => {
       rxHops: 2,
     });
     expect(msg.rxHops).toBe(2);
+  });
+
+  it('strips bracket prefix and sets preview sender when parent is missing', () => {
+    const msg = buildMeshcoreChannelIncomingMessage([], {
+      rawText: 'TB-Dek: @[W0STR mobl] agreed, coffee',
+      senderId: 2,
+      displayName: 'TB-Dek',
+      channel: 8,
+      timestamp: 3_000_000,
+      receivedVia: 'rf',
+    });
+    expect(msg.replyId).toBeUndefined();
+    expect(msg.payload).toBe('agreed, coffee');
+    expect(msg.replyPreviewSender).toBe('W0STR mobl');
+    expect(msg.payload).not.toMatch(/@\[/);
+  });
+});
+
+describe('meshcoreChannelRepairRawText', () => {
+  it('does not duplicate Sender prefix when payload already has colon form', () => {
+    const raw = meshcoreChannelRepairRawText({
+      sender_id: 1,
+      sender_name: 'TB-Dek',
+      payload: 'TB-Dek: @[W0STR mobl] agreed',
+      channel: 8,
+      timestamp: 1,
+      status: 'acked',
+    });
+    expect(raw).toBe('TB-Dek: @[W0STR mobl] agreed');
+  });
+});
+
+describe('parseMeshcoreBracketPrefix', () => {
+  it('parses empty bracket reply @[] with body only', () => {
+    expect(parseMeshcoreBracketPrefix('@[] agreed, coffee')).toEqual({
+      hadBracketPrefix: true,
+      targetName: undefined,
+      body: 'agreed, coffee',
+    });
+  });
+});
+
+describe('repairMeshcoreDisplayMessages', () => {
+  it('repairs stored rows that still contain @[ in payload', () => {
+    const broken: ChatMessage = {
+      sender_id: 2,
+      sender_name: 'TB-Dek',
+      payload: '@[W0STR mobl] agreed',
+      channel: 8,
+      timestamp: 3_000_001,
+      status: 'acked',
+    };
+    const parent: ChatMessage = {
+      sender_id: 1,
+      sender_name: '🛩️ W0STR 01',
+      payload: 'morning',
+      channel: 8,
+      timestamp: 3_000_000,
+      status: 'acked',
+      packetId: 77,
+    };
+    const out = meshcoreChatMessagesForDisplay([parent, broken]);
+    expect(out[1]?.payload).toBe('agreed');
+    expect(out[1]?.replyId).toBe(77);
+    expect(out[1]?.replyPreviewSender).toBe('🛩️ W0STR 01');
+  });
+
+  it('repairs @[] empty bracket by inferring latest prior speaker on channel', () => {
+    const parent: ChatMessage = {
+      sender_id: 1,
+      sender_name: '🔥 W0RMT 03',
+      payload: 'morning. It is absolutely necessary this morning',
+      channel: 8,
+      timestamp: 3_000_000,
+      status: 'acked',
+      packetId: 88,
+    };
+    const broken: ChatMessage = {
+      sender_id: 2,
+      sender_name: 'TB-Dek',
+      payload: '@[] agreed, a nice yirgacheffe',
+      channel: 8,
+      timestamp: 3_000_001,
+      status: 'acked',
+    };
+    const out = meshcoreChatMessagesForDisplay([parent, broken]);
+    expect(out[1]?.payload).toBe('agreed, a nice yirgacheffe');
+    expect(out[1]?.replyId).toBe(88);
+    expect(out[1]?.replyPreviewSender).toBe('🔥 W0RMT 03');
   });
 });
 

--- a/src/renderer/lib/meshcoreChannelText.ts
+++ b/src/renderer/lib/meshcoreChannelText.ts
@@ -8,24 +8,43 @@ export interface MeshcoreNormalizedText {
   payload: string;
   /** Name inside `@[...]` when that prefix was present on the payload (after `Sender: `). */
   bracketTargetName?: string;
+  /** True when payload began with `@[…]` even if the name inside brackets was empty (`@[]`). */
+  hadBracketReplyPrefix?: boolean;
 }
 
-const BRACKET_PAYLOAD = /^@\[([^\]]+)\]\s*(.*)$/su;
+/** Leading reply/tapback marker; name inside brackets may be empty on the wire (`@[] body`). */
+const BRACKET_PREFIX = /^@\[([^\]]*)\]\s*(.*)$/su;
 
-/** DM / plain-text tapback lines are the full body `@[TargetName] …` (no `Sender: ` prefix). */
-const PLAIN_BRACKET_LINE = /^@\[([^\]]+)\]\s*(.*)$/su;
+/**
+ * Parse a leading `@[Name] rest` segment (name may be empty — firmware sometimes sends `@[] body`).
+ */
+export function parseMeshcoreBracketPrefix(rawText: string): {
+  hadBracketPrefix: boolean;
+  targetName?: string;
+  body: string;
+} {
+  const t = (rawText ?? '').trim();
+  if (!t) return { hadBracketPrefix: false, body: '' };
+  const m = BRACKET_PREFIX.exec(t);
+  if (!m) return { hadBracketPrefix: false, body: t };
+  const targetName = m[1].trim();
+  return {
+    hadBracketPrefix: true,
+    targetName: targetName.length > 0 ? targetName : undefined,
+    body: (m[2] ?? '').trim(),
+  };
+}
 
 /**
  * Parse a full DM body (or any line) for a leading `@[Name] rest` segment.
  */
 export function parseMeshcorePlainBracketLine(rawText: string): MeshcoreNormalizedText {
-  const t = (rawText ?? '').trim();
-  if (!t) return { payload: '' };
-  const m = PLAIN_BRACKET_LINE.exec(t);
-  if (!m) return { payload: t };
+  const parsed = parseMeshcoreBracketPrefix(rawText);
+  if (!parsed.hadBracketPrefix) return { payload: parsed.body };
   return {
-    bracketTargetName: m[1].trim(),
-    payload: (m[2] ?? '').trim(),
+    hadBracketReplyPrefix: true,
+    payload: parsed.body,
+    ...(parsed.targetName ? { bracketTargetName: parsed.targetName } : {}),
   };
 }
 
@@ -83,13 +102,17 @@ export function normalizeMeshcoreIncomingText(rawText: string): MeshcoreNormaliz
   const senderCandidate = text.slice(0, colonIdx).trim();
   let payload = text.slice(colonIdx + 1).trim();
   if (!senderCandidate || !payload) return { payload: text };
-  const m = BRACKET_PAYLOAD.exec(payload);
-  let bracketTargetName: string | undefined;
-  if (m) {
-    bracketTargetName = m[1].trim();
-    payload = (m[2] ?? '').trim();
+  const bracket = parseMeshcoreBracketPrefix(payload);
+  if (bracket.hadBracketPrefix) {
+    payload = bracket.body;
+    return {
+      senderName: senderCandidate,
+      payload,
+      hadBracketReplyPrefix: true,
+      ...(bracket.targetName ? { bracketTargetName: bracket.targetName } : {}),
+    };
   }
-  return { senderName: senderCandidate, payload, bracketTargetName };
+  return { senderName: senderCandidate, payload };
 }
 
 /** True when `payload` is a single grapheme cluster and normalizes as a reaction emoji. */
@@ -114,6 +137,62 @@ export interface MeshcoreParentResolveOpts {
   to: number | undefined;
 }
 
+/** Alphanumeric tokens for callsign matching (emoji/punctuation stripped). */
+export function meshcoreDisplayNameTokens(name: string): string[] {
+  const stripped = name.replace(/\p{Extended_Pictographic}/gu, ' ');
+  const tokens: string[] = [];
+  for (const part of stripped.toLowerCase().split(/\s+/)) {
+    const t = part.replace(/[^a-z0-9]/gi, '');
+    if (t.length >= 3) tokens.push(t);
+  }
+  return tokens;
+}
+
+/** Compare bracket `@[Name]` targets to stored `sender_name` (trim, case, callsign tokens). */
+export function meshcoreBracketDisplayNamesMatch(target: string, senderName: string): boolean {
+  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, ' ');
+  const t = norm(target);
+  const n = norm(senderName);
+  if (!t || !n) return false;
+  if (t === n) return true;
+  if (t.length >= 4 && (n.includes(t) || t.includes(n))) return true;
+  const tTokens = meshcoreDisplayNameTokens(target);
+  const nTokens = meshcoreDisplayNameTokens(senderName);
+  if (tTokens.length > 0 && nTokens.length > 0) {
+    for (const tt of tTokens) {
+      for (const nt of nTokens) {
+        if (tt === nt || nt.startsWith(tt) || tt.startsWith(nt)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function meshcoreBracketUnresolvedReplyFields(
+  target: string,
+  body: string,
+  fallbackPayload: string,
+): Pick<ChatMessage, 'payload' | 'replyPreviewSender'> {
+  const trimmed = body.trim();
+  return {
+    payload: trimmed.length > 0 ? trimmed : fallbackPayload,
+    replyPreviewSender: target,
+  };
+}
+
+/** Rebuild wire text for {@link repairMeshcoreDisplayMessages} without duplicating `Sender: `. */
+export function meshcoreChannelRepairRawText(msg: ChatMessage): string {
+  const p = msg.payload.trim();
+  if (/^[^:\n]{1,80}:\s/u.test(p)) return p;
+  return `${msg.sender_name}: ${p}`;
+}
+
+/** Sort + parse/repair MeshCore chat rows for UI (store, runtime, ChatPanel). */
+export function meshcoreChatMessagesForDisplay(messages: readonly ChatMessage[]): ChatMessage[] {
+  const sorted = [...messages].sort((a, b) => a.timestamp - b.timestamp);
+  return repairMeshcoreDisplayMessages(sorted);
+}
+
 /**
  * Latest message in the same thread whose `sender_name` matches `targetName` and is strictly older than `beforeTimestamp`.
  */
@@ -127,7 +206,7 @@ export function resolveMeshcoreBracketParentKey(
     if ((m.to ?? undefined) !== (opts.to ?? undefined)) continue;
     if (m.emoji != null && m.replyId != null) continue;
     if (m.timestamp >= opts.beforeTimestamp) continue;
-    if (m.sender_name !== opts.targetName) continue;
+    if (!meshcoreBracketDisplayNamesMatch(opts.targetName, m.sender_name)) continue;
     if (!best || m.timestamp > best.timestamp) best = m;
   }
   if (!best) return undefined;
@@ -156,7 +235,7 @@ export function resolveMeshcoreBracketParentKeyDm(
     if (!inThread) continue;
     if (m.emoji != null && m.replyId != null) continue;
     if (m.timestamp >= opts.beforeTimestamp) continue;
-    if (m.sender_name !== opts.targetName) continue;
+    if (!meshcoreBracketDisplayNamesMatch(opts.targetName, m.sender_name)) continue;
     if (!best || m.timestamp > best.timestamp) best = m;
   }
   if (!best) return undefined;
@@ -231,6 +310,13 @@ export function buildMeshcoreChannelIncomingMessage(
   };
 
   const target = normalized.bracketTargetName;
+  if (normalized.hadBracketReplyPrefix && !target) {
+    const body = normalized.payload.trim();
+    return {
+      ...base,
+      payload: body.length > 0 ? body : fallbackPayload,
+    };
+  }
   if (target) {
     const parentKey = resolveMeshcoreBracketParentKey(messages, {
       channel: opts.channel,
@@ -257,13 +343,123 @@ export function buildMeshcoreChannelIncomingMessage(
         return { ...base, payload: body, replyId: parentKey, ...previewFields };
       }
     }
-    return { ...base, payload: fallbackPayload };
+    const body = normalized.payload.trim();
+    return { ...base, ...meshcoreBracketUnresolvedReplyFields(target, body, fallbackPayload) };
   }
 
   return {
     ...base,
     payload: normalized.payload.length > 0 ? normalized.payload : fallbackPayload,
   };
+}
+
+/**
+ * Re-parse stored/live rows that still carry `@[Name]` in payload without `replyId` (e.g. parent
+ * was missing at first ingest). Runs in timestamp order so parent resolution can use prior rows.
+ */
+/** When the wire sends `@[] body`, infer parent as the latest prior message from another sender in-thread. */
+function inferMeshcoreEmptyBracketReplyParent(
+  prior: readonly ChatMessage[],
+  msg: ChatMessage,
+): ChatMessage | undefined {
+  let best: ChatMessage | undefined;
+  for (const m of prior) {
+    if (m.channel !== msg.channel) continue;
+    if ((m.to ?? undefined) !== (msg.to ?? undefined)) continue;
+    if (m.timestamp >= msg.timestamp) continue;
+    if (m.sender_id === msg.sender_id) continue;
+    if (m.emoji != null && m.replyId != null) continue;
+    if (!best || m.timestamp > best.timestamp) best = m;
+  }
+  return best;
+}
+
+function mergeRepairedMeshcoreMessage(existing: ChatMessage, rebuilt: ChatMessage): ChatMessage {
+  return {
+    ...rebuilt,
+    id: existing.id,
+    packetId: existing.packetId ?? rebuilt.packetId,
+    receivedVia: existing.receivedVia ?? rebuilt.receivedVia,
+    isHistory: existing.isHistory ?? rebuilt.isHistory,
+    meshcoreDedupeKey: existing.meshcoreDedupeKey ?? rebuilt.meshcoreDedupeKey,
+    status: existing.status ?? rebuilt.status,
+  };
+}
+
+export function repairMeshcoreDisplayMessages(messages: readonly ChatMessage[]): ChatMessage[] {
+  const prior: ChatMessage[] = [];
+  const out: ChatMessage[] = [];
+  for (const msg of messages) {
+    let next = msg;
+    if (msg.emoji != null && msg.replyId != null) {
+      prior.push(next);
+      out.push(next);
+      continue;
+    }
+    if (msg.replyId != null && !msg.replyPreviewSender && !msg.replyPreviewText) {
+      const parent = findParentMessageForReply(prior, msg.replyId);
+      if (parent) {
+        next = {
+          ...msg,
+          replyPreviewText: truncateReplyPreviewText(parent.payload),
+          replyPreviewSender: parent.sender_name,
+        };
+      }
+    }
+    const parsed = parseMeshcorePlainBracketLine(msg.payload.trim());
+    if (parsed.hadBracketReplyPrefix && !parsed.bracketTargetName) {
+      const body =
+        parsed.payload.length > 0
+          ? parsed.payload
+          : msg.payload.replace(/^@\[\s*\]\s*/u, '').trim();
+      const inferred = inferMeshcoreEmptyBracketReplyParent(prior, msg);
+      if (inferred) {
+        const parentKey = inferred.packetId ?? inferred.timestamp;
+        next = {
+          ...msg,
+          payload: body,
+          replyId: parentKey,
+          replyPreviewText: truncateReplyPreviewText(inferred.payload),
+          replyPreviewSender: inferred.sender_name,
+        };
+      } else {
+        next = { ...msg, payload: body };
+      }
+    } else if (parsed.bracketTargetName) {
+      if (msg.channel === -1 && msg.to != null) {
+        next = mergeRepairedMeshcoreMessage(
+          msg,
+          buildMeshcoreDmIncomingMessage(prior, {
+            rawText: msg.payload,
+            senderId: msg.sender_id,
+            displayName: msg.sender_name,
+            timestamp: msg.timestamp,
+            receivedVia: msg.receivedVia,
+            peerNodeId: msg.sender_id,
+            myNodeId: msg.to,
+            to: msg.to,
+            rxHops: msg.rxHops,
+          }),
+        );
+      } else if (msg.channel >= 0) {
+        next = mergeRepairedMeshcoreMessage(
+          msg,
+          buildMeshcoreChannelIncomingMessage(prior, {
+            rawText: meshcoreChannelRepairRawText(msg),
+            senderId: msg.sender_id,
+            displayName: msg.sender_name,
+            channel: msg.channel,
+            timestamp: msg.timestamp,
+            receivedVia: msg.receivedVia,
+            rxHops: msg.rxHops,
+          }),
+        );
+      }
+    }
+    prior.push(next);
+    out.push(next);
+  }
+  return out;
 }
 
 export interface BuildMeshcoreDmIncomingOpts {
@@ -309,6 +505,10 @@ export function buildMeshcoreDmIncomingMessage(
     ...rxFields,
   };
 
+  if (parsed.hadBracketReplyPrefix && !parsed.bracketTargetName) {
+    const body = parsed.payload.trim();
+    return { ...base, payload: body.length > 0 ? body : opts.rawText };
+  }
   const target = parsed.bracketTargetName;
   if (target) {
     const parentKey = resolveMeshcoreBracketParentKeyDm(messages, {
@@ -336,6 +536,8 @@ export function buildMeshcoreDmIncomingMessage(
         return { ...base, payload: body, replyId: parentKey, ...previewFields };
       }
     }
+    const body = parsed.payload.trim();
+    return { ...base, ...meshcoreBracketUnresolvedReplyFields(target, body, opts.rawText) };
   }
 
   return { ...base, payload: opts.rawText };

--- a/src/renderer/lib/meshcoreStoreDedup.ts
+++ b/src/renderer/lib/meshcoreStoreDedup.ts
@@ -1,6 +1,7 @@
 import {
   findMeshcoreCrossTransportDuplicate,
   findMeshcoreRoomPostDuplicate,
+  findMeshcoreTapbackEchoDuplicate,
   MESHCORE_ROOM_MESSAGE_CHANNEL,
   meshcoreMessageDedupeKey,
 } from '../hooks/meshcore/meshcoreHookPreamble';
@@ -151,6 +152,28 @@ export function upsertMeshcoreMessageWithDedup(
       message: exactMatch,
       canonicalId,
     };
+  }
+
+  const tapbackDup = findMeshcoreTapbackEchoDuplicate(storeMessages, msg);
+  if (tapbackDup) {
+    const merged: ChatMessage = {
+      ...tapbackDup,
+      receivedVia: mergeMeshcoreReceivedVia(tapbackDup.receivedVia, msg.receivedVia),
+      rxHops: tapbackDup.rxHops ?? msg.rxHops,
+      meshcoreDedupeKey: msg.meshcoreDedupeKey ?? tapbackDup.meshcoreDedupeKey,
+    };
+    const canonicalId =
+      preferredId ??
+      findStoreRecordIdForMessage(identityId, tapbackDup) ??
+      meshcoreMessageStoreId(merged);
+    const record = chatMessageToMessageRecord(merged);
+    record.id = canonicalId;
+    upsertMessage(identityId, record);
+    const altId = meshcoreMessageStoreId(msg);
+    if (altId !== canonicalId) {
+      deleteMessage(identityId, altId);
+    }
+    return { inserted: false, message: merged, canonicalId };
   }
 
   const crossDup = findMeshcoreCrossTransportDuplicate(storeMessages, msg);

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -85,6 +85,7 @@ import type {
 import {
   buildMeshcoreChannelIncomingMessage,
   findMeshcoreDmReplyParent,
+  meshcoreChatMessagesForDisplay,
   normalizeMeshcoreIncomingText,
   resolveMeshcoreChannelMessageSender,
 } from '../lib/meshcoreChannelText';
@@ -180,11 +181,7 @@ import { createRepeaterRemoteRpcQueue } from '../lib/repeaterRemoteRpcQueue';
 import { LAST_SERIAL_PORT_KEY } from '../lib/serialPortSignature';
 import { registerMeshcoreSession } from '../lib/sessions/meshcoreSession';
 import { getStoredMeshProtocol } from '../lib/storedMeshProtocol';
-import {
-  chatMessageToMessageRecord,
-  messageRecordsToChatMessages,
-  nodeRecordsToMeshNodeMap,
-} from '../lib/storeRecordAdapters';
+import { messageRecordsToChatMessages, nodeRecordsToMeshNodeMap } from '../lib/storeRecordAdapters';
 import {
   MESHCORE_ROOM_POST_SENT_TIMEOUT_MS,
   MESHCORE_ROOM_SYNC_MIN_MESH_TX_SPACING_MS,
@@ -202,7 +199,7 @@ import type {
 } from '../lib/types';
 import { mirrorMqttStatusToConnection, setConnection } from '../stores/connectionStore';
 import { useDiagnosticsStore } from '../stores/diagnosticsStore';
-import { upsertMessage, useMessageStore } from '../stores/messageStore';
+import { useMessageStore } from '../stores/messageStore';
 import { useNodeStore } from '../stores/nodeStore';
 import { computePathHash, usePathHistoryStore } from '../stores/pathHistoryStore';
 import { useRepeaterSignalStore } from '../stores/repeaterSignalStore';
@@ -3989,9 +3986,6 @@ export function useMeshcoreRuntime() {
 
       const publishTapback = (tapbackMsg: ChatMessage) => {
         addMessage(tapbackMsg);
-        if (storeId) {
-          upsertMessage(storeId, chatMessageToMessageRecord(tapbackMsg));
-        }
         void window.electronAPI.db
           .saveMeshcoreMessage(messageToDbRow(tapbackMsg))
           .catch((e: unknown) => {
@@ -4472,8 +4466,10 @@ export function useMeshcoreRuntime() {
     if (!meshcoreIdentityId) return messages;
     const byId = useMessageStore.getState().messages[meshcoreIdentityId];
     if (!byId) return messages;
-    const fromStore = messageRecordsToChatMessages(Object.values(byId));
-    return fromStore.length > 0 ? fromStore : messages;
+    const fromStore = meshcoreChatMessagesForDisplay(
+      messageRecordsToChatMessages(Object.values(byId)),
+    );
+    return fromStore.length > 0 ? fromStore : meshcoreChatMessagesForDisplay(messages);
   }, [meshcoreIdentityId, messages]);
   const resolvedNodes = useMemo(() => {
     if (!meshcoreIdentityId) return nodes;


### PR DESCRIPTION
## Summary

- Fix MeshCore channel replies that showed only a lone `@` chip when the wire sent empty bracket targets (`@[] body`) or when the quoted name did not exactly match stored `sender_name`.
- Add `meshcoreChatMessagesForDisplay()` to sort and repair reply metadata on load (App, runtime, ChatPanel) with callsign token matching for mobile/station aliases.
- Show quote preview UI when `replyPreviewSender` / `replyPreviewText` exist even without `replyId`; skip empty mention chips in `ChatPayloadText`.
- Deduplicate outbound tapback RF echoes and remove a duplicate store upsert in `sendReaction`.

## Test plan

- [x] `pnpm run test:run` (pre-commit)
- [ ] MeshCore ch8: TB-Dek reply shows quote bar + body (no orphan `@` chip)
- [ ] Send one tapback — only one reaction appears (no duplicate emoji)
- [ ] Reply to a node with a slightly different display name (e.g. mobl vs `W0STR 01`) still resolves quote parent when possible