### PR TITLE
fix: omit wire reply key from MeshCore reaction tapbacks

### DIFF
--- a/src/renderer/lib/meshcoreChannelText.test.ts
+++ b/src/renderer/lib/meshcoreChannelText.test.ts
@@ -5,6 +5,7 @@ import {
   buildMeshcoreChannelIncomingMessage,
   buildMeshcoreDmIncomingMessage,
   findMeshcoreDmReplyParent,
+  formatMeshcoreWireTapbackPrefix,
   meshcoreBracketDisplayNamesMatch,
   meshcoreChannelRepairRawText,
   meshcoreChatMessagesForDisplay,
@@ -474,6 +475,12 @@ describe('meshcoreChannelRepairRawText', () => {
       status: 'acked',
     });
     expect(raw).toBe('TB-Dek: @[W0STR mobl] agreed');
+  });
+});
+
+describe('formatMeshcoreWireTapbackPrefix', () => {
+  it('omits wire reply key so MQTT bridges do not show #timestamp in mentions', () => {
+    expect(formatMeshcoreWireTapbackPrefix('🐧 KF0KIT EDC')).toBe('@[🐧 KF0KIT EDC]');
   });
 });
 

--- a/src/renderer/lib/meshcoreChannelText.ts
+++ b/src/renderer/lib/meshcoreChannelText.ts
@@ -30,6 +30,11 @@ export function formatMeshcoreWireReplyPrefix(displayName: string, replyKey: num
   return `@[${displayName}#${key}]`;
 }
 
+/** Tapback wire prefix — name only (no `#key`; bridges and other clients show `#timestamp` as part of the mention). */
+export function formatMeshcoreWireTapbackPrefix(displayName: string): string {
+  return `@[${displayName}]`;
+}
+
 function parseMeshcoreBracketTarget(rawTarget: string): {
   targetName?: string;
   wireReplyKey?: number;

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -116,6 +116,7 @@ import {
 import {
   findMeshcoreDmReplyParent,
   formatMeshcoreWireReplyPrefix,
+  formatMeshcoreWireTapbackPrefix,
   MESHCORE_TXT_TYPE_PLAIN,
   meshcoreChatMessagesForDisplay,
   normalizeMeshcoreIncomingText,
@@ -4977,8 +4978,7 @@ export function useMeshcoreRuntime() {
         storeMessages.find((m) => m.packetId === replyId || m.timestamp === replyId) ??
         messagesRef.current.find((m) => m.packetId === replyId || m.timestamp === replyId);
       const targetName = reactedTo?.sender_name || 'Unknown';
-      const replyKey = reactedTo ? (reactedTo.packetId ?? reactedTo.timestamp) : replyId;
-      const tapbackText = `${formatMeshcoreWireReplyPrefix(targetName, replyKey)} ${parsed.glyph}`;
+      const tapbackText = `${formatMeshcoreWireTapbackPrefix(targetName)} ${parsed.glyph}`;
       const conn = connRef.current;
       const me = myNodeNumRef.current;
 


### PR DESCRIPTION
## Summary

- MeshCore reactions were sent as `@[DisplayName#1781896497000] 👍`, leaking mesh-client's internal parent key onto the wire.
- MQTT/Discord bridges (e.g. N7-p) rendered the `#timestamp` as part of the mention: `@MeshnCrap T096#1781973235000 👍`.
- Reactions now use name-only `@[DisplayName] 👍` via `formatMeshcoreWireTapbackPrefix`; text replies still use `@[Name#key]` when parent disambiguation is needed.

## Test plan

- [x] `pnpm exec vitest run src/renderer/lib/meshcoreChannelText.test.ts`
- [ ] React to a channel message on MeshCore RF; confirm Discord bridge shows `@Name 👍` without `#timestamp`
- [ ] Confirm tapback still attaches to the correct message in mesh-client UI
- [ ] Confirm text replies with `@[Name#key]` still work when same sender has multiple messages