### PR TITLE
fix(ChatPanel): restore scroll position on tab re-entry

### DIFF
--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -1190,6 +1190,39 @@ describe('ChatPanel scroll pinning', () => {
     expect(mockScrollToIndex).toHaveBeenCalledWith(0, { align: 'center', behavior: 'smooth' });
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
+
+  it('restores scrollTop on tab re-entry instead of leaving it at the value set while hidden', () => {
+    const { container, rerender } = render(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={[makeMsg(0)]} isActive />
+      </ToastProvider>,
+    );
+
+    const scrollContainer = container.querySelector('div.overflow-y-auto')!;
+    Object.defineProperty(scrollContainer, 'scrollTop', {
+      value: 500,
+      writable: true,
+      configurable: true,
+    });
+
+    rerender(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={[makeMsg(0)]} isActive={false} />
+      </ToastProvider>,
+    );
+
+    // Simulate the scroll position drifting while the tab is hidden (e.g. a stale
+    // virtualizer recalculation against the collapsed 0x0 `display: none` container).
+    (scrollContainer as HTMLDivElement).scrollTop = 0;
+
+    rerender(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={[makeMsg(0)]} isActive />
+      </ToastProvider>,
+    );
+
+    expect((scrollContainer as HTMLDivElement).scrollTop).toBe(500);
+  });
 });
 
 describe('ChatPanel StatusBadge', () => {

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -441,6 +441,7 @@ function ChatPanel({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   /** Sticky intent: user is reading latest messages and wants auto-follow on new traffic. */
   const isPinnedToBottomRef = useRef(true);
+  const savedScrollTopRef = useRef<number | null>(null);
   const reactionPickerRef = useRef<HTMLElement | null>(null);
   const reactionPickerTarget = useRef<{ id: number; channel: number } | null>(null);
   const reactionHiddenInputRef = useRef<HTMLInputElement | null>(null);
@@ -997,6 +998,19 @@ function ChatPanel({
     // Only scroll on explicit view-switch trigger — not when message list or virtualizer updates.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- triggerScrollToUnread is the sole scroll intent
   }, [triggerScrollToUnread, isActive]);
+
+  // Preserve native scroll position across tab/view switches (separate from the
+  // virtualizer-driven unread-scroll effect above, which only fires on new triggers).
+  useLayoutEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    if (!isActive) {
+      savedScrollTopRef.current = el.scrollTop;
+    } else if (savedScrollTopRef.current !== null) {
+      el.scrollTop = savedScrollTopRef.current;
+      savedScrollTopRef.current = null;
+    }
+  }, [isActive]);
 
   useEffect(() => {
     if (!isActive) return;


### PR DESCRIPTION
When switching away from the Chat tab and returning, the scroll position was jumping to older messages instead of staying at the bottom.

Root cause: the useLayoutEffect gated on [triggerScrollToUnread, isActive] re-fires on every tab re-entry. When it calls scrollToEnd() via the TanStack virtualizer, the viewport size may still be stale from when the panel was hidden (display:none), causing the scroll calculation to land in the wrong position.

Fix: add a separate useLayoutEffect keyed only on isActive that saves scrollTop to a ref when the tab is hidden, and restores it directly on the DOM element when the tab becomes visible again. Because layout effects fire in declaration order, this write happens after the existing effect's potentially-stale virtualizer call, overriding it. No changes to the existing view-switch scroll behavior.