### PR TITLE
fix: MeshCore dedup, tray unread, and room admin relogin

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -243,6 +243,7 @@ beforeEach(() => {
   });
   useMessageStore.setState({ messages: {} });
   useConnectionStore.setState({ connections: {} });
+  vi.mocked(window.electronAPI.setTrayUnread).mockClear();
   registerMeshtasticSession({
     prepareRfConnect: vi.fn().mockResolvedValue(undefined),
     attachRfSession: vi.fn().mockResolvedValue(undefined),
@@ -850,6 +851,115 @@ describe('App accessibility', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'Chat 1 unread' })).toBeInTheDocument();
+    });
+  });
+
+  it('includes MeshCore Rooms unread in the tray unread total', async () => {
+    getStoredMeshProtocolMock.mockReturnValue('meshcore');
+    localStorage.setItem('mesh-client:meshcoreChatUnread', '7');
+    localStorage.setItem('mesh-client:meshcoreRoomsUnread', '99');
+    const selfNodeId = 0x12345678;
+    const messages: ChatMessage[] = [
+      {
+        sender_id: 0x200,
+        sender_name: 'Alice',
+        payload: 'Room ping',
+        channel: -2,
+        timestamp: Date.now(),
+        status: 'acked',
+        roomServerId: 0x1005,
+        to: 0x1005,
+      },
+    ];
+    useMeshCoreMock.mockReturnValue({
+      ...createMeshCoreMock(),
+      state: { status: 'configured', myNodeNum: selfNodeId, connectionType: 'serial' },
+      selfNodeId,
+      messages,
+    });
+    syncMeshcoreMessagesToStore(messages);
+    setConnection(OFFLINE_MESHCORE_IDENTITY_ID, {
+      status: 'configured',
+      myNodeNum: selfNodeId,
+      connectionType: 'serial',
+      mqttStatus: 'disconnected',
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(window.electronAPI.setTrayUnread).toHaveBeenCalledWith(1);
+    });
+    expect(localStorage.getItem('mesh-client:meshcoreRoomsUnread')).toBe('1');
+    expect(localStorage.getItem('mesh-client:meshcoreChatUnread')).toBe('0');
+  });
+
+  it('sums meshtastic chat, meshcore chat, and rooms unread for tray badge', async () => {
+    const ts = Date.now();
+    const meshtasticMessages: ChatMessage[] = [
+      {
+        sender_id: 2,
+        sender_name: 'Alice',
+        payload: 'Meshtastic ping',
+        channel: 0,
+        timestamp: ts,
+        status: 'acked',
+      },
+    ];
+    const meshcoreSelfNodeId = 0x12345678;
+    const meshcoreMessages: ChatMessage[] = [
+      {
+        sender_id: 0x301,
+        sender_name: 'Bob',
+        payload: 'MeshCore ping',
+        channel: 1,
+        timestamp: ts,
+        status: 'acked',
+      },
+      {
+        sender_id: 0x302,
+        sender_name: 'Carol',
+        payload: 'Room ping',
+        channel: -2,
+        timestamp: ts,
+        status: 'acked',
+        roomServerId: 0x1005,
+        to: 0x1005,
+      },
+    ];
+    useDeviceMock.mockReturnValue({
+      ...createDeviceMock(),
+      state: { status: 'configured', myNodeNum: 1, connectionType: 'serial' },
+      selfNodeId: 1,
+      messages: meshtasticMessages,
+    });
+    syncMeshtasticMessagesToStore(meshtasticMessages);
+    useMeshCoreMock.mockReturnValue({
+      ...createMeshCoreMock(),
+      state: {
+        status: 'configured',
+        myNodeNum: meshcoreSelfNodeId,
+        connectionType: 'serial',
+      },
+      selfNodeId: meshcoreSelfNodeId,
+      channels: [
+        { index: 0, name: 'General', secret: new Uint8Array(16).fill(0x11) },
+        { index: 1, name: 'Ops', secret: new Uint8Array(16).fill(0x22) },
+      ],
+      messages: meshcoreMessages,
+    });
+    syncMeshcoreMessagesToStore(meshcoreMessages);
+    setConnection(OFFLINE_MESHCORE_IDENTITY_ID, {
+      status: 'configured',
+      myNodeNum: meshcoreSelfNodeId,
+      connectionType: 'serial',
+      mqttStatus: 'disconnected',
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(window.electronAPI.setTrayUnread).toHaveBeenCalledWith(3);
     });
   });
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -259,6 +259,7 @@ export interface UpdateState {
 
 const MESHTASTIC_UNREAD_KEY = 'mesh-client:meshtasticChatUnread';
 const MESHCORE_UNREAD_KEY = 'mesh-client:meshcoreChatUnread';
+const MESHCORE_ROOMS_UNREAD_KEY = 'mesh-client:meshcoreRoomsUnread';
 const LOG_PANEL_VISIBLE_KEY = 'mesh-client:logPanelVisible';
 /** Legacy key (pre–footer indicator): `checkOnStartup` / `dismissedVersion` — removed on launch so updates always check on startup. */
 const LEGACY_UPDATE_SETTINGS_KEY = 'mesh-client:updateSettings';
@@ -279,6 +280,15 @@ function persistUnread(protocol: 'meshtastic' | 'meshcore', count: number): void
     localStorage.setItem(key, String(n));
   } catch (e) {
     console.debug('[App] persistUnread quota/private mode ' + errLikeToLogString(e));
+  }
+}
+
+function persistMeshcoreRoomsUnread(count: number): void {
+  try {
+    const n = Math.max(0, Math.min(Math.floor(count) || 0, 99999));
+    localStorage.setItem(MESHCORE_ROOMS_UNREAD_KEY, String(n));
+  } catch (e) {
+    console.debug('[App] persistMeshcoreRoomsUnread quota/private mode ' + errLikeToLogString(e));
   }
 }
 
