### PR TITLE
fix: restore node favorite toggles after identity-scoped store migration

### DIFF
--- a/src/renderer/hooks/useMeshcoreRuntime.contact-management.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.contact-management.test.tsx
@@ -6,7 +6,12 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { meshcoreSyntheticPlaceholderPubKeyHex } from '../lib/meshcoreUtils';
+import {
+  ensureOfflineProtocolIdentities,
+  OFFLINE_MESHCORE_IDENTITY_ID,
+} from '../lib/offlineProtocolIdentities';
 import { useMeshcoreRuntime } from '../runtime/useMeshcoreRuntime';
+import { upsertNode, useNodeStore } from '../stores/nodeStore';
 
 const STUB_SENDER_ID = 0x12345678;
 
@@ -102,5 +107,24 @@ describe('useMeshcoreRuntime contact management (no radio connection)', () => {
       true,
       meshcoreSyntheticPlaceholderPubKeyHex(STUB_SENDER_ID),
     );
+  });
+
+  it('setNodeFavorited updates nodeStore when contact exists only in the UI store bucket', async () => {
+    ensureOfflineProtocolIdentities();
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+    upsertNode(OFFLINE_MESHCORE_IDENTITY_ID, {
+      nodeId: STUB_SENDER_ID,
+      longName: 'Alice',
+    });
+
+    const { result } = renderHook(() => useMeshcoreRuntime());
+
+    await act(async () => {
+      await result.current.setNodeFavorited(STUB_SENDER_ID, true);
+    });
+
+    expect(
+      useNodeStore.getState().nodes[OFFLINE_MESHCORE_IDENTITY_ID][STUB_SENDER_ID].favorited,
+    ).toBe(true);
   });
 });

--- a/src/renderer/hooks/useMeshtasticRuntime.favorited.test.ts
+++ b/src/renderer/hooks/useMeshtasticRuntime.favorited.test.ts
@@ -1,0 +1,33 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ensureOfflineProtocolIdentities,
+  OFFLINE_MESHTASTIC_IDENTITY_ID,
+} from '../lib/offlineProtocolIdentities';
+import { useMeshtasticRuntime } from '../runtime/useMeshtasticRuntime';
+import { upsertNode, useNodeStore } from '../stores/nodeStore';
+
+const NODE_ID = 0x42424242;
+
+describe('useMeshtasticRuntime setNodeFavorited', () => {
+  beforeEach(() => {
+    ensureOfflineProtocolIdentities();
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+  });
+
+  it('updates nodeStore when node exists only in the UI store bucket', async () => {
+    upsertNode(OFFLINE_MESHTASTIC_IDENTITY_ID, { nodeId: NODE_ID, longName: 'Node B' });
+
+    const { result } = renderHook(() => useMeshtasticRuntime());
+
+    await act(async () => {
+      await result.current.setNodeFavorited(NODE_ID, true);
+    });
+
+    expect(window.electronAPI.db.setNodeFavorited).toHaveBeenCalledWith(NODE_ID, true);
+    expect(useNodeStore.getState().nodes[OFFLINE_MESHTASTIC_IDENTITY_ID][NODE_ID].favorited).toBe(
+      true,
+    );
+  });
+});

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -67,6 +67,7 @@ import { connectionDriver } from '../lib/drivers/ConnectionDriver';
 import type { OurPosition } from '../lib/gpsSource';
 import { hasStoredStaticGps, readStoredStaticGps, resolveOurPosition } from '../lib/gpsSource';
 import { syncMeshcoreNodesMapToIdentityStore } from '../lib/hydrateIdentityStoresFromDb';
+import { getIdentityIdForProtocol } from '../lib/identityByProtocol';
 import { attachMeshcoreIngest } from '../lib/ingest/meshcoreIngest';
 import { resolveLastBlePeripheralId } from '../lib/lastConnectionStorage';
 import { tryPersistMeshcoreIdentityFromRadioExport } from '../lib/letsMeshJwt';
