### PR TITLE
fix: chunk MeshCore contact batch saves over 500 IPC limit

### DIFF
--- a/src/main/index.contract.test.ts
+++ b/src/main/index.contract.test.ts
@@ -98,6 +98,15 @@ describe('MeshCore DB IPC (source contract)', () => {
     );
     expect(DATABASE_SOURCE).not.toContain('INSERT OR REPLACE INTO meshcore_contacts');
   });
+
+  it('saveMeshcoreContactsBatch IPC slices large radio syncs at MESHCORE_CONTACTS_BATCH_MAX', () => {
+    expect(INDEX_SOURCE).toContain('MESHCORE_CONTACTS_BATCH_MAX');
+    expect(INDEX_SOURCE).toMatch(
+      /for \(let i = 0; i < contacts\.length; i \+= MESHCORE_CONTACTS_BATCH_MAX\)/,
+    );
+    expect(INDEX_SOURCE).toContain('contacts.slice(i, i + MESHCORE_CONTACTS_BATCH_MAX)');
+    expect(INDEX_SOURCE).not.toContain('max 500 contacts per batch');
+  });
 });
 
 describe('Persistent app settings IPC (source contract)', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,7 @@ import { pathToFileURL } from 'url';
 import zlib from 'zlib';
 
 import type { MQTTSettings } from '../renderer/lib/types';
+import { MESHCORE_CONTACTS_BATCH_MAX } from '../shared/meshcoreContactsBatchLimit';
 import { sanitizeUnicodeReactionScalar } from '../shared/reactionEmoji';
 import type { TAKServerStatus, TAKSettings } from '../shared/tak-types';
 import {
@@ -4377,15 +4378,17 @@ ipcMain.handle('db:saveMeshcoreContactsBatch', (_event, contacts: unknown) => {
     if (!Array.isArray(contacts)) {
       throw new Error('db:saveMeshcoreContactsBatch: contacts must be an array');
     }
-    if (contacts.length > 500) {
-      throw new Error('db:saveMeshcoreContactsBatch: max 500 contacts per batch');
+    let saved = 0;
+    for (let i = 0; i < contacts.length; i += MESHCORE_CONTACTS_BATCH_MAX) {
+      const slice = contacts.slice(i, i + MESHCORE_CONTACTS_BATCH_MAX);
+      const rows: MeshcoreContactUpsertParams[] = [];
+      for (const contact of slice) {
+        validateSaveMeshcoreContact(contact);
+        rows.push(meshcoreContactInputToUpsertParams(contact));
+      }
+      saved += saveMeshcoreContactsBatch(rows);
     }
-    const rows: MeshcoreContactUpsertParams[] = [];
-    for (const contact of contacts) {
-      validateSaveMeshcoreContact(contact);
-      rows.push(meshcoreContactInputToUpsertParams(contact));
-    }
-    return saveMeshcoreContactsBatch(rows);
+    return saved;
   } catch (err) {
     console.error(
       '[IPC] db:saveMeshcoreContactsBatch failed:',

--- a/src/shared/meshcoreContactsBatchLimit.test.ts
+++ b/src/shared/meshcoreContactsBatchLimit.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  MESHCORE_CONTACTS_BATCH_MAX,
+  meshcoreContactsBatchSliceCount,
+} from './meshcoreContactsBatchLimit';
+
+describe('meshcoreContactsBatchLimit', () => {
+  it('exports IPC slice size of 500', () => {
+    expect(MESHCORE_CONTACTS_BATCH_MAX).toBe(500);
+  });
+
+  it('meshcoreContactsBatchSliceCount matches ceil(total / max)', () => {
+    expect(meshcoreContactsBatchSliceCount(0)).toBe(0);
+    expect(meshcoreContactsBatchSliceCount(1)).toBe(1);
+    expect(meshcoreContactsBatchSliceCount(500)).toBe(1);
+    expect(meshcoreContactsBatchSliceCount(501)).toBe(2);
+    expect(meshcoreContactsBatchSliceCount(688)).toBe(2);
+    expect(meshcoreContactsBatchSliceCount(1000)).toBe(2);
+    expect(meshcoreContactsBatchSliceCount(1001)).toBe(3);
+  });
+});

--- a/src/shared/meshcoreContactsBatchLimit.ts
+++ b/src/shared/meshcoreContactsBatchLimit.ts
@@ -1,0 +1,8 @@
+/** Max MeshCore contacts per SQLite upsert slice (IPC payload guard). */
+export const MESHCORE_CONTACTS_BATCH_MAX = 500;
+
+/** Number of batch slices required to persist `total` contacts. */
+export function meshcoreContactsBatchSliceCount(total: number): number {
+  if (!Number.isFinite(total) || total <= 0) return 0;
+  return Math.ceil(total / MESHCORE_CONTACTS_BATCH_MAX);
+}


### PR DESCRIPTION
## Summary

- Add `MESHCORE_CONTACTS_BATCH_MAX` (500) in `src/shared/meshcoreContactsBatchLimit.ts` with slice-count helper and unit tests.
- `db:saveMeshcoreContactsBatch` IPC handler now validates and upserts contacts in 500-row slices instead of rejecting payloads over 500.
- Contract test asserts the chunk loop and removal of the old hard error.

Fixes failed SQLite persist when MeshCore radios return large contact tables (reported with **688** contacts over TCP on 5.19.1). The UI already showed all radio contacts in-session, but restart only restored the smaller DB cache until reconnect.

## Test plan

- [x] `pnpm run test:run` — `meshcoreContactsBatchLimit.test.ts`, `index.contract.test.ts`
- [ ] MeshCore TCP connect with **>500** contacts on radio
- [ ] Log has no `max 500 contacts per batch` error
- [ ] `meshcore_contacts` row count matches radio sync (~688 in reporter log)
- [ ] Restart app offline — contact list reflects persisted DB rows (minus prune rules)