### PR TITLE
fix: address AI review findings for backup index and docs

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -306,23 +306,20 @@ Not installed by pnpm (install separately when needed):
 
 Run these quality checks before opening a PR:
 
-# Quality checks
-
+```bash
 pnpm run test:run
 pnpm run lint
 pnpm run lint:md
 pnpm run typecheck
 pnpm run format:check
 pnpm run check:i18n
-
-````
+```
 
 Other useful test commands:
 
 - `pnpm test` (watch mode)
 - `pnpm run test:verbose` (verbose failures)
 - `pnpm run i18n:auto-translate` (fill missing keys)
-
 
 ### 5) Building a distributable
 
@@ -332,7 +329,7 @@ Use the platform-specific packaging command:
 pnpm run dist:mac   # macOS -> .dmg + .zip in release/
 pnpm run dist:linux # Linux -> .AppImage + .deb in release/
 pnpm run dist:win   # Windows -> .exe installer in release/
-````
+```
 
 Output goes to the `release/` directory.
 

--- a/src/renderer/components/KeyBackupRestoreSection.tsx
+++ b/src/renderer/components/KeyBackupRestoreSection.tsx
@@ -17,6 +17,7 @@ import {
 import type { MeshtasticDmKeyBackupIndexEntry } from '@/renderer/lib/meshtasticDmKeyBackupStorage';
 import {
   deleteMeshtasticDmKeyBackup,
+  ensureMeshtasticDmKeyBackupIndex,
   formatMeshtasticBackupDetail,
   hasMeshtasticDmKeyBackup,
   listMeshtasticDmKeyBackups,
@@ -117,6 +118,7 @@ export function KeyBackupRestoreSection({
     void (async () => {
       if (protocol === 'meshtastic') {
         await migrateLegacyMeshtasticDmKeyBackup(localNodeKey);
+        await ensureMeshtasticDmKeyBackupIndex();
       }
       refreshStatus();
     })();

--- a/src/renderer/lib/meshtasticDmKeyBackupStorage.test.ts
+++ b/src/renderer/lib/meshtasticDmKeyBackupStorage.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  ensureMeshtasticDmKeyBackupIndex,
   hasMeshtasticDmKeyBackup,
   LEGACY_MESHTASTIC_DM_KEY_BACKUP_KEY,
   listMeshtasticDmKeyBackups,
   loadMeshtasticDmKeyBackup,
+  MESHTASTIC_DM_KEY_BACKUP_INDEX_KEY,
   meshtasticDmKeyBackupStorageKey,
   migrateLegacyMeshtasticDmKeyBackup,
+  rebuildMeshtasticDmKeyBackupIndex,
   saveMeshtasticDmKeyBackup,
 } from './meshtasticDmKeyBackupStorage';
 
@@ -54,6 +57,39 @@ describe('meshtasticDmKeyBackupStorage', () => {
         privateKey: new Uint8Array(16),
       }),
     ).rejects.toThrow(/private key/);
+  });
+
+  it('rebuilds index from encrypted slots when index is missing', async () => {
+    const pub = new Uint8Array(32).fill(5);
+    const priv = new Uint8Array(32).fill(6);
+    const payload = JSON.stringify({
+      protocol: 'meshtastic',
+      nodeNum: 0x300,
+      publicKey: btoa(String.fromCharCode(...pub)),
+      privateKey: btoa(String.fromCharCode(...priv)),
+      nodeLabel: 'Node C',
+      backedUpAt: 1_700_000_000_000,
+    });
+    localStorage.setItem(meshtasticDmKeyBackupStorageKey(0x300), `enc:${payload}`);
+
+    expect(listMeshtasticDmKeyBackups()).toHaveLength(0);
+
+    const rebuilt = await rebuildMeshtasticDmKeyBackupIndex();
+    expect(rebuilt).toHaveLength(1);
+    expect(rebuilt[0]?.nodeNum).toBe(0x300);
+    expect(rebuilt[0]?.nodeLabel).toBe('Node C');
+    expect(listMeshtasticDmKeyBackups()).toHaveLength(1);
+  });
+
+  it('ensureMeshtasticDmKeyBackupIndex rebuilds corrupt index JSON', async () => {
+    const pub = new Uint8Array(32).fill(7);
+    const priv = new Uint8Array(32).fill(8);
+    await saveMeshtasticDmKeyBackup({ nodeNum: 0x400, publicKey: pub, privateKey: priv });
+    localStorage.setItem(MESHTASTIC_DM_KEY_BACKUP_INDEX_KEY, '{not-json');
+
+    await ensureMeshtasticDmKeyBackupIndex();
+    expect(listMeshtasticDmKeyBackups()).toHaveLength(1);
+    expect(listMeshtasticDmKeyBackups()[0]?.nodeNum).toBe(0x400);
   });
 
   it('migrates legacy single-slot backup to per-node storage', async () => {

--- a/src/renderer/lib/meshtasticDmKeyBackupStorage.ts
+++ b/src/renderer/lib/meshtasticDmKeyBackupStorage.ts
@@ -61,12 +61,12 @@ function parsePayload(raw: string): MeshtasticDmKeyBackupPayload {
 function readIndex(): MeshtasticDmKeyBackupIndexEntry[] {
   try {
     const raw = localStorage.getItem(MESHTASTIC_DM_KEY_BACKUP_INDEX_KEY);
-    if (!raw) return rebuildIndexFromStorage();
+    if (!raw) return [];
     const parsed = JSON.parse(raw) as MeshtasticDmKeyBackupIndexEntry[];
-    return Array.isArray(parsed) ? parsed : rebuildIndexFromStorage();
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
-    // catch-no-log-ok corrupt index JSON — rebuild from per-node slots
-    return rebuildIndexFromStorage();
+    // catch-no-log-ok corrupt index JSON — ensureMeshtasticDmKeyBackupIndex rebuilds async
+    return [];
   }
 }
 
@@ -74,20 +74,62 @@ function writeIndex(entries: MeshtasticDmKeyBackupIndexEntry[]): void {
   localStorage.setItem(MESHTASTIC_DM_KEY_BACKUP_INDEX_KEY, JSON.stringify(entries));
 }
 
-function rebuildIndexFromStorage(): MeshtasticDmKeyBackupIndexEntry[] {
-  const entries: MeshtasticDmKeyBackupIndexEntry[] = [];
+function listBackupStorageKeys(): string[] {
+  const keys: string[] = [];
   try {
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (!key?.startsWith(MESHTASTIC_DM_KEY_BACKUP_PREFIX)) continue;
-      const ciphertext = localStorage.getItem(key);
-      if (!ciphertext) continue;
-      // Index metadata only; skip decrypt in rebuild — use stored index on next save
+      if (key?.startsWith(MESHTASTIC_DM_KEY_BACKUP_PREFIX)) keys.push(key);
     }
   } catch {
     // catch-no-log-ok localStorage iteration
   }
+  return keys;
+}
+
+/** Decrypt per-node slots and rewrite the index (missing or corrupt index). */
+export async function rebuildMeshtasticDmKeyBackupIndex(): Promise<
+  MeshtasticDmKeyBackupIndexEntry[]
+> {
+  const entries: MeshtasticDmKeyBackupIndexEntry[] = [];
+  for (const key of listBackupStorageKeys()) {
+    const ciphertext = localStorage.getItem(key);
+    if (!ciphertext) continue;
+    try {
+      const decrypted = await window.electronAPI.safeStorage.decrypt(ciphertext);
+      if (!decrypted) continue;
+      const payload = parsePayload(decrypted);
+      entries.push({
+        nodeNum: normalizeNodeNum(payload.nodeNum),
+        nodeLabel: payload.nodeLabel,
+        publicKeyB64: payload.publicKey,
+        backedUpAt: payload.backedUpAt,
+      });
+    } catch {
+      // catch-no-log-ok skip corrupt slot during rebuild
+    }
+  }
+  entries.sort((a, b) => b.backedUpAt - a.backedUpAt);
+  writeIndex(entries);
   return entries;
+}
+
+function indexNeedsRebuild(index: MeshtasticDmKeyBackupIndexEntry[]): boolean {
+  const slotKeys = listBackupStorageKeys();
+  if (slotKeys.length === 0) return false;
+  if (index.length === 0) return true;
+  const indexedNums = new Set(index.map((e) => normalizeNodeNum(e.nodeNum)));
+  return slotKeys.some((key) => {
+    const suffix = key.slice(MESHTASTIC_DM_KEY_BACKUP_PREFIX.length);
+    const nodeNum = Number(suffix);
+    return Number.isFinite(nodeNum) && !indexedNums.has(normalizeNodeNum(nodeNum));
+  });
+}
+
+/** Rebuild index from encrypted slots when missing, corrupt, or out of sync. */
+export async function ensureMeshtasticDmKeyBackupIndex(): Promise<void> {
+  if (!indexNeedsRebuild(readIndex())) return;
+  await rebuildMeshtasticDmKeyBackupIndex();
 }
 
 function upsertIndexEntry(entry: MeshtasticDmKeyBackupIndexEntry): void {

--- a/src/renderer/stores/messageStore.ts
+++ b/src/renderer/stores/messageStore.ts
@@ -42,6 +42,7 @@ const defaultState: MessageStoreState = {
 export const useMessageStore = create<MessageStoreState>()(() => defaultState);
 
 function messageRecordFieldsEqual(a: MessageRecord, b: MessageRecord): boolean {
+  // MessageRecord fields are primitives (string/number/boolean/undefined); strict === is sufficient.
   const keys = new Set([...Object.keys(a), ...Object.keys(b)]) as Set<keyof MessageRecord>;
   for (const key of keys) {
     if (a[key] !== b[key]) return false;
@@ -60,6 +61,7 @@ function mergeIdentityMessages(
   };
 }
 
+/** Insert or replace the full record when fields differ (no merge). Use upsertMessage for partial updates. */
 export function addMessage(identityId: IdentityId, message: MessageRecord): void {
   useMessageStore.setState((s) => {
     const byIdentity = s.messages[identityId] ?? {};
@@ -124,15 +126,23 @@ export function replaceMessageRecordsForIdentity(
     }
     const prior = s.messages[identityId];
     if (prior && Object.keys(prior).length === records.length) {
-      let identical = true;
+      let idsMatch = true;
       for (const message of records) {
-        const existing = prior[message.id];
-        if (!existing || !messageRecordFieldsEqual(existing, message)) {
-          identical = false;
+        if (!prior[message.id]) {
+          idsMatch = false;
           break;
         }
       }
-      if (identical) return s;
+      if (idsMatch) {
+        let identical = true;
+        for (const message of records) {
+          if (!messageRecordFieldsEqual(prior[message.id], message)) {
+            identical = false;
+            break;
+          }
+        }
+        if (identical) return s;
+      }
     }
     return mergeIdentityMessages(s, identityId, byIdentity);
   });

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -4,7 +4,7 @@
   --color-app-bg: #020617;
   --color-sidebar-active-bg: #1e293b;
   --color-brand-green: #86efac;
-  --color-bright-green: #86efac;
+  --color-bright-green: var(--color-brand-green);
   --color-readable-green: #16a34a;
   --color-deep-black: #0f172a;
   --color-secondary-dark: #334155;

--- a/src/shared/formatIsoDate.test.ts
+++ b/src/shared/formatIsoDate.test.ts
@@ -35,6 +35,17 @@ describe('formatIsoDate', () => {
     process.env.TZ = 'UTC';
     expect(formatIsoDate(new Date(SAMPLE_TS))).toBe('2026-04-12');
   });
+
+  it('formats invalid dates as NaN components', () => {
+    process.env.TZ = 'UTC';
+    expect(formatIsoDate(NaN)).toBe('NaN-NaN-NaN');
+    expect(formatIsoDate(new Date('invalid'))).toBe('NaN-NaN-NaN');
+  });
+
+  it('formats epoch boundary in UTC', () => {
+    process.env.TZ = 'UTC';
+    expect(formatIsoDate(0)).toBe('1970-01-01');
+  });
 });
 
 describe('formatIsoDateTime', () => {
@@ -60,5 +71,22 @@ describe('formatIsoDateTime', () => {
   it('formats YYYY-MM-DD HH:mm in local time (America/Los_Angeles)', () => {
     process.env.TZ = 'America/Los_Angeles';
     expect(formatIsoDateTime(SAMPLE_TS)).toBe('2026-04-12 13:15');
+  });
+
+  it('pads single-digit hours and minutes', () => {
+    process.env.TZ = 'UTC';
+    const ts = Date.UTC(2026, 0, 5, 3, 4, 59);
+    expect(formatIsoDateTime(ts)).toBe('2026-01-05 03:04');
+  });
+
+  it('formats invalid dates as NaN components', () => {
+    process.env.TZ = 'UTC';
+    expect(formatIsoDateTime(NaN)).toBe('NaN-NaN-NaN NaN:NaN');
+    expect(formatIsoDateTime(new Date('invalid'))).toBe('NaN-NaN-NaN NaN:NaN');
+  });
+
+  it('formats epoch boundary in UTC', () => {
+    process.env.TZ = 'UTC';
+    expect(formatIsoDateTime(0)).toBe('1970-01-01 00:00');
   });
 });

--- a/src/shared/formatIsoDate.ts
+++ b/src/shared/formatIsoDate.ts
@@ -3,10 +3,6 @@
  * Uses the runtime's default timezone (Electron main + renderer match on the same machine).
  */
 
-function pad2(n: number): string {
-  return String(n).padStart(2, '0');
-}
-
 function toDate(ts: number | Date): Date {
   return typeof ts === 'number' ? new Date(ts) : ts;
 }
@@ -15,8 +11,8 @@ function toDate(ts: number | Date): Date {
 export function formatIsoDate(ts: number | Date): string {
   const d = toDate(ts);
   const y = d.getFullYear();
-  const mo = pad2(d.getMonth() + 1);
-  const day = pad2(d.getDate());
+  const mo = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${mo}-${day}`;
 }
 
