### PR TITLE
chore: move pnpm settings from .npmrc to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,16 +1,2 @@
-# Delay updates by 6 hours (malware is usually caught within 6 hours and dependabot is on a 6 hour delay)
-minimum-release-age=540
-minimum-release-age-exclude[]=lodash
-minimum-release-age-exclude[]=lodash-es
-
 # We use the JSR registry since it's better for typescript and also because it's where @meshtastic lives.
 @jsr:registry=https://npm.jsr.io
-
-# Electron breaks without this
-node-linker=hoisted
-
-# Verify that the package downloaded matches the registry's hash exactly
-verify-store-integrity=true
-
-# Enforce pnpm
-engine-strict=true

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -9,7 +9,7 @@ These requirements apply to all platforms.
 ### 1) Required software
 
 - Git
-- Node.js **22.13.0+** and pnpm **10+** (`package.json` `engines`; `.npmrc` sets `engine-strict=true` so `pnpm install` fails on version mismatch)
+- Node.js **22.13.0+** and pnpm **10+** (`package.json` `engines`; `pnpm-workspace.yaml` sets `engineStrict: true` so `pnpm install` fails on version mismatch)
 - [CI](https://github.com/Colorado-Mesh/mesh-client/blob/main/.github/workflows/ci.yaml) uses Node 22
 - Python 3 + `pip` (needed for MkDocs documentation build and yamllint)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,18 @@
+# Delay updates by 6 hours (malware is usually caught within 6 hours and dependabot is on a 6 hour delay)
+minimumReleaseAge: 540
+minimumReleaseAgeExclude:
+  - lodash
+  - lodash-es
+
+# Electron breaks without this
+nodeLinker: hoisted
+
+# Verify that the package downloaded matches the registry's hash exactly
+verifyStoreIntegrity: true
+
+# Enforce pnpm
+engineStrict: true
+
 allowBuilds:
   '@meshtastic/core': true
   '@meshtastic/transport-http': true


### PR DESCRIPTION
## Summary

- Move pnpm-only settings (`minimumReleaseAge`, `nodeLinker`, `verifyStoreIntegrity`, `engineStrict`) from `.npmrc` into `pnpm-workspace.yaml` using pnpm 10 camelCase keys.
- Leave only the JSR registry line in `.npmrc` so npm 11 no longer emits `Unknown project config` warnings when `release.sh` runs `pnpm version` (which delegates to npm internally).
- Update `docs/development-environment.md` to reference `engineStrict` in `pnpm-workspace.yaml`.

## Test plan

- [x] `pnpm install` succeeds with hoisted linker and release-age settings applied
- [x] `pnpm version patch --no-git-tag-version --dry-run` runs without npm config warnings
- [ ] `./release.sh` version bump step is quiet (no `Unknown project config` warnings)