### PR TITLE
fix: lock Rooms panel scroll layout and match Chat jump UX

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1965,7 +1965,7 @@ function AppContent({
               >
                 Meshtastic
                 {meshtasticChatUnread > 0 && protocol !== 'meshtastic' && (
-                  <span className="bg-brand-green/30 text-brand-green ml-1.5 inline-flex h-4 min-w-[1.1rem] animate-pulse items-center justify-center rounded-full px-0.5 text-[10px] font-bold">
+                  <span className="bg-brand-green text-deep-black ml-1.5 inline-flex h-4 min-w-[1.1rem] animate-pulse items-center justify-center rounded-full px-0.5 text-[10px] font-bold">
                     {meshtasticChatUnread > 99 ? '99+' : meshtasticChatUnread}
                   </span>
                 )}
@@ -1986,7 +1986,7 @@ function AppContent({
               >
                 MeshCore
                 {meshcoreChatUnread > 0 && protocol !== 'meshcore' && (
-                  <span className="ml-1.5 inline-flex h-4 min-w-[1.1rem] animate-pulse items-center justify-center rounded-full bg-cyan-600/30 px-0.5 text-[10px] font-bold text-cyan-400">
+                  <span className="text-deep-black ml-1.5 inline-flex h-4 min-w-[1.1rem] animate-pulse items-center justify-center rounded-full bg-cyan-400 px-0.5 text-[10px] font-bold">
                     {meshcoreChatUnread > 99 ? '99+' : meshcoreChatUnread}
                   </span>
                 )}
@@ -2654,7 +2654,7 @@ function AppContent({
                       role="tabpanel"
                       aria-labelledby="tab-7"
                       hidden={activePanelIndex !== 7}
-                      className="w-full min-w-0"
+                      className="h-full w-full min-w-0"
                     >
                       {(activePanelIndex === ROOMS_PANEL_INDEX || roomsTabVisited) &&
                       protocol === 'meshcore' ? (

--- a/src/renderer/components/RoomsPanel.test.tsx
+++ b/src/renderer/components/RoomsPanel.test.tsx
@@ -4,6 +4,10 @@ import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { mergeAppSetting } from '@/renderer/lib/appSettingsStorage';
+import {
+  mergeRoomLastReadWatermark,
+  savePersistedRoomsLastRead,
+} from '@/renderer/lib/chatPanelProtocolStorage';
 import { buildMeshcoreRoomIncomingMessage } from '@/renderer/lib/meshcoreChannelText';
 import {
   clearAllMeshcoreRoomAutoLoginFailures,
@@ -18,6 +22,7 @@ import {
 import { computeRoomUnreadCounts } from '@/renderer/lib/meshcoreRoomsUnread';
 import type { ChatMessage, MeshNode } from '@/renderer/lib/types';
 
+import * as chatScrollUtils from '../lib/chatScrollUtils';
 import RoomsPanel from './RoomsPanel';
 
 vi.mock('react-i18next', () => ({
@@ -647,5 +652,125 @@ describe('RoomsPanel', () => {
       expect(onLoginRoom).toHaveBeenCalled();
     });
     expect(screen.queryByLabelText('roomsPanel.autoLoginFailedAria')).not.toBeInTheDocument();
+  });
+
+  it('locks post stream scroll inside a fixed-height flex column', () => {
+    meshcoreClearAllRoomSessions();
+    const room = makeRoom(0x1011, 'Scroll Room');
+    const nodes = new Map<number, MeshNode>([[room.node_id, room]]);
+    meshcoreApplyRoomSession(room.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+
+    render(
+      <div className="flex flex-col" style={{ height: '600px' }}>
+        <RoomsPanel
+          nodes={nodes}
+          messages={[]}
+          myNodeNum={1}
+          isConnected
+          isActive
+          initialRoomTarget={room.node_id}
+          onLoginRoom={vi.fn().mockResolvedValue(undefined)}
+          onCancelRoomLogin={vi.fn()}
+          onLeaveRoom={vi.fn().mockResolvedValue(undefined)}
+          onSendRoomPost={vi.fn()}
+          onSendRoomAdminCli={vi.fn()}
+        />
+      </div>,
+    );
+
+    const stream = screen.getByTestId('rooms-post-stream');
+    expect(stream).toHaveClass('overflow-y-auto');
+    expect(stream.parentElement).toHaveClass('min-h-0', 'flex-1');
+    expect(screen.getByTestId('rooms-composer-footer')).toHaveClass('shrink-0');
+  });
+
+  it('shows new messages divider when selecting a room with unread posts', async () => {
+    meshcoreClearAllRoomSessions();
+    const roomA = makeRoom(0x1012, 'Unread Room');
+    const roomB = makeRoom(0x1013, 'Current Room');
+    const nodes = new Map<number, MeshNode>([
+      [roomA.node_id, roomA],
+      [roomB.node_id, roomB],
+    ]);
+    meshcoreApplyRoomSession(roomA.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+    meshcoreApplyRoomSession(roomB.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+    savePersistedRoomsLastRead(mergeRoomLastReadWatermark({}, roomA.node_id, 1000));
+    const messages: ChatMessage[] = [
+      buildMeshcoreRoomIncomingMessage({
+        rawText: 'Unread post',
+        roomServerId: roomA.node_id,
+        authorId: 0x200,
+        authorName: 'Alice',
+        timestamp: 5000,
+        receivedVia: 'rf',
+      }),
+    ];
+
+    renderRoomsPanel(nodes, {
+      initialRoomTarget: roomB.node_id,
+      messages,
+      isActive: true,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Unread Room/i }));
+    expect(screen.getByText('roomsPanel.newMessagesDivider')).toBeInTheDocument();
+  });
+
+  it('jump-to-unread button scrolls toward the unread divider', async () => {
+    meshcoreClearAllRoomSessions();
+    const room = makeRoom(0x1014, 'Jump Room');
+    const nodes = new Map<number, MeshNode>([[room.node_id, room]]);
+    meshcoreApplyRoomSession(room.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+    savePersistedRoomsLastRead(mergeRoomLastReadWatermark({}, room.node_id, 1000));
+    const messages: ChatMessage[] = [
+      buildMeshcoreRoomIncomingMessage({
+        rawText: 'Older post',
+        roomServerId: room.node_id,
+        authorId: 0x200,
+        authorName: 'Alice',
+        timestamp: 2000,
+        receivedVia: 'rf',
+      }),
+      buildMeshcoreRoomIncomingMessage({
+        rawText: 'Unread post',
+        roomServerId: room.node_id,
+        authorId: 0x201,
+        authorName: 'Bob',
+        timestamp: 5000,
+        receivedVia: 'rf',
+      }),
+    ];
+    const distSpy = vi.spyOn(chatScrollUtils, 'getDistFromChatBottom').mockReturnValue(300);
+    const scrollIntoView = vi.fn();
+    vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(scrollIntoView);
+
+    renderRoomsPanel(nodes, {
+      initialRoomTarget: room.node_id,
+      messages,
+      isActive: true,
+    });
+
+    const jumpButton = await screen.findByRole('button', { name: 'roomsPanel.jumpToUnread' });
+    await userEvent.click(jumpButton);
+
+    expect(scrollIntoView).toHaveBeenCalled();
+    distSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 });

--- a/src/renderer/components/RoomsPanel.tsx
+++ b/src/renderer/components/RoomsPanel.tsx
@@ -215,6 +215,7 @@ export default function RoomsPanel({
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [showScrollTopButton, setShowScrollTopButton] = useState(false);
   const [unreadDividerTimestamp, setUnreadDividerTimestamp] = useState(0);
+  const [triggerScrollToUnread, setTriggerScrollToUnread] = useState(0);
   const [, setAutoLoginFailureEpoch] = useState(0);
   const [storedRoomIds, setStoredRoomIds] = useState<Set<number>>(
     () => new Set(listMeshcoreRoomCredentialNodeIds()),
@@ -224,9 +225,12 @@ export default function RoomsPanel({
   const loginQueueRevision = useMeshcoreRoomLoginQueueRevision();
   const streamRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const unreadDividerRef = useRef<HTMLDivElement>(null);
   const [persistedRoomsLastRead, setPersistedRoomsLastRead] = useState(() =>
     loadPersistedRoomsLastRead(),
   );
+  const persistedRoomsLastReadRef = useRef(persistedRoomsLastRead);
+  persistedRoomsLastReadRef.current = persistedRoomsLastRead;
   const [streamView, setStreamView] = useState<'posts' | 'starred'>('posts');
   const [starred, setStarred] = useState<StarredMessage[]>(() => loadStarred('meshcore'));
   const [membersOpen, setMembersOpen] = useState(true);
@@ -309,14 +313,17 @@ export default function RoomsPanel({
   const markSelectedRoomRead = useCallback(() => {
     if (selectedRoomId == null || roomPosts.length === 0) return;
     const latest = Math.max(...roomPosts.map((m) => m.timestamp));
-    setPersistedRoomsLastRead((prev) => {
-      const next = mergeRoomLastReadWatermark(prev, selectedRoomId, latest);
-      if (next === prev) return prev;
-      savePersistedRoomsLastRead(next);
-      notifyPersistedRoomsLastReadChanged();
-      return next;
-    });
+    setPersistedRoomsLastRead((prev) => mergeRoomLastReadWatermark(prev, selectedRoomId, latest));
   }, [roomPosts, selectedRoomId]);
+
+  useEffect(() => {
+    try {
+      savePersistedRoomsLastRead(persistedRoomsLastRead);
+      notifyPersistedRoomsLastReadChanged();
+    } catch (e) {
+      console.warn('[RoomsPanel] persist rooms lastRead failed ' + errLikeToLogString(e));
+    }
+  }, [persistedRoomsLastRead]);
 
   const updateScrollButtonVisibility = useCallback(() => {
     const distFromBottom = getDistFromChatBottom(
@@ -352,6 +359,27 @@ export default function RoomsPanel({
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, []);
 
+  const scrollToUnreadOrBottom = useCallback(() => {
+    const el = streamRef.current;
+    if (unreadDividerRef.current) {
+      if (el) {
+        const onEnd = () => {
+          el.removeEventListener('scrollend', onEnd);
+          const dist = getDistFromChatBottom(
+            el,
+            messagesEndRef.current,
+            outerScrollMetricsRootRef?.current ?? null,
+          );
+          if (dist !== null) applyNearBottomReadState(dist);
+        };
+        el.addEventListener('scrollend', onEnd, { once: true });
+      }
+      unreadDividerRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    } else {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [applyNearBottomReadState, outerScrollMetricsRootRef]);
+
   useLayoutEffect(() => {
     requestAnimationFrame(() => {
       updateScrollButtonVisibility();
@@ -383,16 +411,61 @@ export default function RoomsPanel({
   ]);
 
   useEffect(() => {
-    const outer = outerScrollMetricsRootRef?.current;
-    if (!outer) return;
+    if (!isActive) return;
+    const root = outerScrollMetricsRootRef?.current;
+    if (!root) return;
     const onOuterScroll = () => {
-      handleStreamScroll();
+      const dist = updateScrollButtonVisibility();
+      if (dist !== undefined) applyNearBottomReadState(dist);
     };
-    outer.addEventListener('scroll', onOuterScroll);
+    root.addEventListener('scroll', onOuterScroll, { passive: true });
     return () => {
-      outer.removeEventListener('scroll', onOuterScroll);
+      root.removeEventListener('scroll', onOuterScroll);
     };
-  }, [handleStreamScroll, outerScrollMetricsRootRef]);
+  }, [applyNearBottomReadState, isActive, outerScrollMetricsRootRef, updateScrollButtonVisibility]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const root = outerScrollMetricsRootRef?.current;
+    if (!root || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => {
+      requestAnimationFrame(() => {
+        updateScrollButtonVisibility();
+      });
+    });
+    ro.observe(root);
+    return () => {
+      ro.disconnect();
+    };
+  }, [isActive, outerScrollMetricsRootRef, updateScrollButtonVisibility]);
+
+  useLayoutEffect(() => {
+    if (triggerScrollToUnread === 0) return;
+    if (!isActive) return;
+    if (unreadDividerRef.current) {
+      unreadDividerRef.current.scrollIntoView({ block: 'center' });
+    } else {
+      messagesEndRef.current?.scrollIntoView();
+    }
+    requestAnimationFrame(() => {
+      const dist = updateScrollButtonVisibility();
+      if (dist !== undefined && dist < 50) setUnreadDividerTimestamp(0);
+    });
+  }, [triggerScrollToUnread, isActive, updateScrollButtonVisibility]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    requestAnimationFrame(() => {
+      updateScrollButtonVisibility();
+    });
+  }, [isActive, selectedRoomId, updateScrollButtonVisibility]);
+
+  useEffect(() => {
+    if (selectedRoomId == null) return;
+    const snapshot = persistedRoomsLastReadRef.current[selectedRoomId] ?? 0;
+    setUnreadDividerTimestamp(snapshot);
+    setTriggerScrollToUnread((n) => n + 1);
+  }, [selectedRoomId]);
 
   useEffect(() => {
     if (initialRoomTarget != null) {
@@ -411,8 +484,6 @@ export default function RoomsPanel({
 
   const handleSelectRoom = useCallback(
     (nodeId: number) => {
-      const lastRead = persistedRoomsLastRead[nodeId] ?? 0;
-      setUnreadDividerTimestamp(lastRead);
       setSelectedRoomId(nodeId);
       setLoginErrorsByRoom((prev) => {
         if (!prev.has(nodeId)) return prev;
@@ -431,7 +502,7 @@ export default function RoomsPanel({
       setManageOpen(false);
       loadSyncConfig(nodeId);
     },
-    [loadSyncConfig, persistedRoomsLastRead],
+    [loadSyncConfig],
   );
 
   const loginQueueSnapshot = useMemo(() => {
@@ -874,7 +945,7 @@ export default function RoomsPanel({
     <div className="flex h-full min-h-0 min-w-0 flex-col gap-3">
       {RemoteAuthModal}
       <div className="flex min-h-0 flex-1 gap-3">
-        <div className="bg-secondary-dark flex w-64 shrink-0 flex-col overflow-hidden rounded-lg border border-gray-700">
+        <div className="bg-secondary-dark flex min-h-0 w-64 shrink-0 flex-col overflow-hidden rounded-lg border border-gray-700">
           <div className="flex items-center gap-2 border-b border-gray-700 px-3 py-2">
             <span className="min-w-0 flex-1 text-sm font-medium text-gray-200">
               {t('roomsPanel.title')} <span className="text-gray-500">({roomServers.length})</span>
@@ -1007,7 +1078,7 @@ export default function RoomsPanel({
           </div>
         </div>
 
-        <div className="bg-secondary-dark relative flex min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-700">
+        <div className="bg-secondary-dark relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-700">
           {!selectedRoomId && (
             <div className="flex flex-1 items-center justify-center p-6 text-sm text-gray-500">
               {t('roomsPanel.selectRoom')}
@@ -1123,7 +1194,7 @@ export default function RoomsPanel({
           )}
 
           {selectedRoomId && loggedIn && (
-            <>
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-gray-700 px-3 py-2">
                 <span className="text-sm font-medium text-gray-200">{activeRoom?.long_name}</span>
                 <span className="text-xs text-gray-500">
@@ -1389,6 +1460,7 @@ export default function RoomsPanel({
               <div className="relative min-h-0 flex-1">
                 <div
                   ref={streamRef}
+                  data-testid="rooms-post-stream"
                   onScroll={handleStreamScroll}
                   className="h-full min-h-0 space-y-2 overflow-y-auto px-3 py-2"
                 >
@@ -1453,7 +1525,9 @@ export default function RoomsPanel({
                       return (
                         <div key={rowKey}>
                           {showUnreadDivider && (
-                            <RoomUnreadDivider label={t('roomsPanel.newMessagesDivider')} />
+                            <div ref={unreadDividerRef}>
+                              <RoomUnreadDivider label={t('roomsPanel.newMessagesDivider')} />
+                            </div>
                           )}
                           <div
                             ref={(el) => {
@@ -1607,8 +1681,11 @@ export default function RoomsPanel({
                   <button
                     type="button"
                     onClick={() => {
-                      scrollToBottom();
-                      setUnreadDividerTimestamp(0);
+                      if (unreadDividerRef.current) {
+                        scrollToUnreadOrBottom();
+                      } else {
+                        scrollToBottom();
+                      }
                     }}
                     className="bg-secondary-dark absolute bottom-2 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-300 shadow-lg transition-all hover:bg-gray-600"
                     aria-label={
@@ -1640,6 +1717,7 @@ export default function RoomsPanel({
 
               <div
                 className={`shrink-0 border-t border-gray-700 p-3 ${streamView === 'starred' ? 'hidden' : ''}`}
+                data-testid="rooms-composer-footer"
               >
                 {!canPost ? (
                   <div className="space-y-2">
@@ -1820,7 +1898,7 @@ export default function RoomsPanel({
                   </div>
                 </div>
               )}
-            </>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Restore viewport-locked layout for the MeshCore Rooms panel: `#panel-7` gets `h-full`, columns use `min-h-0`, and the logged-in stack is a flex column so only the post stream scrolls while the composer stays pinned.
- Match Chat scroll UX in Rooms: unread divider ref, jump-to-unread/latest, scroll-to-top, auto-scroll on room switch, `ResizeObserver`, and outer scroll metrics.
- Move rooms last-read persistence/notification into a `useEffect` (same pattern as ChatPanel) to avoid updating `AppContent` during `RoomsPanel` render.
- Fix protocol switcher unread badge color contrast (solid background + `text-deep-black`).
- Add RoomsPanel tests for layout contract, unread divider on room select, and jump-to-unread button behavior.

## Test plan

- [x] Open MeshCore → Rooms with many room servers and a room with many posts
- [x] Confirm server list scrolls in the left column; post stream scrolls internally; composer stays visible without page scroll
- [ ] Switch to a room with unread posts → “New messages” divider appears and view scrolls to unread
- [ ] Scroll up in post stream → “Jump to unread” / “Jump to latest” and “Back to top” buttons work
- [ ] No React warning about updating `AppContent` while rendering `RoomsPanel`
- [ ] `pnpm run test:run src/renderer/components/RoomsPanel.test.tsx`