### PR TITLE
fix: shorten MeshCore room login timeouts for TCP and 0-hop paths

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -501,6 +501,38 @@ With **Wi‑Fi off** or **airplane mode** on, using a **packaged** build if poss
 - The device must be **flashed as Companion HTTP** (not BLE-only firmware).
 - If `meshtastic.local` is not resolved, see [HTTP / WiFi connection issues](#http--wifi-connection-issues).
 
+### MeshCore: Room server login, posts, and Windows 10
+
+**Minimum Windows**: Mesh-Client (Electron 41) supports **Windows 10 version 1809+** and Windows 11. Windows 10 22H2 is supported; issues reported only on Win10 are usually MeshCore protocol or app regressions, not an unsupported OS.
+
+**Rooms vs Chat**: Official MeshCore room clients use the **Rooms** tab BBS login path. Room-server posts appear there (`SignedPlain` / channel `-2`), **not** in Chat channel pills. Admin traffic sent as normal **channel text** shows in **Chat** only.
+
+**Guest / read-only login fails with timeout or "rejected"**:
+
+- Many room servers reject blank passwords; use guest password **`hello`** or the password configured on the server.
+- Logs showing `unhandled frame: code=134` (push `0x86`) mean the room server sent **LoginFail** (wrong password or ACL denied). Current builds fail fast with a clear message instead of waiting the full timeout.
+- **Admin password** working while guest fails usually means the server ACL does not allow guest/read-only login with that password.
+
+**No room history after login**:
+
+- Firmware only **pushes new posts** after a successful login; it does not backfill old BBS messages. Enable **Auto-sync** on the Rooms tab to periodic re-login while connected.
+
+**Queue badge stuck at `Q: 255/256`**:
+
+- Usually means the companion radio outbound queue is nearly full, or (on older builds) CORE stats were mis-parsed. Enable debug logging and export logs if the badge stays red for minutes with no traffic; look for `[useMeshcoreRuntime] high queue depth=`.
+
+**Windows packaged updater: `Cannot find module 'semver'`**:
+
+- Fixed by declaring `semver` as a direct production dependency (same class of issue as `builder-util-runtime` on hoisted `dist:win` builds). Updater falls back to GitHub Releases API until you install a build with the fix.
+
+**Retest checklist (after upgrading from a known-good build)**:
+
+1. Connect MeshCore over TCP or BLE; confirm nodes load.
+2. Open **Rooms** → log in with explicit guest password **`hello`** (or admin if testing post/admin CLI).
+3. Confirm room posts appear in **Rooms**, not Chat channels.
+4. Open **Chat** on another channel; verify unread badges on channel pills when messages arrive.
+5. Export logs (**Log → Export**) if login still fails; include `[meshcoreRoomLoginRpc]` lines.
+
 ### MeshCore: Trace Route or Ping trace times out
 
 **Cause**: Nodes you only **hear** on the mesh; but that do **not** have **your** node in **their** contact list; are sometimes called foreign or one-way contacts. MeshCore firmware may not answer **Trace Route** (node detail) or **Ping trace** (Repeaters panel) for those peers, so the app waits until the trace/ping timeout with no TraceData response. You may see **Trace route timed out** in the node detail modal or an error toast from **Ping trace**.

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-i18next": "^17.0.8",
     "react-leaflet-cluster": "^4.1.3",
     "readable-stream": "^4.7.0",
+    "semver": "7.7.4",
     "systeminformation": "^5.31.7"
   },
   "devDependencies": {

--- a/patches/@liamcottle__meshcore.js@1.13.0.patch
+++ b/patches/@liamcottle__meshcore.js@1.13.0.patch
@@ -1,8 +1,8 @@
 diff --git a/src/connection/connection.js b/src/connection/connection.js
-index af6f6d670adc0948d3453df34acbbde46c1b4250..b0eaddb5675fab04fa3d149b5e0f35b33198fdd5 100644
+index af6f6d670adc0948d3453df34acbbde46c1b4250..4ec84dae698ee87e63b98bfc2a4fcab302b1d2c5 100644
 --- a/src/connection/connection.js
 +++ b/src/connection/connection.js
-@@ -231,7 +231,13 @@
+@@ -231,7 +231,13 @@ class Connection extends EventEmitter {
          const data = new BufferWriter();
          data.writeByte(Constants.CommandCodes.SendLogin);
          data.writeBytes(publicKey); // 32 bytes - id of repeater or room server
@@ -17,7 +17,30 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..b0eaddb5675fab04fa3d149b5e0f35b3
          await this.sendToRadioFrame(data.toBytes());
      }
  
-@@ -494,15 +494,24 @@ class Connection extends EventEmitter {
+@@ -400,6 +406,8 @@ class Connection extends EventEmitter {
+             this.onRawDataPush(bufferReader);
+         } else if(responseCode === Constants.PushCodes.LoginSuccess){
+             this.onLoginSuccessPush(bufferReader);
++        } else if(responseCode === Constants.PushCodes.LoginFail){
++            this.onLoginFailPush(bufferReader);
+         } else if(responseCode === Constants.PushCodes.StatusResponse){
+             this.onStatusResponsePush(bufferReader);
+         } else if(responseCode === Constants.PushCodes.LogRxData){
+@@ -459,6 +467,13 @@ class Connection extends EventEmitter {
+         });
+     }
+ 
++    onLoginFailPush(bufferReader) {
++        this.emit(Constants.PushCodes.LoginFail, {
++            reserved: bufferReader.readByte(), // reserved
++            pubKeyPrefix: bufferReader.readBytes(6), // 6 bytes of public key this login fail is from
++        });
++    }
++
+     onStatusResponsePush(bufferReader) {
+         this.emit(Constants.PushCodes.StatusResponse, {
+             reserved: bufferReader.readByte(), // reserved
+@@ -494,15 +509,24 @@ class Connection extends EventEmitter {
      onTraceDataPush(bufferReader) {
          const reserved = bufferReader.readByte();
          const pathLen = bufferReader.readUInt8();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ patchedDependencies:
     hash: 27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74
     path: patches/@jsr__meshtastic__transport-web-serial@0.2.5.patch
   '@liamcottle/meshcore.js@1.13.0':
-    hash: cb054ae2e703a540c49884ed779d16e5804e8c0a82e7ce11bc09d68604c62c8e
+    hash: adc81eb0e938c09ed8436a4dac5717c13b33a1dcfcb1907541cc6347e1dd155a
     path: patches/@liamcottle__meshcore.js@1.13.0.patch
   debug@4.4.3:
     hash: cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37
@@ -80,6 +80,9 @@ importers:
       readable-stream:
         specifier: ^4.7.0
         version: 4.7.0(patch_hash=96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1)
+      semver:
+        specifier: 7.7.4
+        version: 7.7.4
       systeminformation:
         specifier: ^5.31.7
         version: 5.31.7
@@ -92,7 +95,7 @@ importers:
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       '@liamcottle/meshcore.js':
         specifier: ^1.13.0
-        version: 1.13.0(patch_hash=cb054ae2e703a540c49884ed779d16e5804e8c0a82e7ce11bc09d68604c62c8e)
+        version: 1.13.0(patch_hash=adc81eb0e938c09ed8436a4dac5717c13b33a1dcfcb1907541cc6347e1dd155a)
       '@meshtastic/core':
         specifier: npm:@jsr/meshtastic__core@^2.6.6
         version: '@jsr/meshtastic__core@2.6.6(patch_hash=714af0fd567c3a11b0ee94c68743dce951b199d388f217bd3cb5770a7b3e278a)(buffer@6.0.3)'
@@ -3899,11 +3902,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
@@ -4875,7 +4873,7 @@ snapshots:
       node-gyp: 11.5.0
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.8.1
+      semver: 7.7.4
       tar: 7.5.15
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -5110,7 +5108,7 @@ snapshots:
     transitivePeerDependencies:
       - buffer
 
-  '@liamcottle/meshcore.js@1.13.0(patch_hash=cb054ae2e703a540c49884ed779d16e5804e8c0a82e7ce11bc09d68604c62c8e)':
+  '@liamcottle/meshcore.js@1.13.0(patch_hash=adc81eb0e938c09ed8436a4dac5717c13b33a1dcfcb1907541cc6347e1dd155a)':
     dependencies:
       '@noble/curves': 1.9.7
       serialport: 13.0.0
@@ -5180,11 +5178,11 @@ snapshots:
 
   '@npmcli/fs@3.1.1':
     dependencies:
-      semver: 7.8.1
+      semver: 7.7.4
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.8.1
+      semver: 7.7.4
 
   '@oxc-project/types@0.132.0': {}
 
@@ -5717,7 +5715,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.7.4
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -7133,7 +7131,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.8.1
+      semver: 7.7.4
       serialize-error: 7.0.1
     optional: true
 
@@ -7587,7 +7585,7 @@ snapshots:
       mkdirp: 1.0.4
       nopt: 7.2.1
       read-installed-packages: 2.0.1
-      semver: 7.8.1
+      semver: 7.7.4
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
       spdx-satisfies: 5.0.1
@@ -8066,7 +8064,7 @@ snapshots:
 
   node-abi@4.31.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.7.4
 
   node-addon-api@1.7.2:
     optional: true
@@ -8080,7 +8078,7 @@ snapshots:
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.8.1
+      semver: 7.7.4
 
   node-exports-info@1.6.0:
     dependencies:
@@ -8104,7 +8102,7 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.1.0
       proc-log: 5.0.0
-      semver: 7.8.1
+      semver: 7.7.4
       tar: 7.5.15
       tinyglobby: 0.2.16
       which: 5.0.0
@@ -8127,7 +8125,7 @@ snapshots:
     dependencies:
       hosted-git-info: 6.1.3
       is-core-module: 2.16.2
-      semver: 7.8.1
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-url@8.1.1: {}
@@ -8267,7 +8265,7 @@ snapshots:
       klaw-sync: 6.0.0
       minimist: 1.2.8
       open: 7.4.2
-      semver: 7.8.1
+      semver: 7.7.4
       slash: 2.0.0
       tmp: 0.2.7
       yaml: 2.9.0
@@ -8451,7 +8449,7 @@ snapshots:
       '@npmcli/fs': 3.1.1
       debug: 4.4.3(patch_hash=cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37)
       read-package-json: 6.0.4
-      semver: 7.8.1
+      semver: 7.7.4
       slide: 1.1.6
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -8679,8 +8677,6 @@ snapshots:
 
   semver@7.7.4: {}
 
-  semver@7.8.1: {}
-
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
@@ -8797,7 +8793,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.7.4
 
   slash@2.0.0: {}
 
@@ -8837,7 +8833,7 @@ snapshots:
       detect-newline: 4.0.1
       git-hooks-list: 4.2.1
       is-plain-obj: 4.1.0
-      semver: 7.8.1
+      semver: 7.7.4
       sort-object-keys: 2.1.0
       tinyglobby: 0.2.16
 

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -345,6 +345,9 @@ describe('app_settings table + message retention defaults (schema sync)', () => 
     expect(INDEX_SOURCE).toContain('meshtasticMessageRetentionCount');
     expect(INDEX_SOURCE).toContain('meshcoreMessageRetentionEnabled');
     expect(INDEX_SOURCE).toContain('meshcoreMessageRetentionCount');
+    expect(INDEX_SOURCE).toContain('meshcoreRoomSync:');
+    expect(INDEX_SOURCE).toContain('meshcoreRoomLastPost:');
+    expect(INDEX_SOURCE).toContain('meshcoreRoomCredential:');
     expect(INDEX_SOURCE).toMatch(/INSERT OR REPLACE INTO app_settings\(key, value\) VALUES/);
   });
 

--- a/src/main/index.contract.test.ts
+++ b/src/main/index.contract.test.ts
@@ -108,6 +108,9 @@ describe('Persistent app settings IPC (source contract)', () => {
     expect(INDEX_SOURCE).toMatch(/key not allowed/);
     expect(INDEX_SOURCE).toContain("'meshtasticLastRfSelfNodeId'");
     expect(INDEX_SOURCE).toContain('meshtasticRemoteAdminKey:');
+    expect(INDEX_SOURCE).toContain('meshcoreRoomSync:');
+    expect(INDEX_SOURCE).toContain('meshcoreRoomLastPost:');
+    expect(INDEX_SOURCE).toContain('meshcoreRoomCredential:');
     expect(INDEX_SOURCE).toContain('isAppSettingsKeyAllowed');
   });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2990,10 +2990,18 @@ const APP_SETTINGS_ALLOWED_KEYS: ReadonlySet<string> = new Set([
 ]);
 const APP_SETTINGS_MAX_VALUE_LENGTH = 256;
 const MESHTASTIC_REMOTE_ADMIN_KEY_SETTING_PREFIX = 'meshtasticRemoteAdminKey:';
+/** MeshCore Rooms tab — must match renderer meshcoreRoomSyncStorage / meshcoreRoomCredentialStorage. */
+const MESHCORE_ROOM_SYNC_SETTING_PREFIX = 'meshcoreRoomSync:';
+const MESHCORE_ROOM_LAST_POST_SETTING_PREFIX = 'meshcoreRoomLastPost:';
+const MESHCORE_ROOM_CREDENTIAL_SETTING_PREFIX = 'meshcoreRoomCredential:';
 
 function isAppSettingsKeyAllowed(key: string): boolean {
   return (
-    APP_SETTINGS_ALLOWED_KEYS.has(key) || key.startsWith(MESHTASTIC_REMOTE_ADMIN_KEY_SETTING_PREFIX)
+    APP_SETTINGS_ALLOWED_KEYS.has(key) ||
+    key.startsWith(MESHTASTIC_REMOTE_ADMIN_KEY_SETTING_PREFIX) ||
+    key.startsWith(MESHCORE_ROOM_SYNC_SETTING_PREFIX) ||
+    key.startsWith(MESHCORE_ROOM_LAST_POST_SETTING_PREFIX) ||
+    key.startsWith(MESHCORE_ROOM_CREDENTIAL_SETTING_PREFIX)
   );
 }
 

--- a/src/main/updater.contract.test.ts
+++ b/src/main/updater.contract.test.ts
@@ -24,4 +24,8 @@ describe('updater source contracts', () => {
   it('declares builder-util-runtime so electron-updater resolves in packaged Windows builds', () => {
     expect(PACKAGE_JSON.dependencies?.['builder-util-runtime']).toBeTruthy();
   });
+
+  it('declares semver so electron-updater resolves in hoisted Windows app.asar builds', () => {
+    expect(PACKAGE_JSON.dependencies?.semver).toBeTruthy();
+  });
 });

--- a/src/renderer/lib/meshcoreRoomLoginRpc.test.ts
+++ b/src/renderer/lib/meshcoreRoomLoginRpc.test.ts
@@ -18,6 +18,7 @@ import {
 const MC_RESP_ERR = 1;
 const MC_RESP_SENT = 6;
 const MC_PUSH_LOGIN_SUCCESS = 0x85;
+const MC_PUSH_LOGIN_FAIL = 0x86;
 
 function makePubKey(seed: number): Uint8Array {
   const key = new Uint8Array(32);
@@ -238,5 +239,36 @@ describe('runMeshcoreRoomLogin', () => {
     conn.emit(MC_RESP_ERR);
 
     await expect(loginPromise).rejects.toThrow(/rejected room login/i);
+  });
+
+  it('rejects immediately on matching LoginFail push', async () => {
+    const conn = createMockConn();
+    const pubKey = makePubKey(0xab);
+
+    const loginPromise = runMeshcoreRoomLogin(conn, pubKey, 'hello');
+    await Promise.resolve();
+
+    conn.emit(MC_RESP_SENT, { estTimeout: 45_000 });
+    conn.emit(MC_PUSH_LOGIN_FAIL, { pubKeyPrefix: pubKey.subarray(0, 6), reserved: 0 });
+
+    await expect(loginPromise).rejects.toThrow(/wrong password or ACL denied/i);
+  });
+
+  it('ignores LoginFail with wrong pubkey prefix', async () => {
+    const conn = createMockConn();
+    const pubKey = makePubKey(0xab);
+    const wrongPrefix = makePubKey(0xcd).subarray(0, 6);
+
+    const loginPromise = runMeshcoreRoomLogin(conn, pubKey, 'hello', { hopsAway: 0 });
+    await Promise.resolve();
+
+    conn.emit(MC_RESP_SENT, { estTimeout: 1_000 });
+    conn.emit(MC_PUSH_LOGIN_FAIL, { pubKeyPrefix: wrongPrefix, reserved: 0 });
+    conn.emit(MC_PUSH_LOGIN_SUCCESS, { pubKeyPrefix: pubKey.subarray(0, 6), reserved: 1 });
+
+    await expect(loginPromise).resolves.toEqual({
+      pubKeyPrefix: pubKey.subarray(0, 6),
+      reserved: 1,
+    });
   });
 });

--- a/src/renderer/lib/meshcoreRoomLoginRpc.test.ts
+++ b/src/renderer/lib/meshcoreRoomLoginRpc.test.ts
@@ -8,7 +8,11 @@ import {
 } from './meshcoreRoomLoginRpc';
 import {
   computeRoomLoginExtraTimeoutMs,
+  computeRoomLoginSentWaitMs,
+  MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_DIRECT_MS,
   MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_MS,
+  MESHCORE_ROOM_LOGIN_SENT_WAIT_DIRECT_MS,
+  MESHCORE_ROOM_LOGIN_SENT_WAIT_MS,
 } from './timeConstants';
 
 const MC_RESP_ERR = 1;
@@ -94,7 +98,11 @@ describe('buildSendLoginFrame', () => {
 });
 
 describe('computeRoomLoginExtraTimeoutMs', () => {
-  it('uses floor for nearby rooms', () => {
+  it('uses shorter floor for direct (0-hop) rooms', () => {
+    expect(computeRoomLoginExtraTimeoutMs(0)).toBe(MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_DIRECT_MS);
+  });
+
+  it('uses RF floor for nearby multi-hop rooms', () => {
     expect(computeRoomLoginExtraTimeoutMs(2)).toBe(MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_MS);
   });
 
@@ -103,6 +111,18 @@ describe('computeRoomLoginExtraTimeoutMs', () => {
     expect(computeRoomLoginExtraTimeoutMs(18)).toBeGreaterThan(
       MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_MS,
     );
+  });
+});
+
+describe('computeRoomLoginSentWaitMs', () => {
+  it('uses BLE SENT wait by default', () => {
+    expect(computeRoomLoginSentWaitMs()).toBe(MESHCORE_ROOM_LOGIN_SENT_WAIT_MS);
+    expect(computeRoomLoginSentWaitMs('ble')).toBe(MESHCORE_ROOM_LOGIN_SENT_WAIT_MS);
+  });
+
+  it('uses shorter SENT wait for TCP and serial companion links', () => {
+    expect(computeRoomLoginSentWaitMs('tcp')).toBe(MESHCORE_ROOM_LOGIN_SENT_WAIT_DIRECT_MS);
+    expect(computeRoomLoginSentWaitMs('serial')).toBe(MESHCORE_ROOM_LOGIN_SENT_WAIT_DIRECT_MS);
   });
 });
 
@@ -135,19 +155,31 @@ describe('runMeshcoreRoomLogin', () => {
     });
   });
 
-  it('rejects when Sent acknowledgment never arrives', async () => {
+  it('rejects when Sent acknowledgment never arrives on TCP within direct wait', async () => {
     const conn = createMockConn();
     const pubKey = makePubKey(3);
 
-    const loginPromise = runMeshcoreRoomLogin(conn, pubKey, 'hello');
+    const loginPromise = runMeshcoreRoomLogin(conn, pubKey, 'hello', { companionTransport: 'tcp' });
     await Promise.resolve();
 
     const rejection = expect(loginPromise).rejects.toThrow(/acknowledgment/i);
-    await vi.advanceTimersByTimeAsync(45_000);
+    await vi.advanceTimersByTimeAsync(MESHCORE_ROOM_LOGIN_SENT_WAIT_DIRECT_MS);
     await rejection;
   });
 
-  it('rejects on response timeout after Sent', async () => {
+  it('rejects when Sent acknowledgment never arrives on BLE within full wait', async () => {
+    const conn = createMockConn();
+    const pubKey = makePubKey(3);
+
+    const loginPromise = runMeshcoreRoomLogin(conn, pubKey, 'hello', { companionTransport: 'ble' });
+    await Promise.resolve();
+
+    const rejection = expect(loginPromise).rejects.toThrow(/acknowledgment/i);
+    await vi.advanceTimersByTimeAsync(MESHCORE_ROOM_LOGIN_SENT_WAIT_MS);
+    await rejection;
+  });
+
+  it('rejects on response timeout after Sent for direct room', async () => {
     const conn = createMockConn();
     const pubKey = makePubKey(4);
 
@@ -156,7 +188,7 @@ describe('runMeshcoreRoomLogin', () => {
 
     conn.emit(MC_RESP_SENT, { estTimeout: 2_000 });
     const rejection = expect(loginPromise).rejects.toThrow('timeout');
-    await vi.advanceTimersByTimeAsync(45_000 + 2_000);
+    await vi.advanceTimersByTimeAsync(MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_DIRECT_MS + 2_000);
     await rejection;
   });
 

--- a/src/renderer/lib/meshcoreRoomLoginRpc.ts
+++ b/src/renderer/lib/meshcoreRoomLoginRpc.ts
@@ -1,4 +1,8 @@
-import { computeRoomLoginExtraTimeoutMs, MESHCORE_ROOM_LOGIN_SENT_WAIT_MS } from './timeConstants';
+import {
+  computeRoomLoginExtraTimeoutMs,
+  computeRoomLoginSentWaitMs,
+  type MeshcoreCompanionTransport,
+} from './timeConstants';
 
 /** DOMException.message when user cancels an in-flight room login. */
 export const MESHCORE_ROOM_LOGIN_ABORT_MESSAGE = 'Room login cancelled';
@@ -81,10 +85,15 @@ export function runMeshcoreRoomLogin(
   conn: MeshcoreRoomLoginRpcConnection,
   contactPublicKey: Uint8Array,
   password: string,
-  opts?: { hopsAway?: number; signal?: AbortSignal },
+  opts?: {
+    hopsAway?: number;
+    signal?: AbortSignal;
+    companionTransport?: MeshcoreCompanionTransport;
+  },
 ): Promise<MeshcoreRoomLoginResponse> {
   const expectedPrefix = contactPublicKey.subarray(0, 6);
   const extraTimeoutMs = computeRoomLoginExtraTimeoutMs(opts?.hopsAway ?? 0);
+  const sentWaitMs = computeRoomLoginSentWaitMs(opts?.companionTransport);
   const signal = opts?.signal;
 
   return new Promise((resolve, reject) => {
@@ -190,7 +199,7 @@ export function runMeshcoreRoomLogin(
     sentWaitTimer = setTimeout(() => {
       if (settled || sentReceived) return;
       fail(new Error('timeout waiting for room login acknowledgment'));
-    }, MESHCORE_ROOM_LOGIN_SENT_WAIT_MS);
+    }, sentWaitMs);
 
     void conn
       .sendToRadioFrame(buildSendLoginFrame(contactPublicKey, password))

--- a/src/renderer/lib/meshcoreRoomLoginRpc.ts
+++ b/src/renderer/lib/meshcoreRoomLoginRpc.ts
@@ -17,6 +17,9 @@ const MC_RESP_SENT = 6;
 /** meshcore.js PushCodes.LoginSuccess */
 const MC_PUSH_LOGIN_SUCCESS = 0x85;
 
+/** meshcore.js PushCodes.LoginFail — wrong password / ACL denied (emitted after patch). */
+const MC_PUSH_LOGIN_FAIL = 0x86;
+
 export interface MeshcoreRoomLoginResponse {
   reserved?: number;
   pubKeyPrefix?: Uint8Array;
@@ -115,6 +118,7 @@ export function runMeshcoreRoomLogin(
       conn.off(MC_RESP_SENT, onSent);
       conn.off(MC_RESP_ERR, onErr);
       conn.off(MC_PUSH_LOGIN_SUCCESS, onLoginSuccess);
+      conn.off(MC_PUSH_LOGIN_FAIL, onLoginFail);
       signal?.removeEventListener('abort', onAbort);
     };
 
@@ -167,7 +171,24 @@ export function runMeshcoreRoomLogin(
         );
         return;
       }
+      console.debug(
+        `[meshcoreRoomLoginRpc] LoginSuccess prefix=${prefixToHex(prefix)} permissions=${String(r.permissions ?? 'n/a')}`,
+      );
       succeed(r);
+    };
+
+    const onLoginFail = (response: unknown): void => {
+      const r = response as MeshcoreRoomLoginResponse;
+      const prefix = r.pubKeyPrefix;
+      if (!(prefix instanceof Uint8Array) || prefix.length !== 6) return;
+      if (!pubKeyPrefixesEqual(expectedPrefix, prefix)) {
+        console.debug(
+          `[meshcoreRoomLoginRpc] LoginFail prefix mismatch expected=${prefixToHex(expectedPrefix)} got=${prefixToHex(prefix)}`,
+        );
+        return;
+      }
+      console.debug(`[meshcoreRoomLoginRpc] LoginFail prefix=${prefixToHex(prefix)}`);
+      fail(new Error('room login rejected (wrong password or ACL denied)'));
     };
 
     const onSent = (response: unknown): void => {
@@ -181,6 +202,9 @@ export function runMeshcoreRoomLogin(
       conn.off(MC_RESP_ERR, onErr);
       const r = response as { estTimeout?: number };
       estTimeoutMs = r.estTimeout ?? 0;
+      console.debug(
+        `[meshcoreRoomLoginRpc] SendLogin SENT estTimeoutMs=${estTimeoutMs} extraTimeoutMs=${extraTimeoutMs} hops=${String(opts?.hopsAway ?? 0)}`,
+      );
       startResponseTimer();
     };
 
@@ -193,6 +217,7 @@ export function runMeshcoreRoomLogin(
     };
 
     conn.on(MC_PUSH_LOGIN_SUCCESS, onLoginSuccess);
+    conn.on(MC_PUSH_LOGIN_FAIL, onLoginFail);
     conn.once(MC_RESP_SENT, onSent);
     conn.once(MC_RESP_ERR, onErr);
 

--- a/src/renderer/lib/meshcoreRoomSession.ts
+++ b/src/renderer/lib/meshcoreRoomSession.ts
@@ -11,6 +11,7 @@ import { getMeshcoreRoomLastPostAt } from './meshcoreRoomSyncStorage';
 import {
   MESHCORE_ROOM_LOGIN_MAX_ATTEMPTS,
   MESHCORE_ROOM_LOGIN_RETRY_DELAY_MS,
+  type MeshcoreCompanionTransport,
 } from './timeConstants';
 
 export { MESHCORE_ROOM_LOGIN_ABORT_MESSAGE };
@@ -191,6 +192,7 @@ export async function meshcoreRoomLogin(
     guestPassword?: string;
     signal?: AbortSignal;
     hopsAway?: number;
+    companionTransport?: MeshcoreCompanionTransport;
   },
 ): Promise<void> {
   const run = async (): Promise<void> => {
@@ -204,6 +206,7 @@ export async function meshcoreRoomLogin(
         try {
           const response = await runMeshcoreRoomLogin(conn, pubKey, password, {
             hopsAway: opts?.hopsAway,
+            companionTransport: opts?.companionTransport,
             signal,
           });
           throwIfRoomLoginAborted(signal);

--- a/src/renderer/lib/meshcoreRoomSession.ts
+++ b/src/renderer/lib/meshcoreRoomSession.ts
@@ -169,6 +169,12 @@ function sleepMs(ms: number): Promise<void> {
 
 export function meshcoreRoomLoginFailureMessage(err: unknown, password: string): string {
   const msg = errLikeToLogString(err).toLowerCase();
+  if (msg.includes('rejected') || msg.includes('wrong password') || msg.includes('acl denied')) {
+    if (password.length === 0) {
+      return 'Room login rejected. Try guest password "hello", or confirm this server allows read-only login.';
+    }
+    return 'Room login rejected. Check the guest or admin password for this room server.';
+  }
   if (msg.includes('timeout')) {
     if (password.length === 0) {
       return 'Room login timed out. Try guest password "hello", or confirm this server allows read-only login.';

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -22,13 +22,34 @@ export const MESHCORE_TRACE_SENT_WAIT_TIMEOUT_MS = 45_000;
 /** Extra wait after SENT for room server login over RF (multi-hop); meshcore.js adds this to estTimeout. */
 export const MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_MS = 45_000;
 
+/** Post-SENT wait when the room server is direct on mesh (0 hops). LAN/TCP users often hit this path. */
+export const MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_DIRECT_MS = 15_000;
+
 /** Max wait for `RESP_SENT` after SendLogin before rejecting (companion never acked the command). */
 export const MESHCORE_ROOM_LOGIN_SENT_WAIT_MS = MESHCORE_TRACE_SENT_WAIT_TIMEOUT_MS;
 
+/** SendLogin SENT ack wait when companion is TCP or USB serial (local link, not BLE). */
+export const MESHCORE_ROOM_LOGIN_SENT_WAIT_DIRECT_MS = 15_000;
+
+/** Companion transport for room login timeout selection. */
+export type MeshcoreCompanionTransport = 'ble' | 'serial' | 'tcp';
+
 /** Hop-scaled floor for room login response wait (matches outbound DM ACK formula in useMeshcoreRuntime). */
 export function computeRoomLoginExtraTimeoutMs(hopsAway: number): number {
-  const hopScaled = 3_000 + Math.max(0, hopsAway) * 2_500;
+  if (hopsAway <= 0) {
+    return MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_DIRECT_MS;
+  }
+  const hopScaled = 3_000 + hopsAway * 2_500;
   return Math.max(MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_MS, hopScaled);
+}
+
+/** Max wait for SendLogin `RESP_SENT` before rejecting; shorter on TCP/serial companion links. */
+export function computeRoomLoginSentWaitMs(
+  companionTransport: MeshcoreCompanionTransport = 'ble',
+): number {
+  return companionTransport === 'ble'
+    ? MESHCORE_ROOM_LOGIN_SENT_WAIT_MS
+    : MESHCORE_ROOM_LOGIN_SENT_WAIT_DIRECT_MS;
 }
 
 /** Cap wait for SendLogin / room post `sendTextMessage` Sent response (meshcore.js has no timeout). */

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -3299,6 +3299,7 @@ export function useMeshcoreRuntime() {
           adminPassword,
           guestPassword,
           hopsAway,
+          companionTransport: meshcoreConnectTypeRef.current,
         });
       });
       if (opts?.rememberPassword) {

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -386,6 +386,18 @@ export function useMeshcoreRuntime() {
       queueLenFromMeshCoreCoreStatsRaw(coreStats.raw, core.queueLen),
       256,
     );
+    if (queueLenCapped >= 250) {
+      const raw = coreStats.raw;
+      const rawHex =
+        raw != null && raw.length > 0
+          ? Array.from(raw)
+              .map((b) => b.toString(16).padStart(2, '0'))
+              .join('')
+          : 'none';
+      console.debug(
+        `[useMeshcoreRuntime] high queue depth=${queueLenCapped} meshcoreJsParsed=${core.queueLen} rawLen=${raw?.length ?? 0} rawHex=${rawHex}`,
+      );
+    }
     setQueueStatus({ free: 256 - queueLenCapped, maxlen: 256, res: 0 });
     const now = Date.now();
     setSelfInfo((prev) => (prev ? { ...prev, batteryMilliVolts: core.batteryMilliVolts } : prev));


### PR DESCRIPTION
## Summary

- Shorten MeshCore room login waits on **direct (0-hop)** room servers from 45s to 15s after `RESP_SENT`.
- Use a **15s SendLogin SENT ack** window when the companion link is **TCP or USB serial**; keep **45s on BLE** where GATT latency is higher.
- Pass `companionTransport` from `useMeshcoreRuntime` into the room login RPC/session layer.
- Add unit tests for `computeRoomLoginSentWaitMs` and transport-specific timeout behavior.

LAN/TCP users (including Win10 reporters on local companion links) previously waited up to 45s per login attempt even when the room server was one hop away or the companion ack was local.

## Test plan

- [ ] Connect MeshCore over **TCP** to a companion on the LAN; log into a **0-hop** room server with guest password `hello` and confirm login completes or fails within ~15s per attempt (not ~45s).
- [ ] Repeat room login over **BLE** and confirm the longer SENT wait still applies when the companion is slow to ack.
- [ ] Log into a **multi-hop** room server over RF and confirm the 45s RF floor still applies.
- [ ] `pnpm run test:run -- src/renderer/lib/meshcoreRoomLoginRpc.test.ts`