### PR TITLE
fix: stop Windows chat message overlap in virtualized rows

### DIFF
--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -72,10 +72,12 @@ import {
   CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX,
   createChatScrollAdjustPredicate,
   createStableChatMeasureElement,
+  estimateChatRowHeight,
   findFirstMessageIndexByDayKey,
   findMessageIndexByKey,
   getChatDayKey,
   getDistFromChatBottom,
+  scheduleVirtualRowRemeasure,
 } from '../lib/chatScrollUtils';
 import {
   type ChatUnreadDmOptions,
@@ -699,14 +701,11 @@ function ChatPanel({
   const estimateMessageSize = useCallback(
     (index: number) => {
       const msg = filteredMessages[index];
-      let base = compactMode ? 56 : 96;
-      if (msg?.replyId != null || msg?.replyPreviewText) {
-        base += compactMode ? 40 : 72;
-      }
-      if ((msg?.payload.length ?? 0) > 120) {
-        base += compactMode ? 24 : 48;
-      }
-      return index === unreadStartIndex ? base + CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : base;
+      return estimateChatRowHeight(msg, {
+        compactMode,
+        unreadDividerExtra:
+          index === unreadStartIndex ? CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : undefined,
+      });
     },
     [compactMode, filteredMessages, unreadStartIndex],
   );
@@ -739,6 +738,16 @@ function ChatPanel({
 
   const messageVirtualizerRef = useRef(messageVirtualizer);
   messageVirtualizerRef.current = messageVirtualizer;
+
+  const scheduleMessageRowRemeasure = useCallback((rowIndex: number) => {
+    scheduleVirtualRowRemeasure(
+      (node) => {
+        messageVirtualizerRef.current.measureElement(node);
+      },
+      scrollContainerRef.current,
+      rowIndex,
+    );
+  }, []);
 
   const computeIsAtChatEnd = useCallback(() => {
     const inner = scrollContainerRef.current;
@@ -2020,6 +2029,9 @@ function ChatPanel({
                                 text={msg.payload}
                                 query={searchQuery}
                                 loadLinkPreviews={!showScrollButton}
+                                onContentResize={() => {
+                                  scheduleMessageRowRemeasure(i);
+                                }}
                               />
                             </div>
 

--- a/src/renderer/components/ChatPayloadText.test.tsx
+++ b/src/renderer/components/ChatPayloadText.test.tsx
@@ -71,4 +71,16 @@ describe('ChatPayloadText', () => {
     expect(mockFetch).toHaveBeenCalledWith('https://example.com');
     expect(mockFetch).toHaveBeenCalledWith('https://other.org');
   });
+
+  it('calls onContentResize when link preview mounts', async () => {
+    const onContentResize = vi.fn();
+    mockFetch.mockResolvedValue({ title: 'Example Site', description: 'desc' });
+    render(
+      <ChatPayloadText text="see https://example.com" query="" onContentResize={onContentResize} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Example Site')).toBeInTheDocument();
+    });
+    expect(onContentResize).toHaveBeenCalled();
+  });
 });

--- a/src/renderer/components/ChatPayloadText.tsx
+++ b/src/renderer/components/ChatPayloadText.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { isSafeChatUrl, parseChatMentionSegments } from '@/renderer/lib/chatMentionSegments';
@@ -54,7 +54,7 @@ function fetchLinkPreviewDeduped(url: string): Promise<LinkPreviewData | null> {
   return pending;
 }
 
-function LinkPreview({ url }: { url: string }) {
+function LinkPreview({ url, onContentResize }: { url: string; onContentResize?: () => void }) {
   const [preview, setPreview] = useState<LinkPreviewData | null>(null);
 
   useEffect(() => {
@@ -70,6 +70,10 @@ function LinkPreview({ url }: { url: string }) {
       cancelled = true;
     };
   }, [url]);
+
+  useLayoutEffect(() => {
+    if (preview) onContentResize?.();
+  }, [preview, onContentResize]);
 
   if (!preview) return null;
 
@@ -108,6 +112,8 @@ export interface ChatPayloadTextProps {
   query: string;
   /** When false, skip async link-preview fetches (avoids layout shift while reading history). */
   loadLinkPreviews?: boolean;
+  /** Fired when async link-preview content mounts and row height may have grown. */
+  onContentResize?: () => void;
 }
 
 /**
@@ -115,7 +121,12 @@ export interface ChatPayloadTextProps {
  * compact inline labels (brackets hidden), http/https URLs as clickable links that
  * open in the system browser, and optional search highlighting.
  */
-export function ChatPayloadText({ text, query, loadLinkPreviews = true }: ChatPayloadTextProps) {
+export function ChatPayloadText({
+  text,
+  query,
+  loadLinkPreviews = true,
+  onContentResize,
+}: ChatPayloadTextProps) {
   const { t } = useTranslation();
   const segments = parseChatMentionSegments(text);
   const urlSegments = segments.filter((seg) => seg.kind === 'url');
@@ -162,7 +173,7 @@ export function ChatPayloadText({ text, query, loadLinkPreviews = true }: ChatPa
       {loadLinkPreviews && urlSegments.length > 0 && (
         <div className="space-y-2">
           {urlSegments.map((seg) => (
-            <LinkPreview key={seg.url} url={seg.url} />
+            <LinkPreview key={seg.url} url={seg.url} onContentResize={onContentResize} />
           ))}
         </div>
       )}

--- a/src/renderer/components/RoomsPanel.tsx
+++ b/src/renderer/components/RoomsPanel.tsx
@@ -81,8 +81,10 @@ import {
   CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX,
   createChatScrollAdjustPredicate,
   createStableChatMeasureElement,
+  estimateChatRowHeight,
   findIndexByRowKey,
   getDistFromChatBottom,
+  scheduleVirtualRowRemeasure,
 } from '../lib/chatScrollUtils';
 import { ChatComposer } from './ChatComposer';
 import { ChatPayloadText } from './ChatPayloadText';
@@ -344,10 +346,13 @@ export default function RoomsPanel({
 
   const estimatePostSize = useCallback(
     (index: number) => {
-      const base = 96;
-      return index === unreadStartIndex ? base + CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : base;
+      const post = roomPosts[index];
+      return estimateChatRowHeight(post, {
+        unreadDividerExtra:
+          index === unreadStartIndex ? CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX : undefined,
+      });
     },
-    [unreadStartIndex],
+    [roomPosts, unreadStartIndex],
   );
 
   const measurePostElement = useMemo(
@@ -378,6 +383,16 @@ export default function RoomsPanel({
 
   const postVirtualizerRef = useRef(postVirtualizer);
   postVirtualizerRef.current = postVirtualizer;
+
+  const schedulePostRowRemeasure = useCallback((rowIndex: number) => {
+    scheduleVirtualRowRemeasure(
+      (node) => {
+        postVirtualizerRef.current.measureElement(node);
+      },
+      streamRef.current,
+      rowIndex,
+    );
+  }, []);
 
   const newestPostTs = useMemo(() => {
     if (roomPosts.length === 0) {
@@ -2023,6 +2038,9 @@ export default function RoomsPanel({
                                   text={m.payload}
                                   query=""
                                   loadLinkPreviews={!showScrollButton}
+                                  onContentResize={() => {
+                                    schedulePostRowRemeasure(index);
+                                  }}
                                 />
                               </div>
                               {isOwn && m.status && selectedRoomId != null && (

--- a/src/renderer/lib/chatScrollUtils.test.ts
+++ b/src/renderer/lib/chatScrollUtils.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  CHAT_LINK_PREVIEW_ESTIMATE_PX,
+  CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX,
   createStableChatMeasureElement,
+  estimateChatRowHeight,
   findFirstMessageIndexByDayKey,
   findIndexByRowKey,
   findMessageIndexByKey,
@@ -86,16 +89,28 @@ describe('findIndexByRowKey', () => {
 });
 
 describe('createStableChatMeasureElement', () => {
-  it('returns measured cache when scrolling backward', () => {
+  it('locks cached size when scrolling backward and DOM would shrink', () => {
     const measure = createStableChatMeasureElement(() => 96);
     const el = document.createElement('div');
-    Object.defineProperty(el, 'offsetHeight', { value: 200, configurable: true });
+    Object.defineProperty(el, 'offsetHeight', { value: 170, configurable: true });
     const size = measure(
       el,
       undefined,
       mockMeasureInstance({ scrollDirection: 'backward', cachedSize: 180 }) as never,
     );
     expect(size).toBe(180);
+  });
+
+  it('allows growth when scrolling backward and DOM is taller than cache', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'offsetHeight', { value: 220, configurable: true });
+    const size = measure(
+      el,
+      undefined,
+      mockMeasureInstance({ scrollDirection: 'backward', cachedSize: 180 }) as never,
+    );
+    expect(size).toBe(220);
   });
 
   it('measures DOM when backward cache is still an estimate', () => {
@@ -145,6 +160,68 @@ describe('createStableChatMeasureElement', () => {
     } as unknown as ResizeObserverEntry;
     const size = measure(el, entry, mockMeasureInstance({ scrollDirection: 'forward' }) as never);
     expect(size).toBe(110);
+  });
+
+  it('honors ResizeObserver growth when scrolling backward', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'offsetHeight', { value: 96, configurable: true });
+    const entry = {
+      borderBoxSize: [{ blockSize: 240, inlineSize: 300 }],
+    } as unknown as ResizeObserverEntry;
+    const size = measure(
+      el,
+      entry,
+      mockMeasureInstance({ scrollDirection: 'backward', cachedSize: 180 }) as never,
+    );
+    expect(size).toBe(240);
+  });
+
+  it('locks ResizeObserver shrink when scrolling backward', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    const entry = {
+      borderBoxSize: [{ blockSize: 160, inlineSize: 300 }],
+    } as unknown as ResizeObserverEntry;
+    const size = measure(
+      el,
+      entry,
+      mockMeasureInstance({ scrollDirection: 'backward', cachedSize: 180 }) as never,
+    );
+    expect(size).toBe(180);
+  });
+});
+
+describe('estimateChatRowHeight', () => {
+  it('adds reply and long-payload budgets', () => {
+    expect(estimateChatRowHeight(makeMsg({ timestamp: 1 }))).toBe(96);
+    expect(
+      estimateChatRowHeight(makeMsg({ timestamp: 1, replyId: 42, replyPreviewText: 'parent' })),
+    ).toBe(168);
+    expect(estimateChatRowHeight(makeMsg({ timestamp: 1, payload: 'x'.repeat(121) }))).toBe(144);
+  });
+
+  it('adds per-URL link preview budget', () => {
+    const oneUrl = estimateChatRowHeight(
+      makeMsg({ timestamp: 1, payload: 'see https://example.com now' }),
+    );
+    expect(oneUrl).toBe(96 + CHAT_LINK_PREVIEW_ESTIMATE_PX);
+    const twoUrls = estimateChatRowHeight(
+      makeMsg({
+        timestamp: 1,
+        payload: 'https://a.com and https://b.com',
+      }),
+    );
+    expect(twoUrls).toBe(96 + CHAT_LINK_PREVIEW_ESTIMATE_PX * 2);
+  });
+
+  it('applies compact mode and unread divider extra', () => {
+    expect(estimateChatRowHeight(makeMsg({ timestamp: 1 }), { compactMode: true })).toBe(56);
+    expect(
+      estimateChatRowHeight(makeMsg({ timestamp: 1 }), {
+        unreadDividerExtra: CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX,
+      }),
+    ).toBe(96 + CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX);
   });
 });
 

--- a/src/renderer/lib/chatScrollUtils.ts
+++ b/src/renderer/lib/chatScrollUtils.ts
@@ -1,6 +1,7 @@
 import type { VirtualItem, Virtualizer } from '@tanstack/react-virtual';
 import type { RefObject } from 'react';
 
+import { parseChatMentionSegments } from './chatMentionSegments';
 import type { ChatMessage } from './types';
 
 /** Pixels from latest message treated as “at bottom” (Jump to Latest, follow-on-append, mark read). */
@@ -8,6 +9,39 @@ export const CHAT_SCROLL_END_THRESHOLD = 200;
 
 /** Extra virtual row height budget when the unread divider renders in that row. */
 export const CHAT_UNREAD_DIVIDER_ESTIMATE_EXTRA_PX = 40;
+
+/** Per-URL link-preview card height budget (matches LinkPreview layout). */
+export const CHAT_LINK_PREVIEW_ESTIMATE_PX = 120;
+export const CHAT_LINK_PREVIEW_ESTIMATE_COMPACT_PX = 80;
+
+export interface EstimateChatRowHeightOptions {
+  compactMode?: boolean;
+  unreadDividerExtra?: number;
+}
+
+/** Heuristic virtual row height for chat messages and room posts. */
+export function estimateChatRowHeight(
+  msg: Pick<ChatMessage, 'payload' | 'replyId' | 'replyPreviewText'> | null | undefined,
+  options: EstimateChatRowHeightOptions = {},
+): number {
+  const compactMode = options.compactMode ?? false;
+  let base = compactMode ? 56 : 96;
+  if (msg?.replyId != null || msg?.replyPreviewText) {
+    base += compactMode ? 40 : 72;
+  }
+  if ((msg?.payload.length ?? 0) > 120) {
+    base += compactMode ? 24 : 48;
+  }
+  const urlCount = parseChatMentionSegments(msg?.payload ?? '').filter(
+    (seg) => seg.kind === 'url',
+  ).length;
+  if (urlCount > 0) {
+    base +=
+      urlCount *
+      (compactMode ? CHAT_LINK_PREVIEW_ESTIMATE_COMPACT_PX : CHAT_LINK_PREVIEW_ESTIMATE_PX);
+  }
+  return base + (options.unreadDividerExtra ?? 0);
+}
 
 /**
  * Distance from the “bottom” of the chat (latest messages). Uses the **maximum** of:
@@ -84,17 +118,32 @@ export function createStableChatMeasureElement(
     const cached = instance.measurementsCache[index]?.size ?? instance.itemSizeCache.get(key);
     const hasMeasuredSize = cached != null && cached !== estimated;
 
-    if (instance.scrollDirection === 'backward' && hasMeasuredSize) {
-      return cached;
-    }
-
     const box = entry?.borderBoxSize?.[0];
-    if (box) {
-      return Math.round(box[instance.options.horizontal ? 'inlineSize' : 'blockSize']);
+    const domSize = box
+      ? Math.round(box[instance.options.horizontal ? 'inlineSize' : 'blockSize'])
+      : htmlEl[sizeProp];
+
+    if (instance.scrollDirection === 'backward' && hasMeasuredSize) {
+      // Allow growth (async previews, layout) but prevent shrink jitter while scrolling up.
+      return domSize > cached ? domSize : cached;
     }
 
-    return htmlEl[sizeProp];
+    return domSize;
   };
+}
+
+/** Re-measure a virtualized chat row after async content (e.g. link preview) changes height. */
+export function scheduleVirtualRowRemeasure(
+  measureElement: (node: Element) => void,
+  container: HTMLElement | null,
+  rowIndex: number,
+): void {
+  requestAnimationFrame(() => {
+    const row = container?.querySelector(`[data-index="${rowIndex}"]`);
+    if (row instanceof HTMLElement) {
+      measureElement(row);
+    }
+  });
 }
 
 export interface ChatScrollAdjustDeps {


### PR DESCRIPTION
## Summary
- Allow virtual row measurement to grow during backward scroll when live DOM/ResizeObserver size exceeds cached size, while still preventing shrink jitter during upward scrolling.
- Add shared `estimateChatRowHeight` sizing (including URL link-preview budget) and use it in both ChatPanel and RoomsPanel virtualizers.
- Re-measure rows when async link previews mount via `onContentResize`, so late content growth does not leave stale virtual heights.
- Add/extend regression tests for measure behavior and chat payload resize signaling.

## Test plan
- [x] `pnpm run test:run`
- [x] `pnpm run typecheck`
- [ ] Validate on Windows with URL-heavy channel near bottom (no preview stacking).
- [ ] Validate on Windows while scrolling upward near unread divider in reply-heavy history (no overlap, no severe jitter).