@@ -1677,8 +1687,14 @@ function AppContent({
   }, [meshcoreChatUnread]);
 
   useEffect(() => {
-    window.electronAPI.setTrayUnread(meshtasticChatUnread + meshcoreChatUnread);
-  }, [meshtasticChatUnread, meshcoreChatUnread]);
+    persistMeshcoreRoomsUnread(meshcoreRoomsUnread);
+  }, [meshcoreRoomsUnread]);
+
+  useEffect(() => {
+    window.electronAPI.setTrayUnread(
+      meshtasticChatUnread + meshcoreChatUnread + meshcoreRoomsUnread,
+    );
+  }, [meshtasticChatUnread, meshcoreChatUnread, meshcoreRoomsUnread]);
 
   // ─── Auto flood advert (MeshCore) ────────────────────────────────
   const advertSentRef = useRef(false);

--- a/src/renderer/components/RoomsPanel.test.tsx
+++ b/src/renderer/components/RoomsPanel.test.tsx
@@ -136,6 +136,31 @@ describe('RoomsPanel', () => {
     });
   });
 
+  it('forces admin relogin when managing from a read-only session', async () => {
+    const room = makeRoom(0x100c, 'Admin Elevate Room');
+    const nodes = new Map<number, MeshNode>([[room.node_id, room]]);
+    meshcoreApplyRoomSession(room.node_id, {
+      guestPassword: '',
+      adminPassword: '',
+      role: 'readonly',
+    });
+    const onLoginRoom = vi.fn().mockResolvedValue(undefined);
+    renderRoomsPanel(nodes, { initialRoomTarget: room.node_id, onLoginRoom });
+
+    fireEvent.click(screen.getByText('roomsPanel.manageRoom'));
+
+    await waitFor(() => {
+      expect(onLoginRoom).toHaveBeenCalledWith(
+        room.node_id,
+        'password',
+        expect.objectContaining({
+          adminPassword: 'password',
+          forceRelogin: true,
+        }),
+      );
+    });
+  });
+
   it('shows login form for room B while room A login is in progress', () => {
     meshcoreClearAllRoomSessions();
     const roomA = makeRoom(0x1001, 'Room A');

--- a/src/renderer/components/RoomsPanel.tsx
+++ b/src/renderer/components/RoomsPanel.tsx
@@ -97,6 +97,7 @@ interface Props {
       adminPassword?: string;
       guestPassword?: string;
       rememberPassword?: boolean;
+      forceRelogin?: boolean;
     },
   ) => Promise<void>;
   onLoginAllSaved?: (roomNodeIds: number[]) => Promise<void>;
@@ -773,7 +774,11 @@ export default function RoomsPanel({
       return;
     }
     startRoomLogin(nodeId, async () => {
-      await onLoginRoom(nodeId, adminPassword, { adminPassword, guestPassword });
+      await onLoginRoom(nodeId, adminPassword, {
+        adminPassword,
+        guestPassword,
+        forceRelogin: true,
+      });
       setManageOpen(true);
     });
   }, [

--- a/src/renderer/hooks/meshcore/meshcoreHookPreamble.crossTransport.test.ts
+++ b/src/renderer/hooks/meshcore/meshcoreHookPreamble.crossTransport.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { meshcoreChatStubNodeIdFromDisplayName } from '../../lib/meshcoreUtils';
 import type { ChatMessage } from '../../lib/types';
 import {
+  findMeshcoreChannelRfDuplicate,
   findMeshcoreCrossTransportDuplicate,
   findMeshcoreTapbackEchoDuplicate,
   mapMeshcoreCrossTransportUpgrade,
+  MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
   MESHCORE_CROSS_TRANSPORT_DEDUP_WINDOW_MS,
+  meshcoreChannelRfMatch,
   meshcoreCrossTransportMatch,
   meshcoreTapbackEchoMatch,
 } from './meshcoreHookPreamble';
@@ -127,5 +130,47 @@ describe('mapMeshcoreCrossTransportUpgrade', () => {
     const { messages, matched } = mapMeshcoreCrossTransportUpgrade([msg], unrelated);
     expect(matched).toBe(false);
     expect(messages[0]).toBe(msg);
+  });
+});
+
+describe('meshcoreChannelRfMatch', () => {
+  it('matches two RF hears on the same channel within the window', () => {
+    const first = baseMsg({ receivedVia: 'rf', timestamp: 1_700_000_000_000 });
+    const replay = baseMsg({
+      receivedVia: 'rf',
+      timestamp: first.timestamp + 60_000,
+    });
+    expect(meshcoreChannelRfMatch(first, replay)).toBe(true);
+    expect(findMeshcoreChannelRfDuplicate([first], replay)).toBe(first);
+  });
+
+  it('does not match when timestamps exceed the window', () => {
+    const first = baseMsg({ receivedVia: 'rf', timestamp: 0 });
+    const replay = baseMsg({
+      receivedVia: 'rf',
+      timestamp: MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS + 1,
+    });
+    expect(meshcoreChannelRfMatch(first, replay)).toBe(false);
+  });
+
+  it('does not match RF replay when the first row was MQTT-only', () => {
+    const mqtt = baseMsg({ receivedVia: 'mqtt', timestamp: 0 });
+    const rf = baseMsg({
+      receivedVia: 'rf',
+      timestamp: 60_000,
+    });
+    expect(meshcoreChannelRfMatch(mqtt, rf)).toBe(false);
+    expect(meshcoreCrossTransportMatch(mqtt, rf)).toBe(true);
+  });
+
+  it('does not match room posts or DMs', () => {
+    const channel = baseMsg({ receivedVia: 'rf', channel: 0 });
+    const dm = baseMsg({
+      receivedVia: 'rf',
+      channel: -1,
+      to: 0xdeadbeef,
+      timestamp: channel.timestamp + 1_000,
+    });
+    expect(meshcoreChannelRfMatch(channel, dm)).toBe(false);
   });
 });

