### PR TITLE
fix: Meshtastic MQTT auto-connect and globe icon UX

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -105,16 +105,7 @@ import {
   semverGt,
 } from './lib/firmwareCheck';
 import { loadLastConnection } from './lib/lastConnectionStorage';
-import {
-  validateLetsMeshManualCredentials,
-  validateLetsMeshPresetConnect,
-} from './lib/letsMeshConnectionGuards';
-import {
-  generateLetsMeshAuthToken,
-  isLetsMeshSettings,
-  letsMeshMqttUsernameFromIdentity,
-  readMeshcoreIdentityAsync,
-} from './lib/letsMeshJwt';
+import { generateLetsMeshAuthToken, readMeshcoreIdentityAsync } from './lib/letsMeshJwt';
 import { meshcoreChatMessagesForDisplay } from './lib/meshcoreChannelText';
 import {
   meshcoreRoomServerIdsFromNodes,
@@ -127,7 +118,7 @@ import {
   shouldAutoLaunchMeshtasticMqtt,
   shouldMaintainMeshtasticMqttConnection,
 } from './lib/meshtasticMqttLiveIngest';
-import { MESHTASTIC_OFFICIAL_PRESET_DEFAULTS } from './lib/meshtasticMqttTlsMigration';
+import { tryAutoLaunchMqtt } from './lib/mqttAutoLaunch';
 import { nodeLabelForRawPacket } from './lib/nodeLongNameOrHex';
 import { ensureOfflineProtocolIdentities } from './lib/offlineProtocolIdentities';
 import { parseStoredJson } from './lib/parseStoredJson';
@@ -148,7 +139,6 @@ import type {
   DeviceState,
   MeshNode,
   MeshProtocol,
-  MQTTSettings,
 } from './lib/types';
 import { MeshcoreRuntimeProvider } from './runtime/MeshcoreRuntimeContext';
 import { MeshtasticRuntimeProvider } from './runtime/MeshtasticRuntimeContext';
@@ -1502,80 +1492,34 @@ function AppContent({
     });
   }, [protocol, hasMeshtasticRfDevice, meshtasticConnectionView.mqttStatus]);
 
+  const prevProtocolForMqttAutostartRef = useRef<MeshProtocol>(protocol);
+
+  // Connect Meshtastic MQTT when switching to the Meshtastic tab after startup skipped it.
+  useEffect(() => {
+    const prev = prevProtocolForMqttAutostartRef.current;
+    prevProtocolForMqttAutostartRef.current = protocol;
+    if (protocol !== 'meshtastic') return;
+    if (prev === 'meshtastic') return;
+    if (meshtasticConnectionView.mqttStatus !== 'disconnected') return;
+    void tryAutoLaunchMqtt('meshtastic').catch((e: unknown) => {
+      console.warn('[App] MQTT auto-launch on tab switch failed ' + errLikeToLogString(e));
+    });
+  }, [protocol, meshtasticConnectionView.mqttStatus]);
+
   // ─── MQTT auto-launch on startup ─────────────────────────────────
-  // Launch MQTT for each protocol when autoLaunch is enabled. Meshtastic MQTT only
-  // auto-connects when Meshtastic is the stored tab so MeshCore-only users are not
-  // subscribed to the public Meshtastic broker in the background.
+  // Launch MQTT for each protocol when autoLaunch is enabled. Meshtastic MQTT skips
+  // startup when MeshCore is the stored tab unless auto-connect is enabled.
   useEffect(() => {
     for (const prot of ['meshtastic', 'meshcore'] as MeshProtocol[]) {
       if (prot === 'meshtastic' && !shouldAutoLaunchMeshtasticMqtt(getStoredMeshProtocol())) {
+        if (getStoredMeshProtocol() === 'meshcore') {
+          console.debug('[App] Meshtastic MQTT auto-launch skipped: stored protocol is meshcore');
+        }
         continue;
       }
-      try {
-        const key =
-          prot === 'meshcore' ? 'mesh-client:mqttSettings:meshcore' : 'mesh-client:mqttSettings';
-        const settings = parseStoredJson<MQTTSettings>(
-          localStorage.getItem(key),
-          'App MQTT auto-launch',
-        );
-        if (settings?.autoLaunch) {
-          const base =
-            prot === 'meshtastic'
-              ? { ...MESHTASTIC_OFFICIAL_PRESET_DEFAULTS, ...settings }
-              : settings;
-          const connectSettings: MQTTSettings = {
-            ...base,
-            mqttTransportProtocol: prot === 'meshcore' ? 'meshcore' : 'meshtastic',
-          };
-          const tryConnect = async () => {
-            if (prot === 'meshcore' && isLetsMeshSettings(connectSettings.server)) {
-              const presetErr = validateLetsMeshPresetConnect(connectSettings);
-              if (presetErr) {
-                console.warn('[App] MQTT auto-launch skipped: ' + errLikeToLogString(presetErr));
-                return;
-              }
-              const identity = await readMeshcoreIdentityAsync();
-              const hasFull = !!(identity?.private_key && identity?.public_key);
-              if (hasFull) {
-                try {
-                  const u = letsMeshMqttUsernameFromIdentity(identity);
-                  if (u) connectSettings.username = u;
-                  const { token, expiresAt } = await generateLetsMeshAuthToken(
-                    identity,
-                    connectSettings.server,
-                  );
-                  connectSettings.password = token;
-                  connectSettings.tokenExpiresAt = expiresAt;
-                } catch (e) {
-                  console.warn(
-                    '[App] LetsMesh auth token auto-launch generation failed ' +
-                      errLikeToLogString(e),
-                  );
-                  return;
-                }
-              } else {
-                if (!connectSettings.password?.trim()) {
-                  console.warn(
-                    '[App] MQTT auto-launch skipped: LetsMesh needs imported identity or password',
-                  );
-                  return;
-                }
-                const manualErr = validateLetsMeshManualCredentials(connectSettings);
-                if (manualErr) {
-                  console.warn('[App] MQTT auto-launch skipped: ' + errLikeToLogString(manualErr));
-                  return;
-                }
-              }
-            }
-            await window.electronAPI.mqtt.connect(connectSettings);
-          };
-          void tryConnect().catch((e: unknown) => {
-            console.warn('[App] MQTT auto-launch connect failed ' + errLikeToLogString(e));
-          });
-        }
-      } catch (e) {
-        console.debug('[App] MQTT auto-launch startup ' + errLikeToLogString(e));
-      }
+      void tryAutoLaunchMqtt(prot).catch((e: unknown) => {
+        console.warn('[App] MQTT auto-launch connect failed ' + errLikeToLogString(e));
+      });
     }
   }, []);
 

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -210,7 +210,7 @@ function TransportBadge({ via }: { via: 'rf' | 'mqtt' | 'both' }) {
   );
   const mqttIcon = (
     <svg
-      className="h-3 w-3 text-purple-400"
+      className="h-3 w-3 text-sky-400"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -806,6 +806,33 @@ describe('ConnectionPanel MeshCore TCP port field', () => {
   });
 });
 
