### PR TITLE
fix: MeshCore chat badges, read-only room login, and SignedPlain posts

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -509,9 +509,14 @@ With **Wi‑Fi off** or **airplane mode** on, using a **packaged** build if poss
 
 **Guest / read-only login fails with timeout or "rejected"**:
 
-- Many room servers reject blank passwords; use guest password **`hello`** or the password configured on the server.
-- Logs showing `unhandled frame: code=134` (push `0x86`) mean the room server sent **LoginFail** (wrong password or ACL denied). Current builds fail fast with a clear message instead of waiting the full timeout.
-- **Admin password** working while guest fails usually means the server ACL does not allow guest/read-only login with that password.
+- When the room server **guest password is empty**, read-only login uses a **blank client password** (same as the official Android app). The SendLogin frame sends **zero password bytes** after the 32-byte room pubkey.
+- When the server **does** configure a guest password, use that value (some communities use **`hello`**).
+- Logs showing push **`0x86`** (frame 134) mean **LoginFail** (wrong password or ACL denied). Current builds fail fast with a clear message instead of waiting the full timeout.
+- **Admin password** working while guest/read-only fails usually means the guest password on the server does not match what the client sent, or ACL denies read-only login.
+
+**Room posts not visible in the official Android app**:
+
+- Outbound room BBS posts must use **SignedPlain** (`txtType` 2) with a **4-byte author pubkey prefix** before the message body. Plain channel text posts appear in mesh-client Chat only and are not stored in the room BBS on the server.
 
 **No room history after login**:
 
@@ -528,10 +533,11 @@ With **Wi‑Fi off** or **airplane mode** on, using a **packaged** build if poss
 **Retest checklist (after upgrading from a known-good build)**:
 
 1. Connect MeshCore over TCP or BLE; confirm nodes load.
-2. Open **Rooms** → log in with explicit guest password **`hello`** (or admin if testing post/admin CLI).
-3. Confirm room posts appear in **Rooms**, not Chat channels.
-4. Open **Chat** on another channel; verify unread badges on channel pills when messages arrive.
-5. Export logs (**Log → Export**) if login still fails; include `[meshcoreRoomLoginRpc]` lines.
+2. Open **Rooms** → with **empty guest password** on the server, log in with a **blank** password (read-only). With a configured guest password, use that value.
+3. Post as admin; confirm the post appears in the **official Android app** on the same room (SignedPlain BBS path).
+4. Confirm room posts appear in **Rooms**, not Chat channel pills.
+5. On **Connection** tab, receive a channel message on a channel you are not viewing → sidebar **Chat** badge and red pill on that channel when you open Chat.
+6. Export logs (**Log → Export**) if login still fails; include `[meshcoreRoomLoginRpc]` lines.
 
 ### MeshCore: Trace Route or Ping trace times out
 

--- a/patches/@liamcottle__meshcore.js@1.13.0.patch
+++ b/patches/@liamcottle__meshcore.js@1.13.0.patch
@@ -1,23 +1,20 @@
 diff --git a/src/connection/connection.js b/src/connection/connection.js
-index af6f6d670adc0948d3453df34acbbde46c1b4250..4ec84dae698ee87e63b98bfc2a4fcab302b1d2c5 100644
+index af6f6d670adc0948d3453df34acbbde46c1b4250..0000000000000000000000000000000000000000 100644
 --- a/src/connection/connection.js
 +++ b/src/connection/connection.js
-@@ -231,7 +231,13 @@ class Connection extends EventEmitter {
+@@ -231,7 +231,10 @@
          const data = new BufferWriter();
          data.writeByte(Constants.CommandCodes.SendLogin);
          data.writeBytes(publicKey); // 32 bytes - id of repeater or room server
 -        data.writeString(password); // password is remainder of frame, max 15 characters
-+        // Empty password must be a null byte (read-only / ACL login). Non-empty uses variable-length
-+        // framing so companion firmware parses the guest/admin password field correctly.
-+        if (password.length === 0) {
-+            data.writeCString(password, 16);
-+        } else {
++        // Empty password = read-only ACL (0 bytes, matches official Android). Non-empty uses writeString.
++        if (password.length > 0) {
 +            data.writeString(password);
 +        }
          await this.sendToRadioFrame(data.toBytes());
      }
  
-@@ -400,6 +406,8 @@ class Connection extends EventEmitter {
+@@ -400,6 +403,8 @@
              this.onRawDataPush(bufferReader);
          } else if(responseCode === Constants.PushCodes.LoginSuccess){
              this.onLoginSuccessPush(bufferReader);
@@ -26,7 +23,7 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..4ec84dae698ee87e63b98bfc2a4fcab3
          } else if(responseCode === Constants.PushCodes.StatusResponse){
              this.onStatusResponsePush(bufferReader);
          } else if(responseCode === Constants.PushCodes.LogRxData){
-@@ -459,6 +467,13 @@ class Connection extends EventEmitter {
+@@ -459,6 +464,13 @@
          });
      }
  
