### PR TITLE
fix: timestamp guards and room login hop timeout constants

### DIFF
--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -23,6 +23,24 @@ export const MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_MS = 45_000;
 /** Post-SENT wait when the room server is direct on mesh (0 hops). LAN/TCP users often hit this path. */
 export const MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_DIRECT_MS = 15_000;
 
+/**
+ * Base post-SENT extra wait before hop scaling in `computeRoomLoginExtraTimeoutMs`.
+ * Matches outbound DM ACK timeout base in `useMeshcoreRuntime` (`3s base + per-hop increment`).
+ */
+export const MESHCORE_ROOM_LOGIN_HOP_BASE_MS = 3_000;
+
+/** Per-hop increment for post-SENT extra wait; each relay adds airtime and queueing on the path. */
+export const MESHCORE_ROOM_LOGIN_HOP_INCREMENT_MS = 2_500;
+
+/**
+ * Minimum LoginSuccess/LoginFail wait for 1+ hop paths in `computeRoomLoginResponseWaitMs`.
+ * Aligns with the RF extra-timeout floor; hop floor uses a larger per-hop increment below.
+ */
+export const MESHCORE_ROOM_LOGIN_RESPONSE_HOP_BASE_MS = MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_MS;
+
+/** Per-hop increment for LoginSuccess/LoginFail floor (response may re-traverse the mesh). */
+export const MESHCORE_ROOM_LOGIN_RESPONSE_HOP_INCREMENT_MS = 20_000;
+
 /** Max wait for `RESP_SENT` after SendLogin before rejecting (companion never acked the command). */
 export const MESHCORE_ROOM_LOGIN_SENT_WAIT_MS = MESHCORE_TRACE_SENT_WAIT_TIMEOUT_MS;
 
@@ -41,13 +59,12 @@ export function computeRoomLoginExtraTimeoutMs(hopsAway?: number | null): number
   if (hops <= 0) {
     return MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_DIRECT_MS;
   }
-  const hopScaled = 3_000 + hops * 2_500;
+  const hopScaled = MESHCORE_ROOM_LOGIN_HOP_BASE_MS + hops * MESHCORE_ROOM_LOGIN_HOP_INCREMENT_MS;
   return Math.max(MESHCORE_ROOM_LOGIN_EXTRA_TIMEOUT_MS, hopScaled);
 }
 
