### PR TITLE
refactor: harden flatpak check and MeshCore room sync; bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,11 +189,16 @@
       "usb"
     ],
     "overrides": {
+      "@babel/core": "^7.29.6",
       "@electron/asar": "^4.0.1",
       "@meshtastic/core": "npm:@jsr/meshtastic__core@^2.6.6",
       "cacheable-request": "^10.0.0",
+      "form-data": "^4.0.6",
+      "js-yaml": "^4.2.0",
       "shell-quote": "^1.8.4",
-      "tmp": "^0.2.6"
+      "tar": "^7.5.16",
+      "tmp": "^0.2.6",
+      "ws": "^8.21.0"
     },
     "patchedDependencies": {
       "@jsr/meshtastic__core@2.6.6": "patches/@jsr__meshtastic__core@2.6.6.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,16 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@babel/core': ^7.29.6
   '@electron/asar': ^4.0.1
   '@meshtastic/core': npm:@jsr/meshtastic__core@^2.6.6
   cacheable-request: ^10.0.0
+  form-data: ^4.0.6
+  js-yaml: ^4.2.0
   shell-quote: ^1.8.4
+  tar: ^7.5.16
   tmp: ^0.2.6
+  ws: ^8.21.0
 
 patchedDependencies:
   '@jsr/meshtastic__core@2.6.6':
@@ -330,7 +335,7 @@ packages:
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.29.6
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -2802,10 +2807,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -7323,10 +7324,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -7594,7 +7591,7 @@ snapshots:
   markdownlint-cli2@0.22.1:
     dependencies:
       globby: 16.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.1.1

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -14,12 +14,36 @@ const PKG = path.join(ROOT, 'package.json');
 const EXPECTED_APP_ID = 'org.coloradomesh.MeshClient';
 const EXPECTED_MAIN = 'dist-electron/main/index.js';
 const EXPECTED_ELECTRON = '/app/lib/mesh-client/electron/electron';
+const SEMVER_PATTERN = /(\d+\.\d+\.\d+)/;
+const PNPM_VERSION_PATTERN = /^pnpm@(\d+\.\d+\.\d+)/;
 
-function checkMetainfoVersionMatchesPackage() {
+function loadPackageJson() {
+  if (!fs.existsSync(PKG)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(PKG, 'utf8'));
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    console.error(
+      `check-flatpak: Failed to parse package.json or missing version field (${detail})`,
+    );
+    process.exit(1);
+  }
+}
+
+const PKG_JSON = loadPackageJson();
+
+function checkMetainfoVersionMatchesPackage(pkg) {
   const violations = [];
-  if (!fs.existsSync(METAINFO) || !fs.existsSync(PKG)) return violations;
+  if (!fs.existsSync(METAINFO) || !pkg) return violations;
 
-  const pkgVersion = JSON.parse(fs.readFileSync(PKG, 'utf8')).version;
+  const pkgVersion = pkg.version;
+  if (typeof pkgVersion !== 'string' || !pkgVersion) {
+    violations.push({
+      file: path.relative(ROOT, PKG),
+      message: 'package.json is missing a valid "version" field',
+    });
+    return violations;
+  }
   const xml = fs.readFileSync(METAINFO, 'utf8');
   const rel = path.relative(ROOT, METAINFO);
 
@@ -82,31 +106,29 @@ function checkManifestAppId() {
   return violations;
 }
 
-function electronVersionFromPackage() {
-  if (!fs.existsSync(PKG)) return null;
-  const pkg = JSON.parse(fs.readFileSync(PKG, 'utf8'));
+function electronVersionFromPackage(pkg) {
+  if (!pkg) return null;
   const spec = pkg.devDependencies?.electron ?? pkg.dependencies?.electron;
   if (typeof spec !== 'string') return null;
-  const m = spec.match(/(\d+\.\d+\.\d+)/);
+  const m = spec.match(SEMVER_PATTERN);
   return m?.[1] ?? null;
 }
 
-function pnpmVersionFromPackage() {
-  if (!fs.existsSync(PKG)) return null;
-  const pkg = JSON.parse(fs.readFileSync(PKG, 'utf8'));
+function pnpmVersionFromPackage(pkg) {
+  if (!pkg) return null;
   const spec = pkg.packageManager;
   if (typeof spec !== 'string') return null;
-  const m = spec.match(/^pnpm@(\d+\.\d+\.\d+)/);
+  const m = spec.match(PNPM_VERSION_PATTERN);
   return m?.[1] ?? null;
 }
 
-function checkManifestPnpmVersion() {
+function checkManifestPnpmVersion(pkg) {
   const violations = [];
   if (!fs.existsSync(MANIFEST)) return violations;
 
   const yaml = fs.readFileSync(MANIFEST, 'utf8');
   const rel = path.relative(ROOT, MANIFEST);
-  const pnpmVersion = pnpmVersionFromPackage();
+  const pnpmVersion = pnpmVersionFromPackage(pkg);
 
   if (!pnpmVersion) return violations;
 
@@ -121,13 +143,13 @@ function checkManifestPnpmVersion() {
   return violations;
 }
 
-function checkManifestBranchAndElectronPayload() {
+function checkManifestBranchAndElectronPayload(pkg) {
   const violations = [];
   if (!fs.existsSync(MANIFEST)) return violations;
 
   const yaml = fs.readFileSync(MANIFEST, 'utf8');
   const rel = path.relative(ROOT, MANIFEST);
-  const electronVersion = electronVersionFromPackage();
+  const electronVersion = electronVersionFromPackage(pkg);
 
   if (!/^branch:\s*stable\s*$/m.test(yaml)) {
     violations.push({
@@ -259,11 +281,18 @@ function checkWrapperLaunchPaths() {
   return violations;
 }
 
-function checkDesktopStartupWMClass() {
+function checkDesktopStartupWMClass(pkg) {
   const violations = [];
-  if (!fs.existsSync(DESKTOP) || !fs.existsSync(PKG)) return violations;
+  if (!fs.existsSync(DESKTOP) || !pkg) return violations;
 
-  const pkgName = JSON.parse(fs.readFileSync(PKG, 'utf8')).name;
+  const pkgName = pkg.name;
+  if (typeof pkgName !== 'string' || !pkgName) {
+    violations.push({
+      file: path.relative(ROOT, PKG),
+      message: 'package.json is missing a valid "name" field',
+    });
+    return violations;
+  }
   const desktop = fs.readFileSync(DESKTOP, 'utf8');
   const rel = path.relative(ROOT, DESKTOP);
 
@@ -283,13 +312,13 @@ function checkDesktopStartupWMClass() {
 
 function main() {
   const violations = [
-    ...checkMetainfoVersionMatchesPackage(),
+    ...checkMetainfoVersionMatchesPackage(PKG_JSON),
     ...checkMetainfoAppId(),
     ...checkManifestAppId(),
-    ...checkManifestPnpmVersion(),
-    ...checkManifestBranchAndElectronPayload(),
+    ...checkManifestPnpmVersion(PKG_JSON),
+    ...checkManifestBranchAndElectronPayload(PKG_JSON),
     ...checkWrapperLaunchPaths(),
-    ...checkDesktopStartupWMClass(),
+    ...checkDesktopStartupWMClass(PKG_JSON),
   ];
 
   if (violations.length === 0) {

--- a/src/renderer/lib/meshcoreRoomSyncStorage.ts
+++ b/src/renderer/lib/meshcoreRoomSyncStorage.ts
@@ -11,6 +11,11 @@ import { MESHCORE_ROOM_SYNC_MIN_INTERVAL_MINUTES } from './timeConstants';
 export const MESHCORE_ROOM_SYNC_SETTING_PREFIX = 'meshcoreRoomSync:';
 export const MESHCORE_ROOM_LAST_POST_SETTING_PREFIX = 'meshcoreRoomLastPost:';
 
+/** Coerce MeshCore node id to unsigned 32-bit for stable setting keys. */
+function toUnsignedNodeId(nodeId: number): number {
+  return nodeId >>> 0;
+}
+
 export interface MeshcoreRoomSyncConfig {
   enabled: boolean;
   intervalMinutes: number;
@@ -20,11 +25,11 @@ export interface MeshcoreRoomSyncConfig {
 }
 
 export function meshcoreRoomSyncSettingForNode(nodeId: number): string {
-  return `${MESHCORE_ROOM_SYNC_SETTING_PREFIX}${String(nodeId >>> 0)}`;
+  return `${MESHCORE_ROOM_SYNC_SETTING_PREFIX}${String(toUnsignedNodeId(nodeId))}`;
 }
 
 export function meshcoreRoomLastPostSettingForNode(nodeId: number): string {
-  return `${MESHCORE_ROOM_LAST_POST_SETTING_PREFIX}${String(nodeId >>> 0)}`;
+  return `${MESHCORE_ROOM_LAST_POST_SETTING_PREFIX}${String(toUnsignedNodeId(nodeId))}`;
 }
 
 function parseSyncConfig(raw: unknown): MeshcoreRoomSyncConfig | undefined {
@@ -63,6 +68,8 @@ export function getMeshcoreRoomSyncConfig(nodeId: number): MeshcoreRoomSyncConfi
   const key = meshcoreRoomSyncSettingForNode(nodeId);
   const parsed = settings ? parseSyncConfig(settings[key]) : undefined;
   const hasSavedPassword = getMeshcoreRoomCredential(nodeId) != null;
+  // Saved room passwords imply connect-time login; default auto-login when the flag
+  // was never persisted (legacy installs and first save after password).
   const autoLoginOnConnect = parsed?.autoLoginOnConnect ?? hasSavedPassword;
   return {
     enabled: parsed?.enabled ?? false,
@@ -121,7 +128,7 @@ export function getMeshcoreRoomLastPostAt(nodeId: number): number | null {
   if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
   if (typeof raw === 'string' && raw.trim()) {
     const n = Number.parseInt(raw, 10);
-    return Number.isFinite(n) ? n : null;
+    return !Number.isNaN(n) ? n : null;
   }
   return null;
 }
@@ -152,7 +159,7 @@ export function listMeshcoreRoomSyncEnabledNodeIds(): number[] {
     if (!cfg?.enabled) continue;
     const idStr = key.slice(prefix.length);
     const nodeId = Number.parseInt(idStr, 10);
-    if (Number.isFinite(nodeId) && nodeId >= 0) ids.push(nodeId >>> 0);
+    if (!Number.isNaN(nodeId) && nodeId >= 0) ids.push(toUnsignedNodeId(nodeId));
   }
   return ids;
 }
@@ -169,9 +176,9 @@ export function listMeshcoreRoomAutoLoginOnConnectNodeIds(): number[] {
       if (!key.startsWith(prefix)) continue;
       const idStr = key.slice(prefix.length);
       const nodeId = Number.parseInt(idStr, 10);
-      if (!Number.isFinite(nodeId) || nodeId < 0) continue;
-      if (getMeshcoreRoomSyncConfig(nodeId >>> 0).autoLoginOnConnect) {
-        ids.add(nodeId >>> 0);
+      if (Number.isNaN(nodeId) || nodeId < 0) continue;
+      if (getMeshcoreRoomSyncConfig(toUnsignedNodeId(nodeId)).autoLoginOnConnect) {
+        ids.add(toUnsignedNodeId(nodeId));
       }
     }
   }


### PR DESCRIPTION
## Summary

- **Flatpak check script:** Parse `package.json` once with try/catch and pass the parsed object into version/name checks instead of re-reading the file on every helper. Extract shared semver regex constants for Electron and pnpm version extraction; validate `version` and `name` fields explicitly.
- **MeshCore room sync storage:** Add `toUnsignedNodeId` helper for stable setting keys; document that saved room passwords imply connect-time auto-login when the flag was never persisted. Use `!Number.isNaN` after `parseInt` for stored integer validation.
- **Dependency bumps:** Add pnpm overrides for `@babel/core`, `form-data`, `js-yaml`, `tar`, and `ws`; bump `js-yaml` from 4.1.1 to 4.2.0 in the lockfile.

## Test plan

- [ ] `pnpm run check:flatpak` passes
- [ ] `pnpm run test:run` passes (especially `meshcoreRoomSyncStorage` tests if present)
- [ ] MeshCore Rooms: saved password on a node without an explicit `autoLoginOnConnect` flag still defaults to auto-login on connect
- [ ] Flatpak manifest/metainfo/desktop version checks still catch mismatches