### PR TITLE
fix: stop keystrokes being sent as tapback reactions after emoji picker

### DIFF
--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -2483,6 +2483,90 @@ describe('ChatPanel tapback reaction picker', () => {
       expect(document.querySelector('emoji-picker')).not.toBeInTheDocument();
     },
   );
+
+  function reactionHiddenInput(): HTMLInputElement {
+    const input = document.querySelector<HTMLInputElement>(
+      'input[aria-hidden="true"][tabindex="-1"]',
+    );
+    expect(input).not.toBeNull();
+    return input!;
+  }
+
+  it.each(['darwin', 'win32'] as const)(
+    'calls onReact when native panel inserts emoji into hidden input (%s)',
+    async (platform) => {
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue(platform);
+      const onReact = vi.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(
+        <ToastProvider>
+          <ChatPanel
+            {...defaultProps}
+            onReact={onReact}
+            messages={[{ ...baseMessage, packetId: 42 }]}
+          />
+        </ToastProvider>,
+      );
+      await user.click(screen.getByTitle('React'));
+      const hidden = reactionHiddenInput();
+      hidden.value = '👍';
+      fireEvent.input(hidden);
+      await waitFor(() => {
+        expect(onReact).toHaveBeenCalledWith('👍', 42, 0);
+      });
+      expect(onReact).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('does not send plain keystrokes as reactions after emoji reaction on Windows', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('win32');
+    const onReact = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel
+          {...defaultProps}
+          onReact={onReact}
+          messages={[{ ...baseMessage, packetId: 42 }]}
+        />
+      </ToastProvider>,
+    );
+    await user.click(screen.getByTitle('React'));
+    const hidden = reactionHiddenInput();
+    hidden.value = '👍';
+    fireEvent.input(hidden);
+    await waitFor(() => {
+      expect(onReact).toHaveBeenCalledWith('👍', 42, 0);
+    });
+    hidden.value = 'j';
+    fireEvent.input(hidden);
+    await waitFor(() => {
+      expect(onReact).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not send keystrokes as reactions after dismissing native panel without selection', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('win32');
+    const onReact = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel
+          {...defaultProps}
+          onReact={onReact}
+          messages={[{ ...baseMessage, packetId: 42 }]}
+        />
+      </ToastProvider>,
+    );
+    await user.click(screen.getByTitle('React'));
+    const hidden = reactionHiddenInput();
+    fireEvent.blur(hidden);
+    hidden.value = 'a';
+    fireEvent.input(hidden);
+    await waitFor(() => {
+      expect(onReact).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('ChatPanel RF hop label', () => {

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -99,7 +99,12 @@ import {
   isUnreasonablyFutureMessageTimestampMs,
 } from '../lib/nodeStatus';
 import { parseStoredJson } from '../lib/parseStoredJson';
-import { emojiDisplayLabel, reactionDisplayGlyph, reactionGlyphFromPicker } from '../lib/reactions';
+import {
+  emojiDisplayLabel,
+  isReactionPickerEmojiGlyph,
+  reactionDisplayGlyph,
+  reactionGlyphFromPicker,
+} from '../lib/reactions';
 import { findMeshtasticParentMessageForReply, truncateReplyPreviewText } from '../lib/replyPreview';
 import { CHAT_COMPACT_CONTINUATION_TIME_GAP_MS } from '../lib/timeConstants';
 import type { ChatMessage, MeshNode, MeshProtocol } from '../lib/types';
@@ -460,7 +465,18 @@ function ChatPanel({
   const handleReactRef = useRef<
     ((glyph: string, packetId: number, msgChannel: number) => Promise<void>) | null
   >(null);
+  const clearReactionCaptureRef = useRef<() => void>(() => {});
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const clearReactionCapture = useCallback(() => {
+    reactionPickerTarget.current = null;
+    const el = reactionHiddenInputRef.current;
+    if (el) {
+      el.value = '';
+      el.blur();
+    }
+  }, []);
+  clearReactionCaptureRef.current = clearReactionCapture;
 
   // Feature: sender filter
   const [filterSender, setFilterSender] = useState<number | null>(null);
@@ -1127,6 +1143,7 @@ function ChatPanel({
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         setPickerOpenFor(null);
+        clearReactionCaptureRef.current();
         if (replyTo) {
           setReplyTo(null);
         } else if (filterSender != null) {
@@ -1173,6 +1190,7 @@ function ChatPanel({
   const handleReact = async (glyph: string, packetId: number, msgChannel: number) => {
     // Match handleSend: UI uses channel -1 as "primary"; MeshCore/Meshtastic send expects 0.
     const sendChannel = msgChannel === -1 ? 0 : msgChannel;
+    clearReactionCapture();
     setPickerOpenFor(null);
     setChatActionError(null);
     try {
@@ -1342,13 +1360,18 @@ function ChatPanel({
       if (!unicode) return;
       const parsed = reactionGlyphFromPicker(unicode);
       const target = reactionPickerTarget.current;
-      if (parsed && target) {
+      if (parsed && target && isReactionPickerEmojiGlyph(parsed.glyph)) {
         void handleReactRef.current?.(parsed.glyph, target.id, target.channel);
       }
     };
+    const onBlur = () => {
+      clearReactionCaptureRef.current();
+    };
     el.addEventListener('input', handler);
+    el.addEventListener('blur', onBlur);
     return () => {
       el.removeEventListener('input', handler);
+      el.removeEventListener('blur', onBlur);
     };
   }, []);
 
@@ -2279,7 +2302,12 @@ function ChatPanel({
                                     const id = msg.packetId ?? msg.timestamp;
                                     reactionPickerTarget.current = { id, channel: msg.channel };
                                     if (chatPanelIsLinux()) {
-                                      setPickerOpenFor(showPicker ? null : id);
+                                      if (showPicker) {
+                                        clearReactionCapture();
+                                        setPickerOpenFor(null);
+                                      } else {
+                                        setPickerOpenFor(id);
+                                      }
                                     } else {
                                       void window.electronAPI.showEmojiPanel();
                                     }
@@ -2437,6 +2465,7 @@ function ChatPanel({
         aria-hidden="true"
         tabIndex={-1}
         readOnly={false}
+        onBlur={clearReactionCapture}
         style={{ position: 'absolute', opacity: 0, width: 0, height: 0, pointerEvents: 'none' }}
       />
 

--- a/src/renderer/lib/reactions.test.ts
+++ b/src/renderer/lib/reactions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { MESHTASTIC_TAPBACK_DATA_EMOJI_FLAG } from '../../shared/reactionEmoji';
 import {
   firstGraphemeCluster,
+  isReactionPickerEmojiGlyph,
   normalizeReactionEmoji,
   reactionDisplayGlyph,
   reactionGlyphFromPicker,
@@ -56,6 +57,18 @@ describe('reactionDisplayGlyph', () => {
 
   it('falls back to scalar when payload is empty', () => {
     expect(reactionDisplayGlyph(0x1f44d, '')).toBe('👍');
+  });
+});
+
+describe('isReactionPickerEmojiGlyph', () => {
+  it('accepts emoji glyphs from the native panel', () => {
+    expect(isReactionPickerEmojiGlyph('👍')).toBe(true);
+    expect(isReactionPickerEmojiGlyph(US_FLAG)).toBe(true);
+  });
+
+  it('rejects plain ASCII letters', () => {
+    expect(isReactionPickerEmojiGlyph('j')).toBe(false);
+    expect(isReactionPickerEmojiGlyph('a')).toBe(false);
   });
 });
 

--- a/src/renderer/lib/reactions.ts
+++ b/src/renderer/lib/reactions.ts
@@ -136,6 +136,11 @@ export interface ReactionGlyphFromPicker {
   scalar: number;
 }
 
+/** True when `glyph` looks like an emoji from the native panel (not plain ASCII letters). */
+export function isReactionPickerEmojiGlyph(glyph: string): boolean {
+  return /\p{Extended_Pictographic}|\p{Regional_Indicator}/u.test(glyph);
+}
+
 /** Parse emoji-picker / native panel output into wire payload + storage scalar. */
 export function reactionGlyphFromPicker(unicode: string): ReactionGlyphFromPicker | undefined {
   const glyph = firstGraphemeCluster(unicode);

--- a/src/shared/messageTimestampSkew.test.ts
+++ b/src/shared/messageTimestampSkew.test.ts
@@ -6,13 +6,17 @@ import {
   isUnreasonablyFutureMessageTimestampMs,
   MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC,
 } from './messageTimestampSkew';
+import { MS_PER_YEAR } from './timeConstants';
+
+/** Well beyond MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC — simulates poisoned RTC skew. */
+const EIGHT_YEARS_MS = 8 * MS_PER_YEAR;
 
 describe('messageTimestampSkew', () => {
   it('clamps unreasonably future message timestamps to now', () => {
     const nowMs = 1_700_000_000_000;
     vi.useFakeTimers();
     vi.setSystemTime(nowMs);
-    const future = nowMs + 8 * 365 * 24 * 3600 * 1000;
+    const future = nowMs + EIGHT_YEARS_MS;
     expect(effectiveMessageTimestampMs(future, nowMs)).toBe(nowMs);
     expect(isUnreasonablyFutureMessageTimestampMs(future, nowMs)).toBe(true);
     vi.useRealTimers();
@@ -47,7 +51,7 @@ describe('messageTimestampSkew', () => {
   it('clamps watermark beyond max future skew to allowed maximum', () => {
     const nowMs = 1_700_000_000_000;
     const maxAllowed = nowMs + MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC * 1000;
-    const farFuture = nowMs + 8 * 365 * 24 * 3600 * 1000;
+    const farFuture = nowMs + EIGHT_YEARS_MS;
     expect(clampReadWatermarkMs(farFuture, nowMs)).toBe(maxAllowed);
   });
 

--- a/src/shared/messageTimestampSkew.ts
+++ b/src/shared/messageTimestampSkew.ts
@@ -1,4 +1,4 @@
-/** Max device clock lead we accept before treating chat timestamps as receive-time estimate. */
+/** Max device clock lead we accept before replacing chat timestamps with local receive time. */
 export const MESSAGE_TIMESTAMP_MAX_FUTURE_SKEW_SEC = 300; // 5 min
 
 /** True when raw device timestamp is unreasonably far in the future (RTC skew / poison). */
@@ -14,7 +14,7 @@ export function isUnreasonablyFutureMessageTimestampMs(
 
 /**
  * Effective chat message timestamp in ms; caps device RTC skew beyond `maxFutureSkewSec`.
- * Timestamps unreasonably far in the future clamp to `nowMs` (receive-time estimate).
+ * Missing or future-skewed timestamps are replaced with `nowMs` (local receive time).
  */
 export function effectiveMessageTimestampMs(
   timestampMs: number,

--- a/src/shared/timeConstants.ts
+++ b/src/shared/timeConstants.ts
@@ -3,3 +3,4 @@ export const MS_PER_SECOND = 1_000;
 export const MS_PER_MINUTE = 60_000;
 export const MS_PER_HOUR = 3_600_000;
 export const MS_PER_DAY = 86_400_000;
+export const MS_PER_YEAR = 365 * MS_PER_DAY;


### PR DESCRIPTION
## Summary

- **Tapback reaction capture:** After closing the OS emoji panel on macOS/Windows, the hidden reaction input kept focus and `reactionPickerTarget` stayed set, so typing in chat sent individual letters (e.g. "joey" → `j`, `o`, `e`) as reactions. Adds `clearReactionCapture()` on react, dismiss, Escape, blur, and Linux picker close, and guards hidden-input handling with `isReactionPickerEmojiGlyph` so only real emoji glyphs are sent.
- **messageTimestampSkew cleanup:** Adds `MS_PER_YEAR` to shared `timeConstants`, replaces duplicated 8-year magic numbers in tests, and clarifies JSDoc to describe local receive-time replacement (matches clamp-to-`nowMs` behavior).

## Test plan

- [ ] On Windows/macOS, open tapback reaction picker on a message, pick an emoji — reaction sends once.
- [ ] Close picker without selecting, then type in chat — no stray reactions.
- [ ] After sending a reaction, type in chat — keystrokes do not become reactions.
- [ ] `pnpm run test:run` — `ChatPanel` tapback tests and `reactions.test.ts` pass.