### PR TITLE
fix(ChatPanel): scroll to latest when pinned on tab return

### DIFF
--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -1192,6 +1192,7 @@ describe('ChatPanel scroll pinning', () => {
   });
 
   it('restores scrollTop on tab re-entry instead of leaving it at the value set while hidden', () => {
+    mockIsAtEnd = false;
     const { container, rerender } = render(
       <ToastProvider>
         <ChatPanel {...baseProps} messages={[makeMsg(0)]} isActive />
@@ -1204,6 +1205,7 @@ describe('ChatPanel scroll pinning', () => {
       writable: true,
       configurable: true,
     });
+    fireEvent.scroll(scrollContainer);
 
     rerender(
       <ToastProvider>
@@ -1222,6 +1224,45 @@ describe('ChatPanel scroll pinning', () => {
     );
 
     expect((scrollContainer as HTMLDivElement).scrollTop).toBe(500);
+  });
+
+  it('scrolls to end on tab re-entry when pinned and messages grew while away', () => {
+    mockIsAtEnd = true;
+    const initialMessages = Array.from({ length: 5 }, (_, i) => makeMsg(i));
+    const { container, rerender } = render(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={initialMessages} isActive />
+      </ToastProvider>,
+    );
+
+    const scrollContainer = container.querySelector('div.overflow-y-auto')!;
+    Object.defineProperty(scrollContainer, 'scrollTop', {
+      value: 400,
+      writable: true,
+      configurable: true,
+    });
+    fireEvent.scroll(scrollContainer);
+
+    rerender(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={initialMessages} isActive={false} />
+      </ToastProvider>,
+    );
+
+    mockScrollToEnd.mockClear();
+    mockScrollToEnd.mockImplementation(() => {
+      (scrollContainer as HTMLDivElement).scrollTop = 900;
+    });
+
+    const messagesWhileAway = Array.from({ length: 10 }, (_, i) => makeMsg(i));
+    rerender(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={messagesWhileAway} isActive />
+      </ToastProvider>,
+    );
+
+    expect(mockScrollToEnd).toHaveBeenCalled();
+    expect((scrollContainer as HTMLDivElement).scrollTop).toBe(900);
   });
 });
 

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -442,6 +442,7 @@ function ChatPanel({
   /** Sticky intent: user is reading latest messages and wants auto-follow on new traffic. */
   const isPinnedToBottomRef = useRef(true);
   const savedScrollTopRef = useRef<number | null>(null);
+  const savedWasPinnedToBottomRef = useRef(false);
   const reactionPickerRef = useRef<HTMLElement | null>(null);
   const reactionPickerTarget = useRef<{ id: number; channel: number } | null>(null);
   const reactionHiddenInputRef = useRef<HTMLInputElement | null>(null);
@@ -1006,9 +1007,16 @@ function ChatPanel({
     if (!el) return;
     if (!isActive) {
       savedScrollTopRef.current = el.scrollTop;
+      savedWasPinnedToBottomRef.current = isPinnedToBottomRef.current;
     } else if (savedScrollTopRef.current !== null) {
-      el.scrollTop = savedScrollTopRef.current;
+      if (savedWasPinnedToBottomRef.current) {
+        messageVirtualizerRef.current.scrollToEnd();
+        isPinnedToBottomRef.current = true;
+      } else {
+        el.scrollTop = savedScrollTopRef.current;
+      }
       savedScrollTopRef.current = null;
+      savedWasPinnedToBottomRef.current = false;
     }
   }, [isActive]);
 


### PR DESCRIPTION
## Summary

- When leaving the Chat tab, snapshot `isPinnedToBottomRef` alongside `scrollTop`.
- On re-entry, call `scrollToEnd()` if the user was pinned; otherwise restore the saved `scrollTop`.
- Adds tests for both paths: reading-history restore vs pinned scroll-to-end after messages grew while away.

Follow-up to #545. That PR fixed scroll jumping on tab re-entry, but pinned users who received new messages while off-tab could still land above the latest traffic. Chat freezes its message list when hidden, so `followOnAppend` never runs until return — and restoring the old bottom offset is wrong once the thawed list is longer. RoomsPanel already re-scrolls via a post-restore effect; Chat needed an explicit pinned branch in the save/restore layout effect.

## Test plan

- [x] `pnpm exec vitest run src/renderer/components/ChatPanel.test.tsx -t "scroll pinning"`
- [ ] Pinned at bottom → switch away → receive messages → return → lands on latest
- [ ] Scrolled up in history → switch away → return → same scroll position preserved
- [ ] Channel/DM switch while on Chat tab still jumps to unread/bottom as before