### PR TITLE
fix(MeshtasticProtocol): show serial port picker on first-time connection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Session Start Reminder
+
+At the start of every new work session, remind the user to sync with upstream before creating any branch or making any changes:
+
+```
+git checkout main && git pull origin main && git status
+```
+
+Do **not** run this automatically. Ask the user first: "Would you like me to run `git checkout main && git pull origin main && git status` before we begin?"
+
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,4 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Session Start Reminder
-
-At the start of every new work session, remind the user to sync with upstream before creating any branch or making any changes:
-
-```
-git checkout main && git pull origin main && git status
-```
-
-Do **not** run this automatically. Ask the user first: "Would you like me to run `git checkout main && git pull origin main && git status` before we begin?"
-
 @AGENTS.md

--- a/src/renderer/lib/protocols/MeshtasticProtocol.ts
+++ b/src/renderer/lib/protocols/MeshtasticProtocol.ts
@@ -82,7 +82,13 @@ export class MeshtasticProtocol implements Protocol {
       case 'ble':
         return createBleConnection(params.peripheralId, 'meshtastic');
       case 'serial':
-        return reconnectSerial(params.portSignature);
+        // Use gesture-free reconnect only when a previously-granted port signature is
+        // known; otherwise call requestPort() so Electron fires select-serial-port and
+        // the port picker appears (mirrors MeshCoreProtocol.createDevice pattern).
+        if (params.portSignature) {
+          return reconnectSerial(params.portSignature);
+        }
+        return createConnection('serial');
       case 'http':
         return createConnection('http', params.host);
       default:


### PR DESCRIPTION
## Summary

- **Serial picker fix:** On a first-time serial connection (no previously granted port signature), \`MeshtasticProtocol.createDevice\` was always calling \`reconnectSerial()\`, which uses \`navigator.serial.getPorts()\`. With no previously granted ports, this returns an empty array and throws, so \`requestPort()\` is never called, the Electron \`select-serial-port\` event never fires, and the picker never appears. Fix mirrors the existing MeshCore pattern — only use \`reconnectSerial()\` when \`params.portSignature\` is set; otherwise fall through to \`createConnection('serial')\` which calls \`requestPort()\` and triggers the picker. Affects all platforms on first-time serial connection, most visible on Windows.
- **CLAUDE.md:** Add session-start reminder to sync with upstream before creating branches or making changes.

## Test plan

- [ ] First-time serial connection (no previously saved port): picker appears
- [ ] Subsequent connection (saved port signature): reconnects without picker
- [ ] MeshCore serial flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)