### PR TITLE
fix: MeshCore DM sender prefix resolution and contact bleed

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -107,6 +107,10 @@ import {
   readMeshcoreIdentityAsync,
 } from './lib/letsMeshJwt';
 import { meshcoreChatMessagesForDisplay } from './lib/meshcoreChannelText';
+import {
+  meshcoreRoomServerIdsFromNodes,
+  repairMeshcoreHydratedMessages,
+} from './lib/meshcoreDbCacheHydration';
 import { syncMeshcoreDisplayReplyRepairs } from './lib/meshcoreStoreDedup';
 import { pubkeyToNodeId } from './lib/meshcoreUtils';
 import { meshNodeStubForDetailModal } from './lib/meshNodeStubForDetail';
@@ -124,7 +128,11 @@ import { repairMeshtasticReplyPreviews } from './lib/replyPreview';
 import { logRfReconnectFailure, reconnectRfFromLastConnection } from './lib/rfReconnectHelper';
 import { runStartupDbPrune } from './lib/startupDbPrune';
 import { getStoredMeshProtocol, MESH_PROTOCOL_STORAGE_KEY } from './lib/storedMeshProtocol';
-import { messageRecordsToChatMessages, nodeRecordsToMeshNodeMap } from './lib/storeRecordAdapters';
+import {
+  messageRecordsToChatMessages,
+  nodeRecordsToMeshNodeMap,
+  nodeRecordToMeshNode,
+} from './lib/storeRecordAdapters';
 import { applyThemeColors, loadThemeColors } from './lib/themeColors';
 import type {
   ChatMessage,
@@ -713,10 +721,16 @@ function AppContent({
     () => repairMeshtasticReplyPreviews(messageRecordsToChatMessages(meshtasticStoreMessages)),
     [meshtasticStoreMessages],
   );
-  const meshcoreUiMessages = useMemo(
-    () => meshcoreChatMessagesForDisplay(messageRecordsToChatMessages(meshcoreStoreMessages)),
-    [meshcoreStoreMessages],
-  );
+  const meshcoreUiMessages = useMemo(() => {
+    const mapped = meshcoreChatMessagesForDisplay(
+      messageRecordsToChatMessages(meshcoreStoreMessages),
+    );
+    if (!meshcoreNodesById) return mapped;
+    const roomIds = meshcoreRoomServerIdsFromNodes(
+      Object.values(meshcoreNodesById).map(nodeRecordToMeshNode),
+    );
+    return repairMeshcoreHydratedMessages(mapped, roomIds);
+  }, [meshcoreStoreMessages, meshcoreNodesById]);
 
   useEffect(() => {
     if (!meshcoreIdentityId) return;

--- a/src/renderer/hooks/meshcore/meshcoreHookPreamble.ts
+++ b/src/renderer/hooks/meshcore/meshcoreHookPreamble.ts
@@ -6,6 +6,7 @@ import type {
   MeshcoreContactDbRow,
   MeshCoreContactRaw,
 } from '../../lib/meshcore/meshcoreHookTypes';
+import { registerMeshcorePubKey } from '../../lib/meshcore/meshcorePubKeyRegistry';
 import {
   meshcoreChatMessagesForDisplay,
   normalizeMeshcoreIncomingText,
@@ -649,6 +650,17 @@ export function meshcoreFullPubKeyBytesFromContactDbHex(raw: string): Uint8Array
   const pairs = hex.match(/.{2}/g);
   if (pairs?.length !== 32) return null;
   return new Uint8Array(pairs.map((b) => parseInt(b, 16)));
+}
+
+/** Pre-seed global pubkey registry from SQLite before PacketRouter subscribe (DM prefix decode). */
+export function registerMeshcorePubKeysFromContactDbRows(
+  rows: readonly Pick<MeshcoreContactDbRow, 'node_id' | 'public_key'>[],
+): void {
+  for (const row of rows) {
+    const bytes = meshcoreFullPubKeyBytesFromContactDbHex(row.public_key);
+    if (!bytes) continue;
+    registerMeshcorePubKey(row.node_id, bytes);
+  }
 }
 
 export interface MergeMeshcoreDbContactsRefs {

--- a/src/renderer/lib/ingest/meshcoreIngest.test.ts
+++ b/src/renderer/lib/ingest/meshcoreIngest.test.ts
@@ -406,4 +406,31 @@ describe('attachMeshcoreIngest', () => {
       expect.objectContaining({ payload: '👍', emoji: expect.any(Number), reply_id: parentTs }),
     );
   });
+
+  it('does not create a contacts-list stub for unresolved RF DMs (from=0)', () => {
+    const botId = 0xac200e59;
+    const msgId = `${botId}:1700000300`;
+    upsertMessage(ID, {
+      id: msgId,
+      from: 0,
+      senderName: 'Unknown',
+      to: 0,
+      payload: 'weather report',
+      channelIndex: -1,
+      timestamp: 1_700_000_000_300,
+    });
+    meshcoreIngestHandleTextMessage(ID, {
+      type: 'text_message',
+      payload: {
+        id: msgId,
+        from: 0,
+        to: 0,
+        payload: 'weather report',
+        channelIndex: -1,
+        timestamp: 1_700_000_000_300,
+      },
+    });
+    expect(useNodeStore.getState().nodes[ID]?.[botId]).toBeUndefined();
+    expect(useNodeStore.getState().nodes[ID]?.[MESHCORE_UNKNOWN_SENDER_STUB_ID]).toBeUndefined();
+  });
 });

--- a/src/renderer/lib/ingest/meshcoreIngest.ts
+++ b/src/renderer/lib/ingest/meshcoreIngest.ts
@@ -34,7 +34,9 @@ import {
 } from '../meshcoreRoomMessageRouting';
 import { meshcoreSortedStorePrior, upsertMeshcoreMessageWithDedup } from '../meshcoreStoreDedup';
 import {
+  MESHCORE_UNKNOWN_SENDER_STUB_ID,
   meshcoreChatStubNodeIdFromDisplayName,
+  meshcoreIsChatStubNodeId,
   meshcoreMinimalNodeFromAdvertEvent,
 } from '../meshcoreUtils';
 import type { DomainEvent } from '../protocols/Protocol';
@@ -233,7 +235,9 @@ function handleTextMessage(
     ? channelSender!.senderId
     : event.payload.from !== 0
       ? event.payload.from
-      : meshcoreChatStubNodeIdFromDisplayName(displayName);
+      : displayName !== 'Unknown'
+        ? meshcoreChatStubNodeIdFromDisplayName(displayName)
+        : 0;
 
   const sortedPrior = messages;
 
@@ -280,7 +284,14 @@ function handleTextMessage(
   } = upsertMeshcoreMessageWithDedup(identityId, reconciled, event.payload.id);
 
   const isEcho = myNodeNum > 0 && senderId === myNodeNum;
-  if (!isEcho) {
+  const isDm = !isChannel && event.payload.channelIndex === -1;
+  const mayBumpDmSender =
+    !isDm ||
+    (event.payload.from > 0 &&
+      senderId === event.payload.from &&
+      senderId !== MESHCORE_UNKNOWN_SENDER_STUB_ID &&
+      !meshcoreIsChatStubNodeId(senderId));
+  if (!isEcho && mayBumpDmSender && senderId > 0) {
     bumpMeshcoreChatSenderLastHeard(identityId, senderId, {
       timestampMs: event.payload.timestamp,
       displayName: displayName !== 'Unknown' ? displayName : undefined,

--- a/src/renderer/lib/meshcore/meshcoreChatSenderNode.test.ts
+++ b/src/renderer/lib/meshcore/meshcoreChatSenderNode.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { useNodeStore } from '../../stores/nodeStore';
+import { MESHCORE_UNKNOWN_SENDER_STUB_ID } from '../meshcoreUtils';
 import { getNodeStatus } from '../nodeStatus';
 import { ensureMeshcoreChatSenderInNodeStore } from './meshcoreChatSenderNode';
 
@@ -66,6 +67,15 @@ describe('ensureMeshcoreChatSenderInNodeStore', () => {
   it('skips node id zero', () => {
     useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
     ensureMeshcoreChatSenderInNodeStore(ID, 0, { lastHeardAtMs: Date.now() });
+    expect(useNodeStore.getState().nodes[ID]).toBeUndefined();
+  });
+
+  it('skips the shared Unknown stub id', () => {
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+    ensureMeshcoreChatSenderInNodeStore(ID, MESHCORE_UNKNOWN_SENDER_STUB_ID, {
+      lastHeardAtMs: Date.now(),
+      displayName: 'Unknown',
+    });
     expect(useNodeStore.getState().nodes[ID]).toBeUndefined();
   });
 });

--- a/src/renderer/lib/meshcore/meshcoreChatSenderNode.ts
+++ b/src/renderer/lib/meshcore/meshcoreChatSenderNode.ts
@@ -1,5 +1,9 @@
 import { upsertNodeRecord, useNodeStore } from '../../stores/nodeStore';
-import { meshcoreMergeChannelDisplayNameOntoNode, minimalMeshcoreChatNode } from '../meshcoreUtils';
+import {
+  MESHCORE_UNKNOWN_SENDER_STUB_ID,
+  meshcoreMergeChannelDisplayNameOntoNode,
+  minimalMeshcoreChatNode,
+} from '../meshcoreUtils';
 import { lastHeardToUnixSeconds, mergeMeshcoreLastHeardFromAdvert } from '../nodeStatus';
 import { meshNodeToNodeRecord, nodeRecordToMeshNode } from '../storeRecordAdapters';
 import type { IdentityId } from '../types';
@@ -18,7 +22,7 @@ export function ensureMeshcoreChatSenderInNodeStore(
   nodeId: number,
   opts?: EnsureMeshcoreChatSenderOpts,
 ): void {
-  if (nodeId <= 0) return;
+  if (nodeId <= 0 || nodeId === MESHCORE_UNKNOWN_SENDER_STUB_ID) return;
   const nowSec = Math.floor(Date.now() / 1000);
   const incomingSec = lastHeardToUnixSeconds(opts?.lastHeardAtMs ?? Date.now());
   const existing = useNodeStore.getState().nodes[identityId]?.[nodeId];

--- a/src/renderer/lib/meshcore/meshcorePubKeyRegistry.test.ts
+++ b/src/renderer/lib/meshcore/meshcorePubKeyRegistry.test.ts
@@ -6,6 +6,7 @@ import {
   meshcorePubKeyRegistrySize,
   registerMeshcorePubKey,
   resolveMeshcoreNodeIdFromPubKeyPrefix,
+  seedMeshcorePrefixLookupMaps,
   setMeshcorePubKeyRegistryRefSync,
 } from './meshcorePubKeyRegistry';
 
@@ -35,5 +36,18 @@ describe('meshcorePubKeyRegistry', () => {
     expect(sync).toHaveBeenCalledTimes(1);
     clearMeshcorePubKeyRegistry();
     expect(sync).toHaveBeenCalledTimes(2);
+  });
+
+  it('seeds per-subscription prefix maps from the global registry', () => {
+    const pk = new Uint8Array(32).fill(9);
+    registerMeshcorePubKey(0xbeef, pk);
+    const prefixByHex = new Map<string, number>();
+    const pubKeyByNodeId = new Map<number, Uint8Array>();
+    seedMeshcorePrefixLookupMaps(prefixByHex, pubKeyByNodeId);
+    const prefix = Array.from(pk.slice(0, 6))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    expect(prefixByHex.get(prefix)).toBe(0xbeef);
+    expect(pubKeyByNodeId.get(0xbeef)).toEqual(pk);
   });
 });

--- a/src/renderer/lib/meshcore/meshcorePubKeyRegistry.ts
+++ b/src/renderer/lib/meshcore/meshcorePubKeyRegistry.ts
@@ -42,6 +42,18 @@ export function resolveMeshcoreNodeIdFromPubKeyPrefix(prefixHex: string): number
   return pubKeyPrefixByHex.get(prefixHex);
 }
 
+/** Seed per-subscription MeshCoreProtocol prefix maps from the global registry (post-connect contacts). */
+export function seedMeshcorePrefixLookupMaps(
+  nodeIdByPrefix: Map<string, number>,
+  pubKeyByNodeIdOut: Map<number, Uint8Array>,
+): void {
+  for (const [nodeId, publicKey] of pubKeyByNodeId) {
+    if (publicKey.length !== 32 || nodeId === 0) continue;
+    pubKeyByNodeIdOut.set(nodeId, publicKey);
+    nodeIdByPrefix.set(prefixHexFromPubKey(publicKey), nodeId);
+  }
+}
+
 export function clearMeshcorePubKeyRegistry(): void {
   pubKeyByNodeId.clear();
   pubKeyPrefixByHex.clear();

--- a/src/renderer/lib/protocols/MeshCoreProtocol.test.ts
+++ b/src/renderer/lib/protocols/MeshCoreProtocol.test.ts
@@ -1,6 +1,11 @@
 import type { Connection } from '@liamcottle/meshcore.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  clearMeshcorePubKeyRegistry,
+  registerMeshcorePubKey,
+} from '../meshcore/meshcorePubKeyRegistry';
+import { pubkeyToNodeId } from '../meshcoreUtils';
 import { meshcoreProtocol } from './MeshCoreProtocol';
 import type { DomainEvent } from './Protocol';
 
@@ -29,6 +34,7 @@ function mockMeshCoreConnection() {
 
 describe('MeshCoreProtocol.subscribe', () => {
   beforeEach(() => {
+    clearMeshcorePubKeyRegistry();
     vi.spyOn(meshcoreProtocol, 'createDevice').mockResolvedValue(
       mockMeshCoreConnection() as unknown as Connection,
     );
@@ -99,6 +105,31 @@ describe('MeshCoreProtocol.subscribe', () => {
       payload: expect.objectContaining({
         source: 'meshcore',
         message: expect.stringContaining('SNR -1.75'),
+      }),
+    });
+    teardown();
+  });
+
+  it('resolves DM sender from global pubkey registry without a live advert in this subscription', () => {
+    const publicKey = Uint8Array.from({ length: 32 }, (_, i) => i + 1);
+    const nodeId = pubkeyToNodeId(publicKey);
+    registerMeshcorePubKey(nodeId, publicKey);
+    const conn = mockMeshCoreConnection();
+    const events: DomainEvent[] = [];
+    const teardown = meshcoreProtocol.subscribe(conn, (e) => events.push(e));
+    conn.emit(EVENT_DIRECT_MESSAGE, {
+      pubKeyPrefix: publicKey.slice(0, 6),
+      text: 'weather report',
+      senderTimestamp: 1_700_000_300,
+      txtType: 0,
+    });
+    const text = events.find((e) => e.type === 'text_message');
+    expect(text).toMatchObject({
+      type: 'text_message',
+      payload: expect.objectContaining({
+        from: nodeId,
+        channelIndex: -1,
+        payload: 'weather report',
       }),
     });
     teardown();

--- a/src/renderer/lib/protocols/MeshCoreProtocol.ts
+++ b/src/renderer/lib/protocols/MeshCoreProtocol.ts
@@ -5,6 +5,10 @@ import {
   MESHCORE_ROOM_MESSAGE_CHANNEL,
   meshcoreDmAckKeyU32,
 } from '../../hooks/meshcore/meshcoreHookPreamble';
+import {
+  resolveMeshcoreNodeIdFromPubKeyPrefix,
+  seedMeshcorePrefixLookupMaps,
+} from '../meshcore/meshcorePubKeyRegistry';
 import { MESHCORE_TXT_TYPE_SIGNED_PLAIN } from '../meshcoreChannelText';
 import { meshcoreCoerceRadioRxFrame, parseAutoaddConfigResponse } from '../meshcoreContactAutoAdd';
 import {
@@ -176,6 +180,7 @@ export class MeshCoreProtocol implements Protocol {
     const pubKeyByNodeId = new Map<number, Uint8Array>();
     const nodeIdByPrefix = new Map<string, number>();
     const roomNodeIds = new Set<number>();
+    seedMeshcorePrefixLookupMaps(nodeIdByPrefix, pubKeyByNodeId);
 
     const onAdvert = (data: unknown) => {
       this.decodeAdvert(data, pubKeyByNodeId, nodeIdByPrefix).forEach(emit);
@@ -540,7 +545,13 @@ export class MeshCoreProtocol implements Protocol {
     const prefix = Array.from(d.pubKeyPrefix)
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');
-    const senderId = nodeIdByPrefix.get(prefix) ?? 0;
+    let senderId = nodeIdByPrefix.get(prefix) ?? 0;
+    if (senderId === 0) {
+      senderId = resolveMeshcoreNodeIdFromPubKeyPrefix(prefix) ?? 0;
+      if (senderId !== 0) {
+        nodeIdByPrefix.set(prefix, senderId);
+      }
+    }
     const isSignedPlain = d.txtType === MESHCORE_TXT_TYPE_SIGNED_PLAIN;
     if (isSignedPlain && senderId !== 0) {
       roomNodeIds.add(senderId);

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -47,6 +47,7 @@ import {
   normalizeMeshCoreError,
   type PendingDmAckEntry,
   persistMeshcoreMessageSenderRepairs,
+  registerMeshcorePubKeysFromContactDbRows,
   serializeErrorLike,
   waitForMeshcorePath129ForNode,
 } from '../hooks/meshcore/meshcoreHookPreamble';
@@ -1603,6 +1604,8 @@ export function useMeshcoreRuntime() {
             window.electronAPI.db.getNodes(),
           ]);
           const contactRows = rows as MeshcoreContactDbRow[];
+          registerMeshcorePubKeysFromContactDbRows(contactRows);
+          copyMeshcorePubKeyRegistryToRefs(pubKeyMapRef.current, pubKeyPrefixMapRef.current);
           const mapped = repairMeshcoreHydratedMessages(
             mapMeshcoreDbRowsToChatMessages(dbMsgs as MeshcoreMessageDbRow[]),
             meshcoreRoomServerIdsFromContacts(contactRows),


### PR DESCRIPTION
## Summary

- Seed `MeshCoreProtocol` pubkey prefix maps from the global registry on subscribe and fall back to registry lookup when per-subscription maps miss (typical right after connect).
- Pre-load the pubkey registry from SQLite contacts during `initConn` before PacketRouter ingress so live/queued DMs resolve to the correct peer immediately.
- Stop collapsing unresolved DMs under the shared Unknown stub id; skip contact-list stub creation for unresolved or stub DM senders during ingest.
- Reclassify misfiled room-server chat rows at live UI hydration in `App.tsx`.

Fixes user report: bot DM replies opened a new tab (e.g. `Node-AC200E59`) with unrelated messages and a phantom contacts-list row when pubkey prefixes were not yet mapped after connect.

## Test plan

- [x] `pnpm exec vitest run src/renderer/lib/protocols/MeshCoreProtocol.test.ts src/renderer/lib/meshcore/meshcorePubKeyRegistry.test.ts src/renderer/lib/ingest/meshcoreIngest.test.ts src/renderer/lib/meshcore/meshcoreChatSenderNode.test.ts`
- [ ] Connect MeshCore radio, DM a repeater/bot; confirm response stays in the same DM tab (no new hex-named tab)
- [ ] Confirm unrelated contacts do not appear in that DM thread
- [ ] Confirm no phantom `Node-XXXXXXXX` contact row appears for unresolved traffic before adverts land