### PR TITLE
fix: harden MeshCore protocol maps, node merges, and batch guards

### DIFF
--- a/src/renderer/lib/meshcore/meshcorePubKeyRegistry.ts
+++ b/src/renderer/lib/meshcore/meshcorePubKeyRegistry.ts
@@ -1,4 +1,4 @@
-import { pubkeyToNodeId } from '../meshcoreUtils';
+import { pubKeyPrefixHex, pubkeyToNodeId } from '../meshcoreUtils';
 
 const pubKeyByNodeId = new Map<number, Uint8Array>();
 const pubKeyPrefixByHex = new Map<string, number>();
@@ -12,15 +12,9 @@ export function setMeshcorePubKeyRegistryRefSync(fn: MeshcorePubKeyRegistryRefSy
   refSyncImpl = fn;
 }
 
-function prefixHexFromPubKey(publicKey: Uint8Array): string {
-  return Array.from(publicKey.slice(0, 6))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
-
 function storePubKey(nodeId: number, publicKey: Uint8Array): void {
   pubKeyByNodeId.set(nodeId, publicKey);
-  const prefixHex = prefixHexFromPubKey(publicKey);
+  const prefixHex = pubKeyPrefixHex(publicKey);
   const existingNodeId = pubKeyPrefixByHex.get(prefixHex);
   if (existingNodeId != null && existingNodeId !== nodeId) {
     console.warn(
@@ -59,7 +53,7 @@ export function seedMeshcorePrefixLookupMaps(
   for (const [nodeId, publicKey] of pubKeyByNodeId) {
     if (publicKey.length !== 32 || nodeId === 0) continue;
     pubKeyByNodeIdOut.set(nodeId, publicKey);
-    nodeIdByPrefix.set(prefixHexFromPubKey(publicKey), nodeId);
+    nodeIdByPrefix.set(pubKeyPrefixHex(publicKey), nodeId);
   }
 }
 
@@ -89,7 +83,7 @@ export function copyMeshcorePubKeyRegistryToRefs(
   pubKeyPrefixMapRef.clear();
   for (const [nodeId, key] of pubKeyByNodeId) {
     pubKeyMapRef.set(nodeId, key);
-    pubKeyPrefixMapRef.set(prefixHexFromPubKey(key), nodeId);
+    pubKeyPrefixMapRef.set(pubKeyPrefixHex(key), nodeId);
   }
 }
 

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -174,6 +174,13 @@ export function minimalMeshcoreChatNode(
   };
 }
 
+/** First 6 bytes of a MeshCore pubkey (or prefix field) as lowercase hex. */
+export function pubKeyPrefixHex(publicKey: Uint8Array): string {
+  return Array.from(publicKey.slice(0, 6))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 /**
  * XOR-fold pubkey bytes into a stable unsigned 32-bit node ID.
  * Expects a 32-byte MeshCore public key; returns 0 for any other length.

--- a/src/renderer/lib/protocols/MeshCoreProtocol.ts
+++ b/src/renderer/lib/protocols/MeshCoreProtocol.ts
@@ -16,7 +16,11 @@ import {
   meshcoreRoomMessageId,
   meshcoreRoomWireLooksLikeRoom,
 } from '../meshcoreRoomMessageRouting';
-import { isMeshcoreTransportStatusChatLine, pubkeyToNodeId } from '../meshcoreUtils';
+import {
+  isMeshcoreTransportStatusChatLine,
+  pubKeyPrefixHex,
+  pubkeyToNodeId,
+} from '../meshcoreUtils';
 import type { ProtocolCapabilities } from '../radio/BaseRadioProvider';
 import { MESHCORE_CAPABILITIES } from '../radio/BaseRadioProvider';
 import type { TransportParams } from '../types';
@@ -220,6 +224,9 @@ export class MeshCoreProtocol implements Protocol {
       bus.off(EVENT_PATH_UPDATED, onPathUpdated);
       bus.off(EVENT_RX, onRx);
       bus.off(EVENT_DISCONNECTED, onDisconnected);
+      pubKeyByNodeId.clear();
+      nodeIdByPrefix.clear();
+      roomNodeIds.clear();
     };
   }
 
@@ -261,7 +268,9 @@ export class MeshCoreProtocol implements Protocol {
     const conn = handle as Connection;
     if (opts.destination != null) {
       if (!opts.destinationPubKey) {
-        throw new Error('MeshCore sendMessage requires destinationPubKey for DM');
+        throw new Error(
+          'MeshCore direct messages require destinationPubKey to be provided in SendMessageOptions.',
+        );
       }
       const result = await conn.sendTextMessage(opts.destinationPubKey, opts.text);
       const ackCrc = result?.expectedAckCrc;
@@ -483,9 +492,7 @@ export class MeshCoreProtocol implements Protocol {
     if (nodeId === 0) return [];
 
     pubKeyByNodeId.set(nodeId, d.publicKey);
-    const prefix = Array.from(d.publicKey.slice(0, 6))
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('');
+    const prefix = pubKeyPrefixHex(d.publicKey);
     nodeIdByPrefix.set(prefix, nodeId);
 
     const events: DomainEvent[] = [
@@ -542,9 +549,7 @@ export class MeshCoreProtocol implements Protocol {
     if (isMeshcoreTransportStatusChatLine(d.text)) {
       return this.decodeTransportStatusChatLine(d.text);
     }
-    const prefix = Array.from(d.pubKeyPrefix)
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('');
+    const prefix = pubKeyPrefixHex(d.pubKeyPrefix);
     let senderId = nodeIdByPrefix.get(prefix) ?? 0;
     if (senderId === 0) {
       senderId = resolveMeshcoreNodeIdFromPubKeyPrefix(prefix) ?? 0;

--- a/src/renderer/stores/nodeStore.test.ts
+++ b/src/renderer/stores/nodeStore.test.ts
@@ -98,3 +98,16 @@ describe('patchNodeFavorited', () => {
     expect(rec.favorited).toBe(true);
   });
 });
+
+describe('mergeNode nodeId guard', () => {
+  afterEach(() => {
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+  });
+
+  it('keeps bucket nodeId when patch includes a conflicting nodeId', () => {
+    updateMeshcoreOp(ID, NODE, { nodeId: 999 } as Parameters<typeof updateMeshcoreOp>[2]);
+    const rec = useNodeStore.getState().nodes[ID][NODE];
+    expect(rec.nodeId).toBe(NODE);
+    expect(useNodeStore.getState().nodes[ID][999]).toBeUndefined();
+  });
+});

--- a/src/renderer/stores/nodeStore.ts
+++ b/src/renderer/stores/nodeStore.ts
@@ -134,7 +134,7 @@ function mergeNode(
   const definedPatch = Object.fromEntries(
     Object.entries(patch).filter(([, value]) => value !== undefined),
   ) as Partial<NodeRecord>;
-  return { ...(existing ?? { nodeId }), ...definedPatch };
+  return { ...(existing ?? { nodeId }), ...definedPatch, nodeId };
 }
 
 /** Advert/node_info may omit or send empty names; never wipe stored identity. */
@@ -255,7 +255,6 @@ export function upsertNodeRecordsForIdentity(identityId: IdentityId, records: No
 
 function meshtasticLastHeardPatch(
   identityId: IdentityId,
-  nodeId: number,
   packetTimestampMs: number,
   existingLastHeardAt: number | undefined,
 ): number | undefined {
@@ -335,7 +334,6 @@ export function bumpMeshtasticNodesLastHeardAt(
       const existing = byId[nodeId];
       const lastHeardAt = meshtasticLastHeardPatch(
         identityId,
-        nodeId,
         packetTimestampMs,
         existing?.lastHeardAt,
       );
@@ -353,12 +351,7 @@ export function updatePosition(identityId: IdentityId, event: PositionEvent): vo
     const byId = s.nodes[identityId] ?? {};
     const { nodeId, latitude, longitude, altitude, timestamp, groundSpeed, groundTrack } = event;
     const existing = byId[nodeId];
-    const lastHeardAt = meshtasticLastHeardPatch(
-      identityId,
-      nodeId,
-      timestamp,
-      existing?.lastHeardAt,
-    );
+    const lastHeardAt = meshtasticLastHeardPatch(identityId, timestamp, existing?.lastHeardAt);
     return {
       nodes: {
         ...s.nodes,
@@ -396,12 +389,7 @@ export function updateTelemetry(identityId: IdentityId, event: TelemetryEvent): 
       iaq,
     } = event;
     const existing = byId[nodeId];
-    const lastHeardAt = meshtasticLastHeardPatch(
-      identityId,
-      nodeId,
-      timestamp,
-      existing?.lastHeardAt,
-    );
+    const lastHeardAt = meshtasticLastHeardPatch(identityId, timestamp, existing?.lastHeardAt);
     return {
       nodes: {
         ...s.nodes,

--- a/src/shared/meshcoreContactsBatchLimit.test.ts
+++ b/src/shared/meshcoreContactsBatchLimit.test.ts
@@ -20,4 +20,11 @@ describe('meshcoreContactsBatchLimit', () => {
     expect(meshcoreContactsBatchSliceCount(1000)).toBe(2);
     expect(meshcoreContactsBatchSliceCount(1001)).toBe(3);
   });
+
+  it('meshcoreContactsBatchSliceCount returns 0 for invalid totals', () => {
+    expect(meshcoreContactsBatchSliceCount(-1)).toBe(0);
+    expect(meshcoreContactsBatchSliceCount(NaN)).toBe(0);
+    expect(meshcoreContactsBatchSliceCount(Infinity)).toBe(0);
+    expect(meshcoreContactsBatchSliceCount(1.5)).toBe(0);
+  });
 });

--- a/src/shared/meshcoreContactsBatchLimit.ts
+++ b/src/shared/meshcoreContactsBatchLimit.ts
@@ -3,6 +3,6 @@ export const MESHCORE_CONTACTS_BATCH_MAX = 500;
 
 /** Number of batch slices required to persist `total` contacts. */
 export function meshcoreContactsBatchSliceCount(total: number): number {
-  if (!Number.isFinite(total) || total <= 0) return 0;
+  if (!Number.isFinite(total) || !Number.isInteger(total) || total <= 0) return 0;
   return Math.ceil(total / MESHCORE_CONTACTS_BATCH_MAX);
 }


### PR DESCRIPTION
## Summary

- Clear per-subscription prefix lookup maps when `MeshCoreProtocol.subscribe` tears down, so closure-captured state is released on unsubscribe/re-subscribe.
- Extract shared `pubKeyPrefixHex()` helper (used by protocol decode and pubkey registry) and improve the DM `sendMessage` error when `destinationPubKey` is missing.
- Harden `mergeNode` so the bucket `nodeId` always wins over a conflicting value in the patch; remove unused `meshtasticLastHeardPatch` parameter.
- Reject non-integer totals in `meshcoreContactsBatchSliceCount` and add edge-case tests (negative, NaN, Infinity, fractional).

## Test plan

- [x] `pnpm exec vitest run src/shared/meshcoreContactsBatchLimit.test.ts src/renderer/stores/nodeStore.test.ts src/renderer/lib/protocols/MeshCoreProtocol.test.ts src/renderer/lib/meshcore/meshcorePubKeyRegistry.test.ts`
- [x] Full pre-commit suite passed on commit (2718 tests)