### PR TITLE
fix: deduplicate MS_PER_DAY via shared time constants

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -8,6 +8,7 @@ import {
   MESHCORE_PATH_HISTORY_PER_NODE_ROW_LIMIT,
 } from '../shared/meshcorePathHistoryLimits';
 import { escapeSqlLikePattern } from '../shared/sqlLikeEscape';
+import { MS_PER_DAY } from '../shared/timeConstants';
 import { NodeSqliteDB } from './db-compat';
 import {
   CANONICAL_CREATE_ALL_DDL,
@@ -18,8 +19,6 @@ import { sanitizeLogMessage } from './log-service';
 
 /** Re-export for callers/tests that track the on-disk `user_version`. */
 export { CURRENT_SCHEMA_VERSION };
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /** Thrown when mergeDatabase rejects the source path before opening SQLite. */
 export class MergeSourceInvalidError extends Error {

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -1,8 +1,6 @@
-/** Time duration constants in milliseconds. */
-export const MS_PER_SECOND = 1_000;
-export const MS_PER_MINUTE = 60_000;
-export const MS_PER_HOUR = 3_600_000;
-export const MS_PER_DAY = 86_400_000;
+import { MS_PER_MINUTE } from '../../shared/timeConstants';
+
+export { MS_PER_DAY, MS_PER_HOUR, MS_PER_MINUTE, MS_PER_SECOND } from '../../shared/timeConstants';
 
 /**
  * Compact chat: merged consecutive bubbles from the same sender show a muted timestamp when the gap

--- a/src/shared/timeConstants.ts
+++ b/src/shared/timeConstants.ts
@@ -1,0 +1,5 @@
+/** Time duration constants in milliseconds (main + renderer). */
+export const MS_PER_SECOND = 1_000;
+export const MS_PER_MINUTE = 60_000;
+export const MS_PER_HOUR = 3_600_000;
+export const MS_PER_DAY = 86_400_000;


### PR DESCRIPTION
## Summary

- Add `src/shared/timeConstants.ts` with `MS_PER_SECOND` through `MS_PER_DAY` for use in both Electron processes.
- Remove the duplicate `MS_PER_DAY` definition in `src/main/database.ts`; prune cutoffs now import the shared constant.
- `src/renderer/lib/timeConstants.ts` re-exports the base durations from shared so existing renderer import paths stay unchanged.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/main/database.test.ts`
- [x] Pre-commit hook (lint, checks, full test suite) on commit