--- a/src/renderer/hooks/meshcore/meshcoreHookPreamble.ts
+++ b/src/renderer/hooks/meshcore/meshcoreHookPreamble.ts
@@ -25,7 +25,19 @@ import {
   pubkeyToNodeId,
 } from '../../lib/meshcoreUtils';
 import { mergeMeshcoreLastHeardFromAdvert } from '../../lib/nodeStatus';
-import { MESHCORE_ROOM_POST_DEDUP_WINDOW_MS } from '../../lib/timeConstants';
+import {
+  MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
+  MESHCORE_CROSS_TRANSPORT_DEDUP_WINDOW_MS,
+  MESHCORE_ROOM_POST_DEDUP_WINDOW_MS,
+  MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS,
+} from '../../lib/timeConstants';
+
+export {
+  MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
+  MESHCORE_CROSS_TRANSPORT_DEDUP_WINDOW_MS,
+  MESHCORE_ROOM_POST_DEDUP_WINDOW_MS,
+  MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS,
+} from '../../lib/timeConstants';
 import type { ChatMessage, DeviceState, MeshNode } from '../../lib/types';
 
 /** MeshCore expected ACK CRCs are uint32; meshcore.js / BLE may surface them as signed. Normalize for Map keys, React state, and SQLite packet_id. */
