### PR TITLE
fix: MeshCore tapback dedup, Rooms scroll race, and timestamp guards (#494)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file is self-contained. ARCHITECTURE.md and CONTRIBUTING.md are human refer
 - Only change what was asked. No drive-by refactors, reformatting, or types/comments outside scope.
 - **Testing:** Ship a passing test for behavioral changes; do not call the task done without it.
 - **Stateful/I/O code:** Preserve integrity on failure; document failure point, fallback, and logging where it matters.
+- **Pre-commit patience:** This repo has a very long pre-commit hook chain (lint, typecheck, thousands of tests, audit, actionlint, yamllint, many check:\* scripts). Commits can take 2+ minutes. Be patient and let them finish — do not interrupt or force-skip hooks.
 
 ## 2. Architecture & Domain
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -118,7 +118,9 @@ Startup maintenance can delete stale MeshCore contacts by age. Important details
 - Contacts with **`NULL last_advert`** are never age-pruned (only count-based limits apply).
 - If favorite stars stopped working after a store migration, update to a build with identity-scoped favorite toggles (`patchNodeFavorited` on the active connection identity).
 
-### MeshCore duplicate chat messages
+### MeshCore reply misquote / duplicate chat messages
+
+**Reply misquote cause:** The official MeshCore companion firmware sends unkeyed replies — `@[Display Name] body` — without identifying the parent message. The receiving client makes a best-guess match using the most recent message from that sender, which is wrong when the user replies to an older message. This is a wire protocol limitation, not a bug in any single client.
 
 The client deduplicates overlapping RF and MQTT hears within **5 minutes** (cross-transport and channel RF replay). Room posts and tapbacks use a **60 second** window. A second MQTT-only copy may still appear if both hears arrive via MQTT without RF — that can be expected.
 

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -90,6 +90,7 @@ import {
 import {
   findMeshcoreParentMessageForReply,
   meshcoreChatMessagesForDisplay,
+  meshcorePayloadIsTapbackEmojiOnly,
 } from '../lib/meshcoreChannelText';
 import { nodeDisplayName } from '../lib/nodeLongNameOrHex';
 import {
@@ -595,20 +596,28 @@ function ChatPanel({
       { emoji: number; payload: string; sender_id: number; sender_name: string; id?: number }[]
     >();
 
+    const reactionDedupeKey = (senderId: number, emoji: number, payload: string): string =>
+      `${senderId}|${emoji}|${payload.trim()}`;
+
     for (const msg of displayMessages) {
       if (protocol === 'meshcore' && isMeshcoreRoomChatMessage(msg)) {
         continue;
       }
       if (msg.emoji && msg.replyId) {
         const existing = reactions.get(msg.replyId) ?? [];
-        existing.push({
-          emoji: msg.emoji,
-          payload: msg.payload,
-          sender_id: msg.sender_id,
-          sender_name: msg.sender_name,
-          id: msg.id,
-        });
-        reactions.set(msg.replyId, existing);
+        const dedupeKey = reactionDedupeKey(msg.sender_id, msg.emoji, msg.payload);
+        if (
+          !existing.some((r) => reactionDedupeKey(r.sender_id, r.emoji, r.payload) === dedupeKey)
+        ) {
+          existing.push({
+            emoji: msg.emoji,
+            payload: msg.payload,
+            sender_id: msg.sender_id,
+            sender_name: msg.sender_name,
+            id: msg.id,
+          });
+          reactions.set(msg.replyId, existing);
+        }
       } else {
         regular.push(msg);
       }
@@ -1147,10 +1156,18 @@ function ChatPanel({
     async (text: string, opts?: { replyId?: number }) => {
       const sendChannel = channel;
       const destination = viewMode === 'dm' && activeDmNode != null ? activeDmNode : undefined;
+      if (
+        protocol === 'meshcore' &&
+        opts?.replyId != null &&
+        meshcorePayloadIsTapbackEmojiOnly(text)
+      ) {
+        await onReact(text, opts.replyId, sendChannel);
+        return;
+      }
       const sendOutcome = onSend(text, sendChannel, destination, opts?.replyId);
       await Promise.resolve(sendOutcome);
     },
-    [activeDmNode, channel, onSend, viewMode],
+    [activeDmNode, channel, onReact, onSend, protocol, viewMode],
   );
 
   const handleReact = async (glyph: string, packetId: number, msgChannel: number) => {
@@ -1255,9 +1272,30 @@ function ChatPanel({
   }
 
   /** Flat reaction rows for a message key (chronological as stored). */
-  function getReactionRows(messageKey: number | undefined) {
-    if (!messageKey) return [];
-    return reactionsByReplyId.get(messageKey) ?? [];
+  function getReactionRows(messageKey: number | undefined, parentMsg?: ChatMessage) {
+    if (messageKey == null) return [];
+    const lookupKeys = new Set<number>([messageKey]);
+    if (parentMsg?.packetId != null && parentMsg.packetId !== parentMsg.timestamp) {
+      lookupKeys.add(parentMsg.packetId);
+      lookupKeys.add(parentMsg.timestamp);
+    }
+    const seen = new Set<string>();
+    const rows: {
+      emoji: number;
+      payload: string;
+      sender_id: number;
+      sender_name: string;
+      id?: number;
+    }[] = [];
+    for (const key of lookupKeys) {
+      for (const row of reactionsByReplyId.get(key) ?? []) {
+        const dedupeKey = `${row.sender_id}|${row.emoji}|${row.payload.trim()}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        rows.push(row);
+      }
+    }
+    return rows;
   }
 
   // Pre-compute day separator indices (avoids mutable variable during render)
@@ -1850,7 +1888,7 @@ function ChatPanel({
                 if (!msg) return null;
                 const isOwn = isOwnNode(msg.sender_id);
                 const isDm = !!msg.to;
-                const reactionRows = getReactionRows(msg.packetId ?? msg.timestamp);
+                const reactionRows = getReactionRows(msg.packetId ?? msg.timestamp, msg);
                 const messageRowKey = msg.packetId ?? msg.timestamp;
                 const showPicker = pickerOpenFor === (msg.packetId ?? msg.timestamp);
                 const pickerOpensAbove = i >= filteredMessages.length - 3;

--- a/src/renderer/components/RoomsPanel.tsx
+++ b/src/renderer/components/RoomsPanel.tsx
@@ -707,6 +707,7 @@ export default function RoomsPanel({
     }
 
     if (triggerScrollToUnread === 0) return;
+    if (suppressNextRoomSwitchScrollRef.current || scrollToRowKey != null) return;
     if (unreadStartIndex >= 0) {
       postVirtualizerRef.current.scrollToIndex(unreadStartIndex, { align: 'center' });
       isPinnedToBottomRef.current = false;
@@ -719,7 +720,7 @@ export default function RoomsPanel({
       if (dist !== undefined && dist < 50) applyNearBottomReadState(dist);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- triggerScrollToUnread is the sole scroll intent
-  }, [triggerScrollToUnread, isActive]);
+  }, [triggerScrollToUnread, isActive, scrollToRowKey]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -735,8 +736,8 @@ export default function RoomsPanel({
     if (suppressNextRoomSwitchScrollRef.current) {
       // An explicit row-key jump (e.g. "Go to message" from Starred) selected this
       // room and owns the scroll for this transition — skip the auto unread/end
-      // scroll, which would otherwise fire one render later and clobber it.
-      suppressNextRoomSwitchScrollRef.current = false;
+      // scroll. suppressNextRoomSwitchScrollRef clears in the scrollToRowKey effect
+      // after scrollToIndex so pinned-bottom follow cannot race ahead of it.
       return;
     }
     setTriggerScrollToUnread((n) => n + 1);
@@ -1116,6 +1117,9 @@ export default function RoomsPanel({
       postVirtualizerRef.current.scrollToIndex(index, { align: 'center', behavior: 'smooth' });
     }
     setScrollToRowKey(null);
+    requestAnimationFrame(() => {
+      suppressNextRoomSwitchScrollRef.current = false;
+    });
   }, [scrollToRowKey, streamView, roomPosts]);
 
   const toggleStar = useCallback(
@@ -2407,6 +2411,7 @@ export default function RoomsPanel({
                                 const roomId = Number.parseInt(roomRaw ?? '', 10);
                                 if (Number.isFinite(roomId)) {
                                   suppressNextRoomSwitchScrollRef.current = true;
+                                  setTriggerScrollToUnread(0);
                                   handleSelectRoom(roomId);
                                 }
                                 setStreamView('posts');

--- a/src/renderer/hooks/meshcore/meshcoreHookPreamble.crossTransport.test.ts
+++ b/src/renderer/hooks/meshcore/meshcoreHookPreamble.crossTransport.test.ts
@@ -7,12 +7,16 @@ import {
   findMeshcoreCrossTransportDuplicate,
   findMeshcoreDmRfDuplicate,
   findMeshcoreTapbackEchoDuplicate,
+  findMeshcoreTapbackRfReplayDuplicate,
   MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
   MESHCORE_CROSS_TRANSPORT_DEDUP_WINDOW_MS,
+  MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS,
   meshcoreChannelRfMatch,
   meshcoreCrossTransportMatch,
   meshcoreDmRfMatch,
   meshcoreTapbackEchoMatch,
+  meshcoreTapbackReplyIdsMatch,
+  meshcoreTapbackRfReplayMatch,
   upgradeMeshcoreCrossTransportMessage,
 } from './meshcoreHookPreamble';
 
@@ -106,6 +110,103 @@ describe('meshcoreCrossTransportMatch', () => {
       timestamp: mqtt.timestamp + 500,
     });
     expect(meshcoreCrossTransportMatch(mqtt, rf)).toBe(true);
+  });
+});
+
+describe('meshcoreTapbackEchoMatch', () => {
+  it('matches replyId in firmware seconds against stored ms parent key', () => {
+    const parentMs = 1_719_000_000_000;
+    const parentSec = Math.floor(parentMs / 1000);
+    const local = baseMsg({
+      emoji: 0x1f44d,
+      replyId: parentMs,
+      payload: '👍',
+      timestamp: Date.now(),
+    });
+    const echo = baseMsg({
+      emoji: 0x1f44d,
+      replyId: parentSec,
+      payload: '👍',
+      timestamp: local.timestamp + 90_000,
+    });
+    expect(meshcoreTapbackReplyIdsMatch(local.replyId, echo.replyId)).toBe(true);
+    expect(meshcoreTapbackEchoMatch(local, echo)).toBe(true);
+  });
+
+  it('matches composer-shaped optimistic row without emoji field', () => {
+    const composer = baseMsg({
+      replyId: 1_719_000_000_000,
+      payload: '👍',
+      timestamp: Date.now(),
+    });
+    const echo = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 1_719_000_000_000,
+      payload: '👍',
+      timestamp: composer.timestamp + 120_000,
+    });
+    expect(meshcoreTapbackEchoMatch(composer, echo)).toBe(true);
+    expect(findMeshcoreTapbackEchoDuplicate([composer], echo)).toBe(composer);
+  });
+
+  it('matches optimistic client time vs skewed device echo beyond 60s within 10 min', () => {
+    const local = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 42,
+      payload: '👍',
+      timestamp: 1_700_000_000_000,
+    });
+    const echo = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 42,
+      payload: '👍',
+      timestamp: local.timestamp - 120_000,
+      receivedVia: 'rf',
+    });
+    expect(meshcoreTapbackEchoMatch(local, echo)).toBe(true);
+    expect(local.timestamp - echo.timestamp).toBeGreaterThan(60_000);
+    expect(local.timestamp - echo.timestamp).toBeLessThanOrEqual(
+      MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS,
+    );
+  });
+});
+
+describe('meshcoreTapbackRfReplayMatch', () => {
+  it('matches duplicate RF hears of the same tapback', () => {
+    const first = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 99,
+      payload: '👍',
+      receivedVia: 'rf',
+      timestamp: 1_700_000_000_000,
+    });
+    const replay = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 99,
+      payload: '👍',
+      receivedVia: 'rf',
+      timestamp: first.timestamp + 60_000,
+    });
+    expect(meshcoreTapbackRfReplayMatch(first, replay)).toBe(true);
+    expect(findMeshcoreTapbackRfReplayDuplicate([first], replay)).toBe(first);
+  });
+
+  it('does not match RF replay across RF/MQTT paths', () => {
+    const rf = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 99,
+      payload: '👍',
+      receivedVia: 'rf',
+    });
+    const mqtt = baseMsg({
+      emoji: 0x1f44d,
+      replyId: 99,
+      payload: '👍',
+      receivedVia: 'mqtt',
+      timestamp: rf.timestamp + 500,
+    });
+    expect(meshcoreTapbackRfReplayMatch(rf, mqtt)).toBe(false);
+    expect(meshcoreCrossTransportMatch(rf, mqtt)).toBe(true);
   });
 });
 

--- a/src/renderer/hooks/meshcore/meshcoreHookPreamble.ts
+++ b/src/renderer/hooks/meshcore/meshcoreHookPreamble.ts
@@ -14,6 +14,8 @@ import {
 } from '../../lib/meshcore/meshcorePubKeyRegistry';
 import {
   meshcoreChatMessagesForDisplay,
+  meshcoreMessageMatchesReplyKey,
+  meshcorePayloadIsTapbackEmojiOnly,
   normalizeMeshcoreIncomingText,
 } from '../../lib/meshcoreChannelText';
 import {
@@ -34,6 +36,7 @@ import {
   effectiveMessageTimestampMs,
   mergeMeshcoreLastHeardFromAdvert,
 } from '../../lib/nodeStatus';
+import { normalizeReactionEmoji } from '../../lib/reactions';
 import {
   MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
   MESHCORE_CROSS_TRANSPORT_DEDUP_WINDOW_MS,
@@ -342,6 +345,38 @@ function meshcoreReceivedViaMerged(
   return existing;
 }
 
+function meshcoreIsTapbackShapedRow(msg: ChatMessage): boolean {
+  return (
+    (msg.emoji != null && msg.replyId != null) ||
+    (msg.replyId != null && meshcorePayloadIsTapbackEmojiOnly(msg.payload))
+  );
+}
+
+/** True when two tapback `replyId` values refer to the same parent (packetId / sec / ms). */
+export function meshcoreTapbackReplyIdsMatch(
+  a: number | undefined,
+  b: number | undefined,
+): boolean {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  if (a === b) return true;
+  const synthA = { packetId: a, timestamp: a } as ChatMessage;
+  const synthB = { packetId: b, timestamp: b } as ChatMessage;
+  return meshcoreMessageMatchesReplyKey(synthA, b) || meshcoreMessageMatchesReplyKey(synthB, a);
+}
+
+function meshcoreTapbackEmojiScalar(msg: ChatMessage): number | undefined {
+  if (msg.emoji != null) return msg.emoji;
+  return normalizeReactionEmoji(undefined, msg.payload.trim());
+}
+
+function meshcoreTapbackEmojisMatch(existing: ChatMessage, incoming: ChatMessage): boolean {
+  const existingScalar = meshcoreTapbackEmojiScalar(existing);
+  const incomingScalar = meshcoreTapbackEmojiScalar(incoming);
+  if (existingScalar == null || incomingScalar == null) return false;
+  return existingScalar === incomingScalar;
+}
+
 export function meshcoreCrossTransportMatch(
   existing: ChatMessage,
   incoming: ChatMessage,
@@ -351,11 +386,16 @@ export function meshcoreCrossTransportMatch(
   if (!meshcoreSenderMatchesForDedup(existing, incoming)) return false;
   if (existing.channel !== incoming.channel) return false;
   if ((existing.to ?? undefined) !== (incoming.to ?? undefined)) return false;
-  if ((existing.emoji ?? undefined) !== (incoming.emoji ?? undefined)) return false;
-  if ((existing.replyId ?? undefined) !== (incoming.replyId ?? undefined)) return false;
-  const existingBody = existing.meshcoreDedupeKey ?? existing.payload;
-  const incomingBody = incoming.meshcoreDedupeKey ?? incoming.payload;
-  if (existingBody !== incomingBody && existing.payload !== incoming.payload) return false;
+  if (meshcoreIsTapbackShapedRow(existing) || meshcoreIsTapbackShapedRow(incoming)) {
+    if (!meshcoreTapbackReplyIdsMatch(existing.replyId, incoming.replyId)) return false;
+    if (!meshcoreTapbackEmojisMatch(existing, incoming)) return false;
+  } else {
+    if ((existing.emoji ?? undefined) !== (incoming.emoji ?? undefined)) return false;
+    if ((existing.replyId ?? undefined) !== (incoming.replyId ?? undefined)) return false;
+    const existingBody = existing.meshcoreDedupeKey ?? existing.payload;
+    const incomingBody = incoming.meshcoreDedupeKey ?? incoming.payload;
+    if (existingBody !== incomingBody && existing.payload !== incoming.payload) return false;
+  }
   if (Math.abs(existing.timestamp - incoming.timestamp) > windowMs) return false;
   return true;
 }
@@ -455,7 +495,12 @@ function meshcoreRoomServerIdForDedup(msg: ChatMessage): number | undefined {
   return undefined;
 }
 
-/** Same room, author, and body within a clock-skew window (RF echo / dual ingress). */
+/**
+ * Same room, author, and body within a clock-skew window (RF echo / dual ingress).
+ * Separate from chat tapback echo and cross-transport dedup; when tuning skew windows,
+ * keep `MESHCORE_ROOM_POST_DEDUP_WINDOW_MS` aligned with chat tapback/optimistic constants
+ * where behavior should match (see `timeConstants.ts`).
+ */
 export function meshcoreRoomPostMatch(
   existing: ChatMessage,
   incoming: ChatMessage,
@@ -494,11 +539,13 @@ export function meshcoreTapbackEchoMatch(
   incoming: ChatMessage,
   windowMs: number = MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS,
 ): boolean {
-  if (existing.emoji == null || incoming.emoji == null) return false;
-  if ((existing.replyId ?? undefined) !== (incoming.replyId ?? undefined)) return false;
+  if (!meshcoreIsTapbackShapedRow(existing) && !meshcoreIsTapbackShapedRow(incoming)) {
+    return false;
+  }
+  if (!meshcoreTapbackReplyIdsMatch(existing.replyId, incoming.replyId)) return false;
   if (existing.channel !== incoming.channel) return false;
   if ((existing.to ?? undefined) !== (incoming.to ?? undefined)) return false;
-  if (existing.emoji !== incoming.emoji) return false;
+  if (!meshcoreTapbackEmojisMatch(existing, incoming)) return false;
   if (!meshcoreSenderMatchesForDedup(existing, incoming)) return false;
   if (Math.abs(existing.timestamp - incoming.timestamp) > windowMs) return false;
   return true;
@@ -513,6 +560,42 @@ export function findMeshcoreTapbackEchoDuplicate(
   for (let i = messages.length - 1; i >= start; i--) {
     const existing = messages[i];
     if (meshcoreTapbackEchoMatch(existing, incoming, windowMs)) {
+      return existing;
+    }
+  }
+  return undefined;
+}
+
+/** Same tapback heard again on RF (multi-hop / repeater re-hear), not RF/MQTT cross-path. */
+export function meshcoreTapbackRfReplayMatch(
+  existing: ChatMessage,
+  incoming: ChatMessage,
+  windowMs: number = MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
+): boolean {
+  if (!meshcoreIsTapbackShapedRow(existing) || !meshcoreIsTapbackShapedRow(incoming)) {
+    return false;
+  }
+  if (!meshcoreReceivedViaIncludesRf(existing.receivedVia)) return false;
+  if (incoming.receivedVia !== 'rf') return false;
+  if (meshcoreTransportsAreCross(existing, incoming)) return false;
+  if (!meshcoreSenderMatchesForDedup(existing, incoming)) return false;
+  if (existing.channel !== incoming.channel) return false;
+  if ((existing.to ?? undefined) !== (incoming.to ?? undefined)) return false;
+  if (!meshcoreTapbackReplyIdsMatch(existing.replyId, incoming.replyId)) return false;
+  if (!meshcoreTapbackEmojisMatch(existing, incoming)) return false;
+  if (Math.abs(existing.timestamp - incoming.timestamp) > windowMs) return false;
+  return true;
+}
+
+export function findMeshcoreTapbackRfReplayDuplicate(
+  messages: readonly ChatMessage[],
+  incoming: ChatMessage,
+  windowMs: number = MESHCORE_CHANNEL_RF_DEDUP_WINDOW_MS,
+): ChatMessage | undefined {
+  const start = Math.max(0, messages.length - MESHCORE_CROSS_TRANSPORT_SCAN_LIMIT);
+  for (let i = messages.length - 1; i >= start; i--) {
+    const existing = messages[i];
+    if (meshcoreTapbackRfReplayMatch(existing, incoming, windowMs)) {
       return existing;
     }
   }

--- a/src/renderer/lib/ingest/meshcoreIngest.ts
+++ b/src/renderer/lib/ingest/meshcoreIngest.ts
@@ -180,6 +180,8 @@ function handleTextMessage(
   const roomServerId = resolveRoomServerIdForIngest(identityId, event.payload);
   const isRoomEvent = looksLikeRoom && roomServerId !== 0;
 
+  // Room BBS branch: SignedPlain strip + plain store — not `parseMeshcoreChannelIncomingFromThread`.
+  // See `meshcoreRoomMessageRouting.ts` for wire vs chat and protocol-alignment notes.
   if (isRoomEvent) {
     const prefixMap = buildPrefixToNodeIdMap(identityId);
     const { authorId, payload } = meshcoreRoomPostBodyFromWire(

--- a/src/renderer/lib/meshcoreChannelText.ts
+++ b/src/renderer/lib/meshcoreChannelText.ts
@@ -1238,6 +1238,12 @@ export function buildMeshcoreDmIncomingMessage(
   return { ...base, payload: rawText };
 }
 
+/**
+ * Room BBS txtTypes (SendTxtMsg). Chat channel/DM text uses the bracket/reply helpers above;
+ * room posts use PLAIN outbound + SignedPlain inbound — see module comment in
+ * `meshcoreRoomMessageRouting.ts`. Keep new room wire features in sync with chat only when
+ * firmware and official clients share the same format.
+ */
 /** meshcore.js `TxtTypes.Plain` — outbound room BBS posts (companion SendTxtMsg). */
 export const MESHCORE_TXT_TYPE_PLAIN = 0;
 
@@ -1285,6 +1291,7 @@ export interface BuildMeshcoreRoomIncomingOpts {
   rxHops?: number;
 }
 
+/** Build a room BBS row after author-prefix strip. Payload is stored verbatim (no bracket reply parse). */
 export function buildMeshcoreRoomIncomingMessage(opts: BuildMeshcoreRoomIncomingOpts): ChatMessage {
   const rawText = sanitizeMeshcoreChatWireText(opts.rawText);
   const rxFields =

--- a/src/renderer/lib/meshcoreRoomMessageRouting.ts
+++ b/src/renderer/lib/meshcoreRoomMessageRouting.ts
@@ -1,3 +1,23 @@
+/**
+ * Room BBS wire routing (RF-only SendTxtMsg path).
+ *
+ * **Wire vs Chat:** Channel/DM chat uses companion text with optional `Sender:` prefix,
+ * keyless `@[Name]` replies/tapbacks, and (App toggle) MeshCore Open keyed/`r:`/`g:` wire
+ * — see `meshcoreChannelText.ts` + `meshcoreOpenReaction.ts`. Room BBS is a separate stack:
+ * outbound `TXT_TYPE_PLAIN` (raw UTF-8, optional mesh-client `[i/N]` chunks); inbound user
+ * posts are `SignedPlain` (4-byte author pubkey prefix + body, stripped here). System/bot
+ * lines may arrive as Plain without a strip. Room posts do not carry `replyId` / tapback
+ * metadata; ingest does not run bracket parent lookup or `meshcorePromoteEmojiOnlyReplyToTapback`.
+ *
+ * **Protocol alignment:** Prefer keeping room and chat behavior consistent where the room-server
+ * firmware allows it (dedup skew windows, timestamp clamping, display sanitization). Do not
+ * paste chat-only wire (`@[Name#key]`, `r:HASH:INDEX`) into room outbound send unless the
+ * official room protocol documents the same shape — other clients would show raw text. Inbound
+ * `g:` / `@[…]` in room bodies may still render via `ChatPayloadText` (display-only).
+ *
+ * **Dedup:** Room duplicates use `meshcoreRoomPostMatch` (not tapback echo or cross-transport
+ * channel dedup). MQTT does not carry room traffic.
+ */
 import { MESHCORE_ROOM_MESSAGE_CHANNEL } from '@/renderer/hooks/meshcore/meshcoreHookPreamble';
 
 import {

--- a/src/renderer/lib/meshcoreRoomPostRpc.ts
+++ b/src/renderer/lib/meshcoreRoomPostRpc.ts
@@ -68,6 +68,10 @@ export interface MeshcoreRoomPostSentResult {
  * Send a plain-text room BBS post via SendTxtMsg + SENT wait.
  * Companion firmware accepts TXT_TYPE_PLAIN (0) only for outbound SendTxtMsg; SignedPlain is
  * for room-server pushes inbound. Avoids meshcore.js `sendTextMessage` bare reject() on Err.
+ *
+ * Intentionally not routed through chat reply/tapback helpers (`buildMeshcoreOutboundSendText`,
+ * Open wire toggle): room outbound is raw post body only. When extending Rooms (replies,
+ * reactions), align UX with Chat but confirm room-server wire before reusing chat prefixes.
  */
 export function runMeshcoreRoomPostSend(
   conn: MeshcoreRoomPostRpcConnection,

--- a/src/renderer/lib/meshcoreStoreDedup.test.ts
+++ b/src/renderer/lib/meshcoreStoreDedup.test.ts
@@ -402,4 +402,67 @@ describe('meshcoreStoreDedup', () => {
     expect(row?.replyTo).toBe('99');
     expect(window.electronAPI.db.saveMeshcoreMessage).toHaveBeenCalled();
   });
+
+  it('merges optimistic sendReaction row with skewed RF echo into one entry', () => {
+    const parentReplyId = 1_719_000_000_000;
+    const optimisticTs = 1_780_240_708_234;
+    const deviceTs = 1_780_240_600_000;
+    const optimistic: ChatMessage = {
+      sender_id: 100,
+      sender_name: 'Me',
+      payload: '👍',
+      channel: 25,
+      timestamp: optimisticTs,
+      status: 'acked',
+      emoji: 0x1f44d,
+      replyId: parentReplyId,
+    };
+    upsertMeshcoreMessageWithDedup(ID, optimistic);
+
+    const rfEcho: ChatMessage = {
+      sender_id: 100,
+      sender_name: 'Me',
+      payload: '👍',
+      channel: 25,
+      timestamp: deviceTs,
+      status: 'acked',
+      emoji: 0x1f44d,
+      replyId: parentReplyId,
+      receivedVia: 'rf',
+      meshcoreDedupeKey: 'Me: @[durk] 👍',
+    };
+    const result = upsertMeshcoreMessageWithDedup(ID, rfEcho);
+    expect(result.inserted).toBe(false);
+
+    const rows = Object.values(useMessageStore.getState().messages[ID] ?? {});
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.tapback).toBe(true);
+    expect(rows[0]?.replyTo).toBe(String(parentReplyId));
+    expect(rows[0]?.payload).toBe('👍');
+  });
+
+  it('merges duplicate RF tapback replays into one entry', () => {
+    const tapback: ChatMessage = {
+      sender_id: 100,
+      sender_name: 'Me',
+      payload: '👍',
+      channel: 0,
+      timestamp: 1_700_000_000_000,
+      status: 'acked',
+      emoji: 0x1f44d,
+      replyId: 42,
+      receivedVia: 'rf',
+    };
+    upsertMeshcoreMessageWithDedup(ID, tapback);
+
+    const replay: ChatMessage = {
+      ...tapback,
+      timestamp: tapback.timestamp + 45_000,
+    };
+    const result = upsertMeshcoreMessageWithDedup(ID, replay);
+    expect(result.inserted).toBe(false);
+
+    const rows = Object.values(useMessageStore.getState().messages[ID] ?? {});
+    expect(rows).toHaveLength(1);
+  });
 });

--- a/src/renderer/lib/meshcoreStoreDedup.ts
+++ b/src/renderer/lib/meshcoreStoreDedup.ts
@@ -4,6 +4,7 @@ import {
   findMeshcoreDmRfDuplicate,
   findMeshcoreRoomPostDuplicate,
   findMeshcoreTapbackEchoDuplicate,
+  findMeshcoreTapbackRfReplayDuplicate,
   MESHCORE_ROOM_MESSAGE_CHANNEL,
   meshcoreMessageDedupeKey,
   messageToDbRow,
@@ -351,6 +352,30 @@ export function upsertMeshcoreMessageWithDedup(
     const canonicalId =
       preferredId ??
       findStoreRecordIdForMessage(identityId, tapbackDup) ??
+      meshcoreMessageStoreId(merged);
+    const record = chatMessageToMessageRecord(merged);
+    record.id = canonicalId;
+    upsertMessage(identityId, record);
+    persistMeshcoreDedupeIndex(identityId, merged, canonicalId);
+    const altId = meshcoreMessageStoreId(msg);
+    if (altId !== canonicalId) {
+      deleteMessage(identityId, altId);
+      removeMeshcoreDedupeIndexForMessage(identityId, msg);
+    }
+    return { inserted: false, storeUpdated: true, message: merged, canonicalId };
+  }
+
+  const tapbackRfDup = findMeshcoreTapbackRfReplayDuplicate(storeMessages, msg);
+  if (tapbackRfDup) {
+    const merged: ChatMessage = {
+      ...tapbackRfDup,
+      receivedVia: mergeMeshcoreReceivedVia(tapbackRfDup.receivedVia, msg.receivedVia),
+      rxHops: tapbackRfDup.rxHops ?? msg.rxHops,
+      meshcoreDedupeKey: msg.meshcoreDedupeKey ?? tapbackRfDup.meshcoreDedupeKey,
+    };
+    const canonicalId =
+      preferredId ??
+      findStoreRecordIdForMessage(identityId, tapbackRfDup) ??
       meshcoreMessageStoreId(merged);
     const record = chatMessageToMessageRecord(merged);
     record.id = canonicalId;

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -103,8 +103,11 @@ export const MESHTASTIC_TAPBACK_OPTIMISTIC_DEDUP_WINDOW_MS = 10 * MS_PER_MINUTE;
 /** Room post dedup window: optimistic client timestamp vs firmware echo / replay overlap. */
 export const MESHCORE_ROOM_POST_DEDUP_WINDOW_MS = MS_PER_MINUTE;
 
-/** Outbound tapback vs RF/MQTT echo of `@[Name] emoji`. */
-export const MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS = MS_PER_MINUTE;
+/**
+ * Outbound tapback vs RF/MQTT echo of `@[Name] emoji`.
+ * Wider than room post dedup (1 min) because client Date.now vs radio rxTime can skew several minutes.
+ */
+export const MESHCORE_TAPBACK_ECHO_DEDUP_WINDOW_MS = 10 * MS_PER_MINUTE;
 
 /** Room login attempts before giving up (matches MeshMonitor loginToRoom). */
 export const MESHCORE_ROOM_LOGIN_MAX_ATTEMPTS = 2;

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -4996,13 +4996,6 @@ export function useMeshcoreRuntime() {
 
       const publishTapback = (tapbackMsg: ChatMessage) => {
         addMessage(tapbackMsg);
-        void window.electronAPI.db
-          .saveMeshcoreMessage(messageToDbRow(tapbackMsg))
-          .catch((e: unknown) => {
-            console.warn(
-              '[useMeshcoreRuntime] saveMeshcoreMessage (tapback) error ' + errLikeToLogString(e),
-            );
-          });
       };
 
       if (reactedTo?.to != null) {


### PR DESCRIPTION
## Summary

- **Fix tapback doubling (#494):** Widen tapback echo dedup to 10 min; match `replyId` across sec/ms and composer-shaped optimistic rows; add RF tapback replay dedup in the store upsert path.
- **Chat UX:** Route emoji-only composer replies through `sendReaction` (same path as the user-validated workaround); dedupe reaction badges in the UI; remove redundant `saveMeshcoreMessage` on tapback publish.
- **Rooms scroll race:** Prevent Starred → Go to message from being clobbered by room-switch `scrollToEnd` (reset stale `triggerScrollToUnread`, defer suppress ref clear, guard layout scroll when `scrollToRowKey` is set).
- **Room protocol notes:** Document room BBS wire (PLAIN out / SignedPlain in) vs chat bracket/tapback/Open wire, and intent to keep behavior aligned where firmware allows.
- **CodeQL:** Use explicit `<= 0` timestamp/watermark guards in `messageTimestampSkew.ts` instead of falsy checks.
- **Docs:** Troubleshooting entry for MeshCore reply misquote root cause (unkeyed wire); AGENTS.md note for AI tooling to wait on long test runs.

Fixes #494

## Commits

1. `docs: explain MeshCore reply misquote cause (unkeyed wire format)`
2. `docs: update AGENTS.md for AI tooling to be patient with tests`
3. `fix: dedupe MeshCore tapback echoes and document room wire vs chat`
4. `fix: prevent room-switch scroll racing Go to message jump`
5. `fix: use explicit non-positive checks in messageTimestampSkew`

## Test plan

- [ ] MeshCore channel: Smile-button 👍 on a message → one reaction badge (not 2–3)
- [ ] MeshCore channel: Reply → composer emoji → Send 👍 → one badge (same `sendReaction` path)
- [ ] MeshCore channel with MQTT + RF: one badge; merged row shows `receivedVia: both` when applicable
- [ ] Parent message with firmware-seconds timestamp: react attaches to correct parent
- [ ] Rooms: Starred → Go to message on another room → scrolls to target post (no jump to bottom)
- [ ] Automated: `pnpm run test:run` (tapback dedup, store upsert, RoomsPanel scroll tests)