+describe('ConnectionPanel Meshtastic MQTT autoLaunch persistence', () => {
+  function renderMeshtasticMqttPanel() {
+    return render(
+      <ConnectionPanel
+        state={disconnectedState}
+        onConnect={vi.fn().mockResolvedValue(undefined)}
+        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+        onDisconnect={vi.fn().mockResolvedValue(undefined)}
+        mqttStatus="disconnected"
+        protocol="meshtastic"
+      />,
+    );
+  }
+
+  it('persists autoLaunch immediately when toggled', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('mesh-client:mqttSettings', JSON.stringify({ autoLaunch: false }));
+    renderMeshtasticMqttPanel();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Auto-connect on application start' }));
+
+    expect(JSON.parse(localStorage.getItem('mesh-client:mqttSettings') ?? '{}').autoLaunch).toBe(
+      true,
+    );
+  });
+});
+
 describe('ConnectionPanel MQTT channel PSKs', () => {
   const KEY_A = '1PG7OiApB1nwvP+rz05pAQ==';
   const KEY_B = 'AAAAAAAAAAAAAAAAAAAAAA==';

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -31,6 +31,7 @@ import {
   readMeshcoreIdentity,
   readMeshcoreIdentityAsync,
 } from '../lib/letsMeshJwt';
+import { readMeshcoreMqttSettingsFromStorage } from '../lib/meshcoreMqttSettingsStorage';
 import { meshcoreMqttUserFacingHint } from '../lib/meshcoreMqttUserHint';
 import {
   formatChannelPskInput,
@@ -38,11 +39,14 @@ import {
   validateChannelPskEntries,
 } from '../lib/meshtasticChannelPskInput';
 import {
+  MESHTASTIC_MQTT_SETTINGS_KEY,
+  readMeshtasticMqttSettingsFromStorage,
+} from '../lib/meshtasticMqttSettingsStorage';
+import {
   isLiamBrokerSettings,
   isMeshtasticOfficialBrokerSettings,
   MESHTASTIC_LIAM_1883,
   MESHTASTIC_OFFICIAL_1883,
-  MESHTASTIC_OFFICIAL_PRESET_DEFAULTS,
   meshtasticMqttErrorUserHint,
 } from '../lib/meshtasticMqttTlsMigration';
 import { parseStoredJson } from '../lib/parseStoredJson';
@@ -462,20 +466,6 @@ function Spinner({ className = '' }: { className?: string }) {
   );
 }
 
-const MQTT_DEFAULTS: MQTTSettings = { ...MESHTASTIC_OFFICIAL_PRESET_DEFAULTS };
-
-const MESHCORE_MQTT_DEFAULTS: MQTTSettings = {
-  server: '',
-  port: 1883,
-  username: '',
-  password: '',
-  topicPrefix: 'meshcore',
-  autoLaunch: false,
-  maxRetries: MQTT_DEFAULT_RECONNECT_ATTEMPTS,
-  meshcorePacketLoggerEnabled: false,
-  tokenExpiresAt: undefined,
-};
-
 function migrateMqttSettingsOnce(): void {
   if (localStorage.getItem('mesh-client:mqttSettings:meshcore') !== null) return;
   const raw = localStorage.getItem('mesh-client:mqttSettings');
@@ -507,29 +497,32 @@ function migrateMeshcoreTopicIataOnce(): void {
 }
 migrateMeshcoreTopicIataOnce();
 
+const MESHCORE_MQTT_SETTINGS_KEY = 'mesh-client:mqttSettings:meshcore';
+
+function persistMqttSettingsIfChanged(key: string, settings: MQTTSettings): void {
+  const serialized = JSON.stringify(settings);
+  if (localStorage.getItem(key) === serialized) return;
+  localStorage.setItem(key, serialized);
+}
+
+function flushPendingMqttSave(
+  timerRef: { current: ReturnType<typeof setTimeout> | null },
+  key: string,
+  settings: MQTTSettings,
+): void {
+  if (timerRef.current) {
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }
+  persistMqttSettingsIfChanged(key, settings);
+}
+
 function loadMqttSettings(): MQTTSettings {
-  const raw = localStorage.getItem('mesh-client:mqttSettings');
-  const parsed = parseStoredJson<Partial<MQTTSettings>>(raw, 'ConnectionPanel loadMqttSettings');
-  const merged = parsed ? { ...MQTT_DEFAULTS, ...parsed } : MQTT_DEFAULTS;
-  const r = merged.maxRetries ?? MQTT_DEFAULT_RECONNECT_ATTEMPTS;
-  return {
-    ...merged,
-    maxRetries: Math.min(MQTT_MAX_RECONNECT_ATTEMPTS, Math.max(1, r)),
-  };
+  return readMeshtasticMqttSettingsFromStorage();
 }
 
 function loadMeshcoreMqttSettings(): MQTTSettings {
-  const raw = localStorage.getItem('mesh-client:mqttSettings:meshcore');
-  const parsed = parseStoredJson<Partial<MQTTSettings>>(
-    raw,
-    'ConnectionPanel loadMeshcoreMqttSettings',
-  );
-  const merged = parsed ? { ...MESHCORE_MQTT_DEFAULTS, ...parsed } : MESHCORE_MQTT_DEFAULTS;
-  const r = merged.maxRetries ?? MQTT_DEFAULT_RECONNECT_ATTEMPTS;
-  return {
-    ...merged,
-    maxRetries: Math.min(MQTT_MAX_RECONNECT_ATTEMPTS, Math.max(1, r)),
-  };
+  return readMeshcoreMqttSettingsFromStorage();
 }
 
 function MqttGlobeIcon({ status }: { status: MQTTStatus }) {
@@ -645,6 +638,10 @@ export default function ConnectionPanel({
   );
   const mqttSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const meshcoreMqttSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mqttSettingsRef = useRef(mqttSettings);
+  mqttSettingsRef.current = mqttSettings;
+  const meshcoreMqttSettingsRef = useRef(meshcoreMqttSettings);
+  meshcoreMqttSettingsRef.current = meshcoreMqttSettings;
   const [meshcorePreset, setMeshcorePreset] = useState<
     'letsmesh' | 'coloradomesh' | 'meshmapper' | 'ripple' | 'custom'
   >(() => {
@@ -672,12 +669,27 @@ export default function ConnectionPanel({
   useEffect(() => {
     if (mqttSaveTimerRef.current) clearTimeout(mqttSaveTimerRef.current);
     mqttSaveTimerRef.current = setTimeout(() => {
-      localStorage.setItem('mesh-client:mqttSettings', JSON.stringify(mqttSettings));
+      persistMqttSettingsIfChanged(MESHTASTIC_MQTT_SETTINGS_KEY, mqttSettingsRef.current);
+      mqttSaveTimerRef.current = null;
     }, 300);
     return () => {
-      if (mqttSaveTimerRef.current) clearTimeout(mqttSaveTimerRef.current);
+      if (mqttSaveTimerRef.current) {
+        clearTimeout(mqttSaveTimerRef.current);
+        mqttSaveTimerRef.current = null;
+      }
     };
   }, [mqttSettings]);
+
+  useEffect(() => {
+    const flushMeshtasticMqtt = () => {
+      flushPendingMqttSave(mqttSaveTimerRef, MESHTASTIC_MQTT_SETTINGS_KEY, mqttSettingsRef.current);
+    };
+    window.addEventListener('beforeunload', flushMeshtasticMqtt);
+    return () => {
+      window.removeEventListener('beforeunload', flushMeshtasticMqtt);
+      flushPendingMqttSave(mqttSaveTimerRef, MESHTASTIC_MQTT_SETTINGS_KEY, mqttSettingsRef.current);
+    };
+  }, []);
 
   // Persist MeshCore preset selection
   useEffect(() => {
@@ -688,15 +700,35 @@ export default function ConnectionPanel({
   useEffect(() => {
     if (meshcoreMqttSaveTimerRef.current) clearTimeout(meshcoreMqttSaveTimerRef.current);
     meshcoreMqttSaveTimerRef.current = setTimeout(() => {
-      localStorage.setItem(
-        'mesh-client:mqttSettings:meshcore',
-        JSON.stringify(meshcoreMqttSettings),
-      );
+      persistMqttSettingsIfChanged(MESHCORE_MQTT_SETTINGS_KEY, meshcoreMqttSettingsRef.current);
+      meshcoreMqttSaveTimerRef.current = null;
     }, 300);
     return () => {
-      if (meshcoreMqttSaveTimerRef.current) clearTimeout(meshcoreMqttSaveTimerRef.current);
+      if (meshcoreMqttSaveTimerRef.current) {
+        clearTimeout(meshcoreMqttSaveTimerRef.current);
+        meshcoreMqttSaveTimerRef.current = null;
+      }
     };
   }, [meshcoreMqttSettings]);
+
+  useEffect(() => {
+    const flushMeshcoreMqtt = () => {
+      flushPendingMqttSave(
+        meshcoreMqttSaveTimerRef,
+        MESHCORE_MQTT_SETTINGS_KEY,
+        meshcoreMqttSettingsRef.current,
+      );
+    };
+    window.addEventListener('beforeunload', flushMeshcoreMqtt);
+    return () => {
+      window.removeEventListener('beforeunload', flushMeshcoreMqtt);
+      flushPendingMqttSave(
+        meshcoreMqttSaveTimerRef,
+        MESHCORE_MQTT_SETTINGS_KEY,
+        meshcoreMqttSettingsRef.current,
+      );
+    };
+  }, []);
 
   // Listen for MQTT events from main process (dual-mode: only errors for the active protocol)
   useEffect(() => {
@@ -773,7 +805,16 @@ export default function ConnectionPanel({
         setMeshtasticPreset('custom');
       }
     }
-    setActiveMqttSettings((prev) => ({ ...prev, [key]: value }));
+    setActiveMqttSettings((prev) => {
+      const next = { ...prev, [key]: value };
+      if (key === 'autoLaunch') {
+        persistMqttSettingsIfChanged(
+          protocol === 'meshcore' ? MESHCORE_MQTT_SETTINGS_KEY : MESHTASTIC_MQTT_SETTINGS_KEY,
+          next,
+        );
+      }
+      return next;
+    });
   };
 
   useEffect(() => {
@@ -2085,11 +2126,13 @@ export default function ConnectionPanel({
                         setMqttSettings({
                           ...MESHTASTIC_OFFICIAL_1883,
                           topicPrefix: mqttSettings.topicPrefix,
+                          autoLaunch: mqttSettings.autoLaunch,
                         });
                       } else if (id === 'liam') {
                         setMqttSettings({
                           ...MESHTASTIC_LIAM_1883,
                           topicPrefix: mqttSettings.topicPrefix,
+                          autoLaunch: mqttSettings.autoLaunch,
                         });
                       }
                     }}

--- a/src/renderer/components/NodeInfoBody.tsx
+++ b/src/renderer/components/NodeInfoBody.tsx
@@ -34,7 +34,7 @@ import { meshtasticHwModelDisplay } from '../lib/hardwareModels';
 import { meshcoreTracePathLenToHops } from '../lib/meshcoreUtils';
 import {
   MeshtasticHybridPathIcons,
-  MeshtasticMqttPathIcon,
+  MeshtasticMqttOnlyPathIcons,
   MeshtasticRfPathIcon,
   resolveMeshtasticPathBadge,
 } from '../lib/meshtasticSourceIcons';
@@ -145,11 +145,7 @@ function NodeSourceBadge({
       : isSelf
         ? t('nodeListPanel.mqttConnectedTooltip')
         : t('nodeInfoBody.receivedViaMqtt');
-    return (
-      <span title={title}>
-        <MeshtasticMqttPathIcon />
-      </span>
-    );
+    return <MeshtasticMqttOnlyPathIcons title={title} ariaLabel={title} />;
   }
   return (
     <span title={t('nodeInfoBody.receivedViaRf')}>

--- a/src/renderer/components/NodeListPanel.test.tsx
+++ b/src/renderer/components/NodeListPanel.test.tsx
@@ -314,7 +314,7 @@ describe('NodeListPanel import contacts', () => {
     const nodes = new Map<number, MeshNode>([
       [1, makeNode({ node_id: 1, long_name: 'Me', heard_via_mqtt_only: false })],
     ]);
-    const { container } = render(
+    render(
       <NodeListPanel
         nodes={nodes}
         myNodeNum={1}
@@ -327,7 +327,36 @@ describe('NodeListPanel import contacts', () => {
     );
     expect(screen.queryByLabelText('Connected via RF and MQTT')).not.toBeInTheDocument();
     expect(screen.queryByLabelText(MESHTASTIC_HYBRID_MQTT_PATH_ARIA_LABEL)).not.toBeInTheDocument();
-    expect(container.querySelector('[title="Connected via MQTT"]')).toBeInTheDocument();
+    expect(screen.getByLabelText('Connected via MQTT')).toBeInTheDocument();
+  });
+
+  it('shows sky MQTT-only path icon centered for heard_via_mqtt_only nodes', () => {
+    const nodes = new Map<number, MeshNode>([
+      [
+        4,
+        makeNode({
+          node_id: 4,
+          long_name: 'MqttOnlyPeer',
+          heard_via_mqtt_only: true,
+          heard_via_mqtt: true,
+        }),
+      ],
+    ]);
+    const { container } = render(
+      <NodeListPanel
+        nodes={nodes}
+        myNodeNum={99}
+        onNodeClick={vi.fn()}
+        locationFilter={defaultFilter}
+        onToggleFavorite={vi.fn()}
+        mode="meshtastic"
+      />,
+    );
+    const badge = screen.getByLabelText('Heard only via MQTT');
+    expect(badge).toBeInTheDocument();
+    expect(badge.querySelector('svg.text-sky-400')).toBeInTheDocument();
+    expect(badge.querySelector(':scope > span[aria-hidden="true"]')).not.toBeInTheDocument();
+    expect(container.querySelector('svg.text-purple-400')).not.toBeInTheDocument();
   });
 
   it('shows dash in MQTT column for self node with RF only', () => {

--- a/src/renderer/components/NodeListPanel.tsx
+++ b/src/renderer/components/NodeListPanel.tsx
@@ -29,7 +29,7 @@ import {
 } from '../lib/meshtasticContactGroupUtils';
 import {
   MeshtasticHybridPathIcons,
-  MeshtasticMqttPathIcon,
+  MeshtasticMqttOnlyPathIcons,
   resolveMeshtasticPathBadge,
 } from '../lib/meshtasticSourceIcons';
 import { nodeHealthScore, nodeHealthTier } from '../lib/nodeHealthScore';
@@ -1329,45 +1329,45 @@ export default function NodeListPanel({
                       )}
                     </td>
                     {mode !== 'meshcore' && (
-                      <td className="px-3 py-2 text-center text-xs text-gray-300">
-                        {(() => {
-                          const pathBadge = resolveMeshtasticPathBadge({
-                            node,
-                            isSelf,
-                            mqttConnected,
-                            radioConnected,
-                          });
-                          if (pathBadge === 'mqttOnly') {
-                            const title = node.heard_via_mqtt_only
-                              ? t('nodeListPanel.mqttHeardOnlyTooltip')
-                              : isSelf
-                                ? t('nodeListPanel.mqttConnectedTooltip')
-                                : t('nodeListPanel.mqttHeardOnlyTooltip');
-                            return (
-                              <span title={title}>
-                                <MeshtasticMqttPathIcon />
-                              </span>
-                            );
-                          }
-                          if (pathBadge === 'hybrid') {
-                            const isSelfHybrid = isSelf && mqttConnected && radioConnected;
-                            return (
-                              <MeshtasticHybridPathIcons
-                                title={
-                                  isSelfHybrid
-                                    ? t('nodeListPanel.connectedViaRfAndMqttTooltip')
-                                    : t('nodeListPanel.hybridMqttPathTooltip')
-                                }
-                                ariaLabel={
-                                  isSelfHybrid
-                                    ? t('nodeListPanel.connectedViaRfAndMqttAria')
-                                    : t('nodeListPanel.hybridMqttPathAria')
-                                }
-                              />
-                            );
-                          }
-                          return '-';
-                        })()}
+                      <td className="px-3 py-2 text-xs text-gray-300">
+                        <div className="flex justify-center">
+                          {(() => {
+                            const pathBadge = resolveMeshtasticPathBadge({
+                              node,
+                              isSelf,
+                              mqttConnected,
+                              radioConnected,
+                            });
+                            if (pathBadge === 'mqttOnly') {
+                              const title = node.heard_via_mqtt_only
+                                ? t('nodeListPanel.mqttHeardOnlyTooltip')
+                                : isSelf
+                                  ? t('nodeListPanel.mqttConnectedTooltip')
+                                  : t('nodeListPanel.mqttHeardOnlyTooltip');
+                              return (
+                                <MeshtasticMqttOnlyPathIcons title={title} ariaLabel={title} />
+                              );
+                            }
+                            if (pathBadge === 'hybrid') {
+                              const isSelfHybrid = isSelf && mqttConnected && radioConnected;
+                              return (
+                                <MeshtasticHybridPathIcons
+                                  title={
+                                    isSelfHybrid
+                                      ? t('nodeListPanel.connectedViaRfAndMqttTooltip')
+                                      : t('nodeListPanel.hybridMqttPathTooltip')
+                                  }
+                                  ariaLabel={
+                                    isSelfHybrid
+                                      ? t('nodeListPanel.connectedViaRfAndMqttAria')
+                                      : t('nodeListPanel.hybridMqttPathAria')
+                                  }
+                                />
+                              );
+                            }
+                            return '-';
+                          })()}
+                        </div>
                       </td>
                     )}
                     {(() => {

--- a/src/renderer/lib/meshtasticMqttLiveIngest.test.ts
+++ b/src/renderer/lib/meshtasticMqttLiveIngest.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   shouldAutoLaunchMeshtasticMqtt,
   shouldIngestMeshtasticMqttLive,
   shouldMaintainMeshtasticMqttConnection,
 } from './meshtasticMqttLiveIngest';
+import { MESHTASTIC_MQTT_SETTINGS_KEY } from './meshtasticMqttSettingsStorage';
 
 describe('shouldIngestMeshtasticMqttLive', () => {
   it('blocks live ingest for MeshCore tab without RF', () => {
@@ -21,14 +22,37 @@ describe('shouldIngestMeshtasticMqttLive', () => {
 });
 
 describe('shouldAutoLaunchMeshtasticMqtt', () => {
-  it('auto-launches only when Meshtastic is the stored protocol', () => {
+  afterEach(() => {
+    localStorage.removeItem(MESHTASTIC_MQTT_SETTINGS_KEY);
+  });
+
+  it('auto-launches when Meshtastic is the stored protocol', () => {
     expect(shouldAutoLaunchMeshtasticMqtt('meshtastic')).toBe(true);
+  });
+
+  it('auto-launches on MeshCore tab when auto-connect is enabled', () => {
+    localStorage.setItem(MESHTASTIC_MQTT_SETTINGS_KEY, JSON.stringify({ autoLaunch: true }));
+    expect(shouldAutoLaunchMeshtasticMqtt('meshcore')).toBe(true);
+  });
+
+  it('skips startup on MeshCore tab when auto-connect is disabled', () => {
+    localStorage.setItem(MESHTASTIC_MQTT_SETTINGS_KEY, JSON.stringify({ autoLaunch: false }));
     expect(shouldAutoLaunchMeshtasticMqtt('meshcore')).toBe(false);
   });
 });
 
 describe('shouldMaintainMeshtasticMqttConnection', () => {
-  it('matches shouldIngestMeshtasticMqttLive', () => {
+  afterEach(() => {
+    localStorage.removeItem(MESHTASTIC_MQTT_SETTINGS_KEY);
+  });
+
+  it('maintains connection on MeshCore tab when auto-connect is enabled', () => {
+    localStorage.setItem(MESHTASTIC_MQTT_SETTINGS_KEY, JSON.stringify({ autoLaunch: true }));
+    expect(shouldMaintainMeshtasticMqttConnection('meshcore', false)).toBe(true);
+  });
+
+  it('matches shouldIngestMeshtasticMqttLive when auto-connect is disabled', () => {
+    localStorage.setItem(MESHTASTIC_MQTT_SETTINGS_KEY, JSON.stringify({ autoLaunch: false }));
     expect(shouldMaintainMeshtasticMqttConnection('meshcore', false)).toBe(false);
     expect(shouldMaintainMeshtasticMqttConnection('meshtastic', false)).toBe(true);
     expect(shouldMaintainMeshtasticMqttConnection('meshcore', true)).toBe(true);

--- a/src/renderer/lib/meshtasticMqttLiveIngest.ts
+++ b/src/renderer/lib/meshtasticMqttLiveIngest.ts
@@ -1,3 +1,4 @@
+import { readMeshtasticMqttSettingsFromStorage } from './meshtasticMqttSettingsStorage';
 import type { MeshProtocol } from './types';
 
 /**
@@ -14,9 +15,10 @@ export function shouldIngestMeshtasticMqttLive(
   return storedProtocol === 'meshtastic' || hasRfDevice;
 }
 
-/** Auto-launch Meshtastic MQTT on startup only when Meshtastic is the last active tab. */
+/** Auto-launch Meshtastic MQTT when Meshtastic is the stored tab or auto-connect is enabled. */
 export function shouldAutoLaunchMeshtasticMqtt(storedProtocol: MeshProtocol): boolean {
-  return storedProtocol === 'meshtastic';
+  if (storedProtocol === 'meshtastic') return true;
+  return readMeshtasticMqttSettingsFromStorage().autoLaunch;
 }
 
 /** When false, Meshtastic MQTT should not stay connected (MeshCore tab, no RF radio). */
@@ -24,5 +26,6 @@ export function shouldMaintainMeshtasticMqttConnection(
   storedProtocol: MeshProtocol,
   hasRfDevice: boolean,
 ): boolean {
+  if (readMeshtasticMqttSettingsFromStorage().autoLaunch) return true;
   return shouldIngestMeshtasticMqttLive(storedProtocol, hasRfDevice);
 }

--- a/src/renderer/lib/meshtasticMqttSettingsStorage.test.ts
+++ b/src/renderer/lib/meshtasticMqttSettingsStorage.test.ts
@@ -3,11 +3,28 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   loadMeshtasticMqttManualChannelPsksFromStorage,
   MESHTASTIC_MQTT_SETTINGS_KEY,
+  readMeshtasticMqttSettingsFromStorage,
 } from './meshtasticMqttSettingsStorage';
 
 const MESHCORE_KEY = 'mesh-client:mqttSettings:meshcore';
 const RECOVERY_FLAG = 'mesh-client:migrated:meshtastic-psk-recovery-v1';
 const KEY_B = 'AAAAAAAAAAAAAAAAAAAAAA==';
+
+describe('readMeshtasticMqttSettingsFromStorage', () => {
+  afterEach(() => {
+    localStorage.removeItem(MESHTASTIC_MQTT_SETTINGS_KEY);
+  });
+
+  it('returns defaults when storage is empty', () => {
+    expect(readMeshtasticMqttSettingsFromStorage().autoLaunch).toBe(false);
+    expect(readMeshtasticMqttSettingsFromStorage().server).toBe('mqtt.meshtastic.org');
+  });
+
+  it('reads autoLaunch from storage', () => {
+    localStorage.setItem(MESHTASTIC_MQTT_SETTINGS_KEY, JSON.stringify({ autoLaunch: true }));
+    expect(readMeshtasticMqttSettingsFromStorage().autoLaunch).toBe(true);
+  });
+});
 
 describe('loadMeshtasticMqttManualChannelPsksFromStorage', () => {
   afterEach(() => {
@@ -45,8 +62,10 @@ describe('loadMeshtasticMqttManualChannelPsksFromStorage', () => {
 
     const recovered = JSON.parse(localStorage.getItem(MESHTASTIC_MQTT_SETTINGS_KEY) ?? '{}') as {
       channelPsks?: string[];
+      autoLaunch?: boolean;
     };
     expect(recovered.channelPsks).toEqual([`LongFast@0=${KEY_B}`, `TGIFMESH@1=${KEY_B}`]);
+    expect(recovered.autoLaunch).toBe(false);
     expect(localStorage.getItem(RECOVERY_FLAG)).toBe('1');
   });
 

--- a/src/renderer/lib/meshtasticMqttSettingsStorage.ts
+++ b/src/renderer/lib/meshtasticMqttSettingsStorage.ts
@@ -1,5 +1,10 @@
 import { parseStoredJson } from '@/renderer/lib/parseStoredJson';
+import {
+  MQTT_DEFAULT_RECONNECT_ATTEMPTS,
+  MQTT_MAX_RECONNECT_ATTEMPTS,
+} from '@/shared/meshtasticMqttReconnect';
 
+import { MESHTASTIC_OFFICIAL_PRESET_DEFAULTS } from './meshtasticMqttTlsMigration';
 import type { MQTTSettings } from './types';
 
 export const MESHTASTIC_MQTT_SETTINGS_KEY = 'mesh-client:mqttSettings';
@@ -36,9 +41,31 @@ function recoverMeshtasticChannelPsksFromLegacyMigration(): void {
     return;
   }
 
-  const merged: MqttSettingsWithPsks = { ...(meshtastic ?? {}), channelPsks: psks };
+  const merged: MqttSettingsWithPsks = {
+    ...MESHTASTIC_OFFICIAL_PRESET_DEFAULTS,
+    ...(meshtastic ?? {}),
+    channelPsks: psks,
+  };
   localStorage.setItem(MESHTASTIC_MQTT_SETTINGS_KEY, JSON.stringify(merged));
   localStorage.setItem(PSK_RECOVERY_FLAG, '1');
+}
+
+/** Read persisted Meshtastic MQTT settings (same merge as ConnectionPanel). */
+export function readMeshtasticMqttSettingsFromStorage(): MQTTSettings {
+  try {
+    const raw = localStorage.getItem(MESHTASTIC_MQTT_SETTINGS_KEY);
+    if (!raw) return { ...MESHTASTIC_OFFICIAL_PRESET_DEFAULTS };
+    const parsed = JSON.parse(raw) as Partial<MQTTSettings>;
+    const merged = { ...MESHTASTIC_OFFICIAL_PRESET_DEFAULTS, ...parsed };
+    const r = merged.maxRetries ?? MQTT_DEFAULT_RECONNECT_ATTEMPTS;
+    return {
+      ...merged,
+      maxRetries: Math.min(MQTT_MAX_RECONNECT_ATTEMPTS, Math.max(1, r)),
+    };
+  } catch {
+    // catch-no-log-ok corrupt localStorage JSON — fall back to defaults
+    return { ...MESHTASTIC_OFFICIAL_PRESET_DEFAULTS };
+  }
 }
 
 /** Manual Connection panel channel PSK lines for Meshtastic MQTT decrypt/publish fallback. */

--- a/src/renderer/lib/meshtasticSourceIcons.tsx
+++ b/src/renderer/lib/meshtasticSourceIcons.tsx
@@ -60,10 +60,13 @@ export function MeshtasticRfPathIcon({ className }: { className?: string }) {
   );
 }
 
+/** Sky (not purple) so the globe does not read as stale in the node list legend. */
+export const MESHTASTIC_MQTT_PATH_ICON_CLASS = 'h-3 w-3 text-sky-400';
+
 export function MeshtasticMqttPathIcon({ className }: { className?: string }) {
   return (
     <svg
-      className={className ?? 'h-3 w-3 text-purple-400'}
+      className={className ?? MESHTASTIC_MQTT_PATH_ICON_CLASS}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -93,11 +96,33 @@ export function MeshtasticHybridPathIcons({
   return (
     <span
       role="img"
-      className={`flex items-center justify-center gap-1 ${className ?? ''}`}
+      className={`inline-flex items-center justify-center gap-1 ${className ?? ''}`}
       title={title}
       aria-label={ariaLabel}
     >
       <MeshtasticRfPathIcon />
+      <MeshtasticMqttPathIcon />
+    </span>
+  );
+}
+
+/** MQTT-only path badge (single globe, centered in the list column). */
+export function MeshtasticMqttOnlyPathIcons({
+  title,
+  ariaLabel,
+  className,
+}: {
+  title?: string;
+  ariaLabel?: string;
+  className?: string;
+}) {
+  return (
+    <span
+      role="img"
+      className={`inline-flex items-center justify-center ${className ?? ''}`}
+      title={title}
+      aria-label={ariaLabel}
+    >
       <MeshtasticMqttPathIcon />
     </span>
   );

--- a/src/renderer/lib/mqttAutoLaunch.test.ts
+++ b/src/renderer/lib/mqttAutoLaunch.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MESHTASTIC_MQTT_SETTINGS_KEY } from './meshtasticMqttSettingsStorage';
+import { tryAutoLaunchMqtt } from './mqttAutoLaunch';
+
+describe('tryAutoLaunchMqtt', () => {
+  afterEach(() => {
+    localStorage.removeItem(MESHTASTIC_MQTT_SETTINGS_KEY);
+    localStorage.removeItem('mesh-client:mqttSettings:meshcore');
+    vi.restoreAllMocks();
+  });
+
+  it('connects Meshtastic MQTT when autoLaunch is enabled', async () => {
+    localStorage.setItem(
+      MESHTASTIC_MQTT_SETTINGS_KEY,
+      JSON.stringify({
+        server: 'mqtt.meshtastic.org',
+        port: 1883,
+        username: 'meshdev',
+        password: 'large4cats',
+        topicPrefix: 'msh/US/',
+        autoLaunch: true,
+      }),
+    );
+    const connect = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('window', {
+      electronAPI: { mqtt: { connect } },
+    });
+
+    await tryAutoLaunchMqtt('meshtastic');
+
+    expect(connect).toHaveBeenCalledOnce();
+    expect(connect.mock.calls[0][0]).toMatchObject({
+      mqttTransportProtocol: 'meshtastic',
+      autoLaunch: true,
+    });
+  });
+
+  it('skips Meshtastic MQTT when autoLaunch is disabled', async () => {
+    localStorage.setItem(
+      MESHTASTIC_MQTT_SETTINGS_KEY,
+      JSON.stringify({ autoLaunch: false, server: 'mqtt.meshtastic.org' }),
+    );
+    const connect = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('window', {
+      electronAPI: { mqtt: { connect } },
+    });
+
+    await tryAutoLaunchMqtt('meshtastic');
+
+    expect(connect).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/lib/mqttAutoLaunch.ts
+++ b/src/renderer/lib/mqttAutoLaunch.ts
@@ -1,0 +1,72 @@
+import { errLikeToLogString } from './errLikeToLogString';
+import {
+  validateLetsMeshManualCredentials,
+  validateLetsMeshPresetConnect,
+} from './letsMeshConnectionGuards';
+import {
+  generateLetsMeshAuthToken,
+  isLetsMeshSettings,
+  letsMeshMqttUsernameFromIdentity,
+  readMeshcoreIdentityAsync,
+} from './letsMeshJwt';
+import { readMeshcoreMqttSettingsFromStorage } from './meshcoreMqttSettingsStorage';
+import { readMeshtasticMqttSettingsFromStorage } from './meshtasticMqttSettingsStorage';
+import { MESHTASTIC_OFFICIAL_PRESET_DEFAULTS } from './meshtasticMqttTlsMigration';
+import type { MeshProtocol, MQTTSettings } from './types';
+
+/** Connect MQTT for `prot` when `autoLaunch` is enabled in persisted settings. */
+export async function tryAutoLaunchMqtt(prot: MeshProtocol): Promise<void> {
+  const settings =
+    prot === 'meshcore'
+      ? readMeshcoreMqttSettingsFromStorage()
+      : readMeshtasticMqttSettingsFromStorage();
+  if (!settings.autoLaunch) return;
+
+  const base =
+    prot === 'meshtastic' ? { ...MESHTASTIC_OFFICIAL_PRESET_DEFAULTS, ...settings } : settings;
+  const connectSettings: MQTTSettings = {
+    ...base,
+    mqttTransportProtocol: prot === 'meshcore' ? 'meshcore' : 'meshtastic',
+  };
+
+  if (prot === 'meshcore' && isLetsMeshSettings(connectSettings.server)) {
+    const presetErr = validateLetsMeshPresetConnect(connectSettings);
+    if (presetErr) {
+      console.warn('[App] MQTT auto-launch skipped: ' + errLikeToLogString(presetErr));
+      return;
+    }
+    const identity = await readMeshcoreIdentityAsync();
+    const hasFull = !!(identity?.private_key && identity?.public_key);
+    if (hasFull) {
+      try {
+        const u = letsMeshMqttUsernameFromIdentity(identity);
+        if (u) connectSettings.username = u;
+        const { token, expiresAt } = await generateLetsMeshAuthToken(
+          identity,
+          connectSettings.server,
+        );
+        connectSettings.password = token;
+        connectSettings.tokenExpiresAt = expiresAt;
+      } catch (e) {
+        console.warn(
+          '[App] LetsMesh auth token auto-launch generation failed ' + errLikeToLogString(e),
+        );
+        return;
+      }
+    } else {
+      if (!connectSettings.password?.trim()) {
+        console.warn(
+          '[App] MQTT auto-launch skipped: LetsMesh needs imported identity or password',
+        );
+        return;
+      }
+      const manualErr = validateLetsMeshManualCredentials(connectSettings);
+      if (manualErr) {
+        console.warn('[App] MQTT auto-launch skipped: ' + errLikeToLogString(manualErr));
+        return;
+      }
+    }
+  }
+
+  await window.electronAPI.mqtt.connect(connectSettings);
+}


### PR DESCRIPTION
## Summary

- **MQTT globe icon:** Change the Meshtastic MQTT path icon from purple to sky so it no longer reads like the stale-node legend color; center lone MQTT globes in the node list column and align the chat transport badge.
- **Auto-connect reliability:** Extract `tryAutoLaunchMqtt`, connect Meshtastic MQTT when switching back to the Meshtastic tab if `autoLaunch` is enabled, and treat `autoLaunch` as explicit opt-in in startup/maintenance gating so dual-protocol users who quit on the MeshCore tab are not silently skipped.
- **Settings persistence:** Centralize `readMeshtasticMqttSettingsFromStorage`, harden ConnectionPanel `autoLaunch` persistence and PSK recovery merge, with unit tests for autostart, gating, and immediate toggle save.

## Test plan

- [ ] Open app with MeshCore as stored protocol tab; enable Meshtastic MQTT auto-connect; restart — verify debug log when startup skips Meshtastic autostart, then switch to Meshtastic tab and confirm MQTT connects.
- [ ] With auto-connect enabled, switch Meshtastic ↔ MeshCore and confirm opted-in MQTT session is maintained (not torn down on MeshCore tab).
- [ ] Toggle auto-connect in ConnectionPanel and confirm `localStorage` updates immediately without connecting.
- [ ] In node list, verify MQTT-only nodes show a centered sky-blue globe; hybrid RF+MQTT rows still show both icons.
- [ ] Chat transport badge uses sky color for MQTT-only messages.
- [ ] `pnpm run test:run` passes (mqttAutoLaunch, meshtasticMqttLiveIngest, meshtasticMqttSettingsStorage, ConnectionPanel tests).