### PR TITLE
fix: MeshCore chat UX, contact retention, and identity-scoped store sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,9 +127,9 @@ See **Renderer: hooks vs runtime vs lib** (layout map above). Legacy `useDevice`
 
 Do **not** remount protocol runtimes in child components. Do **not** compare `protocol === 'meshcore'` for feature gates; use `ProtocolCapabilities` / `useRadioProvider(protocol)`.
 
-Protocol SDK adapters: `src/renderer/lib/protocols/`. Connection lifecycle: `ConnectionDriver`; inbound domain events: `PacketRouter` → stores.
+Protocol SDK adapters: `src/renderer/lib/protocols/`. Connection lifecycle: `ConnectionDriver`; inbound domain events: `PacketRouter` → stores. **MeshCore post-router side effects:** `lib/ingest/meshcoreIngest.ts` (chat persist, `last_heard`, path-updated), `lib/meshcore/meshcoreLiveContactPersist.ts` (SQLite contact rows), `lib/meshcore/meshcorePubKeyRegistry.ts` (DM/trace pubkeys mirrored into runtime refs). Live UI nodes/messages read `nodeStore` / `messageStore`; `useMeshcoreRuntime` still keeps hook-local `nodesRef` for send/RPC until contact rebuild syncs it.
 
-**Identity-scoped UI stores:** `identityStore`, `nodeStore`, `messageStore`, `connectionStore` — nodes/messages keyed by `identityId`. **SQLite → UI:** `lib/hydrateIdentityStoresFromDb.ts` (coordinator: `identityHydrationCoordinator.ts`; Meshtastic node map: `meshtasticDbCacheHydration.ts`; message cap: `meshtasticMessageLoadLimit.ts`); manual refresh via `hooks/useDbRefresh.ts`. Runtimes may still merge DB rows into hook-local refs on connect; identity-scoped Zustand hydration is the canonical UI path ([#375]).
+**Identity-scoped UI stores:** `identityStore`, `nodeStore`, `messageStore`, `connectionStore` — nodes/messages keyed by `identityId`. **SQLite → UI:** `lib/hydrateIdentityStoresFromDb.ts` (coordinator: `identityHydrationCoordinator.ts`; Meshtastic node map: `meshtasticDbCacheHydration.ts`; message cap: `meshtasticMessageLoadLimit.ts`); manual refresh via `hooks/useDbRefresh.ts`. Runtimes may still merge DB rows into hook-local refs on connect; identity-scoped Zustand hydration is the canonical UI path ([#375]). **MeshCore contacts DB:** `meshcore_contacts.last_advert` is Unix **seconds**; age prune uses `src/shared/meshcoreContactAgeCutoff.ts` (do not compare in ms).
 
 ### First places to look
 

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -282,6 +282,15 @@ describe('saveMeshcoreContact UPSERT COALESCE preservation', () => {
       /public_key = CASE WHEN excluded\.public_key IS NOT NULL AND excluded\.public_key != '' AND LENGTH\(excluded\.public_key\) = 64 THEN excluded\.public_key ELSE meshcore_contacts\.public_key END/,
     );
   });
+
+  it('uses meshcoreContactsAgeCutoffSec for deleteMeshcoreContactsByAge (Unix seconds)', () => {
+    expect(DATABASE_SOURCE).toMatch(
+      /deleteMeshcoreContactsByAge[\s\S]*meshcoreContactsAgeCutoffSec\(days\)/,
+    );
+    expect(DATABASE_SOURCE).not.toMatch(
+      /deleteMeshcoreContactsByAge[\s\S]*Date\.now\(\) - days \* MS_PER_DAY/,
+    );
+  });
 });
 
 describe('escapeSqlLikePattern', () => {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2,6 +2,7 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
+import { meshcoreContactsAgeCutoffSec } from '../shared/meshcoreContactAgeCutoff';
 import {
   MESHCORE_PATH_HISTORY_GLOBAL_ROW_LIMIT,
   MESHCORE_PATH_HISTORY_PER_NODE_ROW_LIMIT,
@@ -102,14 +103,16 @@ export function deleteMeshcoreContactsNeverAdvertised(): number {
   return Number(result.changes);
 }
 
+export { meshcoreContactsAgeCutoffSec } from '../shared/meshcoreContactAgeCutoff';
+
 export function deleteMeshcoreContactsByAge(days: number): number {
   const d = getDatabase();
-  const cutoff = Date.now() - days * MS_PER_DAY;
+  const cutoffSec = meshcoreContactsAgeCutoffSec(days);
   const result = d
     .prepareOnce(
       'DELETE FROM meshcore_contacts WHERE last_advert IS NOT NULL AND last_advert < ? AND (favorited IS NULL OR favorited = 0)',
     )
-    .run(cutoff);
+    .run(cutoffSec);
   return Number(result.changes);
 }
 

--- a/src/main/meshcore-contact-age-prune.test.ts
+++ b/src/main/meshcore-contact-age-prune.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { meshcoreContactsAgeCutoffSec } from '../shared/meshcoreContactAgeCutoff';
+import { NodeSqliteDB } from './db-compat';
+import { runSchemaUpgrade } from './db-schema-sync';
+
+const RECENT_PUBKEY = 'aa'.repeat(32);
+const STALE_PUBKEY = 'bb'.repeat(32);
+
+describe('meshcore_contacts age prune SQL cutoff', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  it('deletes only non-favorited contacts older than the cutoff (Unix seconds)', () => {
+    const nowMs = 1_750_000_000_000;
+    const cutoffSec = meshcoreContactsAgeCutoffSec(30, nowMs);
+    const recentSec = Math.floor(nowMs / 1000) - 86400;
+    const staleSec = cutoffSec - 86_400;
+
+    dir = mkdtempSync(join(tmpdir(), 'mesh-mc-age-prune-'));
+    const db = new NodeSqliteDB(join(dir, 'test.db'));
+    db.pragma('journal_mode = WAL');
+    runSchemaUpgrade(db);
+
+    const insert = db.prepareOnce(
+      `INSERT INTO meshcore_contacts (node_id, public_key, last_advert, favorited, on_radio)
+       VALUES (?, ?, ?, 0, 0)`,
+    );
+    insert.run(0x1111, RECENT_PUBKEY, recentSec);
+    insert.run(0x2222, STALE_PUBKEY, staleSec);
+    insert.run(0x3333, 'cc'.repeat(32), staleSec);
+    db.prepareOnce('UPDATE meshcore_contacts SET favorited = 1 WHERE node_id = ?').run(0x3333);
+
+    const deleted = db
+      .prepareOnce(
+        `DELETE FROM meshcore_contacts
+         WHERE last_advert IS NOT NULL AND last_advert < ?
+           AND (favorited IS NULL OR favorited = 0)`,
+      )
+      .run(cutoffSec).changes;
+
+    expect(deleted).toBe(1);
+    const remaining = db
+      .prepareOnce('SELECT node_id FROM meshcore_contacts ORDER BY node_id')
+      .all() as { node_id: number }[];
+    expect(remaining.map((r) => r.node_id)).toEqual([0x1111, 0x3333]);
+    db.close();
+  });
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -890,14 +890,22 @@ function AppContent({
     return ensureMeshcoreChatLastReadSanitized(meshcoreUiMessages);
   }, [lastReadRevision.meshcore, meshcoreUiMessages]);
 
+  const meshcoreChatUnreadDmOptions = useMemo(
+    () => ({
+      excludeDmPeer: (peer: number) => meshcoreUiNodes.get(peer)?.hw_model === 'Room',
+    }),
+    [meshcoreUiNodes],
+  );
+
   const meshcoreChatUnread = useMemo(() => {
     return totalUnreadCount(
       meshcoreUiMessages,
       meshcoreChatLastRead,
       meshcoreOwnNodeIdSet,
       'meshcore',
+      meshcoreChatUnreadDmOptions,
     );
-  }, [meshcoreChatLastRead, meshcoreOwnNodeIdSet, meshcoreUiMessages]);
+  }, [meshcoreChatLastRead, meshcoreChatUnreadDmOptions, meshcoreOwnNodeIdSet, meshcoreUiMessages]);
 
   const meshcoreRoomsUnread = useMemo(() => {
     void roomsLastReadRevision;

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -391,7 +391,7 @@ describe('ChatPanel accessibility', () => {
     expect(screen.getByRole('button', { name: 'Alice' })).toBeInTheDocument();
     await user.click(screen.getByTitle('Close DM'));
     await waitFor(() => {
-      expect(screen.queryByRole('button', { name: 'Alice' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Alice' })).toBeInTheDocument();
     });
 
     rerender(
@@ -494,6 +494,7 @@ describe('ChatPanel accessibility', () => {
   it('allows closing inferred DM tab in MeshCore and does not resurface without new messages', async () => {
     const user = userEvent.setup();
     const ts = Date.now();
+    localStorage.setItem('mesh-client:lastRead:meshcore', JSON.stringify({ 'dm:2': ts }));
     const messages = [
       {
         sender_id: 2,
@@ -1079,6 +1080,128 @@ describe('ChatPanel unread watermarks', () => {
     nodes: new Map(),
     isActive: true,
   };
+
+  it('keeps DM tab open after unread clears when conversation was opened via DM tab', async () => {
+    const user = userEvent.setup();
+    const ts = Date.now();
+    const nodes = new Map([
+      [
+        2,
+        {
+          node_id: 2,
+          long_name: 'Alice',
+          short_name: 'Alice',
+          hw_model: '',
+          snr: 0,
+          battery: 0,
+          last_heard: ts,
+          latitude: null,
+          longitude: null,
+        },
+      ],
+    ]);
+    const { rerender } = render(
+      <ToastProvider>
+        <ChatPanel
+          {...baseProps}
+          protocol="meshcore"
+          myNodeNum={0x12345678}
+          ownNodeIds={[0x12345678]}
+          nodes={nodes}
+          messages={[
+            {
+              sender_id: 2,
+              sender_name: 'Alice',
+              payload: 'DM ping',
+              channel: 0,
+              timestamp: ts,
+              status: 'acked',
+              to: 0x12345678,
+            },
+          ]}
+        />
+      </ToastProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Alice' }));
+
+    rerender(
+      <ToastProvider>
+        <ChatPanel
+          {...baseProps}
+          protocol="meshcore"
+          myNodeNum={0x12345678}
+          ownNodeIds={[0x12345678]}
+          nodes={nodes}
+          messages={[
+            {
+              sender_id: 0x12345678,
+              sender_name: 'Me',
+              payload: 'My reply',
+              channel: 0,
+              timestamp: ts + 1,
+              status: 'acked',
+              to: 2,
+            },
+          ]}
+        />
+      </ToastProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Alice' })).toBeInTheDocument();
+    });
+  });
+
+  it('keeps dismissed DM tab visible while unread remains', async () => {
+    const user = userEvent.setup();
+    const ts = Date.now();
+    render(
+      <ToastProvider>
+        <ChatPanel
+          {...baseProps}
+          protocol="meshcore"
+          myNodeNum={0x12345678}
+          ownNodeIds={[0x12345678]}
+          nodes={
+            new Map([
+              [
+                2,
+                {
+                  node_id: 2,
+                  long_name: 'Alice',
+                  short_name: 'Alice',
+                  hw_model: '',
+                  snr: 0,
+                  battery: 0,
+                  last_heard: ts,
+                  latitude: null,
+                  longitude: null,
+                },
+              ],
+            ])
+          }
+          messages={[
+            {
+              sender_id: 2,
+              sender_name: 'Alice',
+              payload: 'DM ping',
+              channel: 0,
+              timestamp: ts,
+              status: 'acked',
+              to: 0x12345678,
+            },
+          ]}
+        />
+      </ToastProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Alice' })).toBeInTheDocument();
+    await user.click(screen.getByTitle('Close DM'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Alice' })).toBeInTheDocument();
+    });
+  });
 
   it('clears a non-primary channel badge after that channel is viewed', async () => {
     const user = userEvent.setup();

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -41,7 +41,11 @@ import {
   type StarredMessage,
 } from '../lib/chatPanelProtocolStorage';
 import { getDistFromChatBottom } from '../lib/chatScrollUtils';
-import { computeChannelUnreadCounts, computeDmUnreadCounts } from '../lib/chatUnreadCounts';
+import {
+  type ChatUnreadDmOptions,
+  computeChannelUnreadCounts,
+  computeDmUnreadCounts,
+} from '../lib/chatUnreadCounts';
 import {
   findMeshcoreParentMessageForReply,
   meshcoreChatMessagesForDisplay,
@@ -383,6 +387,17 @@ function ChatPanel({
 
   const isOwnNode = useCallback((nodeId: number) => ownNodeIdSet.has(nodeId), [ownNodeIdSet]);
 
+  const meshcoreExcludeDmPeer = useMemo((): ChatUnreadDmOptions['excludeDmPeer'] | undefined => {
+    if (protocol !== 'meshcore') return undefined;
+    return (peer: number) => nodes.get(peer)?.hw_model === 'Room';
+  }, [nodes, protocol]);
+
+  const chatUnreadDmOptions = useMemo(
+    (): ChatUnreadDmOptions | undefined =>
+      meshcoreExcludeDmPeer ? { excludeDmPeer: meshcoreExcludeDmPeer } : undefined,
+    [meshcoreExcludeDmPeer],
+  );
+
   const composerSelfDisplayName = useMemo(() => {
     if (protocol !== 'meshcore') return undefined;
     return nodeDisplayName(nodes.get(myNodeNum), protocol) || undefined;
@@ -596,26 +611,37 @@ function ChatPanel({
     return peers;
   }, [regularMessages, resolveDmPeer]);
 
+  /** Incoming DM messages per peer newer than persisted last-read for `dm:${peer}` (channel unread map skips DMs). */
+  const dmUnreadCounts = useMemo(
+    () =>
+      computeDmUnreadCounts(
+        unreadSourceMessages,
+        persistedLastRead,
+        ownNodeIdSet,
+        protocol,
+        chatUnreadDmOptions,
+      ),
+    [chatUnreadDmOptions, ownNodeIdSet, persistedLastRead, protocol, unreadSourceMessages],
+  );
+
   const visibleDmTabs = useMemo(() => {
     const all = new Set(openDmTabs);
+    if (activeDmNode != null) all.add(activeDmNode);
     for (const [nodeNum, dmCount] of inferredDmTabs) {
       const dismissedCount = dismissedDmTabs[nodeNum] ?? 0;
       if (dmCount > dismissedCount) {
         all.add(nodeNum);
       }
     }
+    for (const [nodeNum, unread] of dmUnreadCounts) {
+      if (unread > 0) all.add(nodeNum);
+    }
     return Array.from(all).filter(
       (nodeNum) => protocol !== 'meshtastic' || !isMeshtasticBroadcastNodeNum(nodeNum),
     );
-  }, [openDmTabs, inferredDmTabs, dismissedDmTabs, protocol]);
+  }, [activeDmNode, openDmTabs, inferredDmTabs, dismissedDmTabs, dmUnreadCounts, protocol]);
 
   const inferredDmTabSet = useMemo(() => new Set(inferredDmTabs.keys()), [inferredDmTabs]);
-
-  /** Incoming DM messages per peer newer than persisted last-read for `dm:${peer}` (channel unread map skips DMs). */
-  const dmUnreadCounts = useMemo(
-    () => computeDmUnreadCounts(unreadSourceMessages, persistedLastRead, ownNodeIdSet, protocol),
-    [ownNodeIdSet, persistedLastRead, protocol, unreadSourceMessages],
-  );
 
   // Meshtastic / MeshCore quoted replies use protocol-specific parent lookup (see quote render below).
 
@@ -1408,8 +1434,7 @@ function ChatPanel({
                       : 'text-muted hover:text-gray-200'
                   }`}
                   onClick={() => {
-                    setActiveDmNode(nodeNum);
-                    setViewMode('dm');
+                    openDmTo(nodeNum);
                   }}
                 >
                   {getDmLabel(nodeNum)}

--- a/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
+++ b/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
@@ -123,6 +123,8 @@ export function attachMeshcoreLegacyConnEvents(
   conn: MeshCoreConnection,
   ctx: MeshcoreLegacyConnEventsCtx,
 ): () => void {
+  // Driver + MeshCoreProtocol own 128/7/8/129/138/rx when identity ingest is active; handlers
+  // below for those codes are legacy fallbacks (e.g. pre-driver connect). Event 130 stays here.
   const protocolOwnedEvents = new Set<string | number>([128, 7, 8, 129, 138, 'rx']);
   const {
     meshcoreIdentityIdRef,

--- a/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
+++ b/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
@@ -1,4 +1,5 @@
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
+import { isMeshtasticBroadcastNodeNum } from '@/shared/nodeNameUtils';
 
 import { parseMeshCoreRfPacket } from '../../../shared/meshcoreRfPacketParse';
 import {
@@ -67,7 +68,7 @@ import { getStoredMeshProtocol } from '../../lib/storedMeshProtocol';
 import { MESHCORE_RAW_SELF_FLOOD_ADVERT_COALESCE_MS } from '../../lib/timeConstants';
 import type { ChatMessage, IdentityId, MeshNode, TelemetryPoint } from '../../lib/types';
 import { useDiagnosticsStore } from '../../stores/diagnosticsStore';
-import { updateMessageStatus, useMessageStore } from '../../stores/messageStore';
+import { renameMessageId, updateMessageStatus, useMessageStore } from '../../stores/messageStore';
 import { usePathHistoryStore } from '../../stores/pathHistoryStore';
 import { usePositionHistoryStore } from '../../stores/positionHistoryStore';
 import {
@@ -81,21 +82,41 @@ import {
 } from './meshcoreHookPreamble';
 import type { MeshcoreLegacyConnEventsCtx } from './meshcoreLegacyConnEventsCtx';
 
+function isOutboundMeshcoreDmRecord(rec: { from: number; to: number; status?: string }): boolean {
+  return rec.to !== 0xffffffff && !isMeshtasticBroadcastNodeNum(rec.to) && rec.to > 0;
+}
+
 /** Identity-scoped chat rows from {@link useSendMessage} use numeric ids after rename. */
-function syncMeshcoreDmAckToMessageStore(
+export function syncMeshcoreDmAckToMessageStore(
   identityId: IdentityId,
   ackKeyU32: number,
   selfId: number,
   newStatus: 'acked' | 'failed',
-): void {
+): boolean {
   const byId = useMessageStore.getState().messages[identityId] ?? {};
+  let matched = false;
   for (const [id, rec] of Object.entries(byId)) {
     if (rec.from !== selfId) continue;
     if (rec.status !== 'sending' && rec.status !== 'failed') continue;
     if (!/^\d+$/.test(id)) continue;
     if (meshcoreDmAckKeyU32(Number(id)) !== ackKeyU32) continue;
     updateMessageStatus(identityId, id, newStatus);
+    matched = true;
   }
+  if (matched) return true;
+
+  const inflight = Object.entries(byId).filter(
+    ([, rec]) => rec.status === 'sending' && rec.from === selfId && isOutboundMeshcoreDmRecord(rec),
+  );
+  if (inflight.length !== 1) return false;
+
+  const [id] = inflight[0];
+  const ackId = String(ackKeyU32);
+  if (id !== ackId) {
+    renameMessageId(identityId, id, ackId);
+  }
+  updateMessageStatus(identityId, ackId, newStatus);
+  return true;
 }
 
 export function attachMeshcoreLegacyConnEvents(
@@ -506,6 +527,7 @@ export function attachMeshcoreLegacyConnEvents(
       const lateKey = meshcoreDmAckKeyU32(d.ackCode);
       const selfId = myNodeNumRef.current;
       const newStatus = isNack ? 'failed' : 'acked';
+      const storeId = meshcoreIdentityIdRef.current;
       const hadLateOutbound = messagesRef.current.some(
         (m) =>
           m.packetId != null &&
@@ -514,40 +536,30 @@ export function attachMeshcoreLegacyConnEvents(
           m.to != null &&
           (m.status === 'sending' || m.status === 'failed'),
       );
-      const storeId = meshcoreIdentityIdRef.current;
-      const hadLateInMessageStore =
-        storeId != null &&
-        Object.entries(useMessageStore.getState().messages[storeId] ?? {}).some(
-          ([id, rec]) =>
-            rec.from === selfId &&
-            (rec.status === 'sending' || rec.status === 'failed') &&
-            /^\d+$/.test(id) &&
-            meshcoreDmAckKeyU32(Number(id)) === lateKey,
+      if (hadLateOutbound) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.packetId != null &&
+            meshcoreDmAckKeyU32(m.packetId) === lateKey &&
+            m.sender_id === selfId &&
+            m.to != null &&
+            (m.status === 'sending' || m.status === 'failed')
+              ? { ...m, status: newStatus }
+              : m,
+          ),
         );
-      if (hadLateOutbound || hadLateInMessageStore) {
-        if (hadLateOutbound) {
-          setMessages((prev) =>
-            prev.map((m) =>
-              m.packetId != null &&
-              meshcoreDmAckKeyU32(m.packetId) === lateKey &&
-              m.sender_id === selfId &&
-              m.to != null &&
-              (m.status === 'sending' || m.status === 'failed')
-                ? { ...m, status: newStatus }
-                : m,
-            ),
-          );
-        }
-        if (storeId) syncMeshcoreDmAckToMessageStore(storeId, lateKey, selfId, newStatus);
-        void window.electronAPI.db
-          .updateMeshcoreMessageStatus(lateKey, newStatus)
-          .catch((e: unknown) => {
-            console.warn(
-              '[useMeshcoreRuntime] updateMeshcoreMessageStatus (late 130) error ' +
-                errLikeToLogString(e),
-            );
-          });
       }
+      if (storeId) {
+        syncMeshcoreDmAckToMessageStore(storeId, lateKey, selfId, newStatus);
+      }
+      void window.electronAPI.db
+        .updateMeshcoreMessageStatus(lateKey, newStatus)
+        .catch((e: unknown) => {
+          console.warn(
+            '[useMeshcoreRuntime] updateMeshcoreMessageStatus (late 130) error ' +
+              errLikeToLogString(e),
+          );
+        });
       return;
     }
     clearTimeout(pending.timeoutId);

--- a/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
+++ b/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
@@ -123,7 +123,7 @@ export function attachMeshcoreLegacyConnEvents(
   conn: MeshCoreConnection,
   ctx: MeshcoreLegacyConnEventsCtx,
 ): () => void {
-  const protocolOwnedEvents = new Set<string | number>([128, 7, 8, 138, 'rx']);
+  const protocolOwnedEvents = new Set<string | number>([128, 7, 8, 129, 138, 'rx']);
   const {
     meshcoreIdentityIdRef,
     connRef,

--- a/src/renderer/hooks/useMeshcoreRuntime.db-pubkey-backfill.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.db-pubkey-backfill.test.tsx
@@ -239,6 +239,43 @@ describe('useMeshcoreRuntime DB pubkey backfill for DM send', () => {
       }),
     );
   });
+
+  it('refreshContacts backfills pubkeys from SQLite when radio returns no contacts', async () => {
+    const port = makeMockSerialPort();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: {
+        requestPort: vi.fn().mockResolvedValue(port),
+      },
+    });
+
+    const { result } = renderHook(() => useMeshcoreRuntime());
+
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    sendTextMessageMock.mockClear();
+    vi.mocked(window.electronAPI.db.markAllMeshcoreContactsOffRadio).mockClear();
+
+    await act(async () => {
+      await result.current.refreshContacts();
+    });
+
+    expect(window.electronAPI.db.markAllMeshcoreContactsOffRadio).toHaveBeenCalled();
+    expect(window.electronAPI.db.getMeshcoreContacts).toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.sendMessage('after-refresh-dm', 0, PEER_NODE_ID);
+    });
+
+    expect(sendTextMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendTextMessageMock.mock.calls[0]?.[0]).toEqual(pubKeyBytesFromHex(PEER_PUBKEY_HEX));
+  });
 });
 
 describe('useMeshcoreRuntime DM reply (wire + persistence)', () => {

--- a/src/renderer/hooks/useMeshcoreRuntime.offload-contacts.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.offload-contacts.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Regression: offload must persist radio contact pubkeys to SQLite before removeContact.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { pubkeyToNodeId } from '../lib/meshcoreUtils';
+
+vi.spyOn(console, 'warn').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+const MOCK_USB_VENDOR_ID = 0x1234;
+const MOCK_USB_PRODUCT_ID = 0x5678;
+const PEER_PUBKEY_HEX = '0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20';
+const SELF_PUBKEY = new Uint8Array(32).fill(0xcd);
+
+function pubKeyBytesFromHex(hex: string): Uint8Array {
+  const b = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    b[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return b;
+}
+
+const PEER_PUBKEY = pubKeyBytesFromHex(PEER_PUBKEY_HEX);
+const PEER_NODE_ID = pubkeyToNodeId(PEER_PUBKEY);
+const MY_NODE_ID = pubkeyToNodeId(SELF_PUBKEY);
+
+const offloadCallOrder: string[] = [];
+const getContactsMock = vi.fn();
+const getSelfInfoMock = vi.fn();
+const removeContactMock = vi.fn();
+
+vi.mock('@liamcottle/meshcore.js', () => {
+  class MockWebSerialConnection {
+    constructor(port: unknown) {
+      void port;
+    }
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+    close = vi.fn().mockResolvedValue(undefined);
+    getSelfInfo = getSelfInfoMock;
+    getContacts = getContactsMock;
+    removeContact = removeContactMock;
+    getChannels = vi.fn().mockResolvedValue([]);
+    deviceQuery = vi.fn().mockResolvedValue({
+      firmwareVer: 1,
+      firmware_build_date: 'test',
+      manufacturerModel: 'test',
+    });
+    syncDeviceTime = vi.fn().mockResolvedValue(undefined);
+    getBatteryVoltage = vi.fn().mockResolvedValue({ batteryMilliVolts: 4200 });
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
+  }
+
+  class MockSerialConnection {
+    async write(bytes: Uint8Array) {
+      await Promise.resolve();
+      void bytes;
+    }
+    async onDataReceived(value: Uint8Array) {
+      await Promise.resolve();
+      void value;
+    }
+    async onConnected() {
+      await Promise.resolve();
+    }
+    onDisconnected() {
+      return undefined;
+    }
+    async close() {
+      await Promise.resolve();
+    }
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
+  }
+
+  class MockConnection {
+    async write(bytes: Uint8Array) {
+      await Promise.resolve();
+      void bytes;
+    }
+    async sendToRadioFrame(data: Uint8Array) {
+      await Promise.resolve();
+      void data;
+    }
+    async onConnected() {
+      await Promise.resolve();
+    }
+    onDisconnected() {
+      return undefined;
+    }
+    onFrameReceived() {
+      return undefined;
+    }
+    async close() {
+      await Promise.resolve();
+    }
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+  }
+
+  return {
+    CayenneLpp: { parse: vi.fn().mockReturnValue([]) },
+    Connection: MockConnection,
+    SerialConnection: MockSerialConnection,
+    WebSerialConnection: MockWebSerialConnection,
+  };
+});
+
+import { useMeshcoreRuntime } from '../runtime/useMeshcoreRuntime';
+
+function makeMockSerialPort() {
+  return {
+    open: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    getInfo: vi
+      .fn()
+      .mockReturnValue({ usbVendorId: MOCK_USB_VENDOR_ID, usbProductId: MOCK_USB_PRODUCT_ID }),
+  };
+}
+
+describe('useMeshcoreRuntime offloadContactsFromRadio', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    offloadCallOrder.length = 0;
+    getSelfInfoMock.mockResolvedValue({
+      name: 'SelfRadio',
+      publicKey: SELF_PUBKEY,
+      type: 1,
+      txPower: 22,
+      radioFreq: 902_000_000,
+    });
+    getContactsMock.mockResolvedValue([
+      {
+        publicKey: PEER_PUBKEY,
+        type: 1,
+        advName: 'PeerOffload',
+        lastAdvert: 1_700_000_000,
+        advLat: 0,
+        advLon: 0,
+        flags: 0,
+        outPathLen: 0,
+        outPath: new Uint8Array(0),
+      },
+      {
+        publicKey: SELF_PUBKEY,
+        type: 1,
+        advName: 'SelfRadio',
+        lastAdvert: 1_700_000_000,
+        advLat: 0,
+        advLon: 0,
+        flags: 0,
+        outPathLen: 0,
+        outPath: new Uint8Array(0),
+      },
+    ]);
+    removeContactMock.mockImplementation(() => {
+      offloadCallOrder.push('remove');
+      return Promise.resolve();
+    });
+    vi.mocked(window.electronAPI.db.saveMeshcoreContactsBatch).mockImplementation(() => {
+      offloadCallOrder.push('batch');
+      return Promise.resolve(0);
+    });
+    vi.mocked(window.electronAPI.db.getMeshcoreMessages).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getNodes).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.markAllMeshcoreContactsOffRadio).mockResolvedValue({
+      changes: 0,
+    });
+  });
+
+  it('awaits saveMeshcoreContactsBatch before removeContact', async () => {
+    const port = makeMockSerialPort();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: { requestPort: vi.fn().mockResolvedValue(port) },
+    });
+
+    const { result } = renderHook(() => useMeshcoreRuntime());
+
+    await act(async () => {
+      await result.current.connect('serial');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe('configured');
+    });
+
+    offloadCallOrder.length = 0;
+    vi.mocked(window.electronAPI.db.saveMeshcoreContactsBatch).mockClear();
+    removeContactMock.mockClear();
+    vi.mocked(window.electronAPI.db.saveMeshcoreContactsBatch).mockImplementation(() => {
+      offloadCallOrder.push('batch');
+      return Promise.resolve(0);
+    });
+    removeContactMock.mockImplementation(() => {
+      offloadCallOrder.push('remove');
+      return Promise.resolve();
+    });
+
+    await act(async () => {
+      const removed = await result.current.offloadContactsFromRadio();
+      expect(removed).toBe(1);
+    });
+
+    expect(offloadCallOrder).toEqual(['batch', 'remove']);
+    expect(vi.mocked(window.electronAPI.db.saveMeshcoreContactsBatch)).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          node_id: PEER_NODE_ID,
+          public_key: PEER_PUBKEY_HEX,
+          on_radio: 1,
+        }),
+      ]),
+    );
+    expect(removeContactMock).toHaveBeenCalledWith(PEER_PUBKEY);
+    expect(removeContactMock).not.toHaveBeenCalledWith(SELF_PUBKEY);
+    void MY_NODE_ID;
+  });
+});

--- a/src/renderer/hooks/useSendMessage.test.ts
+++ b/src/renderer/hooks/useSendMessage.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { connectionDriver } from '../lib/drivers/ConnectionDriver';
 import { meshcoreProtocol } from '../lib/protocols/MeshCoreProtocol';
 import { meshtasticProtocol } from '../lib/protocols/MeshtasticProtocol';
+import { registerMeshcoreSession } from '../lib/sessions/meshcoreSession';
 import {
   type MeshtasticSessionApi,
   registerMeshtasticSession,
@@ -11,8 +12,10 @@ import {
 import { setConnection } from '../stores/connectionStore';
 import { addIdentity, useIdentityStore } from '../stores/identityStore';
 import { useMessageStore } from '../stores/messageStore';
+import { upsertNode } from '../stores/nodeStore';
 
 const ID_MC_FAIL = 'id-send-mc-fail';
+const ID_MC_DM = 'id-send-mc-dm';
 import { useSendMessage } from './useSendMessage';
 
 const ID_MT = 'id-send-mt';
@@ -39,6 +42,7 @@ describe('useSendMessage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     registerMeshtasticSession(null);
+    registerMeshcoreSession(null);
     useIdentityStore.setState({ identities: {}, activeIdentityId: null });
     useMessageStore.setState({ messages: {} });
     vi.mocked(connectionDriver.getHandle).mockReturnValue(null);
@@ -151,6 +155,41 @@ describe('useSendMessage', () => {
         handle,
         expect.objectContaining({ text: 'hi meshcore', channelIndex: 1 }),
       );
+    });
+    sendSpy.mockRestore();
+  });
+
+  it('marks MeshCore DM acked when send resolves with packetId', async () => {
+    const sendSpy = vi.spyOn(meshcoreProtocol, 'sendMessage').mockResolvedValue({
+      packetId: 0xabcd,
+    });
+    const handle = { kind: 'rf' };
+    vi.mocked(connectionDriver.getHandle).mockReturnValue(handle);
+    const peerId = 0x22;
+    const pubKey = new Uint8Array(32).fill(0xab);
+    addIdentity({
+      id: ID_MC_DM,
+      protocol: meshcoreProtocol,
+      signature: 'sig-mc-dm',
+      transports: [],
+      createdAt: 1,
+      lastSeenAt: 1,
+    });
+    setConnection(ID_MC_DM, { status: 'configured', myNodeNum: 7 });
+    upsertNode(ID_MC_DM, {
+      nodeId: peerId,
+      longName: 'Peer',
+      publicKey: pubKey,
+    });
+
+    const { result } = renderHook(() => useSendMessage(ID_MC_DM));
+    result.current('dm hello', -1, peerId);
+
+    await vi.waitFor(() => {
+      const rows = Object.values(useMessageStore.getState().messages[ID_MC_DM] ?? {});
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.status).toBe('acked');
+      expect(rows[0]?.id).toBe(String(0xabcd));
     });
     sendSpy.mockRestore();
   });

--- a/src/renderer/hooks/useSendMessage.ts
+++ b/src/renderer/hooks/useSendMessage.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { messageToDbRow } from '../hooks/meshcore/meshcoreHookPreamble';
 import { connectionDriver } from '../lib/drivers/ConnectionDriver';
 import { errLikeToLogString } from '../lib/errLikeToLogString';
+import { tryGetMeshcoreSession } from '../lib/sessions/meshcoreSession';
 import { tryGetMeshtasticSession } from '../lib/sessions/meshtasticSession';
 import { messageRecordToChatMessage } from '../lib/storeRecordAdapters';
 import type { IdentityId } from '../lib/types';
@@ -78,14 +79,19 @@ export function useSendMessage(
       }
 
       const isMeshtastic = identity.protocol.type === 'meshtastic';
-      // Meshtastic: numeric temp packet id (matches RF echo + SQLite packet_id / tapback reply_id).
+      const isMeshcoreDm = identity.protocol.type === 'meshcore' && destination != null;
       const meshtasticTempPacketId = isMeshtastic
+        ? (Math.floor(Math.random() * 0xfffffffe) + 1) >>> 0
+        : undefined;
+      const meshcoreDmTempPacketId = isMeshcoreDm
         ? (Math.floor(Math.random() * 0xfffffffe) + 1) >>> 0
         : undefined;
       const provisionalId =
         meshtasticTempPacketId != null
           ? String(meshtasticTempPacketId)
-          : `out:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+          : meshcoreDmTempPacketId != null
+            ? String(meshcoreDmTempPacketId)
+            : `out:${Date.now()}:${Math.random().toString(36).slice(2)}`;
       const myNodeNum = getConnection(identityId)?.myNodeNum ?? 0;
       const meshcoreSenderName =
         identity.protocol.type === 'meshcore'
@@ -111,10 +117,10 @@ export function useSendMessage(
           });
       }
 
-      // MeshCore DMs need the destination pubkey; look up on nodeStore.
       let destinationPubKey: Uint8Array | undefined;
-      if (identity.protocol.type === 'meshcore' && destination != null) {
+      if (isMeshcoreDm) {
         destinationPubKey = useNodeStore.getState().nodes[identityId]?.[destination]?.publicKey;
+        destinationPubKey ??= tryGetMeshcoreSession()?.getDestinationPubKey?.(destination);
       }
 
       void identity.protocol
@@ -133,6 +139,7 @@ export function useSendMessage(
                 });
             }
           }
+
           updateMessageStatus(identityId, resolvedId, 'acked');
           if (identity.protocol.type === 'meshcore') {
             const rowForDb: MessageRecord = {

--- a/src/renderer/lib/chatUnreadCounts.test.ts
+++ b/src/renderer/lib/chatUnreadCounts.test.ts
@@ -56,6 +56,17 @@ describe('chatUnreadCounts', () => {
     expect(dmCounts.get(2)).toBe(1);
   });
 
+  it('excludes MeshCore room-server peers from DM unread when requested', () => {
+    const dmCounts = computeDmUnreadCounts(
+      [msg({ channel: 0, to: 1, timestamp: 2000 })],
+      {},
+      ownNodes,
+      'meshcore',
+      { excludeDmPeer: (peer) => peer === 2 },
+    );
+    expect(dmCounts.size).toBe(0);
+  });
+
   it('totalUnreadCount sums channel and DM unreads', () => {
     const total = totalUnreadCount(
       [msg({ channel: 0, timestamp: 2000 }), msg({ channel: 1, to: 1, timestamp: 2000 })],

--- a/src/renderer/lib/chatUnreadCounts.ts
+++ b/src/renderer/lib/chatUnreadCounts.ts
@@ -16,11 +16,17 @@ export function filterRegularChatMessages(
   return regular;
 }
 
+export interface ChatUnreadDmOptions {
+  /** MeshCore: omit room-server node ids (BBS belongs in Rooms, not Chat DM unread). */
+  excludeDmPeer?: (peer: number) => boolean;
+}
+
 /** DM peer for unread counting; excludes broadcast and non-DM traffic. */
 export function resolveChatDmPeer(
   msg: ChatMessage,
   ownNodeIds: ReadonlySet<number>,
   protocol: MeshProtocol,
+  options?: ChatUnreadDmOptions,
 ): number | undefined {
   if (protocol === 'meshcore' && isMeshcoreRoomChatMessage(msg)) return undefined;
   if (msg.to == null) return undefined;
@@ -30,7 +36,9 @@ export function resolveChatDmPeer(
   else if (isOwn(msg.to) && !isOwn(msg.sender_id)) peer = msg.sender_id;
   if (peer == null) return undefined;
   if (protocol === 'meshtastic' && isMeshtasticBroadcastNodeNum(peer)) return undefined;
-  return peer >>> 0;
+  const peerU32 = peer >>> 0;
+  if (options?.excludeDmPeer?.(peerU32)) return undefined;
+  return peerU32;
 }
 
 export function computeChannelUnreadCounts(
@@ -58,12 +66,13 @@ export function computeDmUnreadCounts(
   persistedLastRead: Readonly<Record<string, number>>,
   ownNodeIds: ReadonlySet<number>,
   protocol: MeshProtocol,
+  options?: ChatUnreadDmOptions,
 ): Map<number, number> {
   const counts = new Map<number, number>();
   const regular = filterRegularChatMessages(messages, protocol);
   for (const msg of regular) {
     if (msg.isHistory) continue;
-    const peer = resolveChatDmPeer(msg, ownNodeIds, protocol);
+    const peer = resolveChatDmPeer(msg, ownNodeIds, protocol, options);
     if (peer == null) continue;
     if (ownNodeIds.has(msg.sender_id)) continue;
     const lr = persistedLastRead[`dm:${peer}`] ?? 0;
@@ -79,9 +88,10 @@ export function totalUnreadCount(
   persistedLastRead: Readonly<Record<string, number>>,
   ownNodeIds: ReadonlySet<number>,
   protocol: MeshProtocol,
+  dmOptions?: ChatUnreadDmOptions,
 ): number {
   const channel = computeChannelUnreadCounts(messages, persistedLastRead, ownNodeIds, protocol);
-  const dm = computeDmUnreadCounts(messages, persistedLastRead, ownNodeIds, protocol);
+  const dm = computeDmUnreadCounts(messages, persistedLastRead, ownNodeIds, protocol, dmOptions);
   let total = 0;
   for (const n of channel.values()) total += n;
   for (const n of dm.values()) total += n;

--- a/src/renderer/lib/drivers/PacketRouter.ts
+++ b/src/renderer/lib/drivers/PacketRouter.ts
@@ -23,6 +23,7 @@ import { getIdentity } from '../../stores/identityStore';
 import { renameMessageId, upsertMessage, useMessageStore } from '../../stores/messageStore';
 import {
   addTraceRoute,
+  bumpMeshtasticNodesLastHeardAt,
   updatePosition,
   updateTelemetry,
   upsertNeighborInfo,
@@ -32,6 +33,7 @@ import {
 } from '../../stores/nodeStore';
 import { errLikeToLogString } from '../errLikeToLogString';
 import { ensureMeshtasticChatSenderInNodeStore } from '../meshtastic/meshtasticChatSenderNode';
+import { meshtasticTracerouteLastHeardNodeIds } from '../meshtasticLastHeard';
 import type { DomainEvent } from '../protocols/Protocol';
 import { retargetMeshtasticOutboundTempId } from '../sessions/meshtasticSession';
 import { MESHCORE_ROOM_POST_DEDUP_WINDOW_MS } from '../timeConstants';
@@ -171,9 +173,17 @@ class PacketRouter {
       case 'telemetry':
         updateTelemetry(identityId, event.payload);
         break;
-      case 'trace_route':
+      case 'trace_route': {
         addTraceRoute(identityId, event.payload);
+        if (getIdentity(identityId)?.protocol.type === 'meshtastic') {
+          const bumpIds = meshtasticTracerouteLastHeardNodeIds(
+            event.payload.from,
+            event.payload.to,
+          );
+          bumpMeshtasticNodesLastHeardAt(identityId, bumpIds, event.payload.timestamp);
+        }
         break;
+      }
       case 'waypoint':
         upsertWaypoint(identityId, event.payload);
         break;

--- a/src/renderer/lib/ingest/meshcoreIngest.test.ts
+++ b/src/renderer/lib/ingest/meshcoreIngest.test.ts
@@ -7,6 +7,7 @@ import {
   MESHCORE_UNKNOWN_SENDER_STUB_ID,
   meshcoreChatStubNodeIdFromDisplayName,
 } from '../meshcoreUtils';
+import { getNodeStatus } from '../nodeStatus';
 import { attachMeshcoreIngest, meshcoreIngestHandleTextMessage } from './meshcoreIngest';
 
 const ID = 'meshcore-ingest-test';
@@ -70,6 +71,51 @@ describe('attachMeshcoreIngest', () => {
     expect(saveMeshcoreMessage).toHaveBeenCalledWith(
       expect.objectContaining({ sender_id: null, sender_name: 'Unknown' }),
     );
+  });
+
+  it('bumps nodeStore lastHeardAt when a channel message arrives from a known sender', () => {
+    const senderId = meshcoreChatStubNodeIdFromDisplayName('WORMT');
+    const oldLastHeardSec = Math.floor(Date.now() / 1000) - 172_800;
+    const msgTs = Date.now();
+    const msgId = `ch:0:${Math.floor(msgTs / 1000)}`;
+    useNodeStore.setState({
+      nodes: {
+        [ID]: {
+          [senderId]: {
+            nodeId: senderId,
+            longName: 'WORMT',
+            hwModel: 'Chat',
+            lastHeardAt: oldLastHeardSec,
+          },
+        },
+      },
+      traceRoutes: {},
+      waypoints: {},
+      neighborInfo: {},
+    });
+    upsertMessage(ID, {
+      id: msgId,
+      from: 0,
+      to: 0,
+      payload: 'WORMT: Morning mesh',
+      channelIndex: 0,
+      timestamp: msgTs,
+    });
+    meshcoreIngestHandleTextMessage(ID, {
+      type: 'text_message',
+      payload: {
+        id: msgId,
+        from: 0,
+        to: 0,
+        payload: 'WORMT: Morning mesh',
+        channelIndex: 0,
+        timestamp: msgTs,
+        hopCount: 3,
+      },
+    });
+    const node = useNodeStore.getState().nodes[ID][senderId];
+    expect(node.lastHeardAt).toBeGreaterThan(oldLastHeardSec);
+    expect(getNodeStatus(node.lastHeardAt ?? 0)).toBe('online');
   });
 
   it('relinks channel ingest to named sender when history has same channel+payload', () => {

--- a/src/renderer/lib/ingest/meshcoreIngest.test.ts
+++ b/src/renderer/lib/ingest/meshcoreIngest.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { addIdentity } from '../../stores/identityStore';
 import { upsertMessage, useMessageStore } from '../../stores/messageStore';
 import { useNodeStore } from '../../stores/nodeStore';
 import { packetRouter } from '../drivers/PacketRouter';
 import {
   MESHCORE_UNKNOWN_SENDER_STUB_ID,
   meshcoreChatStubNodeIdFromDisplayName,
+  pubkeyToNodeId,
 } from '../meshcoreUtils';
 import { getNodeStatus } from '../nodeStatus';
+import { meshcoreProtocol } from '../protocols/MeshCoreProtocol';
 import { attachMeshcoreIngest, meshcoreIngestHandleTextMessage } from './meshcoreIngest';
 
 const ID = 'meshcore-ingest-test';
@@ -23,6 +26,14 @@ describe('attachMeshcoreIngest', () => {
     saveMeshcoreMessage.mockClear();
     useMessageStore.setState({ messages: {} });
     useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+    addIdentity({
+      id: ID,
+      protocol: meshcoreProtocol,
+      signature: 'meshcore:ingest-test',
+      transports: [],
+      createdAt: Date.now(),
+      lastSeenAt: Date.now(),
+    });
   });
 
   afterEach(() => {
@@ -41,6 +52,64 @@ describe('attachMeshcoreIngest', () => {
       ID,
     );
     expect(saveNode).not.toHaveBeenCalled();
+    detach();
+  });
+
+  it('persists live advert node_info to meshcore_contacts with publicKey', () => {
+    const saveMeshcoreContact = vi.fn().mockResolvedValue(undefined);
+    const updateAdvert = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(window.electronAPI.db, 'saveMeshcoreContact').mockImplementation(saveMeshcoreContact);
+    vi.spyOn(window.electronAPI.db, 'updateMeshcoreContactAdvert').mockImplementation(updateAdvert);
+    const pk = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) pk[i] = i + 1;
+    const nid = pubkeyToNodeId(pk);
+    expect(nid).not.toBe(0);
+    useNodeStore.setState({
+      nodes: {
+        [ID]: {
+          [nid]: { nodeId: nid, longName: '', lastHeardAt: 1_700_000_000, publicKey: pk },
+        },
+      },
+      traceRoutes: {},
+      waypoints: {},
+      neighborInfo: {},
+    });
+    const detach = attachMeshcoreIngest(ID);
+    packetRouter.dispatch(
+      {
+        type: 'node_info',
+        payload: { nodeId: nid, longName: 'LiveAdvert', lastHeardAt: 1_700_000_100, publicKey: pk },
+      },
+      ID,
+    );
+    expect(saveMeshcoreContact).not.toHaveBeenCalled();
+    expect(updateAdvert).toHaveBeenCalledWith(nid, 1_700_000_100, null, null, undefined);
+    detach();
+  });
+
+  it('meshcore_path_updated bumps nodeStore lastHeardAt', () => {
+    const pk = new Uint8Array(32);
+    pk[0] = 9;
+    pk[31] = 2;
+    const nodeId = pubkeyToNodeId(pk);
+    const oldSec = Math.floor(Date.now() / 1000) - 86_400;
+    useNodeStore.setState({
+      nodes: {
+        [ID]: {
+          [nodeId]: { nodeId, longName: 'Peer', lastHeardAt: oldSec, publicKey: pk },
+        },
+      },
+      traceRoutes: {},
+      waypoints: {},
+      neighborInfo: {},
+    });
+    const detach = attachMeshcoreIngest(ID);
+    packetRouter.dispatch(
+      { type: 'meshcore_path_updated', payload: { nodeId, publicKey: pk } },
+      ID,
+    );
+    const node = useNodeStore.getState().nodes[ID][nodeId];
+    expect(node.lastHeardAt).toBeGreaterThan(oldSec);
     detach();
   });
 

--- a/src/renderer/lib/ingest/meshcoreIngest.ts
+++ b/src/renderer/lib/ingest/meshcoreIngest.ts
@@ -10,11 +10,17 @@ import {
   messageToDbRow,
 } from '../../hooks/meshcore/meshcoreHookPreamble';
 import { getConnection } from '../../stores/connectionStore';
+import { useDiagnosticsStore } from '../../stores/diagnosticsStore';
 import { useMessageStore } from '../../stores/messageStore';
-import { useNodeStore } from '../../stores/nodeStore';
+import { patchMeshcoreNodeLastHeardAt, upsertNode, useNodeStore } from '../../stores/nodeStore';
 import { packetRouter, type PacketRouterListener } from '../drivers/PacketRouter';
 import { errLikeToLogString } from '../errLikeToLogString';
 import { ensureMeshcoreChatSenderInNodeStore } from '../meshcore/meshcoreChatSenderNode';
+import {
+  persistMeshcoreNodeInfoAfterAdvert,
+  persistMeshcorePathUpdatedNewContact,
+} from '../meshcore/meshcoreLiveContactPersist';
+import { registerMeshcorePubKey } from '../meshcore/meshcorePubKeyRegistry';
 import {
   buildMeshcoreRoomIncomingMessage,
   parseMeshcoreChannelIncomingFromThread,
@@ -27,14 +33,56 @@ import {
   meshcoreRoomWireLooksLikeRoom,
 } from '../meshcoreRoomMessageRouting';
 import { meshcoreSortedStorePrior, upsertMeshcoreMessageWithDedup } from '../meshcoreStoreDedup';
-import { meshcoreChatStubNodeIdFromDisplayName } from '../meshcoreUtils';
+import {
+  meshcoreChatStubNodeIdFromDisplayName,
+  meshcoreMinimalNodeFromAdvertEvent,
+} from '../meshcoreUtils';
 import type { DomainEvent } from '../protocols/Protocol';
 import type { ChatMessage, IdentityId } from '../types';
 
-/** MeshCore contacts belong in meshcore_contacts SQLite, not the Meshtastic nodes table. */
-function persistContactNodes(identityId: IdentityId): void {
-  // Legacy conn events and refreshContacts persist via saveMeshcoreContact.
-  void identityId;
+export interface MeshcoreIngestOptions {
+  /** Runtime hook for path-updated side effects (outPath refresh, ping-route epoch). */
+  onPathUpdated?: (nodeId: number, publicKey: Uint8Array, isNewContact: boolean) => void;
+}
+
+function handleNodeInfo(
+  identityId: IdentityId,
+  event: Extract<DomainEvent, { type: 'node_info' }>,
+): void {
+  persistMeshcoreNodeInfoAfterAdvert(identityId, event.payload);
+}
+
+function handlePathUpdated(
+  identityId: IdentityId,
+  event: Extract<DomainEvent, { type: 'meshcore_path_updated' }>,
+  options: MeshcoreIngestOptions,
+): void {
+  const { nodeId, publicKey } = event.payload;
+  if (nodeId === 0 || publicKey.length !== 32) return;
+
+  registerMeshcorePubKey(nodeId, publicKey);
+  useDiagnosticsStore.getState().recordPathUpdated(nodeId);
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const existing = useNodeStore.getState().nodes[identityId]?.[nodeId];
+  const isNew = existing == null;
+  if (isNew) {
+    persistMeshcorePathUpdatedNewContact(nodeId, publicKey, nowSec);
+    const built = meshcoreMinimalNodeFromAdvertEvent(publicKey, { nowSec });
+    if (built) {
+      upsertNode(identityId, {
+        nodeId,
+        longName: built.node.long_name,
+        hwModel: built.node.hw_model,
+        lastHeardAt: built.lastHeardSec,
+        publicKey,
+      });
+    }
+  } else {
+    patchMeshcoreNodeLastHeardAt(identityId, nodeId, nowSec);
+  }
+
+  options.onPathUpdated?.(nodeId, publicKey, isNew);
 }
 
 function listChatMessages(identityId: IdentityId): ChatMessage[] {
@@ -251,7 +299,10 @@ function handleTextMessage(
   }
 }
 
-function createListener(identityId: IdentityId): PacketRouterListener {
+function createListener(
+  identityId: IdentityId,
+  options: MeshcoreIngestOptions,
+): PacketRouterListener {
   return (event, routedIdentityId) => {
     if (routedIdentityId !== identityId) return;
     switch (event.type) {
@@ -259,10 +310,30 @@ function createListener(identityId: IdentityId): PacketRouterListener {
         handleTextMessage(identityId, event);
         break;
       case 'node_info':
-        persistContactNodes(identityId);
+        handleNodeInfo(identityId, event);
         break;
+      case 'meshcore_path_updated':
+        handlePathUpdated(identityId, event, options);
+        break;
+      case 'position': {
+        const record = useNodeStore.getState().nodes[identityId]?.[event.payload.nodeId];
+        if (record?.publicKey instanceof Uint8Array) {
+          persistMeshcoreNodeInfoAfterAdvert(
+            identityId,
+            {
+              nodeId: event.payload.nodeId,
+              publicKey: record.publicKey,
+              lastHeardAt: Math.floor(event.payload.timestamp / 1000),
+            },
+            {
+              latitudeDeg: event.payload.latitude,
+              longitudeDeg: event.payload.longitude,
+            },
+          );
+        }
+        break;
+      }
       case 'device_contacts':
-        persistContactNodes(identityId);
         break;
       default:
         break;
@@ -270,8 +341,11 @@ function createListener(identityId: IdentityId): PacketRouterListener {
   };
 }
 
-export function attachMeshcoreIngest(identityId: IdentityId): () => void {
-  return packetRouter.addListener(createListener(identityId));
+export function attachMeshcoreIngest(
+  identityId: IdentityId,
+  options: MeshcoreIngestOptions = {},
+): () => void {
+  return packetRouter.addListener(createListener(identityId, options));
 }
 
 /** @internal Exported for tests. */

--- a/src/renderer/lib/ingest/meshcoreIngest.ts
+++ b/src/renderer/lib/ingest/meshcoreIngest.ts
@@ -14,6 +14,7 @@ import { useMessageStore } from '../../stores/messageStore';
 import { useNodeStore } from '../../stores/nodeStore';
 import { packetRouter, type PacketRouterListener } from '../drivers/PacketRouter';
 import { errLikeToLogString } from '../errLikeToLogString';
+import { ensureMeshcoreChatSenderInNodeStore } from '../meshcore/meshcoreChatSenderNode';
 import {
   buildMeshcoreRoomIncomingMessage,
   parseMeshcoreChannelIncomingFromThread,
@@ -52,6 +53,36 @@ function buildPrefixToNodeIdMap(identityId: IdentityId): Map<string, number> {
     }
   }
   return map;
+}
+
+function chatSourceFromReceivedVia(receivedVia: string | undefined): {
+  source: 'rf' | 'mqtt';
+  heardViaMqtt: boolean;
+} {
+  if (receivedVia === 'mqtt') return { source: 'mqtt', heardViaMqtt: true };
+  if (receivedVia === 'both') return { source: 'rf', heardViaMqtt: true };
+  return { source: 'rf', heardViaMqtt: false };
+}
+
+function bumpMeshcoreChatSenderLastHeard(
+  identityId: IdentityId,
+  nodeId: number,
+  opts: {
+    timestampMs: number;
+    displayName?: string;
+    receivedVia?: string;
+    hopCount?: number;
+  },
+): void {
+  if (nodeId <= 0) return;
+  const { source, heardViaMqtt } = chatSourceFromReceivedVia(opts.receivedVia);
+  ensureMeshcoreChatSenderInNodeStore(identityId, nodeId, {
+    lastHeardAtMs: opts.timestampMs,
+    displayName: opts.displayName,
+    source,
+    heardViaMqtt,
+    ...(opts.hopCount != null ? { hopsAway: opts.hopCount } : {}),
+  });
 }
 
 function resolveRoomServerIdForIngest(
@@ -124,6 +155,14 @@ function handleTextMessage(
       event.payload.id,
     );
     const isEcho = myNodeNum > 0 && authorId === myNodeNum;
+    if (!isEcho) {
+      bumpMeshcoreChatSenderLastHeard(identityId, authorId, {
+        timestampMs: event.payload.timestamp,
+        displayName: authorName !== 'Unknown' ? authorName : undefined,
+        receivedVia: record.receivedVia,
+        hopCount: event.payload.hopCount,
+      });
+    }
     if (inserted && !isEcho) {
       void window.electronAPI.db.saveMeshcoreMessage(messageToDbRow(stored)).catch((e: unknown) => {
         console.warn('[meshcoreIngest] saveMeshcoreMessage failed ' + errLikeToLogString(e));
@@ -193,6 +232,14 @@ function handleTextMessage(
   } = upsertMeshcoreMessageWithDedup(identityId, reconciled, event.payload.id);
 
   const isEcho = myNodeNum > 0 && senderId === myNodeNum;
+  if (!isEcho) {
+    bumpMeshcoreChatSenderLastHeard(identityId, senderId, {
+      timestampMs: event.payload.timestamp,
+      displayName: displayName !== 'Unknown' ? displayName : undefined,
+      receivedVia: record.receivedVia,
+      hopCount: event.payload.hopCount,
+    });
+  }
   const replyUpgraded =
     stored.replyId !== priorReplyId ||
     stored.replyPreviewText !== priorReplyPreviewText ||

--- a/src/renderer/lib/meshcore/meshcoreChatSenderNode.test.ts
+++ b/src/renderer/lib/meshcore/meshcoreChatSenderNode.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { useNodeStore } from '../../stores/nodeStore';
+import { getNodeStatus } from '../nodeStatus';
+import { ensureMeshcoreChatSenderInNodeStore } from './meshcoreChatSenderNode';
+
+const ID = 'meshcore-chat-sender-test';
+
+const OLD_LAST_HEARD_SEC = Math.floor(Date.now() / 1000) - 86_400;
+const NEW_LAST_HEARD_MS = Date.now();
+
+describe('ensureMeshcoreChatSenderInNodeStore', () => {
+  it('creates a Chat stub when the sender is missing from the store', () => {
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+    ensureMeshcoreChatSenderInNodeStore(ID, 0xa58da576, {
+      lastHeardAtMs: NEW_LAST_HEARD_MS,
+      displayName: 'WORMT',
+      source: 'rf',
+    });
+    const node = useNodeStore.getState().nodes[ID][0xa58da576];
+    expect(node.nodeId).toBe(0xa58da576);
+    expect(node.hwModel).toBe('Chat');
+    expect(node.longName).toBe('WORMT');
+    expect(node.lastHeardAt).toBeGreaterThan(OLD_LAST_HEARD_SEC);
+  });
+
+  it('bumps lastHeardAt when the sender already exists', () => {
+    useNodeStore.setState({
+      nodes: {
+        [ID]: {
+          0xa58da576: {
+            nodeId: 0xa58da576,
+            longName: 'WORMT',
+            hwModel: 'Chat',
+            lastHeardAt: OLD_LAST_HEARD_SEC,
+          },
+        },
+      },
+      traceRoutes: {},
+      waypoints: {},
+      neighborInfo: {},
+    });
+    ensureMeshcoreChatSenderInNodeStore(ID, 0xa58da576, { lastHeardAtMs: NEW_LAST_HEARD_MS });
+    const node = useNodeStore.getState().nodes[ID][0xa58da576];
+    expect(node.lastHeardAt).toBeGreaterThan(OLD_LAST_HEARD_SEC);
+    expect(getNodeStatus(node.lastHeardAt ?? 0)).toBe('online');
+  });
+
+  it('does not regress lastHeardAt when incoming time is older', () => {
+    const freshSec = Math.floor(Date.now() / 1000) - 60;
+    const olderSec = freshSec - 3600;
+    useNodeStore.setState({
+      nodes: {
+        [ID]: {
+          9: { nodeId: 9, lastHeardAt: freshSec },
+        },
+      },
+      traceRoutes: {},
+      waypoints: {},
+      neighborInfo: {},
+    });
+    ensureMeshcoreChatSenderInNodeStore(ID, 9, { lastHeardAtMs: olderSec * 1000 });
+    expect(useNodeStore.getState().nodes[ID][9].lastHeardAt).toBe(freshSec);
+  });
+
+  it('skips node id zero', () => {
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+    ensureMeshcoreChatSenderInNodeStore(ID, 0, { lastHeardAtMs: Date.now() });
+    expect(useNodeStore.getState().nodes[ID]).toBeUndefined();
+  });
+});

--- a/src/renderer/lib/meshcore/meshcoreChatSenderNode.ts
+++ b/src/renderer/lib/meshcore/meshcoreChatSenderNode.ts
@@ -1,0 +1,80 @@
+import { upsertNodeRecord, useNodeStore } from '../../stores/nodeStore';
+import { meshcoreMergeChannelDisplayNameOntoNode, minimalMeshcoreChatNode } from '../meshcoreUtils';
+import { lastHeardToUnixSeconds, mergeMeshcoreLastHeardFromAdvert } from '../nodeStatus';
+import { meshNodeToNodeRecord, nodeRecordToMeshNode } from '../storeRecordAdapters';
+import type { IdentityId } from '../types';
+
+export interface EnsureMeshcoreChatSenderOpts {
+  lastHeardAtMs?: number;
+  displayName?: string;
+  source?: 'rf' | 'mqtt';
+  hopsAway?: number;
+  heardViaMqtt?: boolean;
+}
+
+/** Ensure a MeshCore chat sender exists in identity-scoped node store with fresh last_heard. */
+export function ensureMeshcoreChatSenderInNodeStore(
+  identityId: IdentityId,
+  nodeId: number,
+  opts?: EnsureMeshcoreChatSenderOpts,
+): void {
+  if (nodeId <= 0) return;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const incomingSec = lastHeardToUnixSeconds(opts?.lastHeardAtMs ?? Date.now());
+  const existing = useNodeStore.getState().nodes[identityId]?.[nodeId];
+  const mergedSec = mergeMeshcoreLastHeardFromAdvert(incomingSec, existing?.lastHeardAt, nowSec);
+  if (mergedSec <= 0) return;
+
+  const source = opts?.source ?? 'rf';
+  const prevSec = lastHeardToUnixSeconds(existing?.lastHeardAt ?? 0);
+
+  if (!existing) {
+    let stub = minimalMeshcoreChatNode(
+      nodeId,
+      opts?.displayName?.trim() || `Node-${nodeId.toString(16).toUpperCase()}`,
+      mergedSec,
+      source,
+    );
+    if (opts?.displayName) {
+      stub = meshcoreMergeChannelDisplayNameOntoNode(stub, opts.displayName);
+    }
+    if (opts?.hopsAway != null) stub = { ...stub, hops_away: opts.hopsAway };
+    if (opts?.heardViaMqtt) {
+      stub = { ...stub, heard_via_mqtt: true, heard_via_mqtt_only: source === 'mqtt' };
+    }
+    upsertNodeRecord(identityId, meshNodeToNodeRecord(stub));
+    return;
+  }
+
+  let meshNode = nodeRecordToMeshNode(existing);
+  const displayName = opts?.displayName?.trim();
+  if (displayName) {
+    meshNode = meshcoreMergeChannelDisplayNameOntoNode(meshNode, displayName);
+  }
+
+  const patch: Parameters<typeof upsertNodeRecord>[1] = { nodeId };
+  let changed = mergedSec > prevSec;
+
+  if (mergedSec > prevSec) patch.lastHeardAt = mergedSec;
+  if (opts?.hopsAway != null && existing.hopsAway !== opts.hopsAway) {
+    patch.hopsAway = opts.hopsAway;
+    changed = true;
+  }
+  if (opts?.heardViaMqtt && !existing.heardViaMqtt) {
+    patch.heardViaMqtt = true;
+    if (source === 'mqtt') patch.heardViaMqttOnly = true;
+    changed = true;
+  }
+  if (source !== 'rf' && existing.source !== source) {
+    patch.source = source;
+    changed = true;
+  }
+  if (displayName && meshNode.long_name && meshNode.long_name !== existing.longName) {
+    patch.longName = meshNode.long_name;
+    patch.shortName = '';
+    changed = true;
+  }
+
+  if (!changed) return;
+  upsertNodeRecord(identityId, { ...existing, ...patch });
+}

--- a/src/renderer/lib/meshcore/meshcoreLiveContactPersist.ts
+++ b/src/renderer/lib/meshcore/meshcoreLiveContactPersist.ts
@@ -1,0 +1,173 @@
+/**
+ * Persist MeshCore live advert / contact events to SQLite when legacy conn handlers
+ * are skipped (driver + PacketRouter path).
+ *
+ * Failure point: DB IPC — logged; Zustand store remains authoritative for UI.
+ * Fallback: skip DB write; reconnect refreshContacts repairs rows.
+ */
+import { useNodeStore } from '../../stores/nodeStore';
+import { usePositionHistoryStore } from '../../stores/positionHistoryStore';
+import { errLikeToLogString } from '../errLikeToLogString';
+import {
+  CONTACT_TYPE_LABELS,
+  mergeHwModelOnContactUpdate,
+  meshcoreContactTypeFromHwModel,
+  meshcoreMinimalNodeFromAdvertEvent,
+  pubkeyToNodeId,
+} from '../meshcoreUtils';
+import { mergeMeshcoreLastHeardFromAdvert } from '../nodeStatus';
+import type { NodeInfoEvent } from '../protocols/Protocol';
+import type { IdentityId } from '../types';
+import { registerMeshcorePubKey } from './meshcorePubKeyRegistry';
+
+const MESHCORE_COORD_SCALE = 1e6;
+
+export interface PersistMeshcoreNodeInfoOpts {
+  /** MeshCore contact type from advert (138) when known. */
+  contactType?: number;
+  latitudeDeg?: number | null;
+  longitudeDeg?: number | null;
+}
+
+function publicKeyHex(publicKey: Uint8Array): string {
+  return Array.from(publicKey)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * After PacketRouter `upsertNode`, mirror legacy event 128/138 SQLite + pubkey registry side effects.
+ */
+export function persistMeshcoreNodeInfoAfterAdvert(
+  identityId: IdentityId,
+  event: NodeInfoEvent,
+  opts?: PersistMeshcoreNodeInfoOpts,
+): void {
+  const publicKey = event.publicKey;
+  if (!(publicKey instanceof Uint8Array) || publicKey.length !== 32) return;
+
+  const nodeId = event.nodeId > 0 ? event.nodeId : pubkeyToNodeId(publicKey);
+  if (nodeId === 0) return;
+
+  registerMeshcorePubKey(nodeId, publicKey);
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const existingRecord = useNodeStore.getState().nodes[identityId]?.[nodeId];
+  const existingLastHeard = existingRecord?.lastHeardAt;
+  const rawAdvertSec =
+    event.lastHeardAt != null && Number.isFinite(event.lastHeardAt) && event.lastHeardAt > 0
+      ? Math.floor(event.lastHeardAt)
+      : undefined;
+  const lastAdvert = mergeMeshcoreLastHeardFromAdvert(
+    rawAdvertSec,
+    existingLastHeard ?? nowSec,
+    nowSec,
+  );
+
+  const latDeg = opts?.latitudeDeg ?? existingRecord?.latitude ?? null;
+  const lonDeg = opts?.longitudeDeg ?? existingRecord?.longitude ?? null;
+
+  if (
+    latDeg != null &&
+    lonDeg != null &&
+    Number.isFinite(latDeg) &&
+    Number.isFinite(lonDeg) &&
+    latDeg !== 0 &&
+    lonDeg !== 0
+  ) {
+    usePositionHistoryStore.getState().recordPosition(nodeId, latDeg, lonDeg);
+  }
+
+  const built = meshcoreMinimalNodeFromAdvertEvent(publicKey, {
+    nowSec,
+    advLat: latDeg != null && latDeg !== 0 ? Math.round(latDeg * MESHCORE_COORD_SCALE) : undefined,
+    advLon: lonDeg != null && lonDeg !== 0 ? Math.round(lonDeg * MESHCORE_COORD_SCALE) : undefined,
+    lastAdvert: rawAdvertSec,
+    contactType: opts?.contactType,
+    advName: event.longName,
+  });
+
+  const isNew = !existingRecord;
+  if (isNew && built) {
+    void window.electronAPI.db
+      .saveMeshcoreContact({
+        node_id: nodeId,
+        public_key: publicKeyHex(publicKey),
+        adv_name:
+          typeof event.longName === 'string' && event.longName.trim()
+            ? event.longName.trim()
+            : null,
+        contact_type: built.contactType,
+        last_advert: lastAdvert,
+        adv_lat: built.persistAdvLatDeg,
+        adv_lon: built.persistAdvLonDeg,
+        nickname: null,
+        on_radio: 1,
+      })
+      .catch((e: unknown) => {
+        console.warn(
+          '[meshcoreLiveContactPersist] saveMeshcoreContact (new) ' + errLikeToLogString(e),
+        );
+      });
+    return;
+  }
+
+  const advNameTrim =
+    typeof event.longName === 'string' && event.longName.trim() ? event.longName.trim() : undefined;
+  const existingHw = existingRecord?.hwModel;
+  let persistAdvName: string | undefined;
+  if (advNameTrim && !existingRecord?.longName?.trim()) {
+    persistAdvName = advNameTrim;
+  }
+  if (opts?.contactType != null && Number.isFinite(opts.contactType)) {
+    const newHw = CONTACT_TYPE_LABELS[Math.floor(opts.contactType)] ?? 'Unknown';
+    const merged = mergeHwModelOnContactUpdate(existingHw, newHw);
+    if (merged !== existingHw) {
+      const mergedType = meshcoreContactTypeFromHwModel(merged);
+      if (mergedType !== undefined) {
+        void window.electronAPI.db
+          .updateMeshcoreContactType(nodeId, mergedType)
+          .catch((e: unknown) => {
+            console.warn(
+              '[meshcoreLiveContactPersist] updateMeshcoreContactType ' + errLikeToLogString(e),
+            );
+          });
+      }
+    }
+  }
+
+  void window.electronAPI.db
+    .updateMeshcoreContactAdvert(nodeId, lastAdvert, latDeg, lonDeg, persistAdvName)
+    .catch((e: unknown) => {
+      console.warn(
+        '[meshcoreLiveContactPersist] updateMeshcoreContactAdvert ' + errLikeToLogString(e),
+      );
+    });
+}
+
+/** Path-updated (129): insert minimal contact when node was unknown. */
+export function persistMeshcorePathUpdatedNewContact(
+  nodeId: number,
+  publicKey: Uint8Array,
+  lastAdvertSec: number,
+): void {
+  if (nodeId === 0 || publicKey.length !== 32) return;
+  registerMeshcorePubKey(nodeId, publicKey);
+  void window.electronAPI.db
+    .saveMeshcoreContact({
+      node_id: nodeId,
+      public_key: publicKeyHex(publicKey),
+      adv_name: null,
+      contact_type: 0,
+      last_advert: lastAdvertSec,
+      adv_lat: null,
+      adv_lon: null,
+      nickname: null,
+      on_radio: 1,
+    })
+    .catch((e: unknown) => {
+      console.warn(
+        '[meshcoreLiveContactPersist] saveMeshcoreContact (path 129) ' + errLikeToLogString(e),
+      );
+    });
+}

--- a/src/renderer/lib/meshcore/meshcorePathUpdatedRuntime.ts
+++ b/src/renderer/lib/meshcore/meshcorePathUpdatedRuntime.ts
@@ -1,0 +1,44 @@
+import { meshcoreContactRawFromDevice } from '../../hooks/meshcore/meshcoreHookPreamble';
+import { usePathHistoryStore } from '../../stores/pathHistoryStore';
+import { errLikeToLogString } from '../errLikeToLogString';
+import type { MeshCoreConnection } from '../meshcore/meshcoreHookTypes';
+import {
+  meshcoreInferHopsFromOutPath,
+  meshcoreSliceContactOutPathForTrace,
+  pubkeyToNodeId,
+} from '../meshcoreUtils';
+
+/**
+ * Refresh outPath bytes for one contact after path-updated (129) so trace/ping can proceed.
+ *
+ * Failure point: `getContacts` timeout — logged; pending path update retried on debounced refresh.
+ * Fallback: debounced full contact rebuild in legacy conn events.
+ */
+export async function refreshMeshcoreOutPathAfterPathUpdated(
+  conn: MeshCoreConnection,
+  nodeId: number,
+  outPathMapRef: Map<number, Uint8Array>,
+  pathUpdatePending: Set<number>,
+): Promise<void> {
+  try {
+    const contactsRaw = await conn.getContacts();
+    const contacts = contactsRaw.map(meshcoreContactRawFromDevice);
+    for (const contact of contacts) {
+      const cNodeId = pubkeyToNodeId(contact.publicKey);
+      if (cNodeId !== nodeId) continue;
+      const sliced = meshcoreSliceContactOutPathForTrace(contact.outPath, contact.outPathLen);
+      if (sliced.length > 0) {
+        outPathMapRef.set(cNodeId, sliced);
+        const pathBytes = Array.from(sliced);
+        const hops = meshcoreInferHopsFromOutPath(contact) ?? Math.max(0, pathBytes.length - 1);
+        usePathHistoryStore.getState().recordPathUpdated(cNodeId, pathBytes, hops, false);
+        pathUpdatePending.delete(cNodeId);
+      }
+      break;
+    }
+  } catch (e) {
+    console.warn(
+      '[meshcorePathUpdatedRuntime] getContacts refresh failed ' + errLikeToLogString(e),
+    );
+  }
+}

--- a/src/renderer/lib/meshcore/meshcorePubKeyRegistry.test.ts
+++ b/src/renderer/lib/meshcore/meshcorePubKeyRegistry.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearMeshcorePubKeyRegistry,
+  getMeshcorePubKey,
+  meshcorePubKeyRegistrySize,
+  registerMeshcorePubKey,
+  resolveMeshcoreNodeIdFromPubKeyPrefix,
+} from './meshcorePubKeyRegistry';
+
+describe('meshcorePubKeyRegistry', () => {
+  beforeEach(() => {
+    clearMeshcorePubKeyRegistry();
+  });
+
+  it('registers pubkey and resolves by prefix', () => {
+    const pk = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) pk[i] = i;
+    registerMeshcorePubKey(0x1234, pk);
+    expect(meshcorePubKeyRegistrySize()).toBe(1);
+    expect(getMeshcorePubKey(0x1234)).toEqual(pk);
+    const prefix = Array.from(pk.slice(0, 6))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    expect(resolveMeshcoreNodeIdFromPubKeyPrefix(prefix)).toBe(0x1234);
+  });
+});

--- a/src/renderer/lib/meshcore/meshcorePubKeyRegistry.test.ts
+++ b/src/renderer/lib/meshcore/meshcorePubKeyRegistry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   clearMeshcorePubKeyRegistry,
@@ -6,10 +6,12 @@ import {
   meshcorePubKeyRegistrySize,
   registerMeshcorePubKey,
   resolveMeshcoreNodeIdFromPubKeyPrefix,
+  setMeshcorePubKeyRegistryRefSync,
 } from './meshcorePubKeyRegistry';
 
 describe('meshcorePubKeyRegistry', () => {
   beforeEach(() => {
+    setMeshcorePubKeyRegistryRefSync(null);
     clearMeshcorePubKeyRegistry();
   });
 
@@ -23,5 +25,15 @@ describe('meshcorePubKeyRegistry', () => {
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');
     expect(resolveMeshcoreNodeIdFromPubKeyPrefix(prefix)).toBe(0x1234);
+  });
+
+  it('notifies ref sync after register and clear', () => {
+    const sync = vi.fn();
+    setMeshcorePubKeyRegistryRefSync(sync);
+    const pk = new Uint8Array(32).fill(7);
+    registerMeshcorePubKey(0xabcd, pk);
+    expect(sync).toHaveBeenCalledTimes(1);
+    clearMeshcorePubKeyRegistry();
+    expect(sync).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/renderer/lib/meshcore/meshcorePubKeyRegistry.ts
+++ b/src/renderer/lib/meshcore/meshcorePubKeyRegistry.ts
@@ -3,17 +3,35 @@ import { pubkeyToNodeId } from '../meshcoreUtils';
 const pubKeyByNodeId = new Map<number, Uint8Array>();
 const pubKeyPrefixByHex = new Map<string, number>();
 
+type MeshcorePubKeyRegistryRefSync = () => void;
+
+let refSyncImpl: MeshcorePubKeyRegistryRefSync | null = null;
+
+/** Registered by {@link useMeshcoreRuntime} to mirror maps into `pubKeyMapRef` / prefix ref. */
+export function setMeshcorePubKeyRegistryRefSync(fn: MeshcorePubKeyRegistryRefSync | null): void {
+  refSyncImpl = fn;
+}
+
 function prefixHexFromPubKey(publicKey: Uint8Array): string {
   return Array.from(publicKey.slice(0, 6))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
 }
 
+function storePubKey(nodeId: number, publicKey: Uint8Array): void {
+  pubKeyByNodeId.set(nodeId, publicKey);
+  pubKeyPrefixByHex.set(prefixHexFromPubKey(publicKey), nodeId);
+}
+
+function notifyRefSync(): void {
+  refSyncImpl?.();
+}
+
 /** Register a 32-byte MeshCore pubkey for DM/trace and prefix-based RX decode. */
 export function registerMeshcorePubKey(nodeId: number, publicKey: Uint8Array): void {
   if (publicKey.length !== 32 || nodeId === 0) return;
-  pubKeyByNodeId.set(nodeId, publicKey);
-  pubKeyPrefixByHex.set(prefixHexFromPubKey(publicKey), nodeId);
+  storePubKey(nodeId, publicKey);
+  notifyRefSync();
 }
 
 export function getMeshcorePubKey(nodeId: number): Uint8Array | undefined {
@@ -27,6 +45,7 @@ export function resolveMeshcoreNodeIdFromPubKeyPrefix(prefixHex: string): number
 export function clearMeshcorePubKeyRegistry(): void {
   pubKeyByNodeId.clear();
   pubKeyPrefixByHex.clear();
+  notifyRefSync();
 }
 
 /** Replace registry from a full contact sync (e.g. `buildNodesFromContacts`). */
@@ -34,8 +53,10 @@ export function replaceMeshcorePubKeyRegistry(entries: Iterable<[number, Uint8Ar
   pubKeyByNodeId.clear();
   pubKeyPrefixByHex.clear();
   for (const [nodeId, publicKey] of entries) {
-    registerMeshcorePubKey(nodeId, publicKey);
+    if (publicKey.length !== 32 || nodeId === 0) continue;
+    storePubKey(nodeId, publicKey);
   }
+  notifyRefSync();
 }
 
 /** Copy module-level maps into runtime refs (legacy hook compatibility). */

--- a/src/renderer/lib/meshcore/meshcorePubKeyRegistry.ts
+++ b/src/renderer/lib/meshcore/meshcorePubKeyRegistry.ts
@@ -1,0 +1,65 @@
+import { pubkeyToNodeId } from '../meshcoreUtils';
+
+const pubKeyByNodeId = new Map<number, Uint8Array>();
+const pubKeyPrefixByHex = new Map<string, number>();
+
+function prefixHexFromPubKey(publicKey: Uint8Array): string {
+  return Array.from(publicKey.slice(0, 6))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Register a 32-byte MeshCore pubkey for DM/trace and prefix-based RX decode. */
+export function registerMeshcorePubKey(nodeId: number, publicKey: Uint8Array): void {
+  if (publicKey.length !== 32 || nodeId === 0) return;
+  pubKeyByNodeId.set(nodeId, publicKey);
+  pubKeyPrefixByHex.set(prefixHexFromPubKey(publicKey), nodeId);
+}
+
+export function getMeshcorePubKey(nodeId: number): Uint8Array | undefined {
+  return pubKeyByNodeId.get(nodeId);
+}
+
+export function resolveMeshcoreNodeIdFromPubKeyPrefix(prefixHex: string): number | undefined {
+  return pubKeyPrefixByHex.get(prefixHex);
+}
+
+export function clearMeshcorePubKeyRegistry(): void {
+  pubKeyByNodeId.clear();
+  pubKeyPrefixByHex.clear();
+}
+
+/** Replace registry from a full contact sync (e.g. `buildNodesFromContacts`). */
+export function replaceMeshcorePubKeyRegistry(entries: Iterable<[number, Uint8Array]>): void {
+  pubKeyByNodeId.clear();
+  pubKeyPrefixByHex.clear();
+  for (const [nodeId, publicKey] of entries) {
+    registerMeshcorePubKey(nodeId, publicKey);
+  }
+}
+
+/** Copy module-level maps into runtime refs (legacy hook compatibility). */
+export function copyMeshcorePubKeyRegistryToRefs(
+  pubKeyMapRef: Map<number, Uint8Array>,
+  pubKeyPrefixMapRef: Map<string, number>,
+): void {
+  pubKeyMapRef.clear();
+  pubKeyPrefixMapRef.clear();
+  for (const [nodeId, key] of pubKeyByNodeId) {
+    pubKeyMapRef.set(nodeId, key);
+    pubKeyPrefixMapRef.set(prefixHexFromPubKey(key), nodeId);
+  }
+}
+
+/** @internal Test helper */
+export function meshcorePubKeyRegistrySize(): number {
+  return pubKeyByNodeId.size;
+}
+
+/** Register from raw pubkey bytes (validates node id). */
+export function registerMeshcorePubKeyBytes(publicKey: Uint8Array): number {
+  const nodeId = pubkeyToNodeId(publicKey);
+  if (nodeId === 0) return 0;
+  registerMeshcorePubKey(nodeId, publicKey);
+  return nodeId;
+}

--- a/src/renderer/lib/meshcoreDmAckDelivery.ts
+++ b/src/renderer/lib/meshcoreDmAckDelivery.ts
@@ -1,0 +1,29 @@
+import type { IdentityId } from '@/renderer/lib/types';
+
+/** Params for firmware event 130 DM ACK tracking (useSendMessage / runtime send paths). */
+export interface MeshcoreDmAckPendingParams {
+  identityId: IdentityId;
+  ackKeyU32: number;
+  estTimeoutMs: number;
+  destNodeId?: number;
+}
+
+type MeshcoreDmAckPendingImpl = (params: MeshcoreDmAckPendingParams) => void;
+
+let impl: MeshcoreDmAckPendingImpl | null = null;
+
+/** Registered by {@link useMeshcoreRuntime} while mounted (owns pendingAcksRef + event 130). */
+export function setMeshcoreDmAckPendingImpl(fn: MeshcoreDmAckPendingImpl | null): void {
+  impl = fn;
+}
+
+export function isMeshcoreDmAckPendingRegistered(): boolean {
+  return impl != null;
+}
+
+/** Returns false when the MeshCore runtime has not registered ACK tracking yet. */
+export function scheduleMeshcoreDmAckPending(params: MeshcoreDmAckPendingParams): boolean {
+  if (!impl) return false;
+  impl(params);
+  return true;
+}

--- a/src/renderer/lib/protocols/MeshCoreProtocol.test.ts
+++ b/src/renderer/lib/protocols/MeshCoreProtocol.test.ts
@@ -7,6 +7,7 @@ import type { DomainEvent } from './Protocol';
 const EVENT_ADVERT = 128;
 const EVENT_CHANNEL_MESSAGE = 8;
 const EVENT_DIRECT_MESSAGE = 7;
+const EVENT_PATH_UPDATED = 129;
 
 function mockMeshCoreConnection() {
   const handlers = new Map<string | number, Set<(...args: unknown[]) => void>>();
@@ -47,6 +48,21 @@ describe('MeshCoreProtocol.subscribe', () => {
     });
     expect(events.some((e) => e.type === 'node_info')).toBe(true);
     expect(events.some((e) => e.type === 'position')).toBe(true);
+    teardown();
+  });
+
+  it('emits meshcore_path_updated on path-updated (129)', () => {
+    const conn = mockMeshCoreConnection();
+    const events: DomainEvent[] = [];
+    const teardown = meshcoreProtocol.subscribe(conn, (e) => events.push(e));
+    const publicKey = Uint8Array.from({ length: 32 }, (_, i) => (i + 3) % 256);
+    conn.emit(EVENT_PATH_UPDATED, { publicKey });
+    const pathEv = events.find((e) => e.type === 'meshcore_path_updated');
+    expect(pathEv).toMatchObject({
+      type: 'meshcore_path_updated',
+      payload: expect.objectContaining({ publicKey }),
+    });
+    expect(pathEv?.type === 'meshcore_path_updated' && pathEv.payload.nodeId).not.toBe(0);
     teardown();
   });
 

--- a/src/renderer/lib/protocols/MeshCoreProtocol.ts
+++ b/src/renderer/lib/protocols/MeshCoreProtocol.ts
@@ -39,6 +39,7 @@ const EVENT_ADVERT = 128;
 const EVENT_DIRECT_MESSAGE = 7;
 const EVENT_CHANNEL_MESSAGE = 8;
 const EVENT_NEW_CONTACT = 138;
+const EVENT_PATH_UPDATED = 129;
 const EVENT_RX = 'rx';
 const EVENT_DISCONNECTED = 'disconnected';
 
@@ -188,6 +189,9 @@ export class MeshCoreProtocol implements Protocol {
     const onContact = (data: unknown) => {
       this.decodeContact(data, pubKeyByNodeId, nodeIdByPrefix, roomNodeIds).forEach(emit);
     };
+    const onPathUpdated = (data: unknown) => {
+      this.decodePathUpdated(data).forEach(emit);
+    };
     const onRx = (data: unknown) => {
       this.decodeRx(data).forEach(emit);
     };
@@ -199,6 +203,7 @@ export class MeshCoreProtocol implements Protocol {
     bus.on(EVENT_DIRECT_MESSAGE, onDm);
     bus.on(EVENT_CHANNEL_MESSAGE, onChannel);
     bus.on(EVENT_NEW_CONTACT, onContact);
+    bus.on(EVENT_PATH_UPDATED, onPathUpdated);
     bus.on(EVENT_RX, onRx);
     bus.on(EVENT_DISCONNECTED, onDisconnected);
 
@@ -207,6 +212,7 @@ export class MeshCoreProtocol implements Protocol {
       bus.off(EVENT_DIRECT_MESSAGE, onDm);
       bus.off(EVENT_CHANNEL_MESSAGE, onChannel);
       bus.off(EVENT_NEW_CONTACT, onContact);
+      bus.off(EVENT_PATH_UPDATED, onPathUpdated);
       bus.off(EVENT_RX, onRx);
       bus.off(EVENT_DISCONNECTED, onDisconnected);
     };
@@ -446,6 +452,14 @@ export class MeshCoreProtocol implements Protocol {
   }
 
   // --- Decoders (pure; closure state passed in) ---
+
+  private decodePathUpdated(raw: unknown): DomainEvent[] {
+    const d = raw as { publicKey?: Uint8Array };
+    if (!(d.publicKey instanceof Uint8Array) || d.publicKey.length !== 32) return [];
+    const nodeId = pubkeyToNodeId(d.publicKey);
+    if (nodeId === 0) return [];
+    return [{ type: 'meshcore_path_updated', payload: { nodeId, publicKey: d.publicKey } }];
+  }
 
   private decodeAdvert(
     raw: unknown,

--- a/src/renderer/lib/protocols/MeshCoreProtocol.ts
+++ b/src/renderer/lib/protocols/MeshCoreProtocol.ts
@@ -254,7 +254,15 @@ export class MeshCoreProtocol implements Protocol {
       }
       const result = await conn.sendTextMessage(opts.destinationPubKey, opts.text);
       const ackCrc = result?.expectedAckCrc;
-      return ackCrc != null ? { packetId: meshcoreDmAckKeyU32(ackCrc) } : {};
+      if (ackCrc == null) return {};
+      const estTimeout =
+        typeof result?.estTimeout === 'number' && Number.isFinite(result.estTimeout)
+          ? result.estTimeout
+          : undefined;
+      return {
+        packetId: meshcoreDmAckKeyU32(ackCrc),
+        ...(estTimeout != null ? { estTimeoutMs: estTimeout } : {}),
+      };
     }
     await conn.sendChannelTextMessage(opts.channelIndex ?? 0, opts.text);
     return {};

--- a/src/renderer/lib/protocols/Protocol.ts
+++ b/src/renderer/lib/protocols/Protocol.ts
@@ -363,6 +363,8 @@ export interface DiscoveryInfo {
 export interface SendResult {
   /** SDK-assigned packet id, when available. PacketRouter dedupes on echo by this id. */
   packetId?: number;
+  /** MeshCore DM: firmware `estTimeout` hint (ms) for hop ACK (event 130). */
+  estTimeoutMs?: number;
 }
 
 // --- Protocol interface ---

--- a/src/renderer/lib/protocols/Protocol.ts
+++ b/src/renderer/lib/protocols/Protocol.ts
@@ -33,6 +33,12 @@ export interface NodeInfoEvent {
   publicKey?: Uint8Array;
 }
 
+/** MeshCore path-updated push (event 129). */
+export interface MeshcorePathUpdatedEvent {
+  nodeId: number;
+  publicKey: Uint8Array;
+}
+
 // --- Contact / self-info events (populated by protocol implementations) ---
 
 export interface DeviceSelfInfoEvent {
@@ -275,7 +281,8 @@ export type DomainEvent =
   | { type: 'device_self_info'; payload: DeviceSelfInfoEvent }
   | { type: 'device_contacts'; payload: { contacts: ContactRecord[] } }
   | { type: 'device_autoadd'; payload: AutoaddConfigEvent }
-  | { type: 'meshcore_channel'; payload: MeshcoreChannelEvent };
+  | { type: 'meshcore_channel'; payload: MeshcoreChannelEvent }
+  | { type: 'meshcore_path_updated'; payload: MeshcorePathUpdatedEvent };
 
 // --- Raw packet log ---
 

--- a/src/renderer/lib/sessions/meshcoreSession.ts
+++ b/src/renderer/lib/sessions/meshcoreSession.ts
@@ -15,6 +15,8 @@ export interface MeshcoreSessionApi {
     httpAddress?: string,
     lastSerialPortId?: string | null,
   ) => Promise<void>;
+  /** RF contact pubkey for DM send when nodeStore has not been hydrated yet. */
+  getDestinationPubKey?: (nodeId: number) => Uint8Array | undefined;
 }
 
 let activeSession: MeshcoreSessionApi | null = null;

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -70,6 +70,7 @@ import { syncMeshcoreNodesMapToIdentityStore } from '../lib/hydrateIdentityStore
 import { attachMeshcoreIngest } from '../lib/ingest/meshcoreIngest';
 import { resolveLastBlePeripheralId } from '../lib/lastConnectionStorage';
 import { tryPersistMeshcoreIdentityFromRadioExport } from '../lib/letsMeshJwt';
+import { ensureMeshcoreChatSenderInNodeStore } from '../lib/meshcore/meshcoreChatSenderNode';
 import type {
   CayenneLppEntry,
   DeviceLogEntry,
@@ -943,7 +944,16 @@ export function useMeshcoreRuntime() {
       });
       const resolvedId = resolved.senderId;
       const displayName = resolved.displayName;
+      const storeId = meshcoreIdentityIdRef.current;
       if (resolvedId !== 0) {
+        if (storeId) {
+          ensureMeshcoreChatSenderInNodeStore(storeId, resolvedId, {
+            lastHeardAtMs: ts,
+            displayName: m.senderName ?? displayName,
+            source: 'mqtt',
+            heardViaMqtt: true,
+          });
+        }
         setNodes((prev) => {
           const next = new Map(prev);
           const existing = next.get(resolvedId);
@@ -986,7 +996,6 @@ export function useMeshcoreRuntime() {
       }
       const normProbe = normalizeMeshcoreIncomingText(m.text);
       const rawForBuild = normProbe.senderName ? m.text : `${displayName}: ${m.text}`;
-      const storeId = meshcoreIdentityIdRef.current;
       const prior = storeId ? meshcoreSortedStorePrior(storeId) : messagesRef.current;
       addMessage(
         parseMeshcoreChannelIncomingFromThread(prior, {

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -89,6 +89,13 @@ import type {
   MeshcoreTraceResultEntry,
   RxPacketEntry,
 } from '../lib/meshcore/meshcoreHookTypes';
+import { refreshMeshcoreOutPathAfterPathUpdated } from '../lib/meshcore/meshcorePathUpdatedRuntime';
+import {
+  clearMeshcorePubKeyRegistry,
+  copyMeshcorePubKeyRegistryToRefs,
+  registerMeshcorePubKey,
+  replaceMeshcorePubKeyRegistry,
+} from '../lib/meshcore/meshcorePubKeyRegistry';
 import {
   findMeshcoreDmReplyParent,
   formatMeshcoreWireReplyPrefix,
@@ -196,6 +203,7 @@ import {
   meshcoreMergeChannelDisplayNameOntoNode,
   meshcoreMergeContactHopsAwayFromPrevious,
   meshcoreMilliVoltsToApproximateBatteryPercent,
+  meshcoreMinimalNodeFromAdvertEvent,
   meshcoreScaledAdvLatLonToDeg,
   meshcoreSliceContactOutPathForTrace,
   meshcoreSyntheticPlaceholderPubKeyHex,
@@ -246,7 +254,7 @@ import type {
 import { mirrorMqttStatusToConnection, setConnection } from '../stores/connectionStore';
 import { useDiagnosticsStore } from '../stores/diagnosticsStore';
 import { updateMessageStatus, useMessageStore } from '../stores/messageStore';
-import { useNodeStore } from '../stores/nodeStore';
+import { patchMeshcoreNodeLastHeardAt, useNodeStore } from '../stores/nodeStore';
 import { computePathHash, usePathHistoryStore } from '../stores/pathHistoryStore';
 import { useRepeaterSignalStore } from '../stores/repeaterSignalStore';
 
@@ -622,6 +630,14 @@ export function useMeshcoreRuntime() {
     nodesRef.current = nodes;
     setMeshcoreDiagnosticsNodes(nodes, myNodeNumRef.current);
   }, [nodes, state.myNodeNum]);
+
+  // Push runtime node map into identity-scoped Zustand after commit (mirrors Meshtastic #375 path).
+  useEffect(() => {
+    const storeId =
+      meshcoreIdentityIdRef.current ?? meshcorePendingDriverIdentityRef.current ?? null;
+    if (!storeId) return;
+    syncMeshcoreNodesMapToIdentityStore(storeId, nodes);
+  }, [nodes, meshcoreIdentityId]);
 
   useEffect(() => {
     meshcoreTraceResultsRef.current = meshcoreTraceResults;
@@ -1106,6 +1122,15 @@ export function useMeshcoreRuntime() {
         const dbRow = contactToDbRow(contact, undefined, onRadio, now, hopsToSave);
         pendingDbRows.push(dbRow);
       }
+      replaceMeshcorePubKeyRegistry(
+        contacts
+          .map((contact): [number, Uint8Array] => [
+            pubkeyToNodeId(contact.publicKey),
+            contact.publicKey,
+          ])
+          .filter(([id]) => id !== 0),
+      );
+      copyMeshcorePubKeyRegistryToRefs(pubKeyMapRef.current, pubKeyPrefixMapRef.current);
       if (pendingDbRows.length > 0) {
         void window.electronAPI.db.saveMeshcoreContactsBatch(pendingDbRows).catch((e: unknown) => {
           console.warn(
@@ -1249,6 +1274,53 @@ export function useMeshcoreRuntime() {
     [applyMeshcoreNodesToUi],
   );
 
+  const handleMeshcorePathUpdatedFromIngest = useCallback(
+    (nodeId: number, publicKey: Uint8Array, isNewContact: boolean) => {
+      registerMeshcorePubKey(nodeId, publicKey);
+      copyMeshcorePubKeyRegistryToRefs(pubKeyMapRef.current, pubKeyPrefixMapRef.current);
+      if (!meshcoreSessionPathUpdatedNodeIdsRef.current.has(nodeId)) {
+        meshcoreSessionPathUpdatedNodeIdsRef.current.add(nodeId);
+        setMeshcorePingRouteReadyEpoch((e) => e + 1);
+      }
+      const nowSec = Math.floor(Date.now() / 1000);
+      if (isNewContact) {
+        setNodes((prev) => {
+          const built = meshcoreMinimalNodeFromAdvertEvent(publicKey, { nowSec });
+          if (!built) return prev;
+          const nick = nicknameMapRef.current.get(nodeId);
+          const nodeWithNick = nick
+            ? { ...built.node, long_name: nick, short_name: '' }
+            : built.node;
+          const next = new Map(prev);
+          next.set(nodeId, nodeWithNick);
+          return next;
+        });
+      } else {
+        setNodes((prev) => {
+          const existing = prev.get(nodeId);
+          if (!existing) return prev;
+          const next = new Map(prev);
+          next.set(nodeId, {
+            ...existing,
+            last_heard: Math.max(existing.last_heard ?? 0, nowSec),
+          });
+          return next;
+        });
+      }
+      meshcorePathUpdatePendingRef.current.add(nodeId);
+      const conn = connRef.current;
+      if (conn) {
+        void refreshMeshcoreOutPathAfterPathUpdated(
+          conn,
+          nodeId,
+          outPathMapRef.current,
+          meshcorePathUpdatePendingRef.current,
+        );
+      }
+    },
+    [],
+  );
+
   /** Returned by {@link setupEventListeners}; run before `conn.close()` or replacing the connection. */
   const meshcoreConnEventListenersTeardownRef = useRef<(() => void) | null>(null);
   const teardownMeshcoreConnEventListeners = useCallback(
@@ -1280,6 +1352,7 @@ export function useMeshcoreRuntime() {
       meshcoreIdentityIdRef.current = null;
       meshcorePendingDriverIdentityRef.current = null;
       setMeshcoreIdentityId(null);
+      clearMeshcorePubKeyRegistry();
       meshcoreConnEventListenersTeardownRef.current?.();
       meshcoreConnEventListenersTeardownRef.current = null;
     },
@@ -1589,7 +1662,9 @@ export function useMeshcoreRuntime() {
         meshcoreIngestDetachRef.current();
       }
       if (identityId) {
-        meshcoreIngestDetachRef.current = attachMeshcoreIngest(identityId);
+        meshcoreIngestDetachRef.current = attachMeshcoreIngest(identityId, {
+          onPathUpdated: handleMeshcorePathUpdatedFromIngest,
+        });
         setConnection(identityId, {
           status: 'configured',
           connectionType: transportType === 'tcp' ? 'http' : transportType,
@@ -1759,6 +1834,7 @@ export function useMeshcoreRuntime() {
       applyMeshcoreNodesToUi,
       buildNodesFromContacts,
       deferMeshcoreDbContactMerge,
+      handleMeshcorePathUpdatedFromIngest,
       meshcorePreviousNodesBaselineForBuild,
       refreshMeshcoreAutoaddFromDevice,
       resolveMeshcoreStoreIdentityId,
@@ -2863,28 +2939,35 @@ export function useMeshcoreRuntime() {
   );
 
   /** Successful Status/Ping prove reachability; sync `last_heard` when firmware `lastAdvert` is stale. */
-  const bumpMeshcoreNodeLastHeardFromRpc = useCallback((nodeId: number) => {
-    const existing = nodesRef.current.get(nodeId);
-    if (!existing) return;
-    const nowSec = Math.floor(Date.now() / 1000);
-    const lat = existing.latitude ?? null;
-    const lon = existing.longitude ?? null;
-    setNodes((prev) => {
-      const cur = prev.get(nodeId);
-      if (!cur) return prev;
-      const next = new Map(prev);
-      next.set(nodeId, { ...cur, last_heard: nowSec });
-      return next;
-    });
-    void window.electronAPI.db
-      .updateMeshcoreContactAdvert(nodeId, nowSec, lat, lon)
-      .catch((e: unknown) => {
-        console.warn(
-          '[useMeshcoreRuntime] updateMeshcoreContactAdvert (RPC bump) error ' +
-            errLikeToLogString(e),
-        );
+  const bumpMeshcoreNodeLastHeardFromRpc = useCallback(
+    (nodeId: number) => {
+      const existing = nodesRef.current.get(nodeId);
+      if (!existing) return;
+      const nowSec = Math.floor(Date.now() / 1000);
+      const lat = existing.latitude ?? null;
+      const lon = existing.longitude ?? null;
+      const storeId = resolveMeshcoreStoreIdentityId();
+      if (storeId) {
+        patchMeshcoreNodeLastHeardAt(storeId, nodeId, nowSec);
+      }
+      setNodes((prev) => {
+        const cur = prev.get(nodeId);
+        if (!cur) return prev;
+        const next = new Map(prev);
+        next.set(nodeId, { ...cur, last_heard: nowSec });
+        return next;
       });
-  }, []);
+      void window.electronAPI.db
+        .updateMeshcoreContactAdvert(nodeId, nowSec, lat, lon)
+        .catch((e: unknown) => {
+          console.warn(
+            '[useMeshcoreRuntime] updateMeshcoreContactAdvert (RPC bump) error ' +
+              errLikeToLogString(e),
+          );
+        });
+    },
+    [resolveMeshcoreStoreIdentityId],
+  );
 
   /**
    * MeshCore: always allow Ping/trace in the UI. Pre-gating on PathUpdated/path history caused false

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -50,7 +50,10 @@ import {
   serializeErrorLike,
   waitForMeshcorePath129ForNode,
 } from '../hooks/meshcore/meshcoreHookPreamble';
-import { attachMeshcoreLegacyConnEvents } from '../hooks/meshcore/meshcoreLegacyConnEvents';
+import {
+  attachMeshcoreLegacyConnEvents,
+  syncMeshcoreDmAckToMessageStore,
+} from '../hooks/meshcore/meshcoreLegacyConnEvents';
 import type { MeshcoreLegacyConnEventsCtx } from '../hooks/meshcore/meshcoreLegacyConnEventsCtx';
 import { openMeshCoreTransport } from '../hooks/openMeshCoreTransport';
 import { mergeAppSettingsPartial } from '../lib/appSettingsStorage';
@@ -108,6 +111,7 @@ import {
   meshcoreRoomServerIdsFromNodes,
   repairMeshcoreHydratedMessages,
 } from '../lib/meshcoreDbCacheHydration';
+import { setMeshcoreDmAckPendingImpl } from '../lib/meshcoreDmAckDelivery';
 import { awaitDualNobleBleMeshtasticSettle } from '../lib/meshcoreDualNobleBleInit';
 import {
   buildMeshcoreGetNeighboursRequest,
@@ -232,6 +236,7 @@ import type {
   ChatMessage,
   DeviceState,
   EnvironmentTelemetryPoint,
+  IdentityId,
   MeshCoreLocalStats,
   MeshNode,
   MQTTStatus,
@@ -5140,6 +5145,64 @@ export function useMeshcoreRuntime() {
     });
   }, [meshcoreIdentityId, state, mqttStatus]);
 
+  const scheduleMeshcoreDmAckPendingImpl = useCallback(
+    ({
+      identityId,
+      ackKeyU32,
+      estTimeoutMs,
+      destNodeId,
+    }: {
+      identityId: IdentityId;
+      ackKeyU32: number;
+      estTimeoutMs: number;
+      destNodeId?: number;
+    }) => {
+      const pendingMapKeys = meshcorePendingDmAckMapKeys(ackKeyU32);
+      const outPathRaw = destNodeId != null ? outPathMapRef.current.get(destNodeId) : undefined;
+      const sendPathBytes = outPathRaw && outPathRaw.length > 0 ? Array.from(outPathRaw) : [];
+      const sendPathHash = sendPathBytes.length > 0 ? computePathHash(sendPathBytes) : '';
+      const hopsAway = destNodeId != null ? (nodesRef.current.get(destNodeId)?.hops_away ?? 0) : 0;
+      if (sendPathBytes.length > 0 && destNodeId != null) {
+        usePathHistoryStore
+          .getState()
+          .recordPathUpdated(destNodeId, sendPathBytes, hopsAway, false);
+      }
+      const timeoutId = setTimeout(() => {
+        for (const k of pendingMapKeys) {
+          pendingAcksRef.current.delete(k);
+        }
+        if (destNodeId != null && sendPathHash) {
+          usePathHistoryStore.getState().recordOutcome(destNodeId, sendPathHash, false);
+        }
+        syncMeshcoreDmAckToMessageStore(identityId, ackKeyU32, myNodeNumRef.current, 'failed');
+        void window.electronAPI.db
+          .updateMeshcoreMessageStatus(ackKeyU32, 'failed')
+          .catch((e: unknown) => {
+            console.warn(
+              '[useMeshcoreRuntime] updateMeshcoreMessageStatus (DM ack timeout) error ' +
+                errLikeToLogString(e),
+            );
+          });
+      }, estTimeoutMs);
+      const pendingEntry: PendingDmAckEntry = {
+        timeoutId,
+        mapKeys: pendingMapKeys,
+        canonicalPacketIdU32: ackKeyU32,
+        destNodeId,
+        pathHash: sendPathHash,
+      };
+      for (const k of pendingMapKeys) {
+        pendingAcksRef.current.set(k, pendingEntry);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    setMeshcoreDmAckPendingImpl(scheduleMeshcoreDmAckPendingImpl);
+    return () => setMeshcoreDmAckPendingImpl(null);
+  }, [scheduleMeshcoreDmAckPendingImpl]);
+
   useEffect(() => {
     registerMeshcoreSession({
       prepareRfConnect,
@@ -5147,6 +5210,7 @@ export function useMeshcoreRuntime() {
       handleRfConnectFailure,
       finalizeDriverDisconnect,
       connectAutomatic,
+      getDestinationPubKey: (nodeId) => pubKeyMapRef.current.get(nodeId),
     });
     return () => registerMeshcoreSession(null);
   }, [

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -95,6 +95,7 @@ import {
   copyMeshcorePubKeyRegistryToRefs,
   registerMeshcorePubKey,
   replaceMeshcorePubKeyRegistry,
+  setMeshcorePubKeyRegistryRefSync,
 } from '../lib/meshcore/meshcorePubKeyRegistry';
 import {
   findMeshcoreDmReplyParent,
@@ -5318,6 +5319,13 @@ export function useMeshcoreRuntime() {
     setMeshcoreDmAckPendingImpl(scheduleMeshcoreDmAckPendingImpl);
     return () => setMeshcoreDmAckPendingImpl(null);
   }, [scheduleMeshcoreDmAckPendingImpl]);
+
+  useEffect(() => {
+    setMeshcorePubKeyRegistryRefSync(() => {
+      copyMeshcorePubKeyRegistryToRefs(pubKeyMapRef.current, pubKeyPrefixMapRef.current);
+    });
+    return () => setMeshcorePubKeyRegistryRefSync(null);
+  }, []);
 
   useEffect(() => {
     registerMeshcoreSession({

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -2518,7 +2518,7 @@ export function useMeshcoreRuntime() {
         deferPathHistory: true,
       });
       applyMeshcoreNodesToUi(newNodes);
-      void deferMeshcoreDbContactMerge(newNodes, previousNodesBaseline);
+      await deferMeshcoreDbContactMerge(newNodes, previousNodesBaseline);
 
       // Warn if approaching contact limit
       if (contacts.length > MESHCORE_CONTACTS_WARNING_THRESHOLD) {
@@ -2689,6 +2689,30 @@ export function useMeshcoreRuntime() {
     }
     const myId = myNodeNumRef.current;
     const raw = await conn.getContacts();
+    const contacts = raw.map(meshcoreContactRawFromDevice);
+    const now = new Date().toISOString();
+    const pendingDbRows: ReturnType<typeof contactToDbRow>[] = [];
+    for (const contact of contacts) {
+      const id = pubkeyToNodeId(contact.publicKey);
+      if (id === myId) continue;
+      const prevHops = nodesRef.current.get(id)?.hops_away;
+      const base = meshcoreContactToMeshNode(contact);
+      const mergedHops = meshcoreMergeContactHopsAwayFromPrevious(base.hops_away, prevHops, 0);
+      pendingDbRows.push(
+        contactToDbRow(contact, nicknameMapRef.current.get(id) ?? null, 1, now, mergedHops),
+      );
+    }
+    if (pendingDbRows.length > 0) {
+      try {
+        await window.electronAPI.db.saveMeshcoreContactsBatch(pendingDbRows);
+      } catch (e: unknown) {
+        console.warn(
+          '[useMeshcoreRuntime] offloadContactsFromRadio saveMeshcoreContactsBatch error ' +
+            errLikeToLogString(e),
+        );
+        throw e;
+      }
+    }
     let removed = 0;
     for (const c of raw) {
       const id = pubkeyToNodeId(c.publicKey);

--- a/src/renderer/stores/nodeStore.meshcore-meshtastic.test.ts
+++ b/src/renderer/stores/nodeStore.meshcore-meshtastic.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { meshcoreProtocol } from '../lib/protocols/MeshCoreProtocol';
+import { meshtasticProtocol } from '../lib/protocols/MeshtasticProtocol';
+import { addIdentity } from './identityStore';
+import {
+  bumpMeshtasticNodesLastHeardAt,
+  patchMeshcoreNodeLastHeardAt,
+  updatePosition,
+  upsertNode,
+  useNodeStore,
+} from './nodeStore';
+
+const ID_MC = 'id-mc-store';
+const ID_MT = 'id-mt-store';
+
+describe('nodeStore MeshCore / Meshtastic last-heard', () => {
+  beforeEach(() => {
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+    addIdentity({
+      id: ID_MC,
+      protocol: meshcoreProtocol,
+      signature: 'meshcore:test',
+      transports: [],
+      createdAt: Date.now(),
+      lastSeenAt: Date.now(),
+    });
+    addIdentity({
+      id: ID_MT,
+      protocol: meshtasticProtocol,
+      signature: 'meshtastic:test',
+      transports: [],
+      createdAt: Date.now(),
+      lastSeenAt: Date.now(),
+    });
+  });
+
+  it('patchMeshcoreNodeLastHeardAt raises lastHeardAt in store', () => {
+    const oldSec = Math.floor(Date.now() / 1000) - 86_400;
+    useNodeStore.setState({
+      nodes: { [ID_MC]: { 9: { nodeId: 9, lastHeardAt: oldSec } } },
+      traceRoutes: {},
+      waypoints: {},
+      neighborInfo: {},
+    });
+    const nowSec = Math.floor(Date.now() / 1000);
+    patchMeshcoreNodeLastHeardAt(ID_MC, 9, nowSec);
+    expect(useNodeStore.getState().nodes[ID_MC][9].lastHeardAt).toBeGreaterThanOrEqual(nowSec);
+  });
+
+  it('upsertNode merges Meshtastic NodeInfo lastHeard with computeNodeInfoLastHeardMs', () => {
+    upsertNode(ID_MT, { nodeId: 0x51f7e502, lastHeardAt: 1_700_000_100 });
+    const node = useNodeStore.getState().nodes[ID_MT][0x51f7e502];
+    expect(node.lastHeardAt).toBe(1_700_000_100_000);
+  });
+
+  it('updatePosition bumps Meshtastic lastHeardAt from packet timestamp', () => {
+    const rxMs = Date.now() - 5_000;
+    useNodeStore.setState({
+      nodes: { [ID_MT]: { 1: { nodeId: 1, lastHeardAt: 0 } } },
+      traceRoutes: {},
+      waypoints: {},
+      neighborInfo: {},
+    });
+    updatePosition(ID_MT, {
+      nodeId: 1,
+      latitude: 40,
+      longitude: -105,
+      timestamp: rxMs,
+    });
+    expect(useNodeStore.getState().nodes[ID_MT][1].lastHeardAt).toBe(rxMs);
+  });
+
+  it('bumpMeshtasticNodesLastHeardAt merges traceroute hearers', () => {
+    useNodeStore.setState({
+      nodes: {
+        [ID_MT]: {
+          0x1111: { nodeId: 0x1111, lastHeardAt: 1000 },
+          0x2222: { nodeId: 0x2222, lastHeardAt: 1000 },
+        },
+      },
+      traceRoutes: {},
+      waypoints: {},
+      neighborInfo: {},
+    });
+    const ts = Date.now();
+    bumpMeshtasticNodesLastHeardAt(ID_MT, [0x1111, 0x2222], ts);
+    expect(useNodeStore.getState().nodes[ID_MT][0x1111].lastHeardAt).toBe(ts);
+    expect(useNodeStore.getState().nodes[ID_MT][0x2222].lastHeardAt).toBe(ts);
+  });
+});

--- a/src/renderer/stores/nodeStore.ts
+++ b/src/renderer/stores/nodeStore.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand';
 
+import {
+  computeNodeInfoLastHeardMs,
+  mergeMeshtasticLivePacketLastHeard,
+} from '../lib/meshtasticLastHeard';
 import { mergeMeshcoreLastHeardFromAdvert } from '../lib/nodeStatus';
 import type {
   CliEntry,
@@ -15,6 +19,7 @@ import type {
   WaypointEvent,
 } from '../lib/protocols/Protocol';
 import type { IdentityId, MeshCoreLocalStats, MeshNeighbor } from '../lib/types';
+import { getConnection } from './connectionStore';
 import { getIdentity } from './identityStore';
 import { omitRecordKey } from './storeUtils';
 
@@ -142,8 +147,9 @@ export function upsertNode(identityId: IdentityId, event: NodeInfoEvent): void {
       publicKey,
     } = event;
     let lastHeardAt = eventLastHeardAt;
+    const protocolType = getIdentity(identityId)?.protocol.type;
     if (
-      getIdentity(identityId)?.protocol.type === 'meshcore' &&
+      protocolType === 'meshcore' &&
       eventLastHeardAt != null &&
       Number.isFinite(eventLastHeardAt)
     ) {
@@ -153,6 +159,14 @@ export function upsertNode(identityId: IdentityId, event: NodeInfoEvent): void {
         Math.floor(Date.now() / 1000),
       );
       if (merged > 0) lastHeardAt = merged;
+    } else if (protocolType === 'meshtastic') {
+      const selfNum = getConnection(identityId)?.myNodeNum ?? 0;
+      const isSelf = selfNum > 0 && nodeId === selfNum;
+      lastHeardAt = computeNodeInfoLastHeardMs(
+        eventLastHeardAt,
+        existing?.lastHeardAt ?? 0,
+        isSelf,
+      );
     }
     return {
       nodes: {
@@ -210,22 +224,104 @@ export function upsertNodeRecordsForIdentity(identityId: IdentityId, records: No
   });
 }
 
-export function updatePosition(identityId: IdentityId, event: PositionEvent): void {
+function meshtasticLastHeardPatch(
+  identityId: IdentityId,
+  nodeId: number,
+  packetTimestampMs: number,
+  existingLastHeardAt: number | undefined,
+): number | undefined {
+  if (getIdentity(identityId)?.protocol.type !== 'meshtastic') return undefined;
+  const merged = mergeMeshtasticLivePacketLastHeard(
+    existingLastHeardAt ?? 0,
+    packetTimestampMs,
+    false,
+  );
+  return merged > 0 ? merged : undefined;
+}
+
+/** Bump MeshCore `lastHeardAt` in the identity store (path-updated / RPC reachability). */
+export function patchMeshcoreNodeLastHeardAt(
+  identityId: IdentityId,
+  nodeId: number,
+  lastHeardSec: number,
+  extra?: Partial<NodeRecord>,
+): void {
+  if (nodeId <= 0 || !Number.isFinite(lastHeardSec) || lastHeardSec <= 0) return;
   useNodeStore.setState((s) => {
     const byId = s.nodes[identityId] ?? {};
-    const { nodeId, latitude, longitude, altitude, timestamp, groundSpeed, groundTrack } = event;
+    const existing = byId[nodeId];
+    if (!existing) return s;
+    const merged = mergeMeshcoreLastHeardFromAdvert(
+      lastHeardSec,
+      existing.lastHeardAt,
+      Math.floor(Date.now() / 1000),
+    );
     return {
       nodes: {
         ...s.nodes,
         [identityId]: {
           ...byId,
-          [nodeId]: mergeNode(byId[nodeId], nodeId, {
+          [nodeId]: mergeNode(existing, nodeId, {
+            lastHeardAt: merged > 0 ? merged : lastHeardSec,
+            ...extra,
+          }),
+        },
+      },
+    };
+  });
+}
+
+export function bumpMeshtasticNodesLastHeardAt(
+  identityId: IdentityId,
+  nodeIds: number[],
+  packetTimestampMs: number,
+): void {
+  if (getIdentity(identityId)?.protocol.type !== 'meshtastic' || nodeIds.length === 0) return;
+  useNodeStore.setState((s) => {
+    const byId = { ...(s.nodes[identityId] ?? {}) };
+    let changed = false;
+    for (const nodeId of nodeIds) {
+      if (nodeId <= 0) continue;
+      const existing = byId[nodeId];
+      const lastHeardAt = meshtasticLastHeardPatch(
+        identityId,
+        nodeId,
+        packetTimestampMs,
+        existing?.lastHeardAt,
+      );
+      if (lastHeardAt == null) continue;
+      byId[nodeId] = mergeNode(existing, nodeId, { lastHeardAt });
+      changed = true;
+    }
+    if (!changed) return s;
+    return { nodes: { ...s.nodes, [identityId]: byId } };
+  });
+}
+
+export function updatePosition(identityId: IdentityId, event: PositionEvent): void {
+  useNodeStore.setState((s) => {
+    const byId = s.nodes[identityId] ?? {};
+    const { nodeId, latitude, longitude, altitude, timestamp, groundSpeed, groundTrack } = event;
+    const existing = byId[nodeId];
+    const lastHeardAt = meshtasticLastHeardPatch(
+      identityId,
+      nodeId,
+      timestamp,
+      existing?.lastHeardAt,
+    );
+    return {
+      nodes: {
+        ...s.nodes,
+        [identityId]: {
+          ...byId,
+          [nodeId]: mergeNode(existing, nodeId, {
             latitude,
             longitude,
             altitude,
             positionTimestamp: timestamp,
             groundSpeed,
             groundTrack,
+            ...(lastHeardAt != null ? { lastHeardAt } : {}),
           }),
         },
       },
@@ -249,12 +345,19 @@ export function updateTelemetry(identityId: IdentityId, event: TelemetryEvent): 
       barometricPressure,
       iaq,
     } = event;
+    const existing = byId[nodeId];
+    const lastHeardAt = meshtasticLastHeardPatch(
+      identityId,
+      nodeId,
+      timestamp,
+      existing?.lastHeardAt,
+    );
     return {
       nodes: {
         ...s.nodes,
         [identityId]: {
           ...byId,
-          [nodeId]: mergeNode(byId[nodeId], nodeId, {
+          [nodeId]: mergeNode(existing, nodeId, {
             batteryLevel,
             voltage,
             channelUtilization,
@@ -265,6 +368,7 @@ export function updateTelemetry(identityId: IdentityId, event: TelemetryEvent): 
             barometricPressure,
             iaq,
             telemetryTimestamp: timestamp,
+            ...(lastHeardAt != null ? { lastHeardAt } : {}),
           }),
         },
       },

--- a/src/renderer/stores/nodeStore.ts
+++ b/src/renderer/stores/nodeStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 
+import { mergeMeshcoreLastHeardFromAdvert } from '../lib/nodeStatus';
 import type {
   CliEntry,
   NeighborInfoEvent,
@@ -14,6 +15,7 @@ import type {
   WaypointEvent,
 } from '../lib/protocols/Protocol';
 import type { IdentityId, MeshCoreLocalStats, MeshNeighbor } from '../lib/types';
+import { getIdentity } from './identityStore';
 import { omitRecordKey } from './storeUtils';
 
 export interface NodeRecord {
@@ -127,6 +129,7 @@ function mergeNode(
 export function upsertNode(identityId: IdentityId, event: NodeInfoEvent): void {
   useNodeStore.setState((s) => {
     const byId = s.nodes[identityId] ?? {};
+    const existing = byId[event.nodeId];
     const {
       nodeId,
       longName,
@@ -135,15 +138,28 @@ export function upsertNode(identityId: IdentityId, event: NodeInfoEvent): void {
       hwModel,
       isLicensed,
       role,
-      lastHeardAt,
+      lastHeardAt: eventLastHeardAt,
       publicKey,
     } = event;
+    let lastHeardAt = eventLastHeardAt;
+    if (
+      getIdentity(identityId)?.protocol.type === 'meshcore' &&
+      eventLastHeardAt != null &&
+      Number.isFinite(eventLastHeardAt)
+    ) {
+      const merged = mergeMeshcoreLastHeardFromAdvert(
+        eventLastHeardAt,
+        existing?.lastHeardAt,
+        Math.floor(Date.now() / 1000),
+      );
+      if (merged > 0) lastHeardAt = merged;
+    }
     return {
       nodes: {
         ...s.nodes,
         [identityId]: {
           ...byId,
-          [nodeId]: mergeNode(byId[nodeId], nodeId, {
+          [nodeId]: mergeNode(existing, nodeId, {
             longName,
             shortName,
             macAddr,

--- a/src/shared/meshcoreContactAgeCutoff.test.ts
+++ b/src/shared/meshcoreContactAgeCutoff.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { meshcoreContactsAgeCutoffSec } from './meshcoreContactAgeCutoff';
+
+describe('meshcoreContactsAgeCutoffSec', () => {
+  const nowMs = 1_700_000_000_000; // fixed ms anchor
+
+  it('returns epoch seconds minus whole days (not milliseconds)', () => {
+    expect(meshcoreContactsAgeCutoffSec(30, nowMs)).toBe(Math.floor(nowMs / 1000) - 30 * 86400);
+  });
+
+  it('returns 0 for invalid day counts', () => {
+    expect(meshcoreContactsAgeCutoffSec(0, nowMs)).toBe(0);
+    expect(meshcoreContactsAgeCutoffSec(-1, nowMs)).toBe(0);
+    expect(meshcoreContactsAgeCutoffSec(Number.NaN, nowMs)).toBe(0);
+  });
+
+  it('keeps recent last_advert rows when used as SQL cutoff', () => {
+    const cutoff = meshcoreContactsAgeCutoffSec(30, nowMs);
+    const recentSec = Math.floor(nowMs / 1000) - 86400;
+    const staleSec = cutoff - 1;
+    expect(recentSec).toBeGreaterThanOrEqual(cutoff);
+    expect(staleSec).toBeLessThan(cutoff);
+  });
+});

--- a/src/shared/meshcoreContactAgeCutoff.ts
+++ b/src/shared/meshcoreContactAgeCutoff.ts
@@ -1,0 +1,7 @@
+const SECONDS_PER_DAY = 86400;
+
+/** Unix-second cutoff for `meshcore_contacts.last_advert` (stored as epoch seconds, not ms). */
+export function meshcoreContactsAgeCutoffSec(days: number, nowMs: number = Date.now()): number {
+  if (typeof days !== 'number' || days < 1 || !Number.isFinite(days)) return 0;
+  return Math.floor(nowMs / 1000) - Math.floor(days) * SECONDS_PER_DAY;
+}


### PR DESCRIPTION
## Summary

- **Chat UX:** DM unread badges and tabs stay consistent (dismissed peers with unread remain visible, room servers excluded from DM counts, send ACKs update message store, pubkey fallback from session when `nodeStore` lacks keys).
- **Last heard:** Channel/DM/MQTT chat traffic bumps `last_heard` in identity-scoped `nodeStore` so Node Detail no longer shows stale advert-only timestamps.
- **Contact retention:** Fix startup age prune comparing `last_advert` in Unix **seconds** (was ms cutoff, deleting hundreds of contacts); persist radio contacts before offload and await DB pubkey merge after `refreshContacts`.
- **Store sync (#375 / #377):** MeshCore driver path mirrors Meshtastic—live ingest persists contacts, path-updated events, pubkey registry, and `last_heard` patches hit `nodeStore` / runtime refs, not only hook-local refs.
- **Docs:** AGENTS.md notes MeshCore ingest/persist paths and `last_advert` seconds semantics.

## Commits

1. `fix: align MeshCore chat unread and DM tab delivery UX`
2. `fix: bump MeshCore last_heard on channel and DM chat traffic`
3. `fix: prevent MeshCore contact pubkey loss on prune and offload`
4. `fix: sync MeshCore legacy side effects with identity-scoped stores`
5. `fix: sync MeshCore pubkey registry into runtime refs on live adverts`

## Test plan

- [ ] Connect MeshCore (RF and/or MQTT); receive channel + DM traffic; confirm Node Detail **last heard** updates for chat-only peers.
- [ ] DM with unread after dismissing tab: peer still appears in DMS row; sidebar unread matches channel vs DM breakdown (room nodes not counted as DMs).
- [ ] Send DM; tab stays open; message shows acked when radio accepts.
- [ ] Restart app with existing DB: contacts with pubkeys are not mass-deleted on startup prune; offload-from-radio flow retains SQLite pubkeys for DM send.
- [ ] Live advert / path update: DM send and trace paths see fresh `pubKeyMapRef` without waiting for full `refreshContacts`.
- [ ] `pnpm run test:run` (new/updated tests: age prune, ingest, pubkey registry, ChatPanel unread, offload contacts).