### PR TITLE
fix: document zero timestamp sentinel in messageTimestampSkew

### DIFF
--- a/src/shared/messageTimestampSkew.test.ts
+++ b/src/shared/messageTimestampSkew.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   clampMeshcoreMessageTimestampForStorage,
+  clampReadWatermarkMs,
   effectiveMessageTimestampMs,
   isUnreasonablyFutureMessageTimestampMs,
 } from './messageTimestampSkew';
@@ -23,5 +24,17 @@ describe('messageTimestampSkew', () => {
     const within = nowMs + 60_000;
     expect(effectiveMessageTimestampMs(within, nowMs)).toBe(within);
     expect(isUnreasonablyFutureMessageTimestampMs(within, nowMs)).toBe(false);
+  });
+
+  it('treats zero message timestamp as missing (not Unix epoch)', () => {
+    const nowMs = 1_700_000_000_000;
+    expect(effectiveMessageTimestampMs(0, nowMs)).toBe(nowMs);
+    expect(clampMeshcoreMessageTimestampForStorage(0, nowMs)).toBe(nowMs);
+    expect(isUnreasonablyFutureMessageTimestampMs(0, nowMs)).toBe(false);
+  });
+
+  it('treats zero watermark as no last-read marker', () => {
+    const nowMs = 1_700_000_000_000;
+    expect(clampReadWatermarkMs(0, nowMs)).toBe(0);
   });
 });

--- a/src/shared/messageTimestampSkew.ts
+++ b/src/shared/messageTimestampSkew.ts
@@ -7,6 +7,7 @@ export function isUnreasonablyFutureMessageTimestampMs(
   nowMs = Date.now(),
   maxFutureSkewSec = MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC,
 ): boolean {
+  // Zero/negative = missing wire timestamp, not Unix epoch (1970-01-01).
   if (timestampMs <= 0 || !Number.isFinite(timestampMs)) return false;
   return timestampMs > nowMs + maxFutureSkewSec * 1000;
 }
@@ -20,6 +21,7 @@ export function effectiveMessageTimestampMs(
   nowMs = Date.now(),
   maxFutureSkewSec = MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC,
 ): number {
+  // Zero/negative = missing wire timestamp; use receive time instead of Unix epoch.
   if (timestampMs <= 0 || !Number.isFinite(timestampMs)) return nowMs;
   const maxFuture = nowMs + maxFutureSkewSec * 1000;
   if (timestampMs > maxFuture) return nowMs;
@@ -32,6 +34,7 @@ export function clampReadWatermarkMs(
   nowMs = Date.now(),
   maxFutureSkewSec = MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC,
 ): number {
+  // Zero = no last-read watermark (never read), not Unix epoch.
   if (watermarkMs <= 0 || !Number.isFinite(watermarkMs)) return 0;
   const maxAllowed = nowMs + maxFutureSkewSec * 1000;
   return Math.min(watermarkMs, maxAllowed);


### PR DESCRIPTION
## Summary
- Validates CodeQL findings on `timestampMs <= 0` and `watermarkMs <= 0` in `messageTimestampSkew.ts`.
- Keeps `<= 0` guards intentionally: zero is a missing/invalid wire timestamp and a "never read" watermark sentinel, not Unix epoch.
- Adds inline comments documenting the business rules and unit tests that lock in zero-as-sentinel behavior.

## Test plan
- [x] `pnpm exec vitest run src/shared/messageTimestampSkew.test.ts`
- [x] Pre-commit hook (lint, typecheck, full test suite)