@@ -277,7 +289,6 @@ export function meshcoreMessageDedupeKey(msg: ChatMessage): string {
   ].join('|');
 }
 
-export const MESHCORE_CROSS_TRANSPORT_DEDUP_WINDOW_MS = 5_000;
 const MESHCORE_CROSS_TRANSPORT_SCAN_LIMIT = 200;
 
 function normalizeMeshcoreSenderNameForDedup(name: string | undefined): string {
@@ -331,6 +342,56 @@ export function meshcoreCrossTransportMatch(
   return true;
 }
 
+function meshcoreIsBroadcastChannelMessage(msg: ChatMessage): boolean {
+  return msg.channel != null && msg.channel >= 0 && msg.roomServerId == null;
+}
+
+function meshcoreReceivedViaIncludesRf(via: ChatMessage['receivedVia']): boolean {
+  return via === 'rf' || via === 'both';
+}
+
+/** Same broadcast channel text heard again on RF (repeater re-hear), not RF/MQTT cross-path. */
+export function meshcoreChannelRfMatch(
+  existing: ChatMessage,
+  incoming: ChatMessage,
+  windowMs: number = MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
+): boolean {
+  if (
+    !meshcoreIsBroadcastChannelMessage(existing) ||
+    !meshcoreIsBroadcastChannelMessage(incoming)
+  ) {
+    return false;
+  }
+  if (existing.emoji != null || incoming.emoji != null) return false;
+  if (!meshcoreReceivedViaIncludesRf(existing.receivedVia)) return false;
+  if (incoming.receivedVia !== 'rf') return false;
+  if (meshcoreTransportsAreCross(existing, incoming)) return false;
+  if (!meshcoreSenderMatchesForDedup(existing, incoming)) return false;
+  if (existing.channel !== incoming.channel) return false;
+  if ((existing.to ?? undefined) !== (incoming.to ?? undefined)) return false;
+  if ((existing.replyId ?? undefined) !== (incoming.replyId ?? undefined)) return false;
+  const existingBody = existing.meshcoreDedupeKey ?? existing.payload;
+  const incomingBody = incoming.meshcoreDedupeKey ?? incoming.payload;
+  if (existingBody !== incomingBody && existing.payload !== incoming.payload) return false;
+  if (Math.abs(existing.timestamp - incoming.timestamp) > windowMs) return false;
+  return true;
+}
+
+export function findMeshcoreChannelRfDuplicate(
+  messages: readonly ChatMessage[],
+  incoming: ChatMessage,
+  windowMs: number = MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
+): ChatMessage | undefined {
+  const start = Math.max(0, messages.length - MESHCORE_CROSS_TRANSPORT_SCAN_LIMIT);
+  for (let i = messages.length - 1; i >= start; i--) {
+    const existing = messages[i];
+    if (meshcoreChannelRfMatch(existing, incoming, windowMs)) {
+      return existing;
+    }
+  }
+  return undefined;
+}
+
 function meshcoreRoomServerIdForDedup(msg: ChatMessage): number | undefined {
   if (msg.roomServerId != null) return msg.roomServerId;
   if (msg.channel === MESHCORE_ROOM_MESSAGE_CHANNEL && msg.to != null) return msg.to;
@@ -369,8 +430,6 @@ export function findMeshcoreRoomPostDuplicate(
   }
   return undefined;
 }
-
-export const MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS = 30_000;
 
 /** Outbound tapback (local optimistic) vs RF/MQTT echo of `@[Name] emoji` — same transport allowed. */
 export function meshcoreTapbackEchoMatch(

--- a/src/renderer/lib/meshcoreRoomSession.test.ts
+++ b/src/renderer/lib/meshcoreRoomSession.test.ts
@@ -5,6 +5,7 @@ import {
   meshcoreApplyRoomSession,
   meshcoreCancelRoomLogin,
   meshcoreClearAllRoomSessions,
+  meshcoreGetRoomSession,
   meshcoreIsRoomLoggedIn,
   meshcoreIsRoomLoginAbortError,
   meshcoreRoomCanPost,
@@ -72,6 +73,83 @@ describe('meshcoreRoomSession', () => {
     });
     expect(meshcoreIsRoomLoggedIn(42)).toBe(true);
     expect(meshcoreRoomCanPost(42)).toBe(true);
+  });
+
+  it('skips relogin when already logged in without forceRelogin', async () => {
+    meshcoreClearAllRoomSessions();
+    mockRunMeshcoreRoomLogin.mockResolvedValue({ permissions: 2 });
+    const conn = {
+      on: vi.fn(),
+      off: vi.fn(),
+      once: vi.fn(),
+      sendToRadioFrame: vi.fn(),
+    };
+    const pubKey = new Uint8Array(32);
+    meshcoreApplyRoomSession(42, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+
+    await meshcoreRoomLogin(conn, 42, pubKey, 'hello', {
+      guestPassword: 'hello',
+      adminPassword: '',
+    });
+
+    expect(mockRunMeshcoreRoomLogin).not.toHaveBeenCalled();
+    expect(meshcoreGetRoomSession(42)?.role).toBe('readwrite');
+  });
+
+  it('forceRelogin upgrades an existing read-only session to admin', async () => {
+    meshcoreClearAllRoomSessions();
+    mockRunMeshcoreRoomLogin.mockResolvedValue({ permissions: 3 });
+    const conn = {
+      on: vi.fn(),
+      off: vi.fn(),
+      once: vi.fn(),
+      sendToRadioFrame: vi.fn(),
+    };
+    const pubKey = new Uint8Array(32);
+    meshcoreApplyRoomSession(42, {
+      guestPassword: '',
+      adminPassword: '',
+      role: 'readonly',
+    });
+
+    await meshcoreRoomLogin(conn, 42, pubKey, 'password', {
+      guestPassword: '',
+      adminPassword: 'password',
+      forceRelogin: true,
+    });
+
+    expect(mockRunMeshcoreRoomLogin).toHaveBeenCalledTimes(1);
+    expect(meshcoreGetRoomSession(42)?.role).toBe('admin');
+  });
+
+  it('forceRelogin upgrades an existing guest session to admin', async () => {
+    meshcoreClearAllRoomSessions();
+    mockRunMeshcoreRoomLogin.mockResolvedValue({ permissions: 3 });
+    const conn = {
+      on: vi.fn(),
+      off: vi.fn(),
+      once: vi.fn(),
+      sendToRadioFrame: vi.fn(),
+    };
+    const pubKey = new Uint8Array(32);
+    meshcoreApplyRoomSession(42, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+
+    await meshcoreRoomLogin(conn, 42, pubKey, 'password', {
+      guestPassword: 'hello',
+      adminPassword: 'password',
+      forceRelogin: true,
+    });
+
+    expect(mockRunMeshcoreRoomLogin).toHaveBeenCalledTimes(1);
+    expect(meshcoreGetRoomSession(42)?.role).toBe('admin');
   });
 
   it('login throws a helpful message on timeout', async () => {

--- a/src/renderer/lib/meshcoreStoreDedup.test.ts
+++ b/src/renderer/lib/meshcoreStoreDedup.test.ts
@@ -76,6 +76,32 @@ describe('meshcoreStoreDedup', () => {
     expect(useMessageStore.getState().messages[ID]?.[result.canonicalId]?.receivedVia).toBe('both');
   });
 
+  it('merges duplicate RF channel hears within the channel RF window', () => {
+    const tsMs = 1_700_000_020_000;
+    const first = buildMeshcoreChannelIncomingMessage([], {
+      rawText: 'Alice: hello again',
+      senderId: 0xabcd1234,
+      displayName: 'Alice',
+      channel: 0,
+      timestamp: tsMs,
+      receivedVia: 'rf',
+    });
+    upsertMeshcoreMessageWithDedup(ID, first);
+
+    const replay = buildMeshcoreChannelIncomingMessage([], {
+      rawText: 'Alice: hello again',
+      senderId: 0xabcd1234,
+      displayName: 'Alice',
+      channel: 0,
+      timestamp: tsMs + 60_000,
+      receivedVia: 'rf',
+    });
+    const result = upsertMeshcoreMessageWithDedup(ID, replay);
+
+    expect(result.inserted).toBe(false);
+    expect(Object.values(useMessageStore.getState().messages[ID] ?? {})).toHaveLength(1);
+  });
+
   it('assigns room store ids for room server posts', () => {
     const roomId = 0xac200e59;
     const msg = {

--- a/src/renderer/lib/meshcoreStoreDedup.ts
+++ b/src/renderer/lib/meshcoreStoreDedup.ts
@@ -1,4 +1,5 @@
 import {
+  findMeshcoreChannelRfDuplicate,
   findMeshcoreCrossTransportDuplicate,
   findMeshcoreRoomPostDuplicate,
   findMeshcoreTapbackEchoDuplicate,
@@ -295,6 +296,28 @@ export function upsertMeshcoreMessageWithDedup(
     const canonicalId =
       preferredId ??
       findStoreRecordIdForMessage(identityId, crossDup) ??
+      meshcoreMessageStoreId(merged);
+    const record = chatMessageToMessageRecord(merged);
+    record.id = canonicalId;
+    upsertMessage(identityId, record);
+    const altId = meshcoreMessageStoreId(msg);
+    if (altId !== canonicalId) {
+      deleteMessage(identityId, altId);
+    }
+    return { inserted: false, storeUpdated: true, message: merged, canonicalId };
+  }
+
+  const channelRfDup = findMeshcoreChannelRfDuplicate(storeMessages, msg);
+  if (channelRfDup) {
+    const merged: ChatMessage = {
+      ...channelRfDup,
+      ...(meshcorePreferIncomingReplyFields(channelRfDup, msg) ?? {}),
+      receivedVia: mergeMeshcoreReceivedVia(channelRfDup.receivedVia, msg.receivedVia),
+      rxHops: channelRfDup.rxHops ?? msg.rxHops,
+    };
+    const canonicalId =
+      preferredId ??
+      findStoreRecordIdForMessage(identityId, channelRfDup) ??
       meshcoreMessageStoreId(merged);
     const record = chatMessageToMessageRecord(merged);
     record.id = canonicalId;

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -87,8 +87,17 @@ export function computeRoomLoginSentWaitMs(
 /** Cap wait for SendLogin / room post `sendTextMessage` Sent response (meshcore.js has no timeout). */
 export const MESHCORE_ROOM_POST_SENT_TIMEOUT_MS = 45_000;
 
+/** RF vs MQTT duplicate merge for channel/DM text (delayed dual ingress). */
+export const MESHCORE_CROSS_TRANSPORT_DEDUP_WINDOW_MS = 5 * MS_PER_MINUTE;
+
+/** Same broadcast channel message heard twice on RF (repeater re-hear) within this window. */
+export const MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS = 5 * MS_PER_MINUTE;
+
 /** Room post dedup window: optimistic client timestamp vs firmware echo / replay overlap. */
-export const MESHCORE_ROOM_POST_DEDUP_WINDOW_MS = 30_000;
+export const MESHCORE_ROOM_POST_DEDUP_WINDOW_MS = MS_PER_MINUTE;
+
+/** Outbound tapback vs RF/MQTT echo of `@[Name] emoji`. */
+export const MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS = MS_PER_MINUTE;
 
 /** Room login attempts before giving up (matches MeshMonitor loginToRoom). */
 export const MESHCORE_ROOM_LOGIN_MAX_ATTEMPTS = 2;

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -3392,6 +3392,7 @@ export function useMeshcoreRuntime() {
         adminPassword?: string;
         guestPassword?: string;
         rememberPassword?: boolean;
+        forceRelogin?: boolean;
       },
     ): Promise<void> => {
       let pubKey = pubKeyMapRef.current.get(nodeId);
@@ -3431,7 +3432,7 @@ export function useMeshcoreRuntime() {
       if (!conn) {
         throw new Error('Not connected to device');
       }
-      if (meshcoreIsRoomLoggedIn(nodeId)) {
+      if (meshcoreIsRoomLoggedIn(nodeId) && !opts?.forceRelogin) {
         return;
       }
       const guestPassword = opts?.guestPassword ?? password;
@@ -3483,6 +3484,7 @@ export function useMeshcoreRuntime() {
               guestPassword,
               hopsAway,
               companionTransport: meshcoreConnectTypeRef.current,
+              forceRelogin: opts?.forceRelogin,
             });
           });
           if (opts?.rememberPassword) {
@@ -3837,10 +3839,10 @@ export function useMeshcoreRuntime() {
       const storeId = meshcoreIdentityIdRef.current;
       const canonicalId = addMessage(tempMsg);
       try {
-        console.debug(
-          `[useMeshcoreRuntime] sendRoomPost txtType=${MESHCORE_TXT_TYPE_PLAIN} bodyLen=${text.length} room=0x${nodeId.toString(16)}`,
-        );
         const hopsAway = nodesRef.current.get(nodeId)?.hops_away ?? 0;
+        console.debug(
+          `[useMeshcoreRuntime] sendRoomPost mode=post txtType=${MESHCORE_TXT_TYPE_PLAIN} bodyLen=${new TextEncoder().encode(text).length} room=0x${nodeId.toString(16)} hops=${hopsAway} transport=${meshcoreConnectTypeRef.current ?? 'unknown'}`,
+        );
         const session = meshcoreGetRoomSession(nodeId);
         const postOpts = {
           hopsAway,
@@ -3864,6 +3866,9 @@ export function useMeshcoreRuntime() {
             msg.includes('not logged in on the radio') &&
             connRef.current
           ) {
+            console.debug(
+              `[useMeshcoreRuntime] sendRoomPost mode=admin-retry txtType=${MESHCORE_TXT_TYPE_PLAIN} bodyLen=${new TextEncoder().encode(text).length} room=0x${nodeId.toString(16)} hops=${hopsAway} transport=${meshcoreConnectTypeRef.current ?? 'unknown'}`,
+            );
             await repeaterRemoteRpcRef.current(async () => {
               const activeConn = connRef.current;
               if (!activeConn) return;
@@ -3872,6 +3877,7 @@ export function useMeshcoreRuntime() {
                 adminPassword,
                 hopsAway,
                 companionTransport: meshcoreConnectTypeRef.current,
+                forceRelogin: true,
               });
             });
             result = await repeaterRemoteRpcRef.current(sendOnce);


### PR DESCRIPTION
## Summary

- **Message dedup:** Widen MeshCore cross-transport dedup to 5 minutes and add channel RF re-hear merging (same broadcast on RF within 5 min). Room post and tapback echo windows move to 60s via `timeConstants`.
- **Tray unread:** Include MeshCore Rooms unread in `setTrayUnread` (alongside Meshtastic + MeshCore chat). Persist rooms count under `mesh-client:meshcoreRoomsUnread` so chat-only persistence cannot overwrite room state.
- **Room admin elevation:** `forceRelogin` on manage/login and `sendRoomPost` admin-retry so read-only or guest sessions are not skipped when promoting to admin.

## Test plan

- [ ] Receive delayed RF + MQTT duplicates on a MeshCore channel — single chat row, not two.
- [ ] Hear the same channel message twice on RF within ~1 min — merged in chat.
- [ ] Unread in Chat, Rooms, and Meshtastic — tray badge equals sum of all three; sidebar tabs still show per-panel counts.
- [ ] Log into a room as guest, open **Manage room** with admin password — admin session applies (not stuck read-only).
- [ ] Room post after stale read-only session — admin-retry relogin succeeds.
- [ ] `pnpm run test:run` — `App.test.tsx`, `RoomsPanel.test.tsx`, `meshcoreRoomSession.test.ts`, `meshcoreStoreDedup.test.ts`, `meshcoreHookPreamble.crossTransport.test.ts`