### PR TITLE
fix: use zip NSIS payloads for reliable WoA arm64 installs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ See [development-environment.md](development-environment.md) for OS-specific pre
 
 **Cause**
 
-On **native Windows 11 ARM**, the arm64 NSIS installer can partially extract support files while failing to copy the main executable. CI builds the exe correctly (it is inside the installer's `app-arm64.7z`); the failure happens at **install time**, not during packaging.
+On **native Windows 11 ARM**, older arm64 NSIS installers used `Nsis7z` on `app-arm64.7z` archives compressed with ARM64 LZMA. That path can partially extract support files while dropping the main executable. CI builds the exe correctly (it is inside the installer payload); the failure happens at **install time**, not during packaging. Current releases use zip-compressed NSIS payloads (`useZip`) to avoid this extractor path.
 
 Older releases also shipped a **universal** NSIS installer (x64 + arm64 in one `.exe`), which made arch selection worse — use the split **`-arm64.exe`** installer on WoA hardware.
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -76,4 +76,7 @@ win:
   icon: resources/icons/win/colorado-mesh.ico
 nsis:
   buildUniversalInstaller: false
+  # WoA: Nsis7z cannot reliably extract ARM64 LZMA app-arm64.7z (main exe missing).
+  useZip: true
+  differentialPackage: false
   include: resources/installer.nsh

--- a/resources/installer.nsh
+++ b/resources/installer.nsh
@@ -1,9 +1,10 @@
-; electron-builder NSIS include — post-install guard for silent partial installs (WoA).
-; Surfaces missing Mesh-client.exe instead of reporting success with a broken tree.
+; electron-builder NSIS include — post-extract guard for silent partial installs (WoA).
+; customFinish is not invoked by electron-builder; customInstall runs after files land.
 
-!macro customFinish
+!macro customInstall
   IfFileExists "$INSTDIR\Mesh-client.exe" finish_ok 0
-    MessageBox MB_ICONSTOP|MB_OK "Installation incomplete: Mesh-client.exe is missing from $INSTDIR.$\r$\nPlease report this at github.com/Colorado-Mesh/mesh-client/issues."
+    SetErrorLevel 2
+    MessageBox MB_ICONSTOP|MB_OK "Installation incomplete: Mesh-client.exe is missing from $INSTDIR.$\r$\nPlease report this at github.com/Colorado-Mesh/mesh-client/issues." /SD IDOK
     Abort
   finish_ok:
 !macroend

--- a/scripts/find-nsis-app-archive.mjs
+++ b/scripts/find-nsis-app-archive.mjs
@@ -3,10 +3,10 @@ import path from 'path';
 
 /**
  * Recursively find the electron-builder NSIS app payload archive inside a 7z NSIS extract.
- * Prefers app*.7z under $PLUGINSDIR (electron-builder layout).
+ * Prefers app*.7z or app*.zip under $PLUGINSDIR (electron-builder layout).
  *
  * @param {string} rootDir
- * @returns {string | null} absolute path to the chosen .7z archive
+ * @returns {string | null} absolute path to the chosen payload archive
  */
 export function findAppArchive(rootDir) {
   /** @type {string[]} */
@@ -18,7 +18,7 @@ export function findAppArchive(rootDir) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(full);
-      } else if (entry.name.endsWith('.7z')) {
+      } else if (entry.name.endsWith('.7z') || entry.name.endsWith('.zip')) {
         archives.push(full);
       }
     }

--- a/scripts/find-nsis-app-archive.test.mjs
+++ b/scripts/find-nsis-app-archive.test.mjs
@@ -21,10 +21,20 @@ describe('findAppArchive', () => {
     return dir;
   }
 
-  it('returns null when no .7z archives exist', () => {
+  it('returns null when no payload archives exist', () => {
     const root = makeTemp();
     mkdirSync(path.join(root, '$PLUGINSDIR'));
     expect(findAppArchive(root)).toBeNull();
+  });
+
+  it('finds app-arm64.zip nested under $PLUGINSDIR', () => {
+    const root = makeTemp();
+    const pluginsDir = path.join(root, '$PLUGINSDIR');
+    mkdirSync(pluginsDir, { recursive: true });
+    const archive = path.join(pluginsDir, 'app-arm64.zip');
+    writeFileSync(archive, 'fake');
+
+    expect(findAppArchive(root)).toBe(archive);
   });
 
   it('finds app-arm64.7z nested under $PLUGINSDIR', () => {

--- a/scripts/test-win-nsis-install.mjs
+++ b/scripts/test-win-nsis-install.mjs
@@ -118,7 +118,7 @@ function probe7zExtract(installerPath, outDir) {
   const appArchivePath = findAppArchive(outDir);
   if (!appArchivePath) {
     dumpDir('probe-7z output', outDir, 2);
-    fail('No app*.7z found inside installer after 7z extract');
+    fail('No app*.7z or app*.zip found inside installer after 7z extract');
   }
 
   const archiveDir = path.join(outDir, 'app-payload');

--- a/src/main/windows-packaging.contract.test.ts
+++ b/src/main/windows-packaging.contract.test.ts
@@ -67,11 +67,13 @@ describe('Windows packaging (contract)', () => {
   it('disables universal NSIS, includes post-install guard, and verifies split Windows installers', () => {
     const yml = readFileSync(join(REPO_ROOT, 'electron-builder.yml'), 'utf-8');
     expect(yml).toMatch(/nsis:\s*\n\s*buildUniversalInstaller:\s*false/);
+    expect(yml).toMatch(/useZip:\s*true/);
+    expect(yml).toMatch(/differentialPackage:\s*false/);
     expect(yml).toContain('include: resources/installer.nsh');
 
     const installerNsh = readFileSync(join(REPO_ROOT, 'resources', 'installer.nsh'), 'utf-8');
     expect(installerNsh).toContain('Mesh-client.exe');
-    expect(installerNsh).toContain('customFinish');
+    expect(installerNsh).toContain('customInstall');
 
     const verifyScript = readFileSync(
       join(REPO_ROOT, 'scripts', 'verify-win-packaging.mjs'),


### PR DESCRIPTION
## Summary

- Fix failing **Smoke test arm64 NSIS install (WoA)** CI job ([run #94](https://github.com/Colorado-Mesh/mesh-client/actions/runs/27834069005/job/82378873127)) by switching Windows NSIS app payloads from 7z (ARM64 LZMA) to zip (`useZip: true`, `differentialPackage: false`).
- Move the missing-exe install guard from `customFinish` (not invoked by electron-builder) to `customInstall` with a non-zero exit on silent failure.
- Update the 7z probe helper and contract tests for `app*.zip` payloads; document the root cause in troubleshooting.

## Root cause

The arm64 installer embedded `app-arm64.7z` using ARM64 LZMA compression. CI’s 7z probe extracted it fine, but native NSIS `Nsis7z::Extract` on Windows 11 ARM left support files on disk while dropping `Mesh-client.exe`. Zip payloads use `nsisunz::Unzip`, which avoids that extractor path.

## Test plan

- [ ] CI `build` workflow: `win-arm64-install` job passes on `windows-11-arm`
- [ ] CI `build` workflow: x64 NSIS install smoke test still passes on `windows-latest`
- [x] `pnpm exec vitest run src/main/windows-packaging.contract.test.ts scripts/find-nsis-app-archive.test.mjs`