### PR TITLE
fix: serialize Meshtastic BLE toDevice to prevent WritableStream lock

### DIFF
--- a/src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import type { MeshDevice } from '@meshtastic/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { pushMeshtasticTransportSideEffectUnsubs } from './meshtasticLegacyDeviceEvents';
+import { attachMeshtasticTransportLossWatch } from './meshtasticTransportLossDetection';
+
+vi.mock('./meshtasticTransportLossDetection', () => ({
+  attachMeshtasticTransportLossWatch: vi.fn(() => () => {}),
+}));
+
+describe('pushMeshtasticTransportSideEffectUnsubs', () => {
+  const onTransportLost = vi.fn();
+  let unsubs: (() => void)[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unsubs = [];
+    window.electronAPI.onNobleBleDisconnected = vi.fn(() => () => {});
+  });
+
+  function mockDevice(): MeshDevice {
+    return {
+      setHeartbeatInterval: vi.fn(),
+    } as unknown as MeshDevice;
+  }
+
+  it('attaches serialized transport and heartbeat for BLE', () => {
+    const device = mockDevice();
+    pushMeshtasticTransportSideEffectUnsubs(
+      device,
+      'ble',
+      (unsub) => unsubs.push(unsub),
+      onTransportLost,
+    );
+
+    expect(window.electronAPI.onNobleBleDisconnected).toHaveBeenCalledTimes(1);
+    expect(attachMeshtasticTransportLossWatch).toHaveBeenCalledWith(device, 'ble', onTransportLost);
+    expect(device.setHeartbeatInterval).toHaveBeenCalledWith(60_000);
+    expect(unsubs).toHaveLength(2);
+  });
+
+  it('attaches serialized transport and heartbeat for serial', () => {
+    const device = mockDevice();
+    pushMeshtasticTransportSideEffectUnsubs(
+      device,
+      'serial',
+      (unsub) => unsubs.push(unsub),
+      onTransportLost,
+    );
+
+    expect(window.electronAPI.onNobleBleDisconnected).not.toHaveBeenCalled();
+    expect(attachMeshtasticTransportLossWatch).toHaveBeenCalledWith(
+      device,
+      'serial',
+      onTransportLost,
+    );
+    expect(device.setHeartbeatInterval).toHaveBeenCalledWith(60_000);
+    expect(unsubs).toHaveLength(1);
+  });
+
+  it('skips transport loss watch and heartbeat for HTTP', () => {
+    const device = mockDevice();
+    pushMeshtasticTransportSideEffectUnsubs(
+      device,
+      'http',
+      (unsub) => unsubs.push(unsub),
+      onTransportLost,
+    );
+
+    expect(window.electronAPI.onNobleBleDisconnected).not.toHaveBeenCalled();
+    expect(attachMeshtasticTransportLossWatch).not.toHaveBeenCalled();
+    expect(device.setHeartbeatInterval).not.toHaveBeenCalled();
+    expect(unsubs).toHaveLength(0);
+  });
+});

--- a/src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.ts
+++ b/src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.ts
@@ -6,7 +6,8 @@ import { attachMeshtasticTransportLossWatch } from './meshtasticTransportLossDet
 
 /**
  * Transport-level side effects not yet modeled as `DomainEvent`s (Noble disconnect,
- * serial/BLE heartbeat). Pushed onto the hook unsubscribe list by `useMeshtasticRuntime` wire subscriptions.
+ * serialized toDevice for serial/BLE, heartbeat). Pushed onto the hook unsubscribe
+ * list by `useMeshtasticRuntime` wire subscriptions.
  */
 export function pushMeshtasticTransportSideEffectUnsubs(
   device: MeshDevice,
@@ -24,11 +25,8 @@ export function pushMeshtasticTransportSideEffectUnsubs(
     );
   }
 
-  if (type === 'serial') {
-    push(attachMeshtasticTransportLossWatch(device, type, onTransportLost));
-  }
-
   if (type === 'serial' || type === 'ble') {
+    push(attachMeshtasticTransportLossWatch(device, type, onTransportLost));
     try {
       device.setHeartbeatInterval(60_000);
     } catch (e) {


### PR DESCRIPTION
## Summary

- Attach `attachMeshtasticTransportLossWatch` for Meshtastic **BLE** connections (previously serial-only), so `transport.toDevice` uses the serialized `getWriter()` proxy before SDK heartbeats and Store & Forward direct writes run.
- Merge transport wrapping with the existing serial/BLE heartbeat block in `pushMeshtasticTransportSideEffectUnsubs`.
- Add regression tests covering BLE, serial, and HTTP transport side-effect registration.

## Context

Log review showed a single uncaught `WritableStream is locked` error during Noble BLE use: an SDK heartbeat ping collided with a Store & Forward `CLIENT_HISTORY` ToRadio write. Serial already wrapped `toDevice` via `createSerializedWritableStream`; BLE did not.

## Test plan

- [x] `pnpm run test:run -- src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.test.ts`
- [x] `pnpm run test:run -- src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts`
- [x] `pnpm run typecheck`
- [ ] Connect Meshtastic over BLE; wait ~60s for heartbeat + S&F window; confirm no `WritableStream is locked` in app log