### PR TITLE
fix: stop chat/rooms scroll jump on tab return

### DIFF
--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -1264,6 +1264,68 @@ describe('ChatPanel scroll pinning', () => {
     expect(mockScrollToEnd).toHaveBeenCalled();
     expect((scrollContainer as HTMLDivElement).scrollTop).toBe(900);
   });
+
+  it('restores raw scrollTop on tab re-entry instead of re-centering on a still-present unread divider', () => {
+    mockIsAtEnd = false;
+    const ts = Date.now();
+    localStorage.setItem(lastReadStorageKey('meshtastic'), JSON.stringify({ 'ch:0': ts - 5000 }));
+
+    const messages: ChatMessage[] = [
+      {
+        sender_id: 1,
+        sender_name: 'Me',
+        payload: 'Old message',
+        channel: 0,
+        timestamp: ts - 3000,
+        status: 'acked',
+      },
+      {
+        sender_id: 2,
+        sender_name: 'Alice',
+        payload: 'Unread message',
+        channel: 0,
+        timestamp: ts,
+        status: 'acked',
+      },
+    ];
+
+    const { container, rerender } = render(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={messages} isActive />
+      </ToastProvider>,
+    );
+
+    const scrollContainer = container.querySelector('div.overflow-y-auto')!;
+    // Keep distFromBottom large so applyNearBottomReadState doesn't clear the
+    // divider via setUnreadDividerTimestamp(0) before the test exercises it.
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(scrollContainer, 'scrollTop', {
+      value: 250,
+      writable: true,
+      configurable: true,
+    });
+    fireEvent.scroll(scrollContainer);
+
+    mockScrollToIndex.mockClear();
+
+    rerender(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={messages} isActive={false} />
+      </ToastProvider>,
+    );
+
+    rerender(
+      <ToastProvider>
+        <ChatPanel {...baseProps} messages={messages} isActive />
+      </ToastProvider>,
+    );
+
+    // A bare tab return must not re-fire the unread-divider scroll (it would
+    // clobber the restored position with a re-center on the divider — the jump).
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+    expect((scrollContainer as HTMLDivElement).scrollTop).toBe(250);
+  });
 });
 
 describe('ChatPanel StatusBadge', () => {

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -444,6 +444,8 @@ function ChatPanel({
   const isPinnedToBottomRef = useRef(true);
   const savedScrollTopRef = useRef<number | null>(null);
   const savedWasPinnedToBottomRef = useRef(false);
+  /** Distinguishes a tab return (isActive false→true) from a view switch while already active. */
+  const wasActiveRef = useRef(isActive);
   const reactionPickerRef = useRef<HTMLElement | null>(null);
   const reactionPickerTarget = useRef<{ id: number; channel: number } | null>(null);
   const reactionHiddenInputRef = useRef<HTMLInputElement | null>(null);
@@ -994,11 +996,41 @@ function ChatPanel({
     };
   }, [isActive, outerScrollMetricsRootRef, updateScrollButtonVisibility]);
 
-  // Fires after view switch (triggerScrollToUnread increments). useLayoutEffect
-  // ensures DOM is committed before scrolling, preventing flash of wrong position.
+  // Owns all tab/view-switch scrolling. Distinguishes a tab return (isActive
+  // false→true) from a genuine view switch while already active (channel/DM
+  // change bumps triggerScrollToUnread): a tab return restores the
+  // position/pin-state snapshotted on exit; a view switch scrolls to the
+  // unread divider or end. These used to be two separate effects that both
+  // reacted to `isActive`, so a tab return fired the view-switch scroll too
+  // and the restore immediately clobbered it (visible as a jump).
   useLayoutEffect(() => {
+    const el = scrollContainerRef.current;
+    const wasActive = wasActiveRef.current;
+    wasActiveRef.current = isActive;
+
+    if (!isActive) {
+      if (el) {
+        savedScrollTopRef.current = el.scrollTop;
+        savedWasPinnedToBottomRef.current = isPinnedToBottomRef.current;
+      }
+      return;
+    }
+
+    if (!wasActive) {
+      if (savedScrollTopRef.current !== null) {
+        if (savedWasPinnedToBottomRef.current) {
+          messageVirtualizerRef.current.scrollToEnd();
+          isPinnedToBottomRef.current = true;
+        } else if (el) {
+          el.scrollTop = savedScrollTopRef.current;
+        }
+        savedScrollTopRef.current = null;
+        savedWasPinnedToBottomRef.current = false;
+      }
+      return;
+    }
+
     if (triggerScrollToUnread === 0) return; // skip initial mount
-    if (!isActive) return; // skip while hidden
     if (unreadStartIndex >= 0) {
       messageVirtualizerRef.current.scrollToIndex(unreadStartIndex, { align: 'center' });
       isPinnedToBottomRef.current = false;
@@ -1015,26 +1047,6 @@ function ChatPanel({
     // Only scroll on explicit view-switch trigger — not when message list or virtualizer updates.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- triggerScrollToUnread is the sole scroll intent
   }, [triggerScrollToUnread, isActive]);
-
-  // Preserve native scroll position across tab/view switches (separate from the
-  // virtualizer-driven unread-scroll effect above, which only fires on new triggers).
-  useLayoutEffect(() => {
-    const el = scrollContainerRef.current;
-    if (!el) return;
-    if (!isActive) {
-      savedScrollTopRef.current = el.scrollTop;
-      savedWasPinnedToBottomRef.current = isPinnedToBottomRef.current;
-    } else if (savedScrollTopRef.current !== null) {
-      if (savedWasPinnedToBottomRef.current) {
-        messageVirtualizerRef.current.scrollToEnd();
-        isPinnedToBottomRef.current = true;
-      } else {
-        el.scrollTop = savedScrollTopRef.current;
-      }
-      savedScrollTopRef.current = null;
-      savedWasPinnedToBottomRef.current = false;
-    }
-  }, [isActive]);
 
   useEffect(() => {
     if (!isActive) return;

--- a/src/renderer/components/RoomsPanel.test.tsx
+++ b/src/renderer/components/RoomsPanel.test.tsx
@@ -856,6 +856,10 @@ describe('RoomsPanel', () => {
       writable: true,
       configurable: true,
     });
+    // isAtEnd is mocked false, so this marks the user as reading history (not
+    // pinned) before leaving — otherwise the pinned-snapshot branch would
+    // scrollToEnd() on return instead of restoring the raw scrollTop.
+    fireEvent.scroll(stream);
 
     rerender(<RoomsPanel {...commonProps} isActive={false} />);
 
@@ -866,6 +870,119 @@ describe('RoomsPanel', () => {
     rerender(<RoomsPanel {...commonProps} isActive />);
 
     expect((stream as HTMLDivElement).scrollTop).toBe(500);
+  });
+
+  it('scrolls to end on tab re-entry when pinned and posts grew while away', () => {
+    meshcoreClearAllRoomSessions();
+    const room = makeRoom(0x1018, 'Pinned Restore Room');
+    const nodes = new Map<number, MeshNode>([[room.node_id, room]]);
+    meshcoreApplyRoomSession(room.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+    const commonProps = {
+      nodes,
+      messages: [],
+      myNodeNum: 1,
+      isConnected: true,
+      initialRoomTarget: room.node_id,
+      onLoginRoom: vi.fn().mockResolvedValue(undefined),
+      onCancelRoomLogin: vi.fn(),
+      onLeaveRoom: vi.fn().mockResolvedValue(undefined),
+      onSendRoomPost: vi.fn(),
+      onSendRoomAdminCli: vi.fn(),
+    };
+
+    const { rerender } = render(<RoomsPanel {...commonProps} isActive />);
+
+    const stream = screen.getByTestId('rooms-post-stream');
+    Object.defineProperty(stream, 'scrollTop', {
+      value: 400,
+      writable: true,
+      configurable: true,
+    });
+    // Stays pinned (no scroll event fired — isPinnedToBottomRef defaults true).
+    rerender(<RoomsPanel {...commonProps} isActive={false} />);
+
+    mockScrollToEnd.mockClear();
+    mockScrollToEnd.mockImplementation(() => {
+      (stream as HTMLDivElement).scrollTop = 900;
+    });
+
+    rerender(<RoomsPanel {...commonProps} isActive />);
+
+    // The pinned snapshot must win outright — a stale raw-scrollTop restore
+    // running after scrollToEnd() would clobber it back to the pre-thaw value.
+    expect(mockScrollToEnd).toHaveBeenCalled();
+    expect((stream as HTMLDivElement).scrollTop).toBe(900);
+  });
+
+  it('does not re-fire the unread-divider scroll on a bare tab return (only the raw restore should run)', () => {
+    meshcoreClearAllRoomSessions();
+    const room = makeRoom(0x1019, 'Divider Restore Room');
+    const nodes = new Map<number, MeshNode>([[room.node_id, room]]);
+    meshcoreApplyRoomSession(room.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+    savePersistedRoomsLastRead(mergeRoomLastReadWatermark({}, room.node_id, 1000));
+    const messages: ChatMessage[] = [
+      buildMeshcoreRoomIncomingMessage({
+        rawText: 'Older post',
+        roomServerId: room.node_id,
+        authorId: 0x200,
+        authorName: 'Alice',
+        timestamp: 2000,
+        receivedVia: 'rf',
+      }),
+      buildMeshcoreRoomIncomingMessage({
+        rawText: 'Unread post',
+        roomServerId: room.node_id,
+        authorId: 0x201,
+        authorName: 'Bob',
+        timestamp: 5000,
+        receivedVia: 'rf',
+      }),
+    ];
+    const commonProps = {
+      nodes,
+      messages,
+      myNodeNum: 1,
+      isConnected: true,
+      initialRoomTarget: room.node_id,
+      onLoginRoom: vi.fn().mockResolvedValue(undefined),
+      onCancelRoomLogin: vi.fn(),
+      onLeaveRoom: vi.fn().mockResolvedValue(undefined),
+      onSendRoomPost: vi.fn(),
+      onSendRoomAdminCli: vi.fn(),
+    };
+    // Keeps distFromBottom large so applyNearBottomReadState doesn't clear the
+    // divider via setUnreadDividerTimestamp(0) before the test exercises it.
+    const distSpy = vi.spyOn(chatScrollUtils, 'getDistFromChatBottom').mockReturnValue(300);
+
+    try {
+      const { rerender } = render(<RoomsPanel {...commonProps} isActive />);
+
+      const stream = screen.getByTestId('rooms-post-stream');
+      Object.defineProperty(stream, 'scrollTop', {
+        value: 250,
+        writable: true,
+        configurable: true,
+      });
+      fireEvent.scroll(stream);
+
+      mockScrollToIndex.mockClear();
+
+      rerender(<RoomsPanel {...commonProps} isActive={false} />);
+      rerender(<RoomsPanel {...commonProps} isActive />);
+
+      expect(mockScrollToIndex).not.toHaveBeenCalled();
+      expect((stream as HTMLDivElement).scrollTop).toBe(250);
+    } finally {
+      distSpy.mockRestore();
+    }
   });
 
   it('shows new messages divider when selecting a room with unread posts', async () => {

--- a/src/renderer/components/RoomsPanel.test.tsx
+++ b/src/renderer/components/RoomsPanel.test.tsx
@@ -7,6 +7,8 @@ import { mergeAppSetting } from '@/renderer/lib/appSettingsStorage';
 import {
   mergeRoomLastReadWatermark,
   savePersistedRoomsLastRead,
+  saveStarred,
+  type StarredMessage,
 } from '@/renderer/lib/chatPanelProtocolStorage';
 import { buildMeshcoreRoomIncomingMessage } from '@/renderer/lib/meshcoreChannelText';
 import {
@@ -983,6 +985,68 @@ describe('RoomsPanel', () => {
     } finally {
       distSpy.mockRestore();
     }
+  });
+
+  it('lets an explicit Go to message jump win over the room-switch unread/end scroll', async () => {
+    meshcoreClearAllRoomSessions();
+    const roomA = makeRoom(0x1021, 'Origin Room');
+    const roomB = makeRoom(0x1022, 'Target Room');
+    const nodes = new Map<number, MeshNode>([
+      [roomA.node_id, roomA],
+      [roomB.node_id, roomB],
+    ]);
+    meshcoreApplyRoomSession(roomA.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+    meshcoreApplyRoomSession(roomB.node_id, {
+      guestPassword: 'hello',
+      adminPassword: '',
+      role: 'readwrite',
+    });
+
+    const targetMsg = buildMeshcoreRoomIncomingMessage({
+      rawText: 'Find me',
+      roomServerId: roomB.node_id,
+      authorId: 0x200,
+      authorName: 'Alice',
+      timestamp: 5000,
+      receivedVia: 'rf',
+    });
+    const starId = `room:${roomB.node_id}:${Math.floor(targetMsg.timestamp / 1000)}:${targetMsg.sender_id}`;
+    const starred: StarredMessage[] = [
+      {
+        starId,
+        timestamp: targetMsg.timestamp,
+        payload: targetMsg.payload,
+        sender_name: targetMsg.sender_name,
+        sender_id: targetMsg.sender_id,
+        viewKey: `room:${roomB.node_id}`,
+        channel: targetMsg.channel,
+        to: targetMsg.to ?? null,
+        starredAt: Date.now(),
+      },
+    ];
+    saveStarred('meshcore', starred);
+
+    renderRoomsPanel(nodes, {
+      initialRoomTarget: roomA.node_id,
+      messages: [targetMsg],
+      isActive: true,
+    });
+
+    await userEvent.click(screen.getByLabelText('chatPanel.starredMessages'));
+    mockScrollToEnd.mockClear();
+    mockScrollToIndex.mockClear();
+
+    await userEvent.click(screen.getByLabelText('chatPanel.goToMessage'));
+
+    // The room switch (roomA -> roomB) has no unread divider, so without the
+    // scrollToRowKey guard it would also call scrollToEnd() here — clobbering
+    // the explicit jump-to-message the user actually asked for.
+    expect(mockScrollToEnd).not.toHaveBeenCalled();
+    expect(mockScrollToIndex).toHaveBeenCalledWith(0, { align: 'center', behavior: 'smooth' });
   });
 
   it('shows new messages divider when selecting a room with unread posts', async () => {

--- a/src/renderer/components/RoomsPanel.tsx
+++ b/src/renderer/components/RoomsPanel.tsx
@@ -272,6 +272,9 @@ export default function RoomsPanel({
   const [aclError, setAclError] = useState<string | null>(null);
   const [aclFetchedAt, setAclFetchedAt] = useState<number | null>(null);
   const [scrollToRowKey, setScrollToRowKey] = useState<string | null>(null);
+  /** Set alongside an explicit row-key jump so the room-switch effect skips its
+   * own unread/end auto-scroll for that transition instead of racing it. */
+  const suppressNextRoomSwitchScrollRef = useRef(false);
 
   const attachUnreadDividerRef = useCallback((node: HTMLDivElement | null) => {
     unreadDividerRef.current = node;
@@ -640,6 +643,13 @@ export default function RoomsPanel({
     if (selectedRoomId == null) return;
     const snapshot = persistedRoomsLastRead[selectedRoomId] ?? 0;
     setUnreadDividerTimestamp(snapshot);
+    if (suppressNextRoomSwitchScrollRef.current) {
+      // An explicit row-key jump (e.g. "Go to message" from Starred) selected this
+      // room and owns the scroll for this transition — skip the auto unread/end
+      // scroll, which would otherwise fire one render later and clobber it.
+      suppressNextRoomSwitchScrollRef.current = false;
+      return;
+    }
     setTriggerScrollToUnread((n) => n + 1);
   }, [selectedRoomId, persistedRoomsLastRead]);
 
@@ -1942,6 +1952,7 @@ export default function RoomsPanel({
                                 const [, roomRaw] = s.viewKey.split(':');
                                 const roomId = Number.parseInt(roomRaw ?? '', 10);
                                 if (Number.isFinite(roomId)) {
+                                  suppressNextRoomSwitchScrollRef.current = true;
                                   handleSelectRoom(roomId);
                                 }
                                 setStreamView('posts');

--- a/src/renderer/components/RoomsPanel.tsx
+++ b/src/renderer/components/RoomsPanel.tsx
@@ -257,6 +257,9 @@ export default function RoomsPanel({
   /** Sticky intent: user is reading latest posts and wants auto-follow on new traffic. */
   const isPinnedToBottomRef = useRef(true);
   const savedScrollTopRef = useRef<number | null>(null);
+  const savedWasPinnedToBottomRef = useRef(false);
+  /** Distinguishes a tab return (isActive false→true) from a view switch while already active. */
+  const wasActiveRef = useRef(isActive);
   const unreadDividerRef = useRef<HTMLDivElement>(null);
   const [persistedRoomsLastRead, setPersistedRoomsLastRead] = useState(() =>
     loadPersistedRoomsLastRead(),
@@ -576,9 +579,42 @@ export default function RoomsPanel({
     };
   }, [isActive, outerScrollMetricsRootRef, updateScrollButtonVisibility]);
 
+  // Owns all tab/view-switch scrolling. Distinguishes a tab return (isActive
+  // false→true) from a genuine view switch while already active (room change
+  // bumps triggerScrollToUnread): a tab return restores the position/pin-state
+  // snapshotted on exit; a view switch scrolls to the unread divider or end.
+  // These used to be two separate effects that both reacted to `isActive`, so
+  // a tab return fired the view-switch scroll too and the restore immediately
+  // clobbered it — visible as a jump (raw scrollTop restore painted one frame,
+  // then the live-append effect below smooth-scrolled to the true end).
   useLayoutEffect(() => {
+    const el = streamRef.current;
+    const wasActive = wasActiveRef.current;
+    wasActiveRef.current = isActive;
+
+    if (!isActive) {
+      if (el) {
+        savedScrollTopRef.current = el.scrollTop;
+        savedWasPinnedToBottomRef.current = isPinnedToBottomRef.current;
+      }
+      return;
+    }
+
+    if (!wasActive) {
+      if (savedScrollTopRef.current !== null) {
+        if (savedWasPinnedToBottomRef.current) {
+          postVirtualizerRef.current.scrollToEnd();
+          isPinnedToBottomRef.current = true;
+        } else if (el) {
+          el.scrollTop = savedScrollTopRef.current;
+        }
+        savedScrollTopRef.current = null;
+        savedWasPinnedToBottomRef.current = false;
+      }
+      return;
+    }
+
     if (triggerScrollToUnread === 0) return;
-    if (!isActive) return;
     if (unreadStartIndex >= 0) {
       postVirtualizerRef.current.scrollToIndex(unreadStartIndex, { align: 'center' });
       isPinnedToBottomRef.current = false;
@@ -592,19 +628,6 @@ export default function RoomsPanel({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- triggerScrollToUnread is the sole scroll intent
   }, [triggerScrollToUnread, isActive]);
-
-  // Preserve native scroll position across tab/view switches (separate from the
-  // virtualizer-driven unread-scroll effect above, which only fires on new triggers).
-  useLayoutEffect(() => {
-    const el = streamRef.current;
-    if (!el) return;
-    if (!isActive) {
-      savedScrollTopRef.current = el.scrollTop;
-    } else if (savedScrollTopRef.current !== null) {
-      el.scrollTop = savedScrollTopRef.current;
-      savedScrollTopRef.current = null;
-    }
-  }, [isActive]);
 
   useEffect(() => {
     if (!isActive) return;

--- a/src/renderer/lib/chatScrollUtils.test.ts
+++ b/src/renderer/lib/chatScrollUtils.test.ts
@@ -190,6 +190,32 @@ describe('createStableChatMeasureElement', () => {
     );
     expect(size).toBe(180);
   });
+
+  it('ignores a 0px offsetHeight (ancestor display:none) and keeps the cached size', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'offsetHeight', { value: 0, configurable: true });
+    const size = measure(
+      el,
+      undefined,
+      mockMeasureInstance({ scrollDirection: 'forward', cachedSize: 180 }) as never,
+    );
+    expect(size).toBe(180);
+  });
+
+  it('ignores a 0px ResizeObserver entry (ancestor display:none) and keeps the cached size', () => {
+    const measure = createStableChatMeasureElement(() => 96);
+    const el = document.createElement('div');
+    const entry = {
+      borderBoxSize: [{ blockSize: 0, inlineSize: 0 }],
+    } as unknown as ResizeObserverEntry;
+    const size = measure(
+      el,
+      entry,
+      mockMeasureInstance({ scrollDirection: 'forward', cachedSize: 180 }) as never,
+    );
+    expect(size).toBe(180);
+  });
 });
 
 describe('estimateChatRowHeight', () => {

--- a/src/renderer/lib/chatScrollUtils.ts
+++ b/src/renderer/lib/chatScrollUtils.ts
@@ -123,6 +123,14 @@ export function createStableChatMeasureElement(
       ? Math.round(box[instance.options.horizontal ? 'inlineSize' : 'blockSize'])
       : htmlEl[sizeProp];
 
+    // A real chat row is never 0px. The ancestor tab panel goes `display:none` on
+    // tab switch, which fires a 0x0 ResizeObserver entry for every rendered row;
+    // caching that would corrupt the size cache while hidden and make scrollToEnd()
+    // land at a wrong, variable position on return. Fall back to what we already know.
+    if (domSize === 0) {
+      return cached ?? estimated;
+    }
+
     if (instance.scrollDirection === 'backward' && hasMeasuredSize) {
       // Allow growth (async previews, layout) but prevent shrink jitter while scrolling up.
       return domSize > cached ? domSize : cached;


### PR DESCRIPTION
## Summary
- Merge the two competing `useLayoutEffect`s in ChatPanel/RoomsPanel that both reacted to `isActive`: one re-ran the unread-divider/scroll-to-end logic on every tab return (not just a genuine view switch), the other restored the scroll position snapshotted on exit — the restore clobbered the divider/end scroll mid-commit. RoomsPanel also gains the pinned-state snapshot ChatPanel already had from #547.
- Fix the actual source of the "lands at a random position, multiple jumps" symptom: TanStack Virtual's ResizeObserver still fires when the tab panel goes `display:none`, reporting 0×0 for every rendered row. The shared `measureElement` callback was caching that 0 as the row's real height, corrupting the size cache until rows got re-measured on return — `scrollToEnd()`/`scrollToIndex()` then computed wildly wrong target offsets off that corrupted cache. Now a 0px measurement is treated as invalid and falls back to the cached/estimated size.
- Fix a separate race in RoomsPanel: "Go to message" from Starred selects the target room and sets `scrollToRowKey` in the same click, but the room-switch effect unconditionally bumped `triggerScrollToUnread`, so its unread/end auto-scroll fired one render after the explicit jump had already scrolled to (and cleared) its target — clobbering it back to the unread divider/end. A ref now suppresses that auto-scroll for transitions driven by an explicit row-key jump.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` on all changed files
- [x] Added regression tests for each fix; each one verified to fail against the pre-fix code and pass against the fix (temporarily stashed each source change to confirm)
- [x] Full `pnpm run test:run` passes via pre-commit hooks on all three commits
- [x] Manually verified in Meshtastic Chat via `pnpm start` — tab-switch jump no longer reproduces
- [ ] MeshCore Rooms not manually verified (no room server available locally) — relying on regression test coverage, since Rooms shares the same effect pattern and the same `chatScrollUtils.ts` measurement path now confirmed fixed in Chat