-/** Hard cap for multi-hop room login response wait. Without this, `hopFloor` in
- * `computeRoomLoginResponseWaitMs` (`hops <= 0 ? 0 : 45_000 + hops * 20_000`) grows unbounded
- * and can exceed 6 minutes. */
+/** Hard cap for multi-hop room login response wait. Without this, the hop floor in
+ * `computeRoomLoginResponseWaitMs` grows unbounded and can exceed 6 minutes. */
 export const MESHCORE_ROOM_LOGIN_RESPONSE_WAIT_CAP_MS = 90_000;
 
 /**
@@ -62,7 +79,11 @@ export function computeRoomLoginResponseWaitMs(
   const extra = computeRoomLoginExtraTimeoutMs(hopsAway);
   const hops =
     hopsAway != null && Number.isFinite(hopsAway) ? Math.max(0, Math.trunc(hopsAway)) : 0;
-  const hopFloor = hops <= 0 ? 0 : 45_000 + hops * 20_000;
+  const hopFloor =
+    hops <= 0
+      ? 0
+      : MESHCORE_ROOM_LOGIN_RESPONSE_HOP_BASE_MS +
+        hops * MESHCORE_ROOM_LOGIN_RESPONSE_HOP_INCREMENT_MS;
   return Math.min(MESHCORE_ROOM_LOGIN_RESPONSE_WAIT_CAP_MS, Math.max(est + extra, hopFloor));
 }
 

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -270,6 +270,8 @@ import { getStoredMeshProtocol } from '../lib/storedMeshProtocol';
 import { messageRecordsToChatMessages, nodeRecordsToMeshNodeMap } from '../lib/storeRecordAdapters';
 import { delayUnlessSuspended } from '../lib/systemPowerState';
 import {
+  MESHCORE_ROOM_LOGIN_HOP_BASE_MS,
+  MESHCORE_ROOM_LOGIN_HOP_INCREMENT_MS,
   MESHCORE_ROOM_LOGIN_ROUTE_RESOLVE_MAX_MS,
   MESHCORE_ROOM_LOGIN_TOTAL_TIMEOUT_MS,
   MESHCORE_ROOM_SYNC_MIN_MESH_TX_SPACING_MS,
@@ -2459,7 +2461,8 @@ export function useMeshcoreRuntime() {
         // Calculate dynamic timeout based on hop count for multi-hop paths
         const destNode = nodesRef.current.get(destNodeId);
         const hopsAway = destNode?.hops_away ?? 0;
-        const hopBasedTimeoutMs = 3000 + hopsAway * 2500; // 3s base + 2.5s per hop
+        const hopBasedTimeoutMs =
+          MESHCORE_ROOM_LOGIN_HOP_BASE_MS + hopsAway * MESHCORE_ROOM_LOGIN_HOP_INCREMENT_MS;
 
         try {
           const result = await connRef.current.sendTextMessage(pubKey, textToSend);

--- a/src/shared/messageTimestampSkew.ts
+++ b/src/shared/messageTimestampSkew.ts
@@ -7,7 +7,7 @@ export function isUnreasonablyFutureMessageTimestampMs(
   nowMs = Date.now(),
   maxFutureSkewSec = MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC,
 ): boolean {
-  if (!timestampMs || !Number.isFinite(timestampMs)) return false;
+  if (timestampMs <= 0 || !Number.isFinite(timestampMs)) return false;
   return timestampMs > nowMs + maxFutureSkewSec * 1000;
 }
 
@@ -20,7 +20,7 @@ export function effectiveMessageTimestampMs(
   nowMs = Date.now(),
   maxFutureSkewSec = MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC,
 ): number {
-  if (!timestampMs || !Number.isFinite(timestampMs)) return nowMs;
+  if (timestampMs <= 0 || !Number.isFinite(timestampMs)) return nowMs;
   const maxFuture = nowMs + maxFutureSkewSec * 1000;
   if (timestampMs > maxFuture) return nowMs;
   return timestampMs;
@@ -32,8 +32,7 @@ export function clampReadWatermarkMs(
   nowMs = Date.now(),
   maxFutureSkewSec = MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC,
 ): number {
-  if (!watermarkMs || !Number.isFinite(watermarkMs)) return 0;
-  if (watermarkMs < 0) return 0;
+  if (watermarkMs <= 0 || !Number.isFinite(watermarkMs)) return 0;
   const maxAllowed = nowMs + maxFutureSkewSec * 1000;
   return Math.min(watermarkMs, maxAllowed);
 }


### PR DESCRIPTION
## Summary

Follow-up to #569, which merged before the final commits landed on `sunday`.

- **messageTimestampSkew:** Replace falsy `!timestampMs` / `!watermarkMs` guards with explicit `<= 0` checks; remove redundant negative watermark branch.
- **timeConstants:** Extract hop-scaled room login timeout magic numbers into named constants with comments:
  - `MESHCORE_ROOM_LOGIN_HOP_BASE_MS` / `MESHCORE_ROOM_LOGIN_HOP_INCREMENT_MS` — post-SENT extra wait (`3s + 2.5s/hop`)
  - `MESHCORE_ROOM_LOGIN_RESPONSE_HOP_BASE_MS` / `MESHCORE_ROOM_LOGIN_RESPONSE_HOP_INCREMENT_MS` — LoginSuccess/LoginFail floor (`45s + 20s/hop`, capped at 90s)
- **useMeshcoreRuntime:** Reuse the same hop base/increment for outbound DM ACK timeout (was inline `3000 + hops * 2500`).

## Commits

1. `fix: use explicit non-positive checks in messageTimestampSkew`
2. `fix: document MeshCore room login hop timeout constants`

## Test plan

- [ ] Automated: `pnpm exec vitest run src/shared/messageTimestampSkew.test.ts src/renderer/lib/meshcoreRoomLoginRpc.test.ts`
- [ ] MeshCore room login on multi-hop path still completes within hop-scaled timeout