@@ -40,7 +37,7 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..4ec84dae698ee87e63b98bfc2a4fcab3
      onStatusResponsePush(bufferReader) {
          this.emit(Constants.PushCodes.StatusResponse, {
              reserved: bufferReader.readByte(), // reserved
-@@ -494,15 +509,24 @@ class Connection extends EventEmitter {
+@@ -494,15 +506,24 @@
      onTraceDataPush(bufferReader) {
          const reserved = bufferReader.readByte();
          const pathLen = bufferReader.readUInt8();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ patchedDependencies:
     hash: 27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74
     path: patches/@jsr__meshtastic__transport-web-serial@0.2.5.patch
   '@liamcottle/meshcore.js@1.13.0':
-    hash: adc81eb0e938c09ed8436a4dac5717c13b33a1dcfcb1907541cc6347e1dd155a
+    hash: 54aadb84d0488a89a60e625ffeb81eb0f70bcd573478f589195e057dcdcce02c
     path: patches/@liamcottle__meshcore.js@1.13.0.patch
   debug@4.4.3:
     hash: cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37
@@ -95,7 +95,7 @@ importers:
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       '@liamcottle/meshcore.js':
         specifier: ^1.13.0
-        version: 1.13.0(patch_hash=adc81eb0e938c09ed8436a4dac5717c13b33a1dcfcb1907541cc6347e1dd155a)
+        version: 1.13.0(patch_hash=54aadb84d0488a89a60e625ffeb81eb0f70bcd573478f589195e057dcdcce02c)
       '@meshtastic/core':
         specifier: npm:@jsr/meshtastic__core@^2.6.6
         version: '@jsr/meshtastic__core@2.6.6(patch_hash=714af0fd567c3a11b0ee94c68743dce951b199d388f217bd3cb5770a7b3e278a)(buffer@6.0.3)'
@@ -5108,7 +5108,7 @@ snapshots:
     transitivePeerDependencies:
       - buffer
 
-  '@liamcottle/meshcore.js@1.13.0(patch_hash=adc81eb0e938c09ed8436a4dac5717c13b33a1dcfcb1907541cc6347e1dd155a)':
+  '@liamcottle/meshcore.js@1.13.0(patch_hash=54aadb84d0488a89a60e625ffeb81eb0f70bcd573478f589195e057dcdcce02c)':
     dependencies:
       '@noble/curves': 1.9.7
       serialport: 13.0.0

--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe, configureAxe } from 'vitest-axe';
 
 import App from './App';
+import { OFFLINE_MESHCORE_IDENTITY_ID } from './lib/offlineProtocolIdentities';
 import { meshtasticProtocol } from './lib/protocols/MeshtasticProtocol';
 import { MESHCORE_CAPABILITIES, MESHTASTIC_CAPABILITIES } from './lib/radio/BaseRadioProvider';
 import * as providerFactory from './lib/radio/providerFactory';
@@ -23,6 +24,17 @@ function syncMeshtasticMessagesToStore(messages: ChatMessage[]): void {
   }
   useMessageStore.setState((s) => ({
     messages: { ...s.messages, [MESHTASTIC_TEST_IDENTITY]: byId },
+  }));
+}
+
+function syncMeshcoreMessagesToStore(messages: ChatMessage[]): void {
+  const byId: Record<string, ReturnType<typeof chatMessageToMessageRecord>> = {};
+  for (const msg of messages) {
+    const rec = chatMessageToMessageRecord(msg);
+    byId[rec.id] = rec;
+  }
+  useMessageStore.setState((s) => ({
+    messages: { ...s.messages, [OFFLINE_MESHCORE_IDENTITY_ID]: byId },
   }));
 }
 
@@ -802,5 +814,43 @@ describe('App accessibility', () => {
     render(<App />);
 
     expect(screen.queryByText('4')).not.toBeInTheDocument();
+  });
+
+  it('shows MeshCore Sidebar Chat unread badge from store messages on Connection tab', async () => {
+    getStoredMeshProtocolMock.mockReturnValue('meshcore');
+    const selfNodeId = 0x12345678;
+    const ts = Date.now();
+    const messages = [
+      {
+        sender_id: 2,
+        sender_name: 'Alice',
+        payload: 'Ops ping',
+        channel: 1,
+        timestamp: ts,
+        status: 'acked' as const,
+      },
+    ];
+    useMeshCoreMock.mockReturnValue({
+      ...createMeshCoreMock(),
+      state: { status: 'configured', myNodeNum: selfNodeId, connectionType: 'serial' },
+      selfNodeId,
+      channels: [
+        { index: 0, name: 'General', secret: new Uint8Array(16).fill(0x11) },
+        { index: 1, name: 'Ops', secret: new Uint8Array(16).fill(0x22) },
+      ],
+      messages,
+    });
+    syncMeshcoreMessagesToStore(messages);
+    setConnection(OFFLINE_MESHCORE_IDENTITY_ID, {
+      status: 'configured',
+      myNodeNum: selfNodeId,
+      connectionType: 'serial',
+      mqttStatus: 'disconnected',
+    });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Chat 1 unread' })).toBeInTheDocument();
+    });
   });
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,7 +14,7 @@ import {
   loadPersistedLastReadInitial,
   subscribePersistedLastRead,
 } from '@/renderer/lib/chatPanelProtocolStorage';
-import { totalUnreadCount } from '@/renderer/lib/chatUnreadCounts';
+import { filterRegularChatMessages, totalUnreadCount } from '@/renderer/lib/chatUnreadCounts';
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import { meshtasticMqttOwnNodeIds } from '@/renderer/lib/meshtasticMqttIdentity';
 import { remoteConfigChannelRetryRoute } from '@/renderer/lib/meshtasticRemoteAdminSnapshot';
@@ -1566,7 +1566,7 @@ function AppContent({
       protocolRef.current === 'meshcore' && activePanelIndexRef.current === 1 && !document.hidden;
     if (count > prevMeshcoreMsgCountRef.current && !isActiveAndChatOpen) {
       const newMsgs = meshcoreMsgsRef.current.slice(prevMeshcoreMsgCountRef.current);
-      const realNew = newMsgs.filter(
+      const realNew = filterRegularChatMessages(newMsgs, 'meshcore').filter(
         (m) => m.sender_id !== meshcoreSelfIdRef.current && !m.emoji && !m.isHistory,
       );
       if (realNew.length > 0) {

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -1104,8 +1104,8 @@ function ChatPanel({
       clearDraft(protocol, viewKey);
       setMentionQuery(null);
       setReplyTo(null);
-      const now = Date.now();
-      setPersistedLastRead((prev) => ({ ...prev, [viewKey]: now }));
+      // Own sends are excluded from unread counts; do not advance lastRead with Date.now() here —
+      // MeshCore channel rows use device senderTimestamp and a client clock watermark suppresses badges.
       setUnreadDividerTimestamp(0);
     } catch (err) {
       console.error('[ChatPanel] Send failed: ' + errLikeToLogString(err));

--- a/src/renderer/lib/chatUnreadCounts.test.ts
+++ b/src/renderer/lib/chatUnreadCounts.test.ts
@@ -65,4 +65,29 @@ describe('chatUnreadCounts', () => {
     );
     expect(total).toBe(2);
   });
+
+  it('counts device-timestamp message unread despite client-clock lastRead watermark', () => {
+    const clientNow = 1_700_000_000_000;
+    const deviceTs = clientNow - 60_000;
+    const counts = computeChannelUnreadCounts(
+      [msg({ channel: 0, timestamp: deviceTs })],
+      { 'ch:0': clientNow },
+      ownNodes,
+      'meshcore',
+    );
+    expect(counts.get(0)).toBeUndefined();
+  });
+
+  it('excludes MeshCore room BBS posts from channel unread', () => {
+    const total = totalUnreadCount(
+      [
+        msg({ channel: -2, roomServerId: 0xabc, timestamp: 2000 }),
+        msg({ channel: 0, timestamp: 2000 }),
+      ],
+      {},
+      ownNodes,
+      'meshcore',
+    );
+    expect(total).toBe(1);
+  });
 });

--- a/src/renderer/lib/meshcoreChannelText.room.test.ts
+++ b/src/renderer/lib/meshcoreChannelText.room.test.ts
@@ -4,6 +4,7 @@ import { isMeshcoreRoomChatMessage } from '@/renderer/hooks/meshcore/meshcoreHoo
 
 import {
   buildMeshcoreRoomIncomingMessage,
+  formatMeshcoreRoomPostWireText,
   parseMeshcoreRoomPostPayload,
 } from './meshcoreChannelText';
 
@@ -18,6 +19,17 @@ describe('parseMeshcoreRoomPostPayload', () => {
     const parsed = parseMeshcoreRoomPostPayload(raw, map);
     expect(parsed.authorId).toBe(0xdeadbeef);
     expect(parsed.payload).toBe('Hello room');
+  });
+});
+
+describe('formatMeshcoreRoomPostWireText', () => {
+  it('prepends first four pubkey bytes as chars', () => {
+    const pubKey = new Uint8Array(32);
+    pubKey.set([0x01, 0x02, 0x03, 0x04], 0);
+    const wire = formatMeshcoreRoomPostWireText(pubKey, 'Hello room');
+    expect(wire).toBe(String.fromCharCode(0x01, 0x02, 0x03, 0x04) + 'Hello room');
+    const map = new Map<string, number>([['01020304', 0xdeadbeef]]);
+    expect(parseMeshcoreRoomPostPayload(wire, map).payload).toBe('Hello room');
   });
 });
 

--- a/src/renderer/lib/meshcoreChannelText.ts
+++ b/src/renderer/lib/meshcoreChannelText.ts
@@ -560,6 +560,20 @@ export function parseMeshcoreRoomPostPayload(
   return { authorId, payload: text.slice(4) };
 }
 
+/** Build SignedPlain room post wire text (4-byte author pubkey prefix + body). */
+export function formatMeshcoreRoomPostWireText(authorPubKey: Uint8Array, text: string): string {
+  if (authorPubKey.length < 4) {
+    throw new Error('Room post requires at least 4 bytes of author public key');
+  }
+  const prefix = String.fromCharCode(
+    authorPubKey[0] & 0xff,
+    authorPubKey[1] & 0xff,
+    authorPubKey[2] & 0xff,
+    authorPubKey[3] & 0xff,
+  );
+  return prefix + text;
+}
+
 export interface BuildMeshcoreRoomIncomingOpts {
   rawText: string;
   roomServerId: number;

--- a/src/renderer/lib/meshcoreRoomLoginRpc.test.ts
+++ b/src/renderer/lib/meshcoreRoomLoginRpc.test.ts
@@ -82,13 +82,12 @@ function createMockConn(): MeshcoreRoomLoginRpcConnection & {
 }
 
 describe('buildSendLoginFrame', () => {
-  it('encodes empty password as null-terminated 16-byte field', () => {
+  it('encodes empty password as zero-length field (read-only ACL)', () => {
     const key = makePubKey(1);
     const frame = buildSendLoginFrame(key, '');
     expect(frame[0]).toBe(26);
     expect(frame.slice(1, 33)).toEqual(key);
-    expect(frame.slice(33).length).toBe(16);
-    expect(frame[33]).toBe(0);
+    expect(frame.length).toBe(33);
   });
 
   it('encodes non-empty password as variable-length bytes', () => {

--- a/src/renderer/lib/meshcoreRoomLoginRpc.ts
+++ b/src/renderer/lib/meshcoreRoomLoginRpc.ts
@@ -34,23 +34,14 @@ export interface MeshcoreRoomLoginRpcConnection {
   sendToRadioFrame(data: Uint8Array): Promise<void>;
 }
 
-function writeCString(password: string, maxLength: number): Uint8Array {
-  const bytes = new Uint8Array(new ArrayBuffer(maxLength));
-  const encodedString = new TextEncoder().encode(password);
-  for (let i = 0; i < maxLength && i < encodedString.length; i++) {
-    bytes[i] = encodedString[i]!;
-  }
-  bytes[bytes.length - 1] = 0;
-  return bytes;
-}
-
 /** Build SendLogin radio frame (matches patched meshcore.js sendCommandSendLogin). */
 export function buildSendLoginFrame(publicKey: Uint8Array, password: string): Uint8Array {
   if (publicKey.length !== 32) {
     throw new Error('Room login requires a 32-byte public key');
   }
+  // Empty password = read-only ACL login; official Android sends 0 password bytes (writeString('')).
   const passwordField =
-    password.length === 0 ? writeCString(password, 16) : new TextEncoder().encode(password);
+    password.length === 0 ? new Uint8Array(0) : new TextEncoder().encode(password);
   const frame = new Uint8Array(1 + 32 + passwordField.length);
   frame[0] = MC_CMD_SEND_LOGIN;
   frame.set(publicKey, 1);

--- a/src/renderer/lib/meshcoreSendLoginFrame.test.ts
+++ b/src/renderer/lib/meshcoreSendLoginFrame.test.ts
@@ -1,29 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-/** Mirrors patched meshcore.js BufferWriter.writeCString used by SendLogin. */
-function writeCString(password: string, maxLength: number): Uint8Array {
-  const bytes = new Uint8Array(new ArrayBuffer(maxLength));
-  const encodedString = new TextEncoder().encode(password);
-  for (let i = 0; i < maxLength && i < encodedString.length; i++) {
-    bytes[i] = encodedString[i]!;
-  }
-  bytes[bytes.length - 1] = 0;
-  return bytes;
-}
-
 /** Mirrors patched meshcore.js sendCommandSendLogin password field. */
 function buildLoginPasswordField(password: string): Uint8Array {
   if (password.length === 0) {
-    return writeCString(password, 16);
+    return new Uint8Array(0);
   }
   return new TextEncoder().encode(password);
 }
 
 describe('meshcore SendLogin password framing', () => {
-  it('encodes empty password as a null-terminated C string', () => {
+  it('encodes empty password as zero bytes (read-only ACL)', () => {
     const field = buildLoginPasswordField('');
-    expect(field.length).toBe(16);
-    expect(field[0]).toBe(0);
+    expect(field.length).toBe(0);
   });
 
   it('encodes non-empty guest password as variable-length bytes', () => {

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -85,6 +85,8 @@ import type {
 import {
   buildMeshcoreChannelIncomingMessage,
   findMeshcoreDmReplyParent,
+  formatMeshcoreRoomPostWireText,
+  MESHCORE_TXT_TYPE_SIGNED_PLAIN,
   meshcoreChatMessagesForDisplay,
   normalizeMeshcoreIncomingText,
   resolveMeshcoreChannelMessageSender,
@@ -3483,8 +3485,13 @@ export function useMeshcoreRuntime() {
       };
       addMessage(tempMsg);
       try {
+        const authorPubKey = selfInfo?.publicKey;
+        if (!authorPubKey || authorPubKey.length < 4) {
+          throw new Error('Local identity public key unavailable for room post');
+        }
+        const wireText = formatMeshcoreRoomPostWireText(authorPubKey, text);
         const result = await Promise.race([
-          conn.sendTextMessage(pubKey, text),
+          conn.sendTextMessage(pubKey, wireText, MESHCORE_TXT_TYPE_SIGNED_PLAIN),
           new Promise<never>((_, reject) => {
             setTimeout(() => reject(new Error('timeout')), MESHCORE_ROOM_POST_SENT_TIMEOUT_MS);
           }),
@@ -3526,7 +3533,7 @@ export function useMeshcoreRuntime() {
         throw e;
       }
     },
-    [addMessage, fetchAndUpdateLocalStats, selfInfo?.name],
+    [addMessage, fetchAndUpdateLocalStats, selfInfo?.name, selfInfo?.publicKey],
   );
 
   const sendRoomAdminCliCommand = useCallback(


### PR DESCRIPTION
## Summary

- Fix MeshCore Chat unread badges staying at zero while notification beeps still fire: remove post-send `Date.now()` last-read watermark (device timestamps vs client clock) and align background beeps with `filterRegularChatMessages` so room BBS traffic does not alert when Chat badges would not increment.
- Fix read-only room login with blank password: SendLogin uses **0 password bytes** (33-byte frame) to match official Android when the room server guest password is empty; updates meshcore.js patch and `buildSendLoginFrame`.
- Fix room post interoperability: `sendRoomPost` sends **SignedPlain** (`txtType` 2) with 4-byte author pubkey prefix so posts appear in the official Android room BBS.
- Add MeshCore sidebar unread App test, room wire round-trip test, and troubleshooting retest checklist updates.

## Test plan

- [x] `pnpm run test:run` (2342 tests pass)
- [ ] On Connection tab, receive channel message on non-active channel → sidebar **Chat** badge + channel pill when opening Chat
- [ ] Room with empty guest password → blank login succeeds (no LoginFail)
- [ ] Admin room post from mesh-client visible in official Android app on same room