@@ -24,7 +20,7 @@ export function formatIsoDate(ts: number | Date): string {
 export function formatIsoDateTime(ts: number | Date): string {
   const d = toDate(ts);
   const date = formatIsoDate(d);
-  const h = pad2(d.getHours());
-  const mi = pad2(d.getMinutes());
+  const h = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
   return `${date} ${h}:${mi}`;
 }


### PR DESCRIPTION
## Summary

- Implement async Meshtastic DM key backup index rebuild (`rebuildMeshtasticDmKeyBackupIndex`, `ensureMeshtasticDmKeyBackupIndex`) so corrupt or missing index JSON no longer silently hides backup metadata; wired on Security panel mount after legacy migration.
- Fix `docs/development-environment.md` code fences (missing opening backticks, four-backtick closers).
- Clarify `messageStore` replace vs merge semantics and short-circuit ID-set checks in `replaceMessageRecordsForIdentity` before per-field comparison.
- Alias `--color-bright-green` to `--color-brand-green`; simplify `formatIsoDate` padding and add edge-case tests (invalid dates, epoch boundary, single-digit time).

## Test plan

- [x] `pnpm exec vitest run src/renderer/lib/meshtasticDmKeyBackupStorage.test.ts src/shared/formatIsoDate.test.ts src/renderer/stores/messageStore.test.ts`
- [ ] Open Security panel with existing Meshtastic key backups; confirm restore picker lists backups after index corruption simulation
- [ ] Verify dev-environment doc renders quality-check and dist command blocks correctly on GitHub