### PR TITLE
fix: resolve Dependabot undici alerts and security review findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,8 @@
       "shell-quote": "^1.8.4",
       "tar": "^7.5.16",
       "tmp": "^0.2.6",
+      "undici": "^7.28.0",
+      "undici-types": "^7.28.0",
       "ws": "^8.21.0"
     },
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,8 @@ overrides:
   shell-quote: ^1.8.4
   tar: ^7.5.16
   tmp: ^0.2.6
+  undici: ^7.28.0
+  undici-types: ^7.28.0
   ws: ^8.21.0
 
 patchedDependencies:
@@ -4259,15 +4261,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
-    engines: {node: '>=18.17'}
+  undici-types@7.28.0:
+    resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -5539,11 +5534,11 @@ snapshots:
 
   '@types/node@24.13.2':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.28.0
 
   '@types/node@25.9.3':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 7.28.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -7955,7 +7950,7 @@ snapshots:
       semver: 7.7.4
       tar: 7.5.16
       tinyglobby: 0.2.17
-      undici: 6.27.0
+      undici: 7.28.0
       which: 6.0.1
 
   node-int64@0.4.0: {}
@@ -8971,11 +8966,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.18.2: {}
-
-  undici-types@7.24.6: {}
-
-  undici@6.27.0: {}
+  undici-types@7.28.0: {}
 
   undici@7.28.0: {}
 

--- a/src/main/windows-long-path-manifest.contract.test.ts
+++ b/src/main/windows-long-path-manifest.contract.test.ts
@@ -40,9 +40,15 @@ describe('Windows long-path application manifest (packaging contract)', () => {
       dependencies?: Record<string, string>;
       pnpm?: { patchedDependencies?: Record<string, string> };
     };
+    const lockfile = readFileSync(join(REPO_ROOT, 'pnpm-lock.yaml'), 'utf-8');
     expect(packageJson.dependencies?.['readable-stream']).toMatch(/^[\^~]?4\./);
-    expect(packageJson.pnpm?.patchedDependencies?.['readable-stream@4.7.0']).toBe(
-      'patches/readable-stream@4.7.0.patch',
+
+    const readableStreamLockRe = /^ {2}readable-stream@(4\.\d+\.\d+):$/m;
+    const resolvedMatch = readableStreamLockRe.exec(lockfile);
+    expect(resolvedMatch).not.toBeNull();
+    const resolvedVersion = resolvedMatch![1];
+    expect(packageJson.pnpm?.patchedDependencies?.[`readable-stream@${resolvedVersion}`]).toBe(
+      `patches/readable-stream@${resolvedVersion}.patch`,
     );
   });
 