@@ -255,7 +256,11 @@ import type {
 import { mirrorMqttStatusToConnection, setConnection } from '../stores/connectionStore';
 import { useDiagnosticsStore } from '../stores/diagnosticsStore';
 import { updateMessageStatus, useMessageStore } from '../stores/messageStore';
-import { patchMeshcoreNodeLastHeardAt, useNodeStore } from '../stores/nodeStore';
+import {
+  patchMeshcoreNodeLastHeardAt,
+  patchNodeFavorited,
+  useNodeStore,
+} from '../stores/nodeStore';
 import { computePathHash, usePathHistoryStore } from '../stores/pathHistoryStore';
 import { useRepeaterSignalStore } from '../stores/repeaterSignalStore';
 
@@ -4676,16 +4681,15 @@ export function useMeshcoreRuntime() {
   }, []);
 
   const setNodeFavorited = useCallback(async (nodeId: number, favorited: boolean) => {
-    const node = nodesRef.current.get(nodeId);
-    if (!node) return;
-    const prevFav = node.favorited;
-    const pk = pubKeyMapRef.current.get(nodeId);
-    const hex =
-      pk != null
-        ? Array.from(pk)
-            .map((b) => b.toString(16).padStart(2, '0'))
-            .join('')
-        : meshcoreSyntheticPlaceholderPubKeyHex(nodeId);
+    const storeId = getIdentityIdForProtocol('meshcore');
+    const storeRecord = storeId ? useNodeStore.getState().nodes[storeId]?.[nodeId] : undefined;
+    const runtimeNode = nodesRef.current.get(nodeId);
+    if (!runtimeNode && !storeRecord) return;
+
+    const prevFav = runtimeNode?.favorited ?? storeRecord?.favorited ?? false;
+    if (storeId) {
+      patchNodeFavorited(storeId, nodeId, favorited);
+    }
     setNodes((prev) => {
       const n = prev.get(nodeId);
       if (!n) return prev;
@@ -4693,12 +4697,22 @@ export function useMeshcoreRuntime() {
       next.set(nodeId, { ...n, favorited });
       return next;
     });
+    const pk = pubKeyMapRef.current.get(nodeId) ?? storeRecord?.publicKey;
+    const hex =
+      pk != null
+        ? Array.from(pk)
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join('')
+        : meshcoreSyntheticPlaceholderPubKeyHex(nodeId);
     try {
       await window.electronAPI.db.updateMeshcoreContactFavorited(nodeId, favorited, hex);
     } catch (e) {
       console.warn(
         '[useMeshcoreRuntime] updateMeshcoreContactFavorited error ' + errLikeToLogString(e),
       );
+      if (storeId) {
+        patchNodeFavorited(storeId, nodeId, prevFav);
+      }
       setNodes((prev) => {
         const n = prev.get(nodeId);
         if (!n) return prev;

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -80,6 +80,7 @@ import {
   hydrateMeshtasticMessagesFromDb,
   syncMeshtasticNodesMapToIdentityStore,
 } from '../lib/hydrateIdentityStoresFromDb';
+import { getIdentityIdForProtocol } from '../lib/identityByProtocol';
 import type { MeshtasticIngestSession } from '../lib/ingest/meshtasticIngest';
 import { meshtasticTransportParams } from '../lib/meshIdentityBridge';
 import { configureMeshtasticDeviceWithRetry } from '../lib/meshtastic/meshtasticConfigureRetry';
@@ -180,7 +181,7 @@ import {
   upsertMessage,
   useMessageStore,
 } from '../stores/messageStore';
-import { useNodeStore } from '../stores/nodeStore';
+import { patchNodeFavorited, useNodeStore } from '../stores/nodeStore';
 import { usePositionHistoryStore } from '../stores/positionHistoryStore';
 
 type ChannelType = Parameters<MeshDevice['setChannel']>[0];
@@ -3247,6 +3248,10 @@ export function useMeshtasticRuntime() {
   const setNodeFavorited = useCallback(
     async (nodeId: number, favorited: boolean) => {
       await window.electronAPI.db.setNodeFavorited(nodeId, favorited);
+      const storeId = getIdentityIdForProtocol('meshtastic');
+      if (storeId) {
+        patchNodeFavorited(storeId, nodeId, favorited);
+      }
       updateNodes((prev) => {
         const updated = new Map(prev);
         const existing = updated.get(nodeId);

--- a/src/renderer/stores/nodeStore.test.ts
+++ b/src/renderer/stores/nodeStore.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   appendMeshcoreCliEntry,
   clearMeshcoreCliHistory,
+  patchNodeFavorited,
   updateMeshcoreOp,
   updatePosition,
   upsertNode,
@@ -74,5 +75,26 @@ describe('nodeStore MeshCore op setters', () => {
   it('clearMeshcoreCliHistory is a no-op when node does not exist', () => {
     clearMeshcoreCliHistory(ID, 999);
     expect(useNodeStore.getState().nodes[ID]?.[999]).toBeUndefined();
+  });
+});
+
+describe('patchNodeFavorited', () => {
+  afterEach(() => {
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+  });
+
+  it('sets favorited on an existing node without clobbering other fields', () => {
+    upsertNode(ID, { nodeId: NODE, longName: 'Alpha' });
+    patchNodeFavorited(ID, NODE, true);
+    const rec = useNodeStore.getState().nodes[ID][NODE];
+    expect(rec.favorited).toBe(true);
+    expect(rec.longName).toBe('Alpha');
+  });
+
+  it('creates a minimal node record when none exists', () => {
+    patchNodeFavorited(ID, NODE, true);
+    const rec = useNodeStore.getState().nodes[ID][NODE];
+    expect(rec.nodeId).toBe(NODE);
+    expect(rec.favorited).toBe(true);
   });
 });

--- a/src/renderer/stores/nodeStore.ts
+++ b/src/renderer/stores/nodeStore.ts
@@ -239,6 +239,27 @@ function meshtasticLastHeardPatch(
   return merged > 0 ? merged : undefined;
 }
 
+/** Toggle favorite flag on a node in the identity-scoped store (UI reads this bucket). */
+export function patchNodeFavorited(
+  identityId: IdentityId,
+  nodeId: number,
+  favorited: boolean,
+): void {
+  useNodeStore.setState((s) => {
+    const byId = s.nodes[identityId] ?? {};
+    const existing = byId[nodeId];
+    return {
+      nodes: {
+        ...s.nodes,
+        [identityId]: {
+          ...byId,
+          [nodeId]: mergeNode(existing, nodeId, { favorited }),
+        },
+      },
+    };
+  });
+}
+
 /** Bump MeshCore `lastHeardAt` in the identity store (path-updated / RPC reachability). */
 export function patchMeshcoreNodeLastHeardAt(
   identityId: IdentityId,


### PR DESCRIPTION
## Summary

- Add `patchNodeFavorited` so favorite toggles update the identity-scoped `nodeStore` bucket that panels and modals actually read.
- Route Meshtastic and MeshCore `setNodeFavorited` through `getIdentityIdForProtocol` instead of only mutating runtime-local node maps.
- MeshCore favorites now work when contacts exist only in Zustand (e.g. offline DB hydration before connect).

After the #375 / #497 store migration, star buttons wrote to stale runtime state or the wrong identity slice while the UI read from `nodeStore`, so favorites appeared broken everywhere (Node List, Node Detail, Repeaters, Rooms).

## Test plan

- [x] `pnpm run test:run -- src/renderer/stores/nodeStore.test.ts src/renderer/hooks/useMeshtasticRuntime.favorited.test.ts src/renderer/hooks/useMeshcoreRuntime.contact-management.test.tsx`
- [ ] Open Node List and toggle a node favorite — star fills/clears immediately
- [ ] Open Node Detail modal and toggle favorite — persists after closing/reopening
- [ ] Repeat on MeshCore Repeaters and Rooms panels
- [ ] Confirm favorite survives app restart (SQLite round-trip)