### PR TITLE
fix: stop Windows chat scroll snap at unread divider

### DIFF
--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -1032,11 +1032,17 @@ describe('ChatPanel scroll pinning', () => {
       </ToastProvider>,
     );
 
-    await screen.findByText('New messages');
-
     const scrollContainer = container.querySelector('div.overflow-y-auto')!;
     Object.defineProperty(scrollContainer, 'scrollHeight', { value: 2000, configurable: true });
     Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+
+    await screen.findByText('New messages');
+
     Object.defineProperty(scrollContainer, 'scrollTop', {
       value: 1500,
       writable: true,

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -14,13 +14,15 @@ vi.mock('../lib/chatNotifications', () => ({ playMessageNotification: vi.fn() })
 
 let mockIsAtEnd = true;
 const mockScrollToEnd = vi.fn();
+const mockScrollToIndex = vi.fn();
 let lastVirtualizerOptions: Record<string, unknown> | undefined;
+let lastVirtualizerInstance: Record<string, unknown> | undefined;
 
 vi.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: (opts: Record<string, unknown> & { count: number }) => {
     lastVirtualizerOptions = opts;
     const count = opts.count;
-    return {
+    const instance = {
       getVirtualItems: () =>
         Array.from({ length: count }, (_, index) => ({
           index,
@@ -32,8 +34,14 @@ vi.mock('@tanstack/react-virtual', () => ({
       containerRef: { current: null },
       isAtEnd: () => mockIsAtEnd,
       scrollToEnd: mockScrollToEnd,
+      scrollToIndex: mockScrollToIndex,
       scrollDirection: 'forward',
+      shouldAdjustScrollPositionOnItemSizeChange: undefined as
+        | ((item: { index: number }) => boolean)
+        | undefined,
     };
+    lastVirtualizerInstance = instance;
+    return instance;
   },
 }));
 
@@ -41,7 +49,9 @@ beforeEach(() => {
   localStorage.clear();
   mockIsAtEnd = true;
   mockScrollToEnd.mockClear();
+  mockScrollToIndex.mockClear();
   lastVirtualizerOptions = undefined;
+  lastVirtualizerInstance = undefined;
 });
 
 describe('ChatPanel accessibility', () => {
@@ -898,6 +908,176 @@ describe('ChatPanel scroll pinning', () => {
     expect(lastVirtualizerOptions?.anchorTo).toBe('end');
     expect(lastVirtualizerOptions?.followOnAppend).toBe(true);
     expect(lastVirtualizerOptions?.scrollEndThreshold).toBe(200);
+    const adjust = lastVirtualizerInstance?.shouldAdjustScrollPositionOnItemSizeChange as (item: {
+      index: number;
+    }) => boolean;
+    expect(adjust).toBeTypeOf('function');
+    expect(adjust({ index: 0 })).toBe(true);
+  });
+
+  it('scrolls to unread via scrollToIndex on view switch, not scrollIntoView', async () => {
+    mockIsAtEnd = false;
+    const scrollIntoView = vi.fn();
+    vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(scrollIntoView);
+
+    const ts = Date.now();
+    localStorage.setItem(lastReadStorageKey('meshtastic'), JSON.stringify({ 'ch:0': ts - 5000 }));
+
+    const messages: ChatMessage[] = [
+      {
+        sender_id: 1,
+        sender_name: 'Me',
+        payload: 'Old message',
+        channel: 0,
+        timestamp: ts - 3000,
+        status: 'acked',
+      },
+      {
+        sender_id: 2,
+        sender_name: 'Alice',
+        payload: 'Unread message',
+        channel: 0,
+        timestamp: ts,
+        status: 'acked',
+      },
+    ];
+
+    render(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={messages} />
+      </ToastProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockScrollToIndex).toHaveBeenCalledWith(1, { align: 'center' });
+    });
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('Jump to Unread uses scrollToIndex with align start', async () => {
+    mockIsAtEnd = false;
+    const user = userEvent.setup();
+    const ts = Date.now();
+    localStorage.setItem(lastReadStorageKey('meshtastic'), JSON.stringify({ 'ch:0': ts - 5000 }));
+
+    const messages: ChatMessage[] = [
+      {
+        sender_id: 1,
+        sender_name: 'Me',
+        payload: 'Old message',
+        channel: 0,
+        timestamp: ts - 3000,
+        status: 'acked',
+      },
+      {
+        sender_id: 2,
+        sender_name: 'Alice',
+        payload: 'Unread message',
+        channel: 0,
+        timestamp: ts,
+        status: 'acked',
+      },
+    ];
+
+    const { container } = render(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={messages} />
+      </ToastProvider>,
+    );
+
+    mockScrollToIndex.mockClear();
+
+    const scrollContainer = container.querySelector('div.overflow-y-auto')!;
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+    fireEvent.scroll(scrollContainer);
+
+    await user.click(await screen.findByRole('button', { name: 'Jump to Unread' }));
+
+    expect(mockScrollToIndex).toHaveBeenCalledWith(1, { align: 'start', behavior: 'smooth' });
+  });
+
+  it('dismisses unread divider when scrolled past without marking read until near bottom', async () => {
+    mockIsAtEnd = false;
+    const ts = Date.now();
+    localStorage.setItem(lastReadStorageKey('meshtastic'), JSON.stringify({ 'ch:0': ts - 5000 }));
+
+    const messages: ChatMessage[] = [
+      {
+        sender_id: 1,
+        sender_name: 'Me',
+        payload: 'Old message',
+        channel: 0,
+        timestamp: ts - 3000,
+        status: 'acked',
+      },
+      {
+        sender_id: 2,
+        sender_name: 'Alice',
+        payload: 'Unread message',
+        channel: 0,
+        timestamp: ts,
+        status: 'acked',
+      },
+    ];
+
+    const { container } = render(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={messages} />
+      </ToastProvider>,
+    );
+
+    await screen.findByText('New messages');
+
+    const scrollContainer = container.querySelector('div.overflow-y-auto')!;
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollTop', {
+      value: 1500,
+      writable: true,
+      configurable: true,
+    });
+
+    const divider = container.querySelector('[class*="border-red-500"]')?.parentElement;
+    expect(divider).toBeTruthy();
+    vi.spyOn(scrollContainer, 'getBoundingClientRect').mockReturnValue({
+      top: 100,
+      bottom: 500,
+      left: 0,
+      right: 400,
+      width: 400,
+      height: 400,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(divider!, 'getBoundingClientRect').mockReturnValue({
+      top: 50,
+      bottom: 90,
+      left: 0,
+      right: 400,
+      width: 400,
+      height: 40,
+      x: 0,
+      y: 50,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.scroll(scrollContainer);
+
+    await waitFor(() => {
+      expect(screen.queryByText('New messages')).not.toBeInTheDocument();
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem(lastReadStorageKey('meshtastic')) ?? '{}',
+    ) as Record<string, number>;
+    expect(stored['ch:0']).toBe(ts - 5000);
   });
 
   it('does not scroll to end when message count increases while reading history', async () => {

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/incompatible-library */
 import 'emoji-picker-element';
 
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
 import type { TFunction } from 'i18next';
 import {
   Archive,
@@ -68,6 +68,9 @@ import {
   type StarredMessage,
 } from '../lib/chatPanelProtocolStorage';
 import { CHAT_SCROLL_END_THRESHOLD, getDistFromChatBottom } from '../lib/chatScrollUtils';
+
+/** Extra virtual row height budget when the unread divider renders in that row. */
+const UNREAD_DIVIDER_ESTIMATE_EXTRA_PX = 40;
 import {
   type ChatUnreadDmOptions,
   computeChannelUnreadCounts,
@@ -516,13 +519,11 @@ function ChatPanel({
   // Counter-based trigger: increment → useLayoutEffect fires scroll-to-divider
   const [triggerScrollToUnread, setTriggerScrollToUnread] = useState(0);
 
-  // Ref to divider DOM node for scrollIntoView
+  // Ref to divider DOM node for scroll-past detection
   const unreadDividerRef = useRef<HTMLDivElement>(null);
-  const [hasUnreadDivider, setHasUnreadDivider] = useState(false);
 
   const attachUnreadDividerRef = useCallback((node: HTMLDivElement | null) => {
     unreadDividerRef.current = node;
-    setHasUnreadDivider(node != null);
   }, []);
 
   // Persist lastRead timestamps to localStorage
@@ -681,10 +682,28 @@ function ChatPanel({
     return msgs;
   }, [searchQuery, viewMessages, filterSender]);
 
+  // Index of first message from another node newer than unreadDividerTimestamp.
+  // Returns -1 when: search active, timestamp=0, or no qualifying messages.
+  const unreadStartIndex = useMemo(() => {
+    if (searchQuery.trim() || unreadDividerTimestamp === 0) return -1;
+    for (let i = 0; i < filteredMessages.length; i++) {
+      const msg = filteredMessages[i];
+      if (!isOwnNode(msg.sender_id) && msg.timestamp > unreadDividerTimestamp) return i;
+    }
+    return -1;
+  }, [filteredMessages, isOwnNode, searchQuery, unreadDividerTimestamp]);
+
+  const hasUnreadDivider = unreadStartIndex >= 0;
+  const unreadStartIndexRef = useRef(unreadStartIndex);
+  unreadStartIndexRef.current = unreadStartIndex;
+
   const messageVirtualizer = useVirtualizer({
     count: filteredMessages.length,
     getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => (compactMode ? 56 : 96),
+    estimateSize: (index) => {
+      const base = compactMode ? 56 : 96;
+      return index === unreadStartIndex ? base + UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : base;
+    },
     overscan: 10,
     getItemKey: (index) => {
       const msg = filteredMessages[index];
@@ -695,6 +714,12 @@ function ChatPanel({
     followOnAppend: true,
     scrollEndThreshold: CHAT_SCROLL_END_THRESHOLD,
   });
+
+  messageVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item: VirtualItem): boolean => {
+    if (item.index === unreadStartIndexRef.current) return false;
+    if (!isPinnedToBottomRef.current) return false;
+    return true;
+  };
 
   const messageVirtualizerRef = useRef(messageVirtualizer);
   messageVirtualizerRef.current = messageVirtualizer;
@@ -866,10 +891,19 @@ function ChatPanel({
 
   // Scroll tracking for scroll-to-bottom button + mark-as-read when at bottom
   const handleScroll = useCallback(() => {
+    if (unreadStartIndex >= 0 && unreadDividerRef.current && scrollContainerRef.current) {
+      const container = scrollContainerRef.current;
+      const divider = unreadDividerRef.current;
+      const containerRect = container.getBoundingClientRect();
+      const dividerRect = divider.getBoundingClientRect();
+      if (dividerRect.bottom < containerRect.top) {
+        setUnreadDividerTimestamp(0);
+      }
+    }
     const distFromBottom = updateScrollButtonVisibility();
     if (distFromBottom === undefined) return;
     applyNearBottomReadState(distFromBottom);
-  }, [applyNearBottomReadState, updateScrollButtonVisibility]);
+  }, [applyNearBottomReadState, unreadStartIndex, updateScrollButtonVisibility]);
 
   // Initialize scroll button visibility on mount — critical for async message loading (e.g., meshcore SQLite load)
   useLayoutEffect(() => {
@@ -922,8 +956,8 @@ function ChatPanel({
   useLayoutEffect(() => {
     if (triggerScrollToUnread === 0) return; // skip initial mount
     if (!isActive) return; // skip while hidden
-    if (unreadDividerRef.current) {
-      unreadDividerRef.current.scrollIntoView({ block: 'center' });
+    if (unreadStartIndex >= 0) {
+      messageVirtualizerRef.current.scrollToIndex(unreadStartIndex, { align: 'center' });
       isPinnedToBottomRef.current = false;
     } else {
       messageVirtualizerRef.current.scrollToEnd();
@@ -948,7 +982,7 @@ function ChatPanel({
 
   const scrollToUnreadOrBottom = useCallback(() => {
     const el = scrollContainerRef.current;
-    if (unreadDividerRef.current) {
+    if (unreadStartIndex >= 0) {
       isPinnedToBottomRef.current = false;
       if (el) {
         const onEnd = () => {
@@ -962,12 +996,15 @@ function ChatPanel({
         };
         el.addEventListener('scrollend', onEnd, { once: true });
       }
-      unreadDividerRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      messageVirtualizerRef.current.scrollToIndex(unreadStartIndex, {
+        align: 'start',
+        behavior: 'smooth',
+      });
     } else {
       messageVirtualizerRef.current.scrollToEnd({ behavior: 'smooth' });
       isPinnedToBottomRef.current = true;
     }
-  }, [applyNearBottomReadState, outerScrollMetricsRootRef]);
+  }, [applyNearBottomReadState, outerScrollMetricsRootRef, unreadStartIndex]);
 
   const scrollToQuotedParent = useCallback((replyKey: number) => {
     const root = scrollContainerRef.current;
@@ -1135,17 +1172,6 @@ function ChatPanel({
     }
     return indices;
   }, [filteredMessages]);
-
-  // Index of first message from another node newer than unreadDividerTimestamp.
-  // Returns -1 when: search active, timestamp=0, or no qualifying messages.
-  const unreadStartIndex = useMemo(() => {
-    if (searchQuery.trim() || unreadDividerTimestamp === 0) return -1;
-    for (let i = 0; i < filteredMessages.length; i++) {
-      const msg = filteredMessages[i];
-      if (!isOwnNode(msg.sender_id) && msg.timestamp > unreadDividerTimestamp) return i;
-    }
-    return -1;
-  }, [filteredMessages, isOwnNode, searchQuery, unreadDividerTimestamp]);
 
   // Linux reaction picker — attach emoji-click on the <emoji-picker> web component
   useEffect(() => {
@@ -1683,7 +1709,7 @@ function ChatPanel({
         <div
           ref={scrollContainerRef}
           onScroll={handleScroll}
-          className={`bg-deep-black/50 h-full overflow-y-auto rounded-xl p-3`}
+          className="bg-deep-black/50 h-full overflow-y-auto overscroll-contain rounded-xl p-3 [overflow-anchor:none]"
         >
           {filteredMessages.length === 0 ? (
             <div className="text-muted py-12 text-center">


### PR DESCRIPTION
## Summary

- Fix Windows-only scroll snap when wheel-scrolling past the "New messages" divider in MeshCore/Meshtastic chat by using TanStack Virtual `scrollToIndex` instead of `scrollIntoView` (avoids outer `mainViewport` desync).
- Skip virtualizer remeasure scroll correction on the unread divider row and while reading history via `shouldAdjustScrollPositionOnItemSizeChange`.
- Reduce divider layout churn (taller row estimate, scroll-past dismissal) and harden the inner scroller with `overflow-anchor: none` and `overscroll-behavior: contain`.
- Add ChatPanel regression tests for `scrollToIndex`, scroll-past divider dismissal, and the size-adjust callback.

## Test plan

- [x] `pnpm exec vitest run src/renderer/components/ChatPanel.test.tsx`
- [x] `pnpm run typecheck`
- [ ] Windows: open MeshCore channel/DM with unread history, scroll up then wheel down past the divider — no spring-back
- [ ] Windows: Jump to Unread / Jump to Latest buttons still work
- [ ] macOS: no regression in chat scroll or pinned-bottom behavior