@@ -57,7 +63,7 @@ describe('Windows long-path application manifest (packaging contract)', () => {
     expect(major).toBeGreaterThanOrEqual(4);
 
     const lockfile = readFileSync(join(REPO_ROOT, 'pnpm-lock.yaml'), 'utf-8');
-    expect(lockfile).toContain("'@electron/asar': ^4.0.1");
+    expect(lockfile).toMatch(/'@electron\/asar': [\^~]?4\.\d+/);
   });
 
   it('skips dedupe:dist in dist:win scripts; hoisted install helper runs before packaging', () => {

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -1301,7 +1301,7 @@ function ChatPanel({
     (dateStr: string) => {
       if (!dateStr) return;
       const [y, m, d] = dateStr.split('-').map(Number);
-      const targetKey = `${y}-${m - 1}-${d}`;
+      const targetKey = `${y}-${m}-${d}`;
       const index = findFirstMessageIndexByDayKey(filteredMessages, targetKey);
       if (index < 0) return;
       isPinnedToBottomRef.current = false;

--- a/src/renderer/lib/chatScrollUtils.test.ts
+++ b/src/renderer/lib/chatScrollUtils.test.ts
@@ -48,9 +48,9 @@ function mockMeasureInstance(
 }
 
 describe('getChatDayKey', () => {
-  it('matches local calendar day components', () => {
+  it('uses 1-based calendar month (June is 6, not zero-based 5)', () => {
     const ts = new Date(2026, 5, 15, 23, 59).getTime();
-    expect(getChatDayKey(ts)).toBe('2026-5-15');
+    expect(getChatDayKey(ts)).toBe('2026-6-15');
   });
 });
 

--- a/src/renderer/lib/chatScrollUtils.ts
+++ b/src/renderer/lib/chatScrollUtils.ts
@@ -72,10 +72,10 @@ export function getDistFromChatBottom(
   return dist;
 }
 
-/** Day key for grouping messages (matches ChatPanel jump-to-date). */
+/** Day key for grouping messages (matches ChatPanel jump-to-date). Month is 1-based. */
 export function getChatDayKey(ts: number): string {
   const d = new Date(ts);
-  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+  return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
 }
 
 /** Scroll an element within a scroll container without scrollIntoView (avoids outer viewport fights). */

--- a/src/renderer/lib/meshtastic/meshtasticLegacyWireSubscriptions.ts
+++ b/src/renderer/lib/meshtastic/meshtasticLegacyWireSubscriptions.ts
@@ -15,6 +15,7 @@ import {
   resolveMeshtasticMqttPublishFieldsForChannel,
   type ResolveMeshtasticMqttPublishOptions,
 } from '@/renderer/lib/meshtasticMqttPublish';
+import { stripControlCharacters } from '@/renderer/lib/stripControlCharacters';
 import { resolveMeshtasticTextMessagePayload } from '@/shared/meshtasticTextMessagePayload';
 import type { MeshtasticLoraConfig } from '@/shared/meshtasticUrlEncoder';
 
@@ -941,20 +942,13 @@ export function attachMeshtasticLegacyWireSubscriptions(
       }
     }
 
-    // Desktop notification for incoming messages when app is not focused
+    // OS toast when hidden: silent so App.tsx owns typed Web Audio (chatNotifications.ts).
+    // Sound plays via resolveInactiveChatNotificationType + playMessageNotification on message store growth.
     if (!isEcho && !emoji && document.hidden) {
       try {
-        const stripControl = (text: string) => {
-          let out = '';
-          for (const ch of text) {
-            const code = ch.charCodeAt(0);
-            if (code >= 0x20 && code !== 0x7f) out += ch;
-          }
-          return out;
-        };
-        const safeSender = stripControl(msg.sender_name).slice(0, 120);
+        const safeSender = stripControlCharacters(msg.sender_name).slice(0, 120);
         const title = msg.to ? `DM from ${safeSender}` : `Message from ${safeSender}`;
-        const body = stripControl(msg.payload).slice(0, 100);
+        const body = stripControlCharacters(msg.payload).slice(0, 100);
         new Notification(title, {
           body,
           silent: true,

--- a/src/renderer/lib/meshtastic/meshtasticMqttClientProxy.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticMqttClientProxy.test.ts
@@ -175,6 +175,22 @@ describe('meshtasticMqttClientProxy', () => {
     warnSpy.mockRestore();
   });
 
+  it('logs configured writeToRadio rejection without throwing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const writeToRadio = vi.fn().mockRejectedValue(new Error('radio busy'));
+    const bridge = new MeshtasticMqttClientProxyBridge({
+      isProxyActive: () => true,
+      isDeviceConfigured: () => true,
+      publishToBroker: vi.fn(),
+      writeToRadio,
+    });
+    await expect(
+      bridge.handleBrokerRaw('msh/in', new Uint8Array([4, 5]), false),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   it('drops oldest pending frames when count cap exceeded', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     let configured = false;

--- a/src/renderer/lib/meshtastic/meshtasticMqttClientProxy.ts
+++ b/src/renderer/lib/meshtastic/meshtasticMqttClientProxy.ts
@@ -171,6 +171,13 @@ export class MeshtasticMqttClientProxyBridge {
       this.enqueuePendingToDevice(bytes);
       return;
     }
-    await this.deps.writeToRadio(bytes);
+    try {
+      await this.deps.writeToRadio(bytes);
+    } catch (e: unknown) {
+      console.warn(
+        '[MeshtasticMqttClientProxyBridge] writeToRadio failed ' +
+          (e instanceof Error ? e.message : String(e)),
+      );
+    }
   }
 }

--- a/src/renderer/lib/stripControlCharacters.test.ts
+++ b/src/renderer/lib/stripControlCharacters.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripControlCharacters } from './stripControlCharacters';
+
+describe('stripControlCharacters', () => {
+  it('removes ASCII control characters and keeps printable text', () => {
+    expect(stripControlCharacters('hello\x07world')).toBe('helloworld');
+    expect(stripControlCharacters('line\x1fbreak')).toBe('linebreak');
+  });
+});

--- a/src/renderer/lib/stripControlCharacters.ts
+++ b/src/renderer/lib/stripControlCharacters.ts
@@ -1,0 +1,4 @@
+/** Remove ASCII control characters (0x00–0x1F, 0x7F) for safe OS notification text. */
+export function stripControlCharacters(text: string): string {
+  return text.replace(/[\x00-\x1F\x7F]/g, ''); // eslint-disable-line no-control-regex
+}


### PR DESCRIPTION
## Summary

- Add pnpm overrides for `undici` and `undici-types` (^7.28.0) so all transitive copies resolve to the patched release and Dependabot stops conflating `undici-types@7.24.6` with vulnerable `undici`.
- Fix `getChatDayKey` to use 1-based calendar months and align `ChatPanel` jump-to-date with the corrected day-key format.
- Harden `MeshtasticMqttClientProxyBridge` configured-path `writeToRadio` with try/catch and add regression test for rejected writes.
- Extract `stripControlCharacters` for silent OS notification text; document that `App.tsx` owns typed Web Audio for hidden-window alerts.
- Relax Windows packaging contract tests to derive readable-stream patch version from the lockfile and accept any `@electron/asar` 4.x override.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test:run` (352 files / 3102 tests)
- [ ] Confirm Dependabot alerts #41 and #42 close after merge
- [ ] Smoke-test Chat jump-to-date on a day with messages