### PR TITLE
fix(RoomsPanel): restore scroll position on tab re-entry

### DIFF
--- a/src/renderer/components/RoomsPanel.test.tsx
+++ b/src/renderer/components/RoomsPanel.test.tsx
@@ -826,6 +826,48 @@ describe('RoomsPanel', () => {
     expect(screen.getByTestId('rooms-composer-footer')).toHaveClass('shrink-0');
   });
 
+  it('restores stream scrollTop on tab re-entry instead of leaving it at the value set while hidden', () => {
+    meshcoreClearAllRoomSessions();
+    const room = makeRoom(0x1017, 'Scroll Restore Room');
+    const nodes = new Map<number, MeshNode>([[room.node_id, room]]);
+    meshcoreApplyRoomSession(room.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+    const commonProps = {
+      nodes,
+      messages: [],
+      myNodeNum: 1,
+      isConnected: true,
+      initialRoomTarget: room.node_id,
+      onLoginRoom: vi.fn().mockResolvedValue(undefined),
+      onCancelRoomLogin: vi.fn(),
+      onLeaveRoom: vi.fn().mockResolvedValue(undefined),
+      onSendRoomPost: vi.fn(),
+      onSendRoomAdminCli: vi.fn(),
+    };
+
+    const { rerender } = render(<RoomsPanel {...commonProps} isActive />);
+
+    const stream = screen.getByTestId('rooms-post-stream');
+    Object.defineProperty(stream, 'scrollTop', {
+      value: 500,
+      writable: true,
+      configurable: true,
+    });
+
+    rerender(<RoomsPanel {...commonProps} isActive={false} />);
+
+    // Simulate the scroll position drifting while the tab is hidden (e.g. a stale
+    // virtualizer recalculation against the collapsed 0x0 `display: none` container).
+    (stream as HTMLDivElement).scrollTop = 0;
+
+    rerender(<RoomsPanel {...commonProps} isActive />);
+
+    expect((stream as HTMLDivElement).scrollTop).toBe(500);
+  });
+
   it('shows new messages divider when selecting a room with unread posts', async () => {
     meshcoreClearAllRoomSessions();
     const roomA = makeRoom(0x1012, 'Unread Room');

--- a/src/renderer/components/RoomsPanel.tsx
+++ b/src/renderer/components/RoomsPanel.tsx
@@ -256,6 +256,7 @@ export default function RoomsPanel({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   /** Sticky intent: user is reading latest posts and wants auto-follow on new traffic. */
   const isPinnedToBottomRef = useRef(true);
+  const savedScrollTopRef = useRef<number | null>(null);
   const unreadDividerRef = useRef<HTMLDivElement>(null);
   const [persistedRoomsLastRead, setPersistedRoomsLastRead] = useState(() =>
     loadPersistedRoomsLastRead(),
@@ -591,6 +592,19 @@ export default function RoomsPanel({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- triggerScrollToUnread is the sole scroll intent
   }, [triggerScrollToUnread, isActive]);
+
+  // Preserve native scroll position across tab/view switches (separate from the
+  // virtualizer-driven unread-scroll effect above, which only fires on new triggers).
+  useLayoutEffect(() => {
+    const el = streamRef.current;
+    if (!el) return;
+    if (!isActive) {
+      savedScrollTopRef.current = el.scrollTop;
+    } else if (savedScrollTopRef.current !== null) {
+      el.scrollTop = savedScrollTopRef.current;
+      savedScrollTopRef.current = null;
+    }
+  }, [isActive]);
 
   useEffect(() => {
     if (!isActive) return;


### PR DESCRIPTION
Applies the same fix as #545 to RoomsPanel. When switching away from the Rooms tab and returning, the scroll position was jumping instead of being preserved.

Fix: add a savedScrollTopRef save/restore useLayoutEffect keyed only on isActive that snapshots scrollTop when the tab is hidden and restores it directly on the DOM element when the tab becomes visible again.