### PR TITLE
test: expand stripControlCharacters edge-case coverage

### DIFF
--- a/src/renderer/lib/stripControlCharacters.test.ts
+++ b/src/renderer/lib/stripControlCharacters.test.ts
@@ -3,8 +3,30 @@ import { describe, expect, it } from 'vitest';
 import { stripControlCharacters } from './stripControlCharacters';
 
 describe('stripControlCharacters', () => {
+  it('returns empty string unchanged', () => {
+    expect(stripControlCharacters('')).toBe('');
+  });
+
+  it('returns strings with no control characters unchanged', () => {
+    expect(stripControlCharacters('hello world')).toBe('hello world');
+    expect(stripControlCharacters('printable: ABC 123 !@#')).toBe('printable: ABC 123 !@#');
+  });
+
   it('removes ASCII control characters and keeps printable text', () => {
     expect(stripControlCharacters('hello\x07world')).toBe('helloworld');
     expect(stripControlCharacters('line\x1fbreak')).toBe('linebreak');
+  });
+
+  it('removes boundary control characters (NUL and US)', () => {
+    expect(stripControlCharacters('\x00start')).toBe('start');
+    expect(stripControlCharacters('end\x1f')).toBe('end');
+  });
+
+  it('removes DEL (0x7F)', () => {
+    expect(stripControlCharacters('del\x7fchar')).toBe('delchar');
+  });
+
+  it('removes multiple control characters in one string', () => {
+    expect(stripControlCharacters('\x00a\x1fb\x7fc')).toBe('abc');
   });
 });


### PR DESCRIPTION
## Summary

- Adds test cases for empty strings and printable-only input (no false modifications).
- Covers boundary control characters NUL (`\x00`), US (`\x1F`), and DEL (`\x7F`).
- Adds a mixed-control-character case to exercise the full `/[\x00-\x1F\x7F]/g` regex.

Follow-up to review feedback on `stripControlCharacters` tests landed in #553.

## Test plan

- [x] `pnpm exec vitest run src/renderer/lib/stripControlCharacters.test.ts` (6 tests pass)