### PR TITLE
fix: restore usb C++17 patch for Linux electron rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
       "@jsr/meshtastic__transport-web-serial@0.2.5": "patches/@jsr__meshtastic__transport-web-serial@0.2.5.patch",
       "@liamcottle/meshcore.js@1.13.0": "patches/@liamcottle__meshcore.js@1.13.0.patch",
       "debug@4.4.3": "patches/debug@4.4.3.patch",
-      "readable-stream@4.7.0": "patches/readable-stream@4.7.0.patch"
+      "readable-stream@4.7.0": "patches/readable-stream@4.7.0.patch",
+      "usb@2.18.0": "patches/usb@2.18.0.patch"
     },
     "minimumReleaseAgeExclude": [
       "lodash",

--- a/patches/usb@2.18.0.patch
+++ b/patches/usb@2.18.0.patch
@@ -1,0 +1,22 @@
+diff --git a/binding.gyp b/binding.gyp
+index 9f30d6b96d5f7b29399ca34016c77d58c93c054c..8baa506a490543ea45e6cbbea3c8855d8dda7f3f 100644
+--- a/binding.gyp
++++ b/binding.gyp
+@@ -33,7 +33,7 @@
+         'src/hotplug.cc'
+       ],
+       'cflags_cc': [
+-        '-std=c++14'
++        '-std=c++17'
+       ],
+       'defines': [
+         '_FILE_OFFSET_BITS=64',
+@@ -61,7 +61,7 @@
+           ['OS=="mac"', {
+             'xcode_settings': {
+               'OTHER_CFLAGS': [
+-                '-std=c++1y',
++                '-std=c++17',
+                 '-stdlib=libc++',
+                 '-arch x86_64',
+                 '-arch arm64'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ patchedDependencies:
   readable-stream@4.7.0:
     hash: 96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1
     path: patches/readable-stream@4.7.0.patch
+  usb@2.18.0:
+    hash: 87e831a30a3cea544510bd9d1784fba1cdd89ede0ece6a8753fdb4b438500d57
+    path: patches/usb@2.18.0.patch
 
 importers:
 
@@ -5242,7 +5245,7 @@ snapshots:
       patch-package: 8.0.1
       serialport: 12.0.0
     optionalDependencies:
-      usb: 2.18.0
+      usb: 2.18.0(patch_hash=87e831a30a3cea544510bd9d1784fba1cdd89ede0ece6a8753fdb4b438500d57)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -8856,7 +8859,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  usb@2.18.0:
+  usb@2.18.0(patch_hash=87e831a30a3cea544510bd9d1784fba1cdd89ede0ece6a8753fdb4b438500d57):
     dependencies:
       '@types/w3c-web-usb': 1.0.14
       node-addon-api: 8.8.0


### PR DESCRIPTION
## Summary

- Re-add pnpm patch for `usb@2.18.0` that bumps `binding.gyp` from C++14 to C++17 (Linux `cflags_cc` and macOS `OTHER_CFLAGS`).
- Register the patch in `patchedDependencies` and update the lockfile patch hash.

PR #517 removed the `usb@2.17.0` patch when deduping dependencies. `usb@2.18.0` still compiles as C++14, but `node-addon-api@8.8.0` requires C++17 (`std::string_view`), which breaks `pnpm run dist:linux` during `@electron/rebuild` in [Build Binaries run #66](https://github.com/Colorado-Mesh/mesh-client/actions/runs/27473946186/job/81209711713).

## Test plan

- [ ] `pnpm install` applies `patches/usb@2.18.0.patch` and postinstall native rebuild succeeds
- [ ] Build Binaries workflow passes on `ubuntu-latest` (`pnpm run dist:linux`)