### PR TITLE
fix: stabilize chat scroll on Windows/Linux with TanStack Virtual

### DIFF
--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -13,6 +13,7 @@ import { ToastProvider } from './Toast';
 vi.mock('../lib/chatNotifications', () => ({ playMessageNotification: vi.fn() }));
 
 let mockIsAtEnd = true;
+let mockScrollDirection: 'forward' | 'backward' | null = 'forward';
 const mockScrollToEnd = vi.fn();
 const mockScrollToIndex = vi.fn();
 let lastVirtualizerOptions: Record<string, unknown> | undefined;
@@ -35,9 +36,15 @@ vi.mock('@tanstack/react-virtual', () => ({
       isAtEnd: () => mockIsAtEnd,
       scrollToEnd: mockScrollToEnd,
       scrollToIndex: mockScrollToIndex,
-      scrollDirection: 'forward',
+      get scrollDirection() {
+        return mockScrollDirection;
+      },
       shouldAdjustScrollPositionOnItemSizeChange: undefined as
-        | ((item: { index: number }) => boolean)
+        | ((
+            item: { index: number },
+            delta: number,
+            inst: { scrollDirection: string | null },
+          ) => boolean)
         | undefined,
     };
     lastVirtualizerInstance = instance;
@@ -48,6 +55,7 @@ vi.mock('@tanstack/react-virtual', () => ({
 beforeEach(() => {
   localStorage.clear();
   mockIsAtEnd = true;
+  mockScrollDirection = 'forward';
   mockScrollToEnd.mockClear();
   mockScrollToIndex.mockClear();
   lastVirtualizerOptions = undefined;
@@ -908,11 +916,15 @@ describe('ChatPanel scroll pinning', () => {
     expect(lastVirtualizerOptions?.anchorTo).toBe('end');
     expect(lastVirtualizerOptions?.followOnAppend).toBe(true);
     expect(lastVirtualizerOptions?.scrollEndThreshold).toBe(200);
-    const adjust = lastVirtualizerInstance?.shouldAdjustScrollPositionOnItemSizeChange as (item: {
-      index: number;
-    }) => boolean;
+    expect(lastVirtualizerOptions?.measureElement).toBeTypeOf('function');
+    const adjust = lastVirtualizerInstance?.shouldAdjustScrollPositionOnItemSizeChange as (
+      item: { index: number },
+      delta: number,
+      instance: { scrollDirection: 'forward' | 'backward' | null },
+    ) => boolean;
     expect(adjust).toBeTypeOf('function');
-    expect(adjust({ index: 0 })).toBe(true);
+    expect(adjust({ index: 0 }, 0, { scrollDirection: 'forward' })).toBe(true);
+    expect(adjust({ index: 0 }, 0, { scrollDirection: 'backward' })).toBe(false);
   });
 
   it('scrolls to unread via scrollToIndex on view switch, not scrollIntoView', async () => {
@@ -1138,6 +1150,45 @@ describe('ChatPanel scroll pinning', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Jump to Latest' })).toBeInTheDocument();
     });
+  });
+
+  it('jumps to quoted parent via scrollToIndex, not scrollIntoView', async () => {
+    mockScrollToIndex.mockClear();
+    const scrollIntoView = vi.fn();
+    vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(scrollIntoView);
+    const t0 = Date.now() - 5000;
+    const t1 = t0 + 1000;
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel
+          {...baseProps}
+          messages={[
+            {
+              sender_id: 2,
+              sender_name: 'Alice',
+              payload: 'original',
+              channel: 0,
+              timestamp: t0,
+              packetId: 77,
+              status: 'acked',
+            },
+            {
+              sender_id: 3,
+              sender_name: 'Bob',
+              payload: 'reply text',
+              channel: 0,
+              timestamp: t1,
+              replyId: 77,
+              status: 'acked',
+            },
+          ]}
+        />
+      </ToastProvider>,
+    );
+    await user.click(screen.getByRole('button', { name: /Jump to quoted message from Alice/i }));
+    expect(mockScrollToIndex).toHaveBeenCalledWith(0, { align: 'center', behavior: 'smooth' });
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });
 
@@ -2512,6 +2563,36 @@ describe('ChatPanel — jump to date', () => {
     expect(screen.queryByLabelText('Jump to date', { selector: 'input' })).not.toBeInTheDocument();
     await user.click(calBtn);
     expect(screen.getByLabelText('Jump to date', { selector: 'input' })).toBeInTheDocument();
+  });
+
+  it('scrolls to matching day via scrollToIndex, not scrollIntoView', async () => {
+    mockScrollToIndex.mockClear();
+    const scrollIntoView = vi.fn();
+    vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(scrollIntoView);
+    const day = new Date(2026, 5, 10, 14, 0, 0);
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel
+          {...baseProps}
+          messages={[
+            {
+              sender_id: 2,
+              sender_name: 'Alice',
+              payload: 'June tenth',
+              channel: 0,
+              timestamp: day.getTime(),
+              status: 'acked',
+            },
+          ]}
+        />
+      </ToastProvider>,
+    );
+    await user.click(screen.getByLabelText('Jump to date'));
+    const input = screen.getByLabelText('Jump to date', { selector: 'input' });
+    fireEvent.change(input, { target: { value: '2026-06-10' } });
+    expect(mockScrollToIndex).toHaveBeenCalledWith(0, { align: 'start', behavior: 'smooth' });
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });
 

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -698,10 +698,17 @@ function ChatPanel({
 
   const estimateMessageSize = useCallback(
     (index: number) => {
-      const base = compactMode ? 56 : 96;
+      const msg = filteredMessages[index];
+      let base = compactMode ? 56 : 96;
+      if (msg?.replyId != null || msg?.replyPreviewText) {
+        base += compactMode ? 40 : 72;
+      }
+      if ((msg?.payload.length ?? 0) > 120) {
+        base += compactMode ? 24 : 48;
+      }
       return index === unreadStartIndex ? base + CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : base;
     },
-    [compactMode, unreadStartIndex],
+    [compactMode, filteredMessages, unreadStartIndex],
   );
 
   const measureMessageElement = useMemo(

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/incompatible-library */
 import 'emoji-picker-element';
 
-import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import type { TFunction } from 'i18next';
 import {
   Archive,
@@ -67,10 +67,16 @@ import {
   saveStarred,
   type StarredMessage,
 } from '../lib/chatPanelProtocolStorage';
-import { CHAT_SCROLL_END_THRESHOLD, getDistFromChatBottom } from '../lib/chatScrollUtils';
-
-/** Extra virtual row height budget when the unread divider renders in that row. */
-const UNREAD_DIVIDER_ESTIMATE_EXTRA_PX = 40;
+import {
+  CHAT_SCROLL_END_THRESHOLD,
+  CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX,
+  createChatScrollAdjustPredicate,
+  createStableChatMeasureElement,
+  findFirstMessageIndexByDayKey,
+  findMessageIndexByKey,
+  getChatDayKey,
+  getDistFromChatBottom,
+} from '../lib/chatScrollUtils';
 import {
   type ChatUnreadDmOptions,
   computeChannelUnreadCounts,
@@ -270,13 +276,6 @@ function formatDayLabel(ts: number, t: TFunction): string {
   if (diff === 86_400_000) return t('chatPanel.dayYesterday');
   return formatIsoDate(date);
 }
-
-/** Get a day key for grouping messages */
-function getDayKey(ts: number): string {
-  const d = new Date(ts);
-  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
-}
-
 function UnreadDivider() {
   const { t } = useTranslation();
   return (
@@ -697,13 +696,24 @@ function ChatPanel({
   const unreadStartIndexRef = useRef(unreadStartIndex);
   unreadStartIndexRef.current = unreadStartIndex;
 
+  const estimateMessageSize = useCallback(
+    (index: number) => {
+      const base = compactMode ? 56 : 96;
+      return index === unreadStartIndex ? base + CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : base;
+    },
+    [compactMode, unreadStartIndex],
+  );
+
+  const measureMessageElement = useMemo(
+    () => createStableChatMeasureElement(estimateMessageSize),
+    [estimateMessageSize],
+  );
+
   const messageVirtualizer = useVirtualizer({
     count: filteredMessages.length,
     getScrollElement: () => scrollContainerRef.current,
-    estimateSize: (index) => {
-      const base = compactMode ? 56 : 96;
-      return index === unreadStartIndex ? base + UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : base;
-    },
+    estimateSize: estimateMessageSize,
+    measureElement: measureMessageElement,
     overscan: 10,
     getItemKey: (index) => {
       const msg = filteredMessages[index];
@@ -715,11 +725,10 @@ function ChatPanel({
     scrollEndThreshold: CHAT_SCROLL_END_THRESHOLD,
   });
 
-  messageVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item: VirtualItem): boolean => {
-    if (item.index === unreadStartIndexRef.current) return false;
-    if (!isPinnedToBottomRef.current) return false;
-    return true;
-  };
+  messageVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = createChatScrollAdjustPredicate({
+    unreadStartIndexRef,
+    isPinnedToBottomRef,
+  });
 
   const messageVirtualizerRef = useRef(messageVirtualizer);
   messageVirtualizerRef.current = messageVirtualizer;
@@ -1006,12 +1015,15 @@ function ChatPanel({
     }
   }, [applyNearBottomReadState, outerScrollMetricsRootRef, unreadStartIndex]);
 
-  const scrollToQuotedParent = useCallback((replyKey: number) => {
-    const root = scrollContainerRef.current;
-    if (!root) return;
-    const el = root.querySelector(`[data-chat-message-key="${replyKey}"]`);
-    (el as HTMLElement | null)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }, []);
+  const scrollToQuotedParent = useCallback(
+    (replyKey: number) => {
+      const index = findMessageIndexByKey(filteredMessages, replyKey);
+      if (index < 0) return;
+      isPinnedToBottomRef.current = false;
+      messageVirtualizerRef.current.scrollToIndex(index, { align: 'center', behavior: 'smooth' });
+    },
+    [filteredMessages],
+  );
 
   // Escape key handler
   useEffect(() => {
@@ -1164,7 +1176,7 @@ function ChatPanel({
     const indices = new Set<number>();
     let prevDayKey = '';
     for (let i = 0; i < filteredMessages.length; i++) {
-      const dayKey = getDayKey(filteredMessages[i].timestamp);
+      const dayKey = getChatDayKey(filteredMessages[i].timestamp);
       if (dayKey !== prevDayKey) {
         indices.add(i);
         prevDayKey = dayKey;
@@ -1219,17 +1231,19 @@ function ChatPanel({
   const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   // Jump to date — scroll to first message with matching day key
-  const handleJumpToDate = useCallback((dateStr: string) => {
-    if (!dateStr) return;
-    const [y, m, d] = dateStr.split('-').map(Number);
-    const targetKey = `${y}-${m - 1}-${d}`;
-    const root = scrollContainerRef.current;
-    if (!root) return;
-    const el = root.querySelector(`[data-chat-day-key="${targetKey}"]`);
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }, []);
+  const handleJumpToDate = useCallback(
+    (dateStr: string) => {
+      if (!dateStr) return;
+      const [y, m, d] = dateStr.split('-').map(Number);
+      const targetKey = `${y}-${m - 1}-${d}`;
+      const index = findFirstMessageIndexByDayKey(filteredMessages, targetKey);
+      if (index < 0) return;
+      isPinnedToBottomRef.current = false;
+      messageVirtualizerRef.current.scrollToIndex(index, { align: 'start', behavior: 'smooth' });
+      setShowDatePicker(false);
+    },
+    [filteredMessages],
+  );
 
   const composePlaceholder = useMemo(
     () =>
@@ -1797,7 +1811,7 @@ function ChatPanel({
                       <div
                         className={`flex flex-col ${isOwn ? 'items-end' : 'items-start'}`}
                         data-chat-message-key={messageRowKey}
-                        data-chat-day-key={getDayKey(msg.timestamp)}
+                        data-chat-day-key={getChatDayKey(msg.timestamp)}
                       >
                         {/* Bubble row */}
                         <div

--- a/src/renderer/components/RoomsPanel.test.tsx
+++ b/src/renderer/components/RoomsPanel.test.tsx
@@ -30,6 +30,36 @@ import type { ChatMessage, MeshNode } from '@/renderer/lib/types';
 import * as chatScrollUtils from '../lib/chatScrollUtils';
 import RoomsPanel from './RoomsPanel';
 
+const mockScrollToEnd = vi.fn();
+const mockScrollToIndex = vi.fn();
+let lastRoomsVirtualizerOptions: Record<string, unknown> | undefined;
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: (opts: Record<string, unknown> & { count: number }) => {
+    lastRoomsVirtualizerOptions = opts;
+    const count = opts.count;
+    const instance = {
+      getVirtualItems: () =>
+        Array.from({ length: count }, (_, index) => ({
+          index,
+          key: index,
+          start: index * 96,
+        })),
+      getTotalSize: () => count * 96,
+      measureElement: () => {},
+      containerRef: { current: null },
+      isAtEnd: () => false,
+      scrollToEnd: mockScrollToEnd,
+      scrollToIndex: mockScrollToIndex,
+      scrollDirection: 'forward' as const,
+      shouldAdjustScrollPositionOnItemSizeChange: undefined as
+        | ((item: { index: number }) => boolean)
+        | undefined,
+    };
+    return instance;
+  },
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -791,7 +821,7 @@ describe('RoomsPanel', () => {
     );
 
     const stream = screen.getByTestId('rooms-post-stream');
-    expect(stream).toHaveClass('overflow-y-auto');
+    expect(stream).toHaveClass('overflow-y-auto', 'overscroll-contain', '[overflow-anchor:none]');
     expect(stream.parentElement).toHaveClass('min-h-0', 'flex-1');
     expect(screen.getByTestId('rooms-composer-footer')).toHaveClass('shrink-0');
   });
@@ -872,6 +902,7 @@ describe('RoomsPanel', () => {
     const distSpy = vi.spyOn(chatScrollUtils, 'getDistFromChatBottom').mockReturnValue(300);
     const scrollIntoView = vi.fn();
     vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(scrollIntoView);
+    mockScrollToIndex.mockClear();
 
     renderRoomsPanel(nodes, {
       initialRoomTarget: room.node_id,
@@ -882,8 +913,40 @@ describe('RoomsPanel', () => {
     const jumpButton = await screen.findByRole('button', { name: 'roomsPanel.jumpToUnread' });
     await userEvent.click(jumpButton);
 
-    expect(scrollIntoView).toHaveBeenCalled();
+    expect(mockScrollToIndex).toHaveBeenLastCalledWith(0, {
+      align: 'start',
+      behavior: 'smooth',
+    });
+    expect(scrollIntoView).not.toHaveBeenCalled();
     distSpy.mockRestore();
     vi.restoreAllMocks();
+  });
+
+  it('configures TanStack Virtual with rooms scroll contract', () => {
+    meshcoreClearAllRoomSessions();
+    const room = makeRoom(0x1015, 'Virtual Room');
+    const nodes = new Map<number, MeshNode>([[room.node_id, room]]);
+    meshcoreApplyRoomSession(room.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+    renderRoomsPanel(nodes, {
+      initialRoomTarget: room.node_id,
+      messages: [
+        buildMeshcoreRoomIncomingMessage({
+          rawText: 'hello',
+          roomServerId: room.node_id,
+          authorId: 0x200,
+          authorName: 'Alice',
+          timestamp: 2000,
+          receivedVia: 'rf',
+        }),
+      ],
+      isActive: true,
+    });
+    expect(lastRoomsVirtualizerOptions?.anchorTo).toBe('end');
+    expect(lastRoomsVirtualizerOptions?.followOnAppend).toBe(true);
+    expect(lastRoomsVirtualizerOptions?.measureElement).toBeTypeOf('function');
   });
 });

--- a/src/renderer/components/RoomsPanel.tsx
+++ b/src/renderer/components/RoomsPanel.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react-hooks/incompatible-library -- TanStack Virtual useVirtualizer; same as ChatPanel */
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { ArrowDown, Copy, Mail, PARENT_HOVER_ATTR, Star } from 'lucide-react-motion';
 import {
   useCallback,
@@ -74,7 +76,14 @@ import type { ChatMessage, MeshNode } from '@/renderer/lib/types';
 import { writeClipboardText } from '@/renderer/lib/writeClipboardText';
 import { formatIsoDateTime } from '@/shared/formatIsoDate';
 
-import { CHAT_SCROLL_END_THRESHOLD, getDistFromChatBottom } from '../lib/chatScrollUtils';
+import {
+  CHAT_SCROLL_END_THRESHOLD,
+  CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX,
+  createChatScrollAdjustPredicate,
+  createStableChatMeasureElement,
+  findIndexByRowKey,
+  getDistFromChatBottom,
+} from '../lib/chatScrollUtils';
 import { ChatComposer } from './ChatComposer';
 import { ChatPayloadText } from './ChatPayloadText';
 import { ConfirmModal } from './ConfirmModal';
@@ -257,7 +266,10 @@ export default function RoomsPanel({
   const [aclError, setAclError] = useState<string | null>(null);
   const [aclFetchedAt, setAclFetchedAt] = useState<number | null>(null);
   const [scrollToRowKey, setScrollToRowKey] = useState<string | null>(null);
-  const postRowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  const attachUnreadDividerRef = useCallback((node: HTMLDivElement | null) => {
+    unreadDividerRef.current = node;
+  }, []);
 
   const ownNodeIdSet = useMemo(
     () => (myNodeNum > 0 ? new Set([myNodeNum]) : new Set<number>()),
@@ -319,6 +331,54 @@ export default function RoomsPanel({
     return repairMeshcoreHydrationStaleRoomSends(mergeDisplayedRoomPostChunks(posts));
   }, [messages, selectedRoomId]);
 
+  const unreadStartIndex = useMemo(() => {
+    if (unreadDividerTimestamp === 0) return -1;
+    for (let i = 0; i < roomPosts.length; i++) {
+      if (roomPosts[i].timestamp > unreadDividerTimestamp) return i;
+    }
+    return -1;
+  }, [roomPosts, unreadDividerTimestamp]);
+
+  const unreadStartIndexRef = useRef(unreadStartIndex);
+  unreadStartIndexRef.current = unreadStartIndex;
+
+  const estimatePostSize = useCallback(
+    (index: number) => {
+      const base = 96;
+      return index === unreadStartIndex ? base + CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : base;
+    },
+    [unreadStartIndex],
+  );
+
+  const measurePostElement = useMemo(
+    () => createStableChatMeasureElement(estimatePostSize),
+    [estimatePostSize],
+  );
+
+  const postVirtualizer = useVirtualizer({
+    count: roomPosts.length,
+    getScrollElement: () => streamRef.current,
+    estimateSize: estimatePostSize,
+    measureElement: measurePostElement,
+    overscan: 10,
+    getItemKey: (index) => {
+      const post = roomPosts[index];
+      if (!post) return index;
+      return roomPostRowKey(post);
+    },
+    anchorTo: 'end',
+    followOnAppend: true,
+    scrollEndThreshold: CHAT_SCROLL_END_THRESHOLD,
+  });
+
+  postVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = createChatScrollAdjustPredicate({
+    unreadStartIndexRef,
+    isPinnedToBottomRef,
+  });
+
+  const postVirtualizerRef = useRef(postVirtualizer);
+  postVirtualizerRef.current = postVirtualizer;
+
   const newestPostTs = useMemo(() => {
     if (roomPosts.length === 0) {
       if (selectedRoomId == null) return null;
@@ -363,20 +423,33 @@ export default function RoomsPanel({
     }
   }, [persistedRoomsLastRead]);
 
+  const computeIsAtChatEnd = useCallback(() => {
+    const inner = streamRef.current;
+    if (!inner) return false;
+    const virtualAtEnd = postVirtualizerRef.current.isAtEnd(CHAT_SCROLL_END_THRESHOLD);
+    const outerDist = getDistFromChatBottom(
+      inner,
+      messagesEndRef.current,
+      outerScrollMetricsRootRef?.current ?? null,
+    );
+    if (outerDist != null && outerDist > CHAT_SCROLL_END_THRESHOLD) return false;
+    return virtualAtEnd;
+  }, [outerScrollMetricsRootRef]);
+
   const updateScrollButtonVisibility = useCallback(() => {
+    const atEnd = computeIsAtChatEnd();
+    isPinnedToBottomRef.current = atEnd;
+    setShowScrollButton(!atEnd);
+    const scrollTop = streamRef.current?.scrollTop ?? 0;
+    setShowScrollTopButton(scrollTop > CHAT_SCROLL_END_THRESHOLD);
     const distFromBottom = getDistFromChatBottom(
       streamRef.current,
       messagesEndRef.current,
       outerScrollMetricsRootRef?.current ?? null,
     );
     if (distFromBottom == null) return undefined;
-    const atEnd = distFromBottom <= CHAT_SCROLL_END_THRESHOLD;
-    isPinnedToBottomRef.current = atEnd;
-    setShowScrollButton(!atEnd);
-    const scrollTop = streamRef.current?.scrollTop ?? 0;
-    setShowScrollTopButton(scrollTop > CHAT_SCROLL_END_THRESHOLD);
     return distFromBottom;
-  }, [outerScrollMetricsRootRef]);
+  }, [computeIsAtChatEnd, outerScrollMetricsRootRef]);
 
   const applyNearBottomReadState = useCallback(
     (distFromBottom: number) => {
@@ -390,21 +463,28 @@ export default function RoomsPanel({
   );
 
   const handleStreamScroll = useCallback(() => {
+    if (unreadStartIndex >= 0 && unreadDividerRef.current && streamRef.current) {
+      const container = streamRef.current;
+      const divider = unreadDividerRef.current;
+      const containerRect = container.getBoundingClientRect();
+      const dividerRect = divider.getBoundingClientRect();
+      if (dividerRect.bottom < containerRect.top) {
+        setUnreadDividerTimestamp(0);
+      }
+    }
     const distFromBottom = updateScrollButtonVisibility();
     if (distFromBottom === undefined) return;
     applyNearBottomReadState(distFromBottom);
-  }, [applyNearBottomReadState, updateScrollButtonVisibility]);
+  }, [applyNearBottomReadState, unreadStartIndex, updateScrollButtonVisibility]);
 
   const scrollToBottom = useCallback(() => {
-    const el = streamRef.current;
-    if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    postVirtualizerRef.current.scrollToEnd({ behavior: 'smooth' });
     isPinnedToBottomRef.current = true;
   }, []);
 
   const scrollToUnreadOrBottom = useCallback(() => {
     const el = streamRef.current;
-    if (unreadDividerRef.current) {
+    if (unreadStartIndex >= 0) {
       isPinnedToBottomRef.current = false;
       if (el) {
         const onEnd = () => {
@@ -418,11 +498,14 @@ export default function RoomsPanel({
         };
         el.addEventListener('scrollend', onEnd, { once: true });
       }
-      unreadDividerRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      postVirtualizerRef.current.scrollToIndex(unreadStartIndex, {
+        align: 'start',
+        behavior: 'smooth',
+      });
     } else {
       scrollToBottom();
     }
-  }, [applyNearBottomReadState, outerScrollMetricsRootRef, scrollToBottom]);
+  }, [applyNearBottomReadState, outerScrollMetricsRootRef, scrollToBottom, unreadStartIndex]);
 
   useLayoutEffect(() => {
     requestAnimationFrame(() => {
@@ -480,21 +563,19 @@ export default function RoomsPanel({
   useLayoutEffect(() => {
     if (triggerScrollToUnread === 0) return;
     if (!isActive) return;
-    if (unreadDividerRef.current) {
-      unreadDividerRef.current.scrollIntoView({ block: 'center' });
+    if (unreadStartIndex >= 0) {
+      postVirtualizerRef.current.scrollToIndex(unreadStartIndex, { align: 'center' });
       isPinnedToBottomRef.current = false;
     } else {
-      const el = streamRef.current;
-      if (el) {
-        el.scrollTop = el.scrollHeight;
-      }
+      postVirtualizerRef.current.scrollToEnd();
       isPinnedToBottomRef.current = true;
     }
     requestAnimationFrame(() => {
       const dist = updateScrollButtonVisibility();
       if (dist !== undefined && dist < 50) applyNearBottomReadState(dist);
     });
-  }, [triggerScrollToUnread, isActive, updateScrollButtonVisibility, applyNearBottomReadState]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- triggerScrollToUnread is the sole scroll intent
+  }, [triggerScrollToUnread, isActive]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -506,7 +587,6 @@ export default function RoomsPanel({
   useEffect(() => {
     if (selectedRoomId == null) return;
     const snapshot = persistedRoomsLastRead[selectedRoomId] ?? 0;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- placed after scroll/read effects so their rAF does not clear the watermark before it is applied
     setUnreadDividerTimestamp(snapshot);
     setTriggerScrollToUnread((n) => n + 1);
   }, [selectedRoomId, persistedRoomsLastRead]);
@@ -787,11 +867,12 @@ export default function RoomsPanel({
 
   useEffect(() => {
     if (streamView !== 'posts' || !scrollToRowKey) return;
-    const el = postRowRefs.current.get(scrollToRowKey);
-    if (el) {
-      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
-      setScrollToRowKey(null);
+    const index = findIndexByRowKey(roomPosts, scrollToRowKey, roomPostRowKey);
+    if (index >= 0) {
+      isPinnedToBottomRef.current = false;
+      postVirtualizerRef.current.scrollToIndex(index, { align: 'center', behavior: 'smooth' });
     }
+    setScrollToRowKey(null);
   }, [scrollToRowKey, streamView, roomPosts]);
 
   const toggleStar = useCallback(
@@ -1777,7 +1858,7 @@ export default function RoomsPanel({
                   ref={streamRef}
                   data-testid="rooms-post-stream"
                   onScroll={handleStreamScroll}
-                  className="h-full min-h-0 space-y-2 overflow-y-auto px-3 py-2"
+                  className="h-full min-h-0 overflow-y-auto overscroll-contain px-3 py-2 [overflow-anchor:none]"
                 >
                   {streamView === 'starred' ? (
                     roomStarred.length === 0 ? (
@@ -1826,145 +1907,153 @@ export default function RoomsPanel({
                   ) : roomPosts.length === 0 ? (
                     <p className="text-sm text-gray-500">{t('roomsPanel.noPostsYet')}</p>
                   ) : (
-                    roomPosts.map((m, index) => {
-                      const isOwn = m.sender_id === myNodeNum;
-                      const rowKey = roomPostRowKey(m);
-                      const starId = roomMsgStarId(m);
-                      const isStarred = starredIdSet.has(starId);
-                      const showDm =
-                        onMessageNode != null && canDmMeshcorePoster(m.sender_id, myNodeNum, nodes);
-                      const showUnreadDivider =
-                        unreadDividerTimestamp > 0 &&
-                        m.timestamp > unreadDividerTimestamp &&
-                        (index === 0 || roomPosts[index - 1].timestamp <= unreadDividerTimestamp);
-                      return (
-                        <div key={rowKey}>
-                          {showUnreadDivider && (
-                            <div ref={unreadDividerRef}>
-                              <RoomUnreadDivider label={t('roomsPanel.newMessagesDivider')} />
-                            </div>
-                          )}
+                    <div
+                      ref={postVirtualizer.containerRef}
+                      className="relative w-full"
+                      style={{ height: `${postVirtualizer.getTotalSize()}px` }}
+                    >
+                      {postVirtualizer.getVirtualItems().map((vi) => {
+                        const index = vi.index;
+                        const m = roomPosts[index];
+                        if (!m) return null;
+                        const isOwn = m.sender_id === myNodeNum;
+                        const starId = roomMsgStarId(m);
+                        const isStarred = starredIdSet.has(starId);
+                        const showDm =
+                          onMessageNode != null &&
+                          canDmMeshcorePoster(m.sender_id, myNodeNum, nodes);
+                        const isUnreadStart = index === unreadStartIndex;
+                        return (
                           <div
-                            ref={(el) => {
-                              if (el) postRowRefs.current.set(rowKey, el);
-                              else postRowRefs.current.delete(rowKey);
-                            }}
-                            className={`group/msg rounded-lg px-3 py-2 text-sm ${
-                              isOwn
-                                ? 'bg-purple-900/30 text-purple-100'
-                                : 'bg-gray-800/60 text-gray-200'
-                            }`}
+                            key={vi.key}
+                            data-index={vi.index}
+                            ref={postVirtualizer.measureElement}
+                            className="absolute top-0 left-0 w-full pb-2"
+                            style={{ transform: `translateY(${vi.start}px)` }}
                           >
-                            <div className="mb-1 flex items-baseline gap-2 text-xs text-gray-400">
-                              <span className="font-medium text-gray-300">{m.sender_name}</span>
-                              <span>{formatTimestamp(m.timestamp)}</span>
-                              <div className="ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
-                                {showDm && (
+                            {isUnreadStart && (
+                              <div ref={attachUnreadDividerRef}>
+                                <RoomUnreadDivider label={t('roomsPanel.newMessagesDivider')} />
+                              </div>
+                            )}
+                            <div
+                              className={`group/msg rounded-lg px-3 py-2 text-sm ${
+                                isOwn
+                                  ? 'bg-purple-900/30 text-purple-100'
+                                  : 'bg-gray-800/60 text-gray-200'
+                              }`}
+                            >
+                              <div className="mb-1 flex items-baseline gap-2 text-xs text-gray-400">
+                                <span className="font-medium text-gray-300">{m.sender_name}</span>
+                                <span>{formatTimestamp(m.timestamp)}</span>
+                                <div className="ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
+                                  {showDm && (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        onMessageNode?.(m.sender_id);
+                                      }}
+                                      {...{ [PARENT_HOVER_ATTR]: '' }}
+                                      className="rounded p-0.5 text-gray-500 hover:text-cyan-300"
+                                      aria-label={t('nodeDetailModal.messageButton')}
+                                      title={t('nodeDetailModal.messageButton')}
+                                    >
+                                      <Mail
+                                        aria-hidden
+                                        className="h-3.5 w-3.5"
+                                        trigger={parentIconTrigger}
+                                        size={14}
+                                      />
+                                    </button>
+                                  )}
                                   <button
                                     type="button"
                                     onClick={() => {
-                                      onMessageNode?.(m.sender_id);
+                                      toggleStar(m);
                                     }}
                                     {...{ [PARENT_HOVER_ATTR]: '' }}
-                                    className="rounded p-0.5 text-gray-500 hover:text-cyan-300"
-                                    aria-label={t('nodeDetailModal.messageButton')}
-                                    title={t('nodeDetailModal.messageButton')}
+                                    className={`rounded p-0.5 transition-colors ${
+                                      isStarred
+                                        ? 'text-amber-400 hover:text-amber-200'
+                                        : 'text-gray-500 hover:text-amber-400'
+                                    }`}
+                                    aria-label={
+                                      isStarred
+                                        ? t('chatPanel.unstarMessage')
+                                        : t('chatPanel.starMessage')
+                                    }
+                                    title={
+                                      isStarred
+                                        ? t('chatPanel.unstarMessage')
+                                        : t('chatPanel.starMessage')
+                                    }
                                   >
-                                    <Mail
+                                    <Star
+                                      aria-hidden
+                                      className={`h-3.5 w-3.5 ${isStarred ? 'fill-current' : ''}`}
+                                      trigger={parentIconTrigger}
+                                      size={14}
+                                    />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      void writeClipboardText(m.payload).catch((err: unknown) => {
+                                        console.warn(
+                                          '[RoomsPanel] copy failed ' + errLikeToLogString(err),
+                                        );
+                                      });
+                                    }}
+                                    {...{ [PARENT_HOVER_ATTR]: '' }}
+                                    className="rounded p-0.5 text-gray-500 hover:text-gray-300"
+                                    aria-label={t('chatPanel.copyMessage')}
+                                    title={t('chatPanel.copyMessage')}
+                                  >
+                                    <Copy
                                       aria-hidden
                                       className="h-3.5 w-3.5"
                                       trigger={parentIconTrigger}
                                       size={14}
                                     />
                                   </button>
-                                )}
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    toggleStar(m);
-                                  }}
-                                  {...{ [PARENT_HOVER_ATTR]: '' }}
-                                  className={`rounded p-0.5 transition-colors ${
-                                    isStarred
-                                      ? 'text-amber-400 hover:text-amber-200'
-                                      : 'text-gray-500 hover:text-amber-400'
-                                  }`}
-                                  aria-label={
-                                    isStarred
-                                      ? t('chatPanel.unstarMessage')
-                                      : t('chatPanel.starMessage')
-                                  }
-                                  title={
-                                    isStarred
-                                      ? t('chatPanel.unstarMessage')
-                                      : t('chatPanel.starMessage')
-                                  }
-                                >
-                                  <Star
-                                    aria-hidden
-                                    className={`h-3.5 w-3.5 ${isStarred ? 'fill-current' : ''}`}
-                                    trigger={parentIconTrigger}
-                                    size={14}
-                                  />
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    void writeClipboardText(m.payload).catch((err: unknown) => {
-                                      console.warn(
-                                        '[RoomsPanel] copy failed ' + errLikeToLogString(err),
-                                      );
-                                    });
-                                  }}
-                                  {...{ [PARENT_HOVER_ATTR]: '' }}
-                                  className="rounded p-0.5 text-gray-500 hover:text-gray-300"
-                                  aria-label={t('chatPanel.copyMessage')}
-                                  title={t('chatPanel.copyMessage')}
-                                >
-                                  <Copy
-                                    aria-hidden
-                                    className="h-3.5 w-3.5"
-                                    trigger={parentIconTrigger}
-                                    size={14}
-                                  />
-                                </button>
+                                </div>
                               </div>
-                            </div>
-                            <div className="break-words whitespace-pre-wrap">
-                              <ChatPayloadText
-                                text={m.payload}
-                                query=""
-                                loadLinkPreviews={!showScrollButton}
-                              />
-                            </div>
-                            {isOwn && m.status && (
-                              <div className="mt-0.5 flex items-center justify-end gap-1">
-                                {m.status === 'failed' && (
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      void onSendRoomPost(selectedRoomId, m.payload);
-                                    }}
-                                    className="text-gray-500 transition-colors hover:text-gray-300"
-                                    title={t('chatPanel.resendMessage')}
-                                    aria-label={t('chatPanel.resendMessage')}
-                                  >
-                                    ↻
-                                  </button>
-                                )}
-                                <MessageStatusBadge
-                                  status={m.status}
-                                  transport="device"
-                                  connectionType={connectionType}
-                                  error={m.error ?? undefined}
-                                  context="room"
+                              <div className="break-words whitespace-pre-wrap">
+                                <ChatPayloadText
+                                  text={m.payload}
+                                  query=""
+                                  loadLinkPreviews={!showScrollButton}
                                 />
                               </div>
-                            )}
+                              {isOwn && m.status && selectedRoomId != null && (
+                                <div className="mt-0.5 flex items-center justify-end gap-1">
+                                  {m.status === 'failed' && (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        void onSendRoomPost(selectedRoomId, m.payload);
+                                      }}
+                                      className="text-gray-500 transition-colors hover:text-gray-300"
+                                      title={t('chatPanel.resendMessage')}
+                                      aria-label={t('chatPanel.resendMessage')}
+                                    >
+                                      ↻
+                                    </button>
+                                  )}
+                                  <MessageStatusBadge
+                                    status={m.status}
+                                    transport="device"
+                                    connectionType={connectionType}
+                                    error={m.error ?? undefined}
+                                    context="room"
+                                  />
+                                </div>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      );
-                    })
+                        );
+                      })}
+                    </div>
                   )}
                   <div ref={messagesEndRef} />
                 </div>

--- a/src/renderer/lib/chatScrollUtils.test.ts
+++ b/src/renderer/lib/chatScrollUtils.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createStableChatMeasureElement,
+  findFirstMessageIndexByDayKey,
+  findIndexByRowKey,
+  findMessageIndexByKey,
+  getChatDayKey,
+  scrollElementWithinContainer,
+} from './chatScrollUtils';
+import type { ChatMessage } from './types';
+
+function makeMsg(overrides: Partial<ChatMessage> & Pick<ChatMessage, 'timestamp'>): ChatMessage {
+  return {
+    sender_id: 1,
+    sender_name: 'Alice',
+    payload: 'hello',
+    channel: 0,
+    status: 'acked',
+    ...overrides,
+  };
+}
+
+function mockMeasureInstance(
+  overrides: Partial<{
+    scrollDirection: 'forward' | 'backward' | null;
+    cachedSize: number;
+    index: number;
+    key: string;
+  }> = {},
+) {
+  const index = overrides.index ?? 0;
+  const key = overrides.key ?? 'k0';
+  return {
+    indexFromElement: () => index,
+    scrollDirection: overrides.scrollDirection ?? null,
+    measurementsCache: [{ size: overrides.cachedSize ?? 80 }],
+    itemSizeCache: new Map<string, number>([[key, overrides.cachedSize ?? 80]]),
+    options: {
+      getItemKey: () => key,
+      horizontal: false,
+      estimateSize: () => 96,
+    },
+  };
+}
+
+describe('getChatDayKey', () => {
+  it('matches local calendar day components', () => {
+    const ts = new Date(2026, 5, 15, 23, 59).getTime();
+    expect(getChatDayKey(ts)).toBe('2026-5-15');
+  });
+});
+
+describe('findMessageIndexByKey', () => {
+  it('finds by packetId first', () => {
+    const messages = [
+      makeMsg({ timestamp: 100, packetId: 42 }),
+      makeMsg({ timestamp: 200, packetId: 99 }),
+    ];
+    expect(findMessageIndexByKey(messages, 99)).toBe(1);
+  });
+
+  it('falls back to timestamp', () => {
+    const messages = [makeMsg({ timestamp: 12345 })];
+    expect(findMessageIndexByKey(messages, 12345)).toBe(0);
+  });
+});
+
+describe('findFirstMessageIndexByDayKey', () => {
+  it('returns first matching day', () => {
+    const day = getChatDayKey(new Date(2026, 0, 10, 12).getTime());
+    const messages = [
+      makeMsg({ timestamp: new Date(2026, 0, 9).getTime() }),
+      makeMsg({ timestamp: new Date(2026, 0, 10, 8).getTime() }),
+      makeMsg({ timestamp: new Date(2026, 0, 10, 20).getTime() }),
+    ];
+    expect(findFirstMessageIndexByDayKey(messages, day)).toBe(1);
+  });
+});
+
+describe('findIndexByRowKey', () => {
+  it('finds item by custom row key', () => {
+    const items = [{ id: 'a' }, { id: 'b' }];
+    expect(findIndexByRowKey(items, 'b', (x) => x.id)).toBe(1);
+  });
+});
+
+describe('createStableChatMeasureElement', () => {
+  it('returns cached size when scrolling backward', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'offsetHeight', { value: 200, configurable: true });
+    const size = measure(
+      el,
+      undefined,
+      mockMeasureInstance({ scrollDirection: 'backward', cachedSize: 72 }) as never,
+    );
+    expect(size).toBe(72);
+  });
+
+  it('remeasures when scrolling forward with ResizeObserver entry', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'offsetHeight', { value: 200, configurable: true });
+    const entry = {
+      borderBoxSize: [{ blockSize: 180, inlineSize: 300 }],
+    } as unknown as ResizeObserverEntry;
+    const size = measure(
+      el,
+      entry,
+      mockMeasureInstance({ scrollDirection: 'forward', cachedSize: 72 }) as never,
+    );
+    expect(size).toBe(180);
+  });
+
+  it('uses ResizeObserver borderBoxSize when present', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    const entry = {
+      borderBoxSize: [{ blockSize: 110, inlineSize: 300 }],
+    } as unknown as ResizeObserverEntry;
+    const size = measure(el, entry, mockMeasureInstance({ scrollDirection: 'forward' }) as never);
+    expect(size).toBe(110);
+  });
+});
+
+describe('scrollElementWithinContainer', () => {
+  it('scrolls container to element start offset', () => {
+    const container = document.createElement('div');
+    const child = document.createElement('div');
+    container.appendChild(child);
+    document.body.appendChild(container);
+
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true });
+    container.scrollTo = vi.fn();
+
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+      top: 100,
+      bottom: 500,
+      left: 0,
+      right: 300,
+      width: 300,
+      height: 400,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(child, 'getBoundingClientRect').mockReturnValue({
+      top: 250,
+      bottom: 300,
+      left: 0,
+      right: 300,
+      width: 300,
+      height: 50,
+      x: 0,
+      y: 250,
+      toJSON: () => ({}),
+    });
+
+    Object.defineProperty(container, 'scrollTop', {
+      value: 50,
+      writable: true,
+      configurable: true,
+    });
+
+    scrollElementWithinContainer(container, child, 'start', 'auto');
+    expect(container.scrollTo).toHaveBeenCalledWith({ top: 200, behavior: 'auto' });
+
+    document.body.removeChild(container);
+  });
+});

--- a/src/renderer/lib/chatScrollUtils.test.ts
+++ b/src/renderer/lib/chatScrollUtils.test.ts
@@ -86,16 +86,40 @@ describe('findIndexByRowKey', () => {
 });
 
 describe('createStableChatMeasureElement', () => {
-  it('returns cached size when scrolling backward', () => {
+  it('returns measured cache when scrolling backward', () => {
     const measure = createStableChatMeasureElement(() => 96);
     const el = document.createElement('div');
     Object.defineProperty(el, 'offsetHeight', { value: 200, configurable: true });
     const size = measure(
       el,
       undefined,
-      mockMeasureInstance({ scrollDirection: 'backward', cachedSize: 72 }) as never,
+      mockMeasureInstance({ scrollDirection: 'backward', cachedSize: 180 }) as never,
     );
-    expect(size).toBe(72);
+    expect(size).toBe(180);
+  });
+
+  it('measures DOM when backward cache is still an estimate', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'offsetHeight', { value: 200, configurable: true });
+    const size = measure(
+      el,
+      undefined,
+      mockMeasureInstance({ scrollDirection: 'backward', cachedSize: 96 }) as never,
+    );
+    expect(size).toBe(200);
+  });
+
+  it('measures DOM instead of estimate cache when not scrolling backward', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'offsetHeight', { value: 200, configurable: true });
+    const size = measure(
+      el,
+      undefined,
+      mockMeasureInstance({ scrollDirection: null, cachedSize: 96 }) as never,
+    );
+    expect(size).toBe(200);
   });
 
   it('remeasures when scrolling forward with ResizeObserver entry', () => {

--- a/src/renderer/lib/chatScrollUtils.ts
+++ b/src/renderer/lib/chatScrollUtils.ts
@@ -72,28 +72,28 @@ export function createStableChatMeasureElement(
 ): NonNullable<Virtualizer<HTMLDivElement, Element>['options']['measureElement']> {
   return (element, entry, instance: ScrollMeasureInstance) => {
     const index = instance.indexFromElement(element);
+    const htmlEl = element as HTMLElement;
+    const sizeProp = instance.options.horizontal ? 'offsetWidth' : 'offsetHeight';
+
     if (index < 0) {
-      return (element as HTMLElement).offsetHeight;
+      return htmlEl[sizeProp];
     }
 
     const key = instance.options.getItemKey(index);
+    const estimated = estimateSize(index);
     const cached = instance.measurementsCache[index]?.size ?? instance.itemSizeCache.get(key);
+    const hasMeasuredSize = cached != null && cached !== estimated;
 
-    if (instance.scrollDirection === 'backward') {
-      if (cached != null) return cached;
-      return estimateSize(index);
+    if (instance.scrollDirection === 'backward' && hasMeasuredSize) {
+      return cached;
     }
 
     const box = entry?.borderBoxSize?.[0];
     if (box) {
       return Math.round(box[instance.options.horizontal ? 'inlineSize' : 'blockSize']);
     }
-    if (cached != null && !entry) {
-      return cached;
-    }
 
-    const htmlEl = element as HTMLElement;
-    return htmlEl[instance.options.horizontal ? 'offsetWidth' : 'offsetHeight'];
+    return htmlEl[sizeProp];
   };
 }
 

--- a/src/renderer/lib/chatScrollUtils.ts
+++ b/src/renderer/lib/chatScrollUtils.ts
@@ -1,5 +1,13 @@
+import type { VirtualItem, Virtualizer } from '@tanstack/react-virtual';
+import type { RefObject } from 'react';
+
+import type { ChatMessage } from './types';
+
 /** Pixels from latest message treated as “at bottom” (Jump to Latest, follow-on-append, mark read). */
 export const CHAT_SCROLL_END_THRESHOLD = 200;
+
+/** Extra virtual row height budget when the unread divider renders in that row. */
+export const CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX = 40;
 
 /**
  * Distance from the “bottom” of the chat (latest messages). Uses the **maximum** of:
@@ -28,4 +36,114 @@ export function getDistFromChatBottom(
   }
 
   return dist;
+}
+
+/** Day key for grouping messages (matches ChatPanel jump-to-date). */
+export function getChatDayKey(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+/** Scroll an element within a scroll container without scrollIntoView (avoids outer viewport fights). */
+export function scrollElementWithinContainer(
+  container: HTMLElement,
+  element: HTMLElement,
+  align: 'start' | 'center',
+  behavior: ScrollBehavior = 'auto',
+): void {
+  const containerRect = container.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+  const offsetTop = elementRect.top - containerRect.top + container.scrollTop;
+  const targetTop =
+    align === 'center'
+      ? offsetTop - container.clientHeight / 2 + elementRect.height / 2
+      : offsetTop;
+  container.scrollTo({ top: Math.max(0, targetTop), behavior });
+}
+
+type ScrollMeasureInstance = Pick<
+  Virtualizer<HTMLDivElement, Element>,
+  'indexFromElement' | 'scrollDirection' | 'measurementsCache' | 'itemSizeCache' | 'options'
+>;
+
+/** TanStack measureElement that locks cached sizes while scrolling backward. */
+export function createStableChatMeasureElement(
+  estimateSize: (index: number) => number,
+): NonNullable<Virtualizer<HTMLDivElement, Element>['options']['measureElement']> {
+  return (element, entry, instance: ScrollMeasureInstance) => {
+    const index = instance.indexFromElement(element);
+    if (index < 0) {
+      return (element as HTMLElement).offsetHeight;
+    }
+
+    const key = instance.options.getItemKey(index);
+    const cached = instance.measurementsCache[index]?.size ?? instance.itemSizeCache.get(key);
+
+    if (instance.scrollDirection === 'backward') {
+      if (cached != null) return cached;
+      return estimateSize(index);
+    }
+
+    const box = entry?.borderBoxSize?.[0];
+    if (box) {
+      return Math.round(box[instance.options.horizontal ? 'inlineSize' : 'blockSize']);
+    }
+    if (cached != null && !entry) {
+      return cached;
+    }
+
+    const htmlEl = element as HTMLElement;
+    return htmlEl[instance.options.horizontal ? 'offsetWidth' : 'offsetHeight'];
+  };
+}
+
+export interface ChatScrollAdjustDeps {
+  unreadStartIndexRef: RefObject<number>;
+  isPinnedToBottomRef: RefObject<boolean>;
+}
+
+/** Composes TanStack default backward guard with chat unread/pin rules. */
+export function createChatScrollAdjustPredicate(deps: ChatScrollAdjustDeps) {
+  return (
+    item: VirtualItem,
+    _delta: number,
+    instance: Pick<Virtualizer<HTMLDivElement, Element>, 'scrollDirection'>,
+  ): boolean => {
+    if (instance.scrollDirection === 'backward') return false;
+    if (item.index === deps.unreadStartIndexRef.current) return false;
+    if (!deps.isPinnedToBottomRef.current) return false;
+    return true;
+  };
+}
+
+/** Resolve virtual index for quote-reply jump (`packetId ?? timestamp`). */
+export function findMessageIndexByKey(messages: readonly ChatMessage[], key: number): number {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if ((msg.packetId ?? msg.timestamp) === key) return i;
+  }
+  return -1;
+}
+
+/** First message index matching a calendar day key. */
+export function findFirstMessageIndexByDayKey(
+  messages: readonly ChatMessage[],
+  dayKey: string,
+): number {
+  for (let i = 0; i < messages.length; i++) {
+    if (getChatDayKey(messages[i].timestamp) === dayKey) return i;
+  }
+  return -1;
+}
+
+/** Generic row-key lookup for virtualized lists (e.g. room posts). */
+export function findIndexByRowKey<T>(
+  items: readonly T[],
+  rowKey: string,
+  getRowKey: (item: T) => string,
+): number {
+  for (let i = 0; i < items.length; i++) {
+    if (getRowKey(items[i]) === rowKey) return i;
+  }
+  return -1;
 }


### PR DESCRIPTION
## Summary

- Add shared `chatScrollUtils` helpers: backward-scroll `measureElement` cache, scroll-adjust predicate that restores TanStack's `scrollDirection` guard, and `scrollToIndex` lookup helpers for quote/date jumps.
- **ChatPanel:** wire stable `measureElement`, fix `shouldAdjustScrollPositionOnItemSizeChange`, and route jump-to-date / quoted-reply through `scrollToIndex` instead of `scrollIntoView`.
- **RoomsPanel:** virtualize the post stream with the same end-anchored TanStack Virtual contract (`anchorTo: 'end'`, `followOnAppend`), replace unread `scrollIntoView` jumps, add scroll-past divider dismissal, and harden the scroller with `overflow-anchor: none` / `overscroll-contain`.

Wheel-scrolling up through history on Windows/Linux was jittery because remeasure corrections could still run during backward scroll (our custom `shouldAdjustScrollPositionOnItemSizeChange` overrode TanStack's built-in guard) and dynamic row heights shifted `totalSize` mid-gesture.

## Commits

- `79be7350` fix: stabilize chat scroll on Windows/Linux with TanStack Virtual

## Test plan

- [x] `pnpm exec vitest run src/renderer/lib/chatScrollUtils.test.ts src/renderer/components/ChatPanel.test.tsx src/renderer/components/RoomsPanel.test.tsx`
- [ ] **Windows 11:** wheel-scroll up through busy channel/DM history — no snap-back or violent jitter
- [ ] **Windows 11:** scroll past "New messages" divider in Chat and Rooms — no spring-back
- [ ] **Windows 11:** Jump to date and tap quoted reply in Chat — lands on correct message
- [ ] **Linux:** repeat history scroll and Jump to Unread / Latest in Chat and Rooms
- [ ] **macOS:** pinned-bottom auto-follow still works when new messages arrive