### PR TITLE
fix: skip resedit manifest embed on Windows arm64 builds

### DIFF
--- a/scripts/electron-builder-after-pack.cjs
+++ b/scripts/electron-builder-after-pack.cjs
@@ -10,11 +10,24 @@
 const fs = require('fs');
 const path = require('path');
 
+const { Arch } = require('builder-util');
+
 // Ref: https://learn.microsoft.com/en-us/windows/win32/menurc/resource-types
 const RT_MANIFEST_TYPE = 24;
 
 module.exports = async function electronBuilderAfterPack(context) {
   if (context.electronPlatformName !== 'win32') {
+    return;
+  }
+
+  const exeName = `${context.packager.appInfo.productFilename}.exe`;
+  const exePath = path.join(context.appOutDir, exeName);
+
+  // resedit regenerate() can produce an ARM64 PE that passes Node parsing but fails to
+  // materialize during NSIS install on Windows 11 ARM (support files land, exe missing).
+  // Keep stock Electron manifest on arm64; longPathAware remains on x64 builds.
+  if (context.arch === Arch.arm64) {
+    console.debug(`[afterPack] Skipping resedit manifest embed on arm64: ${exePath}`);
     return;
   }
 
@@ -29,8 +42,6 @@ module.exports = async function electronBuilderAfterPack(context) {
     throw new Error(`[afterPack] Missing manifest: ${manifestPath}`);
   }
 
-  const exeName = `${context.packager.appInfo.productFilename}.exe`;
-  const exePath = path.join(context.appOutDir, exeName);
   if (!fs.existsSync(exePath)) {
     throw new Error(`[afterPack] Missing Windows app exe: ${exePath}`);
   }

--- a/src/main/windows-long-path-manifest.contract.test.ts
+++ b/src/main/windows-long-path-manifest.contract.test.ts
@@ -17,6 +17,8 @@ describe('Windows long-path application manifest (packaging contract)', () => {
     expect(hook).toContain('resedit');
     expect(hook).toMatch(/RT_MANIFEST_TYPE|type === 24/);
     expect(hook).toContain('mesh-client-long-path.manifest.xml');
+    expect(hook).toContain('Arch.arm64');
+    expect(hook).toContain('Skipping resedit manifest embed on arm64');
     expect(hook).toContain('renameSync');
     expect(hook).toMatch(/\.tmp['"`]/);
 


### PR DESCRIPTION
## Summary

- Skip the `resedit` long-path manifest embed in `electron-builder-after-pack.cjs` for Windows **arm64** builds; x64 builds still embed `longPathAware` as before.
- Add contract-test assertions that the arm64 skip path is present.

On Windows 11 ARM, `resedit regenerate()` could produce a PE that passed CI validation but failed to materialize during NSIS install—support files and shortcuts landed, but the main executable was missing. Leaving the stock Electron PE on arm64 avoids that broken install.

## Test plan

- [ ] CI passes (including `windows-long-path-manifest.contract.test.ts`)
- [ ] Build Windows arm64 installer and confirm `Mesh-client.exe` installs and launches on Windows 11 ARM
- [ ] Build Windows x64 installer and confirm long-path manifest embed still works