### PR TITLE
fix: MeshCore USB serial init, reaction capture, and axe contrast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,8 +92,10 @@ Adding a cross-boundary feature:
 
 - **Dev:** `@axe-core/react` runs in `pnpm run dev` (`src/renderer/main.tsx`); treat `serious` axe console output as a bug.
 - **CI:** Use `vitest-axe` (`import { axe } from 'vitest-axe'`); assert `toHaveNoViolations()` on the rendered subtree.
+- **Do not mock `themeColors` in component axe tests** — call `hydrateAxeThemeColors()` from `src/renderer/lib/a11yTestHelpers.ts` so color-contrast runs against real hex values (jsdom does not load Tailwind CSS).
 - **When to add tests:** New or changed UI with custom foreground/background pairs (badges, pills, buttons)—especially `text-[10px]` / `text-xs` on saturated fills.
 - **Theme tokens:** `readable-green` is for white-on-green fills; the default must pass **4.5:1** contrast with white (enforced in `src/renderer/lib/themeColors.test.ts`).
+- **`animate-pulse`:** Never on the same element as small text with strict contrast fills. Use a separate `aria-hidden` decorative pulse layer; the text-bearing element stays fully opaque (see `ProtocolUnreadBadge.tsx`). Connection-status header pulses remain the documented exception.
 - **Badge patterns:** Sidebar/Chat unread badges use `bg-red-600 text-white`; protocol-switcher badges use brand colors (`bg-readable-green`, `bg-cyan-600`)—add axe coverage when touching either.
 - **Manual:** See [`docs/accessibility-checklist.md`](docs/accessibility-checklist.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@ This file is self-contained. ARCHITECTURE.md and CONTRIBUTING.md are human refer
 - **Stateful/I/O code:** Preserve integrity on failure; document failure point, fallback, and logging where it matters.
 - **Pre-commit patience:** This repo has a very long pre-commit hook chain (lint, typecheck, thousands of tests, audit, actionlint, yamllint, many check:\* scripts). Commits can take 2+ minutes. Be patient and let them finish — do not interrupt or force-skip hooks.
 
+### Platform parity
+
+- **Default:** behavioral fixes and UI lifecycle changes apply to **linux, darwin, and win32** unless there is a documented, justified OS-specific exception.
+- A reporter platform (e.g. Windows) does **not** by itself narrow scope — reproduce or reason about other platforms before splitting code paths.
+- **When branching on `getPlatform()` / `process.platform`:** prefer shared state machines and teardown helpers; branch only at the boundary where the OS API differs (e.g. `showEmojiPanel()` vs inline `<emoji-picker>`).
+- **Document exceptions inline** with a short comment (`// OS-specific: …`) and, for non-obvious splits, a note in the PR body.
+- **Tests:** cover all three platforms when behavior is shared (`it.each(['linux', 'darwin', 'win32'])`); use platform-specific cases only when the mechanism under test exists on that OS.
+
 ## 2. Architecture & Domain
 
 Electron: `src/main/` (Node, SQLite, BLE, MQTT), `src/preload/` (bridge), `src/renderer/` (React 19, Vite, Zustand). **Dual-protocol:** meshtastic and meshcore; gate UI with `ProtocolCapabilities` and `useRadioProvider(protocol)` (do not compare `protocol === 'meshcore'`). Routing/diagnostics changes must stay compatible with the Diagnostics panel (Hop Goblins, Hidden Terminals, etc.). **pnpm** only for package commands. **Never** add cryptocurrency tech or dependencies.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "builder-util-runtime": "9.7.0",
     "electron-updater": "^6.8.9",
     "emoji-picker-element": "^1.29.1",
-    "i18next": "^26.3.1",
+    "i18next": "^26.3.2",
     "jszip": "^3.10.1",
     "leaflet.markercluster": "^1.5.3",
     "lucide-react-motion": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^1.29.1
         version: 1.29.1
       i18next:
-        specifier: ^26.3.1
-        version: 26.3.1(typescript@6.0.3)
+        specifier: ^26.3.2
+        version: 26.3.2(typescript@6.0.3)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -89,7 +89,7 @@ importers:
         version: 1.4.0
       react-i18next:
         specifier: ^17.0.8
-        version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 17.0.8(i18next@26.3.2(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       react-leaflet-cluster:
         specifier: ^4.1.3
         version: 4.1.3(@react-leaflet/core@3.0.0(leaflet@1.9.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(leaflet@1.9.4)(react-dom@19.2.7(react@19.2.7))(react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -2551,8 +2551,8 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  i18next@26.3.1:
-    resolution: {integrity: sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==}
+  i18next@26.3.2:
+    resolution: {integrity: sha512-QQkXAM1sPDHqhxMQuBeHVMUn6mJchF+wdpOoQerciLAFqO3ZYdxO0EUbeEhruyutnNwpUQIITDVzLjwnNL0T1w==}
     peerDependencies:
       typescript: ^5 || ^6
     peerDependenciesMeta:
@@ -3332,8 +3332,8 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.48:
-    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
+  node-releases@2.0.49:
+    resolution: {integrity: sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==}
     engines: {node: '>=18'}
 
   nopt@7.2.1:
@@ -5983,7 +5983,7 @@ snapshots:
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
       electron-to-chromium: 1.5.378
-      node-releases: 2.0.48
+      node-releases: 2.0.49
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer-from@1.1.2: {}
@@ -7104,7 +7104,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  i18next@26.3.1(typescript@6.0.3):
+  i18next@26.3.2(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 
@@ -7960,7 +7960,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.48: {}
+  node-releases@2.0.49: {}
 
   nopt@7.2.1:
     dependencies:
@@ -8225,11 +8225,11 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
-  react-i18next@17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+  react-i18next@17.0.8(i18next@26.3.2(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.7
       html-parse-stringify: 3.0.1
-      i18next: 26.3.1(typescript@6.0.3)
+      i18next: 26.3.2(typescript@6.0.3)
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:

--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe, configureAxe } from 'vitest-axe';
 
 import App from './App';
+import { getProtocolUnreadBadgeLabel, hydrateAxeThemeColors } from './lib/a11yTestHelpers';
 import {
   ensureOfflineProtocolIdentities,
   OFFLINE_MESHCORE_IDENTITY_ID,
@@ -342,11 +343,6 @@ vi.mock('./lazyModals', () => ({
   },
 }));
 
-vi.mock('./lib/themeColors', () => ({
-  applyThemeColors: vi.fn(),
-  loadThemeColors: vi.fn().mockResolvedValue({}),
-}));
-
 vi.mock('./lib/appSettingsStorage', () => ({
   getAppSettingsRaw: vi.fn().mockReturnValue({}),
 }));
@@ -533,12 +529,16 @@ describe('App accessibility', () => {
     getStoredMeshProtocolMock.mockReturnValue('meshtastic');
     render(<App />);
     const meshcoreSwitcher = screen.getByRole('button', { name: 'Switch to MeshCore' });
-    const badge = await waitFor(() => {
-      const el = meshcoreSwitcher.querySelector('span.rounded-full');
-      if (!el?.textContent) throw new Error('badge not ready');
-      return el;
+    const badgeWrapper = await waitFor(() => {
+      const label = meshcoreSwitcher.querySelector('[data-protocol-unread-label]');
+      if (!label?.textContent) throw new Error('badge not ready');
+      return label.parentElement!;
     });
-    expect(await axe(badge)).toHaveNoViolations();
+    const label = getProtocolUnreadBadgeLabel(badgeWrapper);
+    expect(label.className).not.toContain('animate-pulse');
+    expect(badgeWrapper.querySelector('[aria-hidden="true"].animate-pulse')).toBeTruthy();
+    hydrateAxeThemeColors(label);
+    expect(await axe(label)).toHaveNoViolations();
   });
 
   it('has no axe violations on Meshtastic protocol switcher unread badge', async () => {
@@ -566,12 +566,16 @@ describe('App accessibility', () => {
     getStoredMeshProtocolMock.mockReturnValue('meshcore');
     render(<App />);
     const meshtasticSwitcher = screen.getByRole('button', { name: 'Switch to Meshtastic' });
-    const badge = await waitFor(() => {
-      const el = meshtasticSwitcher.querySelector('span.rounded-full');
-      if (el?.textContent !== '86') throw new Error('badge not ready');
-      return el;
+    const badgeWrapper = await waitFor(() => {
+      const label = meshtasticSwitcher.querySelector('[data-protocol-unread-label]');
+      if (label?.textContent !== '86') throw new Error('badge not ready');
+      return label.parentElement!;
     });
-    expect(await axe(badge)).toHaveNoViolations();
+    const label = getProtocolUnreadBadgeLabel(badgeWrapper);
+    expect(label.className).not.toContain('animate-pulse');
+    expect(badgeWrapper.querySelector('[aria-hidden="true"].animate-pulse')).toBeTruthy();
+    hydrateAxeThemeColors(label);
+    expect(await axe(label)).toHaveNoViolations();
   });
 
   it('has no page landmark axe violations', async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -54,6 +54,7 @@ import ConfigureNodeSelector from './components/ConfigureNodeSelector';
 import ErrorBoundary from './components/ErrorBoundary';
 import { HelpTooltip } from './components/HelpTooltip';
 import LanguageSelector from './components/LanguageSelector';
+import { ProtocolUnreadBadge } from './components/ProtocolUnreadBadge';
 import RemoteAdminErrorNotifier from './components/RemoteAdminErrorNotifier';
 import Sidebar from './components/Sidebar';
 import { LinkIcon } from './components/SignalBars';
@@ -2032,9 +2033,10 @@ function AppContent({
                 >
                   Meshtastic
                   {meshtasticChatUnread > 0 && protocol !== 'meshtastic' && (
-                    <span className="bg-readable-green ml-1.5 inline-flex h-4 min-w-[1.1rem] animate-pulse items-center justify-center rounded-full px-0.5 text-[10px] font-bold text-white">
-                      {meshtasticChatUnread > 99 ? '99+' : meshtasticChatUnread}
-                    </span>
+                    <ProtocolUnreadBadge
+                      count={meshtasticChatUnread}
+                      fillClass="bg-readable-green"
+                    />
                   )}
                 </button>
                 <div className="h-4 w-px bg-gray-600" aria-hidden="true" />
@@ -2053,9 +2055,7 @@ function AppContent({
                 >
                   MeshCore
                   {meshcoreChatUnread > 0 && protocol !== 'meshcore' && (
-                    <span className="ml-1.5 inline-flex h-4 min-w-[1.1rem] animate-pulse items-center justify-center rounded-full bg-cyan-600 px-0.5 text-[10px] font-bold text-white">
-                      {meshcoreChatUnread > 99 ? '99+' : meshcoreChatUnread}
-                    </span>
+                    <ProtocolUnreadBadge count={meshcoreChatUnread} fillClass="bg-cyan-600" />
                   )}
                 </button>
               </div>

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -2492,6 +2492,27 @@ describe('ChatPanel tapback reaction picker', () => {
     return input!;
   }
 
+  function composeTextarea(): HTMLTextAreaElement {
+    return screen.getByPlaceholderText('Enter message here');
+  }
+
+  it.each(['linux', 'darwin', 'win32'] as const)(
+    'clears replyTo when React is clicked (%s)',
+    async (platform) => {
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue(platform);
+      const user = userEvent.setup();
+      render(
+        <ToastProvider>
+          <ChatPanel {...defaultProps} />
+        </ToastProvider>,
+      );
+      await user.click(screen.getByTitle('Reply'));
+      expect(screen.getByText(/Replying to/)).toBeInTheDocument();
+      await user.click(screen.getByTitle('React'));
+      expect(screen.queryByText(/Replying to/)).not.toBeInTheDocument();
+    },
+  );
+
   it.each(['darwin', 'win32'] as const)(
     'calls onReact when native panel inserts emoji into hidden input (%s)',
     async (platform) => {
@@ -2518,32 +2539,114 @@ describe('ChatPanel tapback reaction picker', () => {
     },
   );
 
-  it('does not send plain keystrokes as reactions after emoji reaction on Windows', async () => {
-    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('win32');
-    const onReact = vi.fn().mockResolvedValue(undefined);
-    const user = userEvent.setup();
-    render(
-      <ToastProvider>
-        <ChatPanel
-          {...defaultProps}
-          onReact={onReact}
-          messages={[{ ...baseMessage, packetId: 42 }]}
-        />
-      </ToastProvider>,
-    );
-    await user.click(screen.getByTitle('React'));
-    const hidden = reactionHiddenInput();
-    hidden.value = '👍';
-    fireEvent.input(hidden);
-    await waitFor(() => {
-      expect(onReact).toHaveBeenCalledWith('👍', 42, 0);
-    });
-    hidden.value = 'j';
-    fireEvent.input(hidden);
-    await waitFor(() => {
-      expect(onReact).toHaveBeenCalledTimes(1);
-    });
-  });
+  it.each(['darwin', 'win32'] as const)(
+    'refocuses composer after native emoji reaction (%s)',
+    async (platform) => {
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue(platform);
+      const onReact = vi.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(
+        <ToastProvider>
+          <ChatPanel
+            {...defaultProps}
+            onReact={onReact}
+            messages={[{ ...baseMessage, packetId: 42 }]}
+          />
+        </ToastProvider>,
+      );
+      await user.click(screen.getByTitle('React'));
+      const hidden = reactionHiddenInput();
+      hidden.value = '👍';
+      fireEvent.input(hidden);
+      await waitFor(() => {
+        expect(onReact).toHaveBeenCalledWith('👍', 42, 0);
+      });
+      expect(composeTextarea()).toBe(document.activeElement);
+    },
+  );
+
+  it.each(['darwin', 'win32'] as const)(
+    'does not send plain keystrokes as reactions after emoji reaction (%s)',
+    async (platform) => {
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue(platform);
+      const onReact = vi.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(
+        <ToastProvider>
+          <ChatPanel
+            {...defaultProps}
+            onReact={onReact}
+            messages={[{ ...baseMessage, packetId: 42 }]}
+          />
+        </ToastProvider>,
+      );
+      await user.click(screen.getByTitle('React'));
+      const hidden = reactionHiddenInput();
+      hidden.value = '👍';
+      fireEvent.input(hidden);
+      await waitFor(() => {
+        expect(onReact).toHaveBeenCalledWith('👍', 42, 0);
+      });
+      hidden.value = 'j';
+      fireEvent.input(hidden);
+      await waitFor(() => {
+        expect(onReact).toHaveBeenCalledTimes(1);
+      });
+    },
+  );
+
+  it.each(['darwin', 'win32'] as const)(
+    'redirects printable keys from hidden input to composer while capture is pending (%s)',
+    async (platform) => {
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue(platform);
+      const onReact = vi.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(
+        <ToastProvider>
+          <ChatPanel
+            {...defaultProps}
+            onReact={onReact}
+            messages={[{ ...baseMessage, packetId: 42 }]}
+          />
+        </ToastProvider>,
+      );
+      await user.click(screen.getByTitle('React'));
+      const hidden = reactionHiddenInput();
+      fireEvent.keyDown(hidden, { key: 'g' });
+      await waitFor(() => {
+        expect(onReact).not.toHaveBeenCalled();
+        expect(composeTextarea()).toHaveValue('g');
+        expect(composeTextarea()).toBe(document.activeElement);
+      });
+    },
+  );
+
+  it.each(['darwin', 'win32'] as const)(
+    'clears capture on window focus and refocuses composer (%s)',
+    async (platform) => {
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue(platform);
+      const onReact = vi.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(
+        <ToastProvider>
+          <ChatPanel
+            {...defaultProps}
+            onReact={onReact}
+            messages={[{ ...baseMessage, packetId: 42 }]}
+          />
+        </ToastProvider>,
+      );
+      await user.click(screen.getByTitle('React'));
+      fireEvent.focus(window);
+      const hidden = reactionHiddenInput();
+      hidden.value = 'a';
+      fireEvent.input(hidden);
+      await waitFor(() => {
+        expect(onReact).not.toHaveBeenCalled();
+        expect(composeTextarea()).toBe(document.activeElement);
+      });
+    },
+  );
 
   it('does not send keystrokes as reactions after dismissing native panel without selection', async () => {
     vi.mocked(window.electronAPI.getPlatform).mockReturnValue('win32');
@@ -2565,6 +2668,69 @@ describe('ChatPanel tapback reaction picker', () => {
     fireEvent.input(hidden);
     await waitFor(() => {
       expect(onReact).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not send a second Linux emoji-click after reaction without re-opening React', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
+    const US_FLAG = '\u{1F1FA}\u{1F1F8}';
+    const onReact = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel
+          {...defaultProps}
+          onReact={onReact}
+          messages={[{ ...baseMessage, packetId: 42 }]}
+        />
+      </ToastProvider>,
+    );
+    await user.click(screen.getByTitle('React'));
+    await waitFor(() => {
+      expect(document.querySelector('emoji-picker')).toBeInTheDocument();
+    });
+    const picker = document.querySelector('emoji-picker');
+    expect(picker).not.toBeNull();
+    picker!.dispatchEvent(
+      new CustomEvent('emoji-click', { detail: { emoji: { unicode: US_FLAG } }, bubbles: true }),
+    );
+    await waitFor(() => {
+      expect(onReact).toHaveBeenCalledWith(US_FLAG, 42, 0);
+    });
+    picker!.dispatchEvent(
+      new CustomEvent('emoji-click', { detail: { emoji: { unicode: '👍' } }, bubbles: true }),
+    );
+    await waitFor(() => {
+      expect(onReact).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('clears Linux capture on window focus while inline picker is open', async () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
+    const onReact = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel
+          {...defaultProps}
+          onReact={onReact}
+          messages={[{ ...baseMessage, packetId: 42 }]}
+        />
+      </ToastProvider>,
+    );
+    await user.click(screen.getByTitle('React'));
+    await waitFor(() => {
+      expect(document.querySelector('emoji-picker')).toBeInTheDocument();
+    });
+    fireEvent.focus(window);
+    const picker = document.querySelector('emoji-picker');
+    expect(picker).not.toBeNull();
+    picker!.dispatchEvent(
+      new CustomEvent('emoji-click', { detail: { emoji: { unicode: '👍' } }, bubbles: true }),
+    );
+    await waitFor(() => {
+      expect(onReact).not.toHaveBeenCalled();
+      expect(composeTextarea()).toBe(document.activeElement);
     });
   });
 });

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -47,7 +47,13 @@ import {
 import { writeClipboardText } from '@/renderer/lib/writeClipboardText';
 import type { ChatExportMessage } from '@/shared/electron-api.types';
 import { formatIsoDate, formatIsoDateTime } from '@/shared/formatIsoDate';
+import {
+  clampReadWatermarkMs,
+  effectiveMessageTimestampMs,
+  isUnreasonablyFutureMessageTimestampMs,
+} from '@/shared/messageTimestampSkew';
 import { formatMeshtasticNodeId, isMeshtasticBroadcastNodeNum } from '@/shared/nodeNameUtils';
+import { CHAT_COMPACT_CONTINUATION_TIME_GAP_MS } from '@/shared/timeConstants';
 
 import type { OutboxEntry } from '../../shared/electron-api.types';
 import { isMeshcoreRoomChatMessage } from '../hooks/meshcore/meshcoreHookPreamble';
@@ -93,11 +99,6 @@ import {
   meshcorePayloadIsTapbackEmojiOnly,
 } from '../lib/meshcoreChannelText';
 import { nodeDisplayName } from '../lib/nodeLongNameOrHex';
-import {
-  clampReadWatermarkMs,
-  effectiveMessageTimestampMs,
-  isUnreasonablyFutureMessageTimestampMs,
-} from '../lib/nodeStatus';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import {
   emojiDisplayLabel,
@@ -106,7 +107,6 @@ import {
   reactionGlyphFromPicker,
 } from '../lib/reactions';
 import { findMeshtasticParentMessageForReply, truncateReplyPreviewText } from '../lib/replyPreview';
-import { CHAT_COMPACT_CONTINUATION_TIME_GAP_MS } from '../lib/timeConstants';
 import type { ChatMessage, MeshNode, MeshProtocol } from '../lib/types';
 import type { RequestStoreForwardHistoryResult } from '../runtime/useMeshtasticRuntime';
 import { ChatComposer } from './ChatComposer';

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react-motion';
 import {
   type ComponentProps,
+  type KeyboardEvent as ReactKeyboardEvent,
   memo,
   type ReactNode,
   useCallback,
@@ -93,6 +94,7 @@ import {
   pickAudibleNotificationType,
   resolveChatDmPeer,
 } from '../lib/chatUnreadCounts';
+import { applyControlledEditableValue } from '../lib/controlledEditableValue';
 import {
   findMeshcoreParentMessageForReply,
   meshcoreChatMessagesForDisplay,
@@ -461,22 +463,53 @@ function ChatPanel({
   const reactionPickerRef = useRef<HTMLElement | null>(null);
   const reactionPickerTarget = useRef<{ id: number; channel: number } | null>(null);
   const reactionHiddenInputRef = useRef<HTMLInputElement | null>(null);
+  const reactionCapturePendingRef = useRef(false);
+  const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const handleReactRef = useRef<
     ((glyph: string, packetId: number, msgChannel: number) => Promise<void>) | null
   >(null);
-  const clearReactionCaptureRef = useRef<() => void>(() => {});
+  const clearReactionCaptureRef = useRef<(opts?: { refocusComposer?: boolean }) => void>(() => {});
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  const clearReactionCapture = useCallback(() => {
+  const clearReactionCapture = useCallback((opts?: { refocusComposer?: boolean }) => {
+    reactionCapturePendingRef.current = false;
     reactionPickerTarget.current = null;
     const el = reactionHiddenInputRef.current;
     if (el) {
       el.value = '';
       el.blur();
     }
+    if (opts?.refocusComposer) {
+      composerInputRef.current?.focus();
+    }
   }, []);
   clearReactionCaptureRef.current = clearReactionCapture;
+
+  const insertCharIntoComposer = useCallback((char: string) => {
+    const textarea = composerInputRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart ?? textarea.value.length;
+    const end = textarea.selectionEnd ?? textarea.value.length;
+    const next = textarea.value.slice(0, start) + char + textarea.value.slice(end);
+    applyControlledEditableValue(textarea, next);
+    const caret = start + char.length;
+    textarea.setSelectionRange(caret, caret);
+  }, []);
+
+  const handleHiddenReactionKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      // OS-specific: hidden reaction input exists only on darwin/win32 (showEmojiPanel)
+      if (chatPanelIsLinux()) return;
+      if (!reactionCapturePendingRef.current) return;
+      if (e.key.length !== 1 || e.ctrlKey || e.metaKey || e.altKey) return;
+      if (isReactionPickerEmojiGlyph(e.key)) return;
+      e.preventDefault();
+      clearReactionCapture({ refocusComposer: true });
+      insertCharIntoComposer(e.key);
+    },
+    [clearReactionCapture, insertCharIntoComposer],
+  );
 
   // Feature: sender filter
   const [filterSender, setFilterSender] = useState<number | null>(null);
@@ -1143,7 +1176,7 @@ function ChatPanel({
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         setPickerOpenFor(null);
-        clearReactionCaptureRef.current();
+        clearReactionCaptureRef.current({ refocusComposer: true });
         if (replyTo) {
           setReplyTo(null);
         } else if (filterSender != null) {
@@ -1190,7 +1223,7 @@ function ChatPanel({
   const handleReact = async (glyph: string, packetId: number, msgChannel: number) => {
     // Match handleSend: UI uses channel -1 as "primary"; MeshCore/Meshtastic send expects 0.
     const sendChannel = msgChannel === -1 ? 0 : msgChannel;
-    clearReactionCapture();
+    clearReactionCapture({ refocusComposer: true });
     setPickerOpenFor(null);
     setChatActionError(null);
     try {
@@ -1335,9 +1368,10 @@ function ChatPanel({
     if (!pickerOpenFor) return;
     const el = reactionPickerRef.current;
     if (!el) return;
-    const target = reactionPickerTarget.current;
-    if (!target) return;
     const handler = (e: Event) => {
+      if (!reactionCapturePendingRef.current) return;
+      const target = reactionPickerTarget.current;
+      if (!target) return;
       const unicode = (e as CustomEvent).detail.emoji.unicode as string;
       const parsed = reactionGlyphFromPicker(unicode);
       if (parsed) {
@@ -1355,6 +1389,7 @@ function ChatPanel({
     const el = reactionHiddenInputRef.current;
     if (!el) return;
     const handler = () => {
+      if (!reactionCapturePendingRef.current) return;
       const unicode = el.value;
       el.value = '';
       if (!unicode) return;
@@ -1375,10 +1410,21 @@ function ChatPanel({
     };
   }, []);
 
+  useEffect(() => {
+    const onWindowFocus = () => {
+      if (reactionCapturePendingRef.current) {
+        clearReactionCapture({ refocusComposer: true });
+      }
+    };
+    window.addEventListener('focus', onWindowFocus);
+    return () => {
+      window.removeEventListener('focus', onWindowFocus);
+    };
+  }, [clearReactionCapture]);
+
   const isDmMode = viewMode === 'dm' && activeDmNode != null;
   const nowMs = useNowMs(isDmMode);
   const dmNodeName = activeDmNode != null ? getDmLabel(activeDmNode) : '';
-  const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   // Jump to date — scroll to first message with matching day key
   const handleJumpToDate = useCallback(
@@ -2299,16 +2345,20 @@ function ChatPanel({
                                       reactionHiddenInputRef.current?.focus();
                                   }}
                                   onClick={() => {
+                                    setReplyTo(null);
                                     const id = msg.packetId ?? msg.timestamp;
-                                    reactionPickerTarget.current = { id, channel: msg.channel };
                                     if (chatPanelIsLinux()) {
                                       if (showPicker) {
-                                        clearReactionCapture();
+                                        clearReactionCapture({ refocusComposer: true });
                                         setPickerOpenFor(null);
                                       } else {
+                                        reactionPickerTarget.current = { id, channel: msg.channel };
+                                        reactionCapturePendingRef.current = true;
                                         setPickerOpenFor(id);
                                       }
                                     } else {
+                                      reactionPickerTarget.current = { id, channel: msg.channel };
+                                      reactionCapturePendingRef.current = true;
                                       void window.electronAPI.showEmojiPanel();
                                     }
                                   }}
@@ -2465,7 +2515,10 @@ function ChatPanel({
         aria-hidden="true"
         tabIndex={-1}
         readOnly={false}
-        onBlur={clearReactionCapture}
+        onBlur={() => {
+          clearReactionCapture();
+        }}
+        onKeyDown={handleHiddenReactionKeyDown}
         style={{ position: 'absolute', opacity: 0, width: 0, height: 0, pointerEvents: 'none' }}
       />
 

--- a/src/renderer/components/ProtocolUnreadBadge.tsx
+++ b/src/renderer/components/ProtocolUnreadBadge.tsx
@@ -1,0 +1,24 @@
+/** Protocol switcher unread count — pulse on aria-hidden layer; text span stays fully opaque for contrast. */
+export function ProtocolUnreadBadge({
+  count,
+  fillClass,
+}: {
+  count: number | string;
+  fillClass: 'bg-readable-green' | 'bg-cyan-600';
+}) {
+  const label = typeof count === 'number' && count > 99 ? '99+' : count;
+  return (
+    <span className="relative ml-1.5 inline-flex h-4 min-w-[1.1rem] items-center justify-center">
+      <span
+        className={`absolute inset-0 animate-pulse rounded-full ${fillClass}`}
+        aria-hidden="true"
+      />
+      <span
+        data-protocol-unread-label
+        className={`relative z-[1] inline-flex h-4 min-w-[1.1rem] items-center justify-center rounded-full px-0.5 text-[10px] font-bold text-white ${fillClass}`}
+      >
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/src/renderer/hooks/useMeshcoreRuntime.initconn-rpc-order.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.initconn-rpc-order.test.tsx
@@ -23,12 +23,35 @@ function deferred<T>() {
 
 vi.mock('@liamcottle/meshcore.js', () => {
   class MockWebSerialConnection {
+    private listeners = new Map<string | number, Set<(...args: unknown[]) => void>>();
+
     constructor(port: unknown) {
       void port;
     }
-    on = vi.fn();
-    off = vi.fn();
-    once = vi.fn();
+    on(event: string | number, cb: (...args: unknown[]) => void) {
+      const listeners = this.listeners.get(event) ?? new Set();
+      listeners.add(cb);
+      this.listeners.set(event, listeners);
+      return undefined;
+    }
+    off(event: string | number, cb: (...args: unknown[]) => void) {
+      this.listeners.get(event)?.delete(cb);
+      return undefined;
+    }
+    once(event: string | number, cb: (...args: unknown[]) => void) {
+      const wrapped = (...args: unknown[]) => {
+        this.off(event, wrapped);
+        cb(...args);
+      };
+      this.on(event, wrapped);
+      return undefined;
+    }
+    emit(event: string | number, ...args: unknown[]) {
+      this.listeners.get(event)?.forEach((cb) => {
+        cb(...args);
+      });
+      return undefined;
+    }
     close = vi.fn().mockResolvedValue(undefined);
     getSelfInfo = getSelfInfoMock;
     getContacts = getContactsMock;
@@ -69,7 +92,10 @@ vi.mock('@liamcottle/meshcore.js', () => {
       },
     });
     sendFloodAdvert = vi.fn().mockResolvedValue(undefined);
-    sendToRadioFrame = vi.fn().mockResolvedValue(undefined);
+    sendToRadioFrame = vi.fn().mockImplementation((data: Uint8Array) => {
+      void data;
+      this.emit('rx', new Uint8Array([25, 0x0f, 3]));
+    });
   }
 
   class MockSerialConnection {
@@ -146,6 +172,8 @@ const selfInfoPayload = {
 };
 
 describe('useMeshcoreRuntime initConn RPC ordering', () => {
+  const originalSerial = navigator.serial;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([]);
@@ -159,6 +187,10 @@ describe('useMeshcoreRuntime initConn RPC ordering', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: originalSerial,
+    });
     vi.restoreAllMocks();
   });
 
@@ -194,8 +226,10 @@ describe('useMeshcoreRuntime initConn RPC ordering', () => {
     });
 
     const { result, unmount } = renderHook(() => useMeshcoreRuntime());
-    void act(async () => {
-      await result.current.connect('serial');
+    let connectPromise: Promise<void> | undefined;
+    await act(async () => {
+      connectPromise = result.current.connect('serial');
+      await Promise.resolve();
     });
 
     await waitFor(() => {
@@ -225,7 +259,11 @@ describe('useMeshcoreRuntime initConn RPC ordering', () => {
     });
 
     await act(async () => {
-      await result.current.disconnect().catch(() => {});
+      await connectPromise;
+    });
+
+    await act(async () => {
+      await result.current.disconnect();
     });
     unmount();
   });

--- a/src/renderer/hooks/useMeshcoreRuntime.initconn-rpc-order.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.initconn-rpc-order.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Serial USB init must run getSelfInfo → getContacts before getChannels (UART single-flight).
+ * TCP/BLE keep overlapping init RPCs for faster connect.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { meshcoreProtocol } from '../lib/protocols/MeshCoreProtocol';
+
+const getSelfInfoMock = vi.fn();
+const getContactsMock = vi.fn();
+const getChannelsMock = vi.fn();
+
+const SELF_PUBKEY = new Uint8Array(32).fill(0xab);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+vi.mock('@liamcottle/meshcore.js', () => {
+  class MockWebSerialConnection {
+    constructor(port: unknown) {
+      void port;
+    }
+    on = vi.fn();
+    off = vi.fn();
+    once = vi.fn();
+    close = vi.fn().mockResolvedValue(undefined);
+    getSelfInfo = getSelfInfoMock;
+    getContacts = getContactsMock;
+    getChannels = getChannelsMock;
+    deviceQuery = vi.fn().mockResolvedValue({
+      firmwareVer: 1,
+      firmware_build_date: 'test',
+      manufacturerModel: 'test',
+    });
+    syncDeviceTime = vi.fn().mockResolvedValue(undefined);
+    getWaitingMessages = vi.fn().mockResolvedValue([]);
+    syncNextMessage = vi.fn().mockResolvedValue(null);
+    setOtherParams = vi.fn().mockResolvedValue(undefined);
+    setAutoAddContacts = vi.fn().mockResolvedValue(undefined);
+    setManualAddContacts = vi.fn().mockResolvedValue(undefined);
+    getBatteryVoltage = vi.fn().mockResolvedValue({ batteryMilliVolts: 4200 });
+    getStatsCore = vi.fn().mockResolvedValue({
+      type: 0,
+      raw: new Uint8Array(9),
+      data: { batteryMilliVolts: 4100, uptimeSecs: 1, queueLen: 0 },
+    });
+    getStatsRadio = vi.fn().mockResolvedValue({
+      type: 1,
+      raw: new Uint8Array([1]),
+      data: { noiseFloor: -110, lastRssi: -90, lastSnr: 5, txAirSecs: 0, rxAirSecs: 0 },
+    });
+    getStatsPackets = vi.fn().mockResolvedValue({
+      type: 2,
+      raw: new Uint8Array([2]),
+      data: {
+        recv: 0,
+        sent: 0,
+        nSentFlood: 0,
+        nSentDirect: 0,
+        nRecvFlood: 0,
+        nRecvDirect: 0,
+        nRecvErrors: 0,
+      },
+    });
+    sendFloodAdvert = vi.fn().mockResolvedValue(undefined);
+    sendToRadioFrame = vi.fn().mockResolvedValue(undefined);
+  }
+
+  class MockSerialConnection {
+    write(bytes: Uint8Array) {
+      void bytes;
+    }
+    onDataReceived(value: Uint8Array) {
+      void value;
+    }
+    async onConnected() {
+      await Promise.resolve();
+    }
+    onDisconnected() {
+      return undefined;
+    }
+    close = vi.fn().mockResolvedValue(undefined);
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+    sendToRadioFrame = vi.fn().mockRejectedValue(new Error('mocked'));
+  }
+
+  class MockConnection {
+    close = vi.fn().mockResolvedValue(undefined);
+    on() {
+      return undefined;
+    }
+    off() {
+      return undefined;
+    }
+    once() {
+      return undefined;
+    }
+    emit() {
+      return undefined;
+    }
+  }
+
+  return {
+    CayenneLpp: { parse: vi.fn().mockReturnValue([]) },
+    Connection: MockConnection,
+    SerialConnection: MockSerialConnection,
+    WebSerialConnection: MockWebSerialConnection,
+  };
+});
+
+import { useMeshcoreRuntime } from '../runtime/useMeshcoreRuntime';
+
+function makeMockSerialPort() {
+  return {
+    open: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    writable: new WritableStream<Uint8Array>({ write: vi.fn() }),
+    readable: new ReadableStream(),
+    getInfo: vi.fn().mockReturnValue({ usbVendorId: 0x1234, usbProductId: 0x5678 }),
+  };
+}
+
+const selfInfoPayload = {
+  name: 'SelfRadio',
+  publicKey: SELF_PUBKEY,
+  type: 1,
+  txPower: 22,
+  radioFreq: 902_000_000,
+};
+
+describe('useMeshcoreRuntime initConn RPC ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(window.electronAPI.db.getMeshcoreContacts).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getMeshcoreMessages).mockResolvedValue([]);
+    vi.mocked(window.electronAPI.db.getNodes).mockResolvedValue([]);
+    vi.spyOn(meshcoreProtocol, 'subscribe').mockReturnValue(() => {});
+    vi.spyOn(meshcoreProtocol, 'destroyDevice').mockResolvedValue(undefined);
+    vi.spyOn(meshcoreProtocol, 'discoverSelf').mockResolvedValue({
+      publicKey: SELF_PUBKEY,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('serial: getContacts waits for getSelfInfo; getChannels starts after contacts', async () => {
+    const callOrder: string[] = [];
+    const selfInfoGate = deferred<undefined>();
+    const contactsGate = deferred<undefined>();
+    const channelsGate = deferred<undefined>();
+
+    getSelfInfoMock.mockImplementation(async () => {
+      callOrder.push('getSelfInfo:start');
+      await selfInfoGate.promise;
+      callOrder.push('getSelfInfo:end');
+      return selfInfoPayload;
+    });
+    getContactsMock.mockImplementation(async () => {
+      callOrder.push('getContacts:start');
+      await contactsGate.promise;
+      callOrder.push('getContacts:end');
+      return [];
+    });
+    getChannelsMock.mockImplementation(async () => {
+      callOrder.push('getChannels:start');
+      await channelsGate.promise;
+      callOrder.push('getChannels:end');
+      return [];
+    });
+
+    const port = makeMockSerialPort();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: { requestPort: vi.fn().mockResolvedValue(port) },
+    });
+
+    const { result, unmount } = renderHook(() => useMeshcoreRuntime());
+    void act(async () => {
+      await result.current.connect('serial');
+    });
+
+    await waitFor(() => {
+      expect(callOrder).toContain('getSelfInfo:start');
+    });
+    expect(callOrder).not.toContain('getContacts:start');
+    expect(callOrder).not.toContain('getChannels:start');
+
+    selfInfoGate.resolve(undefined);
+    await waitFor(() => {
+      expect(callOrder).toContain('getSelfInfo:end');
+      expect(callOrder).toContain('getContacts:start');
+    });
+    expect(callOrder).not.toContain('getChannels:start');
+
+    contactsGate.resolve(undefined);
+    await waitFor(() => {
+      expect(callOrder).toContain('getContacts:end');
+    });
+    expect(callOrder.indexOf('getChannels:start')).toBeGreaterThan(
+      callOrder.indexOf('getContacts:end'),
+    );
+
+    channelsGate.resolve(undefined);
+    await waitFor(() => {
+      expect(callOrder).toContain('getChannels:end');
+    });
+
+    await act(async () => {
+      await result.current.disconnect().catch(() => {});
+    });
+    unmount();
+  });
+
+  // TCP/BLE parallel init is preserved in initConn's `if (!isSerialInit)` branch (see useMeshcoreRuntime.ts).
+});

--- a/src/renderer/hooks/useMeshcoreRuntime.stats.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.stats.test.tsx
@@ -259,7 +259,7 @@ describe('useMeshcoreRuntime stats parsing', () => {
     expect(getStatsPacketsMock).toHaveBeenCalled();
   });
 
-  it('hydrates channels before a slow contacts refresh completes', async () => {
+  it('serial defers channel hydration until contacts refresh completes', async () => {
     let resolveContacts: ((value: []) => void) | undefined;
     const contactsPromise = new Promise<[]>((resolve) => {
       resolveContacts = resolve;
@@ -292,13 +292,18 @@ describe('useMeshcoreRuntime stats parsing', () => {
 
     await waitFor(() => {
       expect(result.current.state.status).toBe('configured');
-      expect(result.current.channels).toEqual([{ index: 1, name: 'Ops', secret: opsSecret }]);
     });
+    expect(result.current.channels).toEqual([]);
+    expect(getChannelsMock).not.toHaveBeenCalled();
     expect(result.current.nodes.size).toBe(0);
 
     resolveContacts?.([]);
     await act(async () => {
       await connectPromise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.channels).toEqual([{ index: 1, name: 'Ops', secret: opsSecret }]);
     });
   });
 });

--- a/src/renderer/lib/a11yTestHelpers.ts
+++ b/src/renderer/lib/a11yTestHelpers.ts
@@ -1,0 +1,51 @@
+import { applyThemeColors, loadThemeColors } from './themeColors';
+
+/** Tailwind badge fills used in axe tests — jsdom does not load styles.css. */
+const AXE_BG_CLASS_TO_CSS: Record<string, string> = {
+  'bg-readable-green': '--color-readable-green',
+  'bg-cyan-600': '#0891b2',
+};
+
+const AXE_TEXT_CLASS_TO_CSS: Record<string, string> = {
+  'text-white': '#ffffff',
+};
+
+function resolveThemeBg(tokenOrHex: string): string {
+  if (tokenOrHex.startsWith('--')) {
+    const fromRoot = getComputedStyle(document.documentElement).getPropertyValue(tokenOrHex).trim();
+    return fromRoot || '#15803d';
+  }
+  return tokenOrHex;
+}
+
+/** Apply theme CSS vars and inline colors so vitest-axe color-contrast runs against real hex values. */
+export function hydrateAxeThemeColors(root: Element): void {
+  applyThemeColors(loadThemeColors());
+
+  const nodes =
+    root instanceof HTMLElement
+      ? [root, ...root.querySelectorAll('*')]
+      : [...root.querySelectorAll('*')];
+  for (const node of nodes) {
+    if (!(node instanceof HTMLElement)) continue;
+    for (const cls of node.classList) {
+      const bgToken = AXE_BG_CLASS_TO_CSS[cls];
+      if (bgToken) {
+        node.style.backgroundColor = resolveThemeBg(bgToken);
+      }
+      const textHex = AXE_TEXT_CLASS_TO_CSS[cls];
+      if (textHex) {
+        node.style.color = textHex;
+      }
+    }
+  }
+}
+
+/** Inner text label from ProtocolUnreadBadge (contrast-bearing element). */
+export function getProtocolUnreadBadgeLabel(wrapper: Element): HTMLElement {
+  const label = wrapper.querySelector('[data-protocol-unread-label]');
+  if (!(label instanceof HTMLElement)) {
+    throw new Error('protocol unread badge label not found');
+  }
+  return label;
+}

--- a/src/renderer/lib/meshcoreChannelText.test.ts
+++ b/src/renderer/lib/meshcoreChannelText.test.ts
@@ -323,6 +323,11 @@ describe('meshcorePayloadIsTapbackEmojiOnly', () => {
   it('rejects multi-word reply', () => {
     expect(meshcorePayloadIsTapbackEmojiOnly('hello 👍')).toBe(false);
   });
+
+  it('rejects plain ASCII letters', () => {
+    expect(meshcorePayloadIsTapbackEmojiOnly('g')).toBe(false);
+    expect(meshcorePayloadIsTapbackEmojiOnly('a')).toBe(false);
+  });
 });
 
 describe('meshcoreBracketDisplayNamesMatch', () => {

--- a/src/renderer/lib/meshcoreChannelText.ts
+++ b/src/renderer/lib/meshcoreChannelText.ts
@@ -7,7 +7,7 @@ import {
   meshcoreChatStubNodeIdFromDisplayName,
   sanitizeMeshcoreChatWireText,
 } from './meshcoreUtils';
-import { normalizeReactionEmoji } from './reactions';
+import { isReactionPickerEmojiGlyph, normalizeReactionEmoji } from './reactions';
 import { truncateReplyPreviewText } from './replyPreview';
 import type { ChatMessage, MeshNode } from './types';
 
@@ -205,6 +205,7 @@ export function meshcorePayloadIsTapbackEmojiOnly(payload: string): boolean {
   } else if (t.length > 8) {
     return false;
   }
+  if (!isReactionPickerEmojiGlyph(t)) return false;
   return normalizeReactionEmoji(undefined, t) !== undefined;
 }
 

--- a/src/renderer/lib/meshcoreCompanionTxEchoFilter.test.ts
+++ b/src/renderer/lib/meshcoreCompanionTxEchoFilter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { MeshcoreCompanionTxEchoFilter } from './meshcoreCompanionTxEchoFilter';
+import {
+  MeshcoreCompanionTxEchoFilter,
+  type MeshcoreEchoFilterableConnection,
+  patchMeshcoreCompanionTxEchoFilter,
+} from './meshcoreCompanionTxEchoFilter';
 
 describe('MeshcoreCompanionTxEchoFilter', () => {
   it('drops inbound frames that exactly match a recent outbound frame', () => {
@@ -25,5 +29,24 @@ describe('MeshcoreCompanionTxEchoFilter', () => {
     vi.advanceTimersByTime(501);
     expect(filter.isEcho(cmd)).toBe(false);
     vi.useRealTimers();
+  });
+});
+
+describe('patchMeshcoreCompanionTxEchoFilter', () => {
+  it('wraps sendToRadioFrame and onFrameReceived to drop echoed payloads', async () => {
+    const onFrameReceived = vi.fn<(frame: Uint8Array) => void>();
+    const conn: MeshcoreEchoFilterableConnection = {
+      sendToRadioFrame: vi.fn(async () => {}),
+      onFrameReceived,
+    };
+    patchMeshcoreCompanionTxEchoFilter(conn);
+
+    const cmd = new Uint8Array([22, 1]);
+    await conn.sendToRadioFrame(cmd);
+    conn.onFrameReceived(cmd);
+    expect(onFrameReceived).not.toHaveBeenCalled();
+
+    conn.onFrameReceived(new Uint8Array([0]));
+    expect(onFrameReceived).toHaveBeenCalledWith(new Uint8Array([0]));
   });
 });

--- a/src/renderer/lib/meshcoreCompanionTxEchoFilter.ts
+++ b/src/renderer/lib/meshcoreCompanionTxEchoFilter.ts
@@ -1,4 +1,4 @@
-/** Drop inbound BLE frames that exactly match a recent outbound companion command (TX echo). */
+/** Drop inbound frames that exactly match a recent outbound companion command (TX echo). */
 const TX_ECHO_TTL_MS = 500;
 const MAX_RECENT_TX = 16;
 
@@ -11,9 +11,12 @@ function framesEqual(a: Uint8Array, b: Uint8Array): boolean {
 }
 
 /**
- * Some BLE stacks (or firmware) reflect the last NUS RX write on the TX notify characteristic.
- * meshcore.js treats any inbound byte[0] as a response/push code; echoed commands (e.g. 25 =
- * CMD_SEND_RAW_DATA) log "unhandled frame" even though the real RESP_OK/ERR may follow.
+ * Some transports echo the last companion command back on the RX path:
+ * - BLE NUS stacks reflect the last RX write on TX notify
+ * - USB serial firmware/adapters may return outgoing frames (e.g. CMD DeviceQuery = 22)
+ *
+ * meshcore.js treats inbound byte[0] as response/push codes; echoed commands log
+ * "unhandled frame" even though the real RESP_OK/ERR may follow.
  */
 export class MeshcoreCompanionTxEchoFilter {
   private recent: { frame: Uint8Array; at: number }[] = [];
@@ -36,4 +39,36 @@ export class MeshcoreCompanionTxEchoFilter {
   private prune(now: number): void {
     this.recent = this.recent.filter((e) => now - e.at <= TX_ECHO_TTL_MS);
   }
+}
+
+export interface MeshcoreEchoFilterableConnection {
+  sendToRadioFrame(data: Uint8Array): Promise<void>;
+  onFrameReceived(frame: Uint8Array): void;
+}
+
+/** Wrap send/onFrameReceived so echoed outbound companion payloads are dropped before meshcore.js. */
+export function patchMeshcoreCompanionTxEchoFilter(conn: {
+  sendToRadioFrame?: (data: Uint8Array) => Promise<void>;
+  onFrameReceived?: (frame: Uint8Array) => void;
+}): MeshcoreCompanionTxEchoFilter {
+  const filter = new MeshcoreCompanionTxEchoFilter();
+  const { sendToRadioFrame, onFrameReceived } = conn;
+  if (typeof sendToRadioFrame !== 'function' || typeof onFrameReceived !== 'function') {
+    return filter;
+  }
+
+  const origSend = sendToRadioFrame.bind(conn);
+  const origOnFrame = onFrameReceived.bind(conn);
+
+  conn.sendToRadioFrame = async (data: Uint8Array) => {
+    filter.noteOutbound(data);
+    await origSend(data);
+  };
+
+  conn.onFrameReceived = (frame: Uint8Array) => {
+    if (filter.isEcho(frame)) return;
+    origOnFrame(frame);
+  };
+
+  return filter;
 }

--- a/src/renderer/lib/meshcoreNobleBleFraming.contract.test.ts
+++ b/src/renderer/lib/meshcoreNobleBleFraming.contract.test.ts
@@ -14,7 +14,10 @@
 import { Connection, Constants, SerialConnection } from '@liamcottle/meshcore.js';
 import { describe, expect, it, vi } from 'vitest';
 
-import { MeshcoreCompanionTxEchoFilter } from './meshcoreCompanionTxEchoFilter';
+import {
+  MeshcoreCompanionTxEchoFilter,
+  patchMeshcoreCompanionTxEchoFilter,
+} from './meshcoreCompanionTxEchoFilter';
 
 class CaptureSerial extends SerialConnection {
   writes: Uint8Array[] = [];
@@ -91,6 +94,29 @@ describe('MeshCore Noble IPC TX echo filter contract', () => {
     expect(onFrameReceived).not.toHaveBeenCalled();
 
     onNobleBleFromRadio(new Uint8Array([0])); // RESP_OK
+    expect(onFrameReceived).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops inbound DeviceQuery echo (code 22) via patchMeshcoreCompanionTxEchoFilter', async () => {
+    const onFrameReceived = vi.fn<(frame: Uint8Array) => void>();
+    const conn: {
+      sendToRadioFrame(data: Uint8Array): Promise<void>;
+      onFrameReceived(frame: Uint8Array): void;
+    } = {
+      sendToRadioFrame: async () => {},
+      onFrameReceived,
+    };
+    patchMeshcoreCompanionTxEchoFilter(conn);
+
+    const deviceQuery = new Uint8Array([
+      Constants.CommandCodes.DeviceQuery,
+      Constants.SupportedCompanionProtocolVersion,
+    ]);
+    await conn.sendToRadioFrame(deviceQuery);
+    conn.onFrameReceived(deviceQuery);
+    expect(onFrameReceived).not.toHaveBeenCalled();
+
+    conn.onFrameReceived(new Uint8Array([0])); // RESP_OK
     expect(onFrameReceived).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/renderer/lib/protocols/meshcore/MeshCoreTransport.serial-writable.test.ts
+++ b/src/renderer/lib/protocols/meshcore/MeshCoreTransport.serial-writable.test.ts
@@ -28,6 +28,10 @@ vi.mock('../../connection', () => ({
 
 import { closeSerialPortIfOpen } from '../../connection';
 import {
+  type MeshcoreEchoFilterableConnection,
+  patchMeshcoreCompanionTxEchoFilter,
+} from '../../meshcoreCompanionTxEchoFilter';
+import {
   createMeshCoreConnection,
   patchMeshcoreWebSerialWritable,
   reconnectMeshcoreSerial,
@@ -153,5 +157,21 @@ describe('createMeshCoreConnection serial', () => {
 
     expect(closeSerialPortIfOpen).toHaveBeenCalledWith(port);
     expect(port.open).toHaveBeenCalledWith({ baudRate: 115200 });
+  });
+});
+
+describe('openSerialPort TX echo filter', () => {
+  it('patches WebSerialConnection so DeviceQuery echo is dropped before onFrameReceived', async () => {
+    const onFrameReceived = vi.fn<(frame: Uint8Array) => void>();
+    const conn: MeshcoreEchoFilterableConnection = {
+      sendToRadioFrame: vi.fn(async () => {}),
+      onFrameReceived,
+    };
+    patchMeshcoreCompanionTxEchoFilter(conn);
+
+    const deviceQuery = new Uint8Array([22, 1]);
+    await conn.sendToRadioFrame(deviceQuery);
+    conn.onFrameReceived(deviceQuery);
+    expect(onFrameReceived).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/lib/protocols/meshcore/MeshCoreTransport.serial-writable.test.ts
+++ b/src/renderer/lib/protocols/meshcore/MeshCoreTransport.serial-writable.test.ts
@@ -26,7 +26,12 @@ vi.mock('../../connection', () => ({
   closeSerialPortIfOpen: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { patchMeshcoreWebSerialWritable, reconnectMeshcoreSerial } from './MeshCoreTransport';
+import { closeSerialPortIfOpen } from '../../connection';
+import {
+  createMeshCoreConnection,
+  patchMeshcoreWebSerialWritable,
+  reconnectMeshcoreSerial,
+} from './MeshCoreTransport';
 
 describe('patchMeshcoreWebSerialWritable', () => {
   it('serializes concurrent getWriter calls like WebSerialConnection.write', async () => {
@@ -114,5 +119,39 @@ describe('reconnectMeshcoreSerial writable patch', () => {
     expect(conn).toBe(patched);
     expect(patched.writable).not.toBe(innerWritable);
     expect(port.writable).toBe(innerWritable);
+  });
+});
+
+describe('createMeshCoreConnection serial', () => {
+  const originalSerial = navigator.serial;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: originalSerial,
+    });
+  });
+
+  it('closes a stale open port before openSerialPort on first connect', async () => {
+    webSerialInstances.length = 0;
+    const port = {
+      writable: new WritableStream<Uint8Array>({ write: vi.fn() }),
+      readable: new ReadableStream(),
+      open: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      getInfo: vi.fn().mockReturnValue({ usbVendorId: 0x1234, usbProductId: 0x5678 }),
+    };
+
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: {
+        requestPort: vi.fn().mockResolvedValue(port),
+      },
+    });
+
+    await createMeshCoreConnection({ transport: 'serial' });
+
+    expect(closeSerialPortIfOpen).toHaveBeenCalledWith(port);
+    expect(port.open).toHaveBeenCalledWith({ baudRate: 115200 });
   });
 });

--- a/src/renderer/lib/protocols/meshcore/MeshCoreTransport.ts
+++ b/src/renderer/lib/protocols/meshcore/MeshCoreTransport.ts
@@ -3,7 +3,7 @@ import { Connection, SerialConnection, WebSerialConnection } from '@liamcottle/m
 import { withTimeout } from '../../../../shared/withTimeout';
 import { isMeshcoreRetryableBleErrorMessage } from '../../bleConnectErrors';
 import { closeSerialPortIfOpen } from '../../connection';
-import { MeshcoreCompanionTxEchoFilter } from '../../meshcoreCompanionTxEchoFilter';
+import { patchMeshcoreCompanionTxEchoFilter } from '../../meshcoreCompanionTxEchoFilter';
 import { MeshcoreWebBluetoothConnection } from '../../meshcoreWebBluetoothConnection';
 import { createSerializedWritableStream } from '../../meshtastic/meshtasticTransportLossDetection';
 import { parseTcpAddress } from '../../parseTcpAddress';
@@ -91,6 +91,7 @@ interface NobleIpcMeshcoreConnectionInstance {
   emit(event: string | number, ...args: unknown[]): void;
   onConnected(): Promise<void>;
   onDisconnected(): void;
+  sendToRadioFrame(data: Uint8Array): Promise<void>;
   onFrameReceived(frame: Uint8Array): void;
 }
 
@@ -191,6 +192,7 @@ async function openSerialPort(port: SerialPort): Promise<Connection> {
     port,
   );
   patchMeshcoreWebSerialWritable(conn, rawWritable);
+  patchMeshcoreCompanionTxEchoFilter(conn);
   return conn;
 }
 
@@ -220,7 +222,6 @@ class IpcNobleConnection {
 
   private readonly peripheralId: string;
   private readonly sessionId: NobleBleSessionId;
-  private readonly txEchoFilter = new MeshcoreCompanionTxEchoFilter();
   private inner: NobleIpcMeshcoreConnectionInstance | null = null;
   private cleanupFns: (() => void)[] = [];
 
@@ -232,14 +233,12 @@ class IpcNobleConnection {
   async connect(): Promise<void> {
     const runConnect = async () => {
       const { sessionId } = this;
-      const txEchoFilter = this.txEchoFilter;
 
       class NobleOverIpc extends MeshcoreConnectionBase {
         constructor(private readonly session: NobleBleSessionId) {
           super();
         }
         async sendToRadioFrame(data: Uint8Array) {
-          txEchoFilter.noteOutbound(data);
           this.emit('tx', data);
           await this.write(data);
         }
@@ -252,6 +251,7 @@ class IpcNobleConnection {
       }
 
       const instance = new NobleOverIpc(sessionId) as unknown as NobleIpcMeshcoreConnectionInstance;
+      patchMeshcoreCompanionTxEchoFilter(instance);
       this.inner = instance;
 
       let rejectHandshakeOnDisconnect: ((err: Error) => void) | undefined;
@@ -263,7 +263,6 @@ class IpcNobleConnection {
       const offData = window.electronAPI.onNobleBleFromRadio(({ sessionId: sid, bytes }) => {
         if (sid !== sessionId) return;
         const frame = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-        if (txEchoFilter.isEcho(frame)) return;
         instance.onFrameReceived(frame);
       });
       const offDisc = window.electronAPI.onNobleBleDisconnected((sid) => {

--- a/src/renderer/lib/protocols/meshcore/MeshCoreTransport.ts
+++ b/src/renderer/lib/protocols/meshcore/MeshCoreTransport.ts
@@ -197,6 +197,7 @@ async function openSerialPort(port: SerialPort): Promise<Connection> {
 async function connectSerial(): Promise<Connection> {
   if (!navigator.serial?.requestPort) throw new Error('Web Serial API not available');
   const port = await navigator.serial.requestPort();
+  await closeSerialPortIfOpen(port);
   return openSerialPort(port);
 }
 

--- a/src/renderer/lib/themeColors.test.ts
+++ b/src/renderer/lib/themeColors.test.ts
@@ -106,5 +106,16 @@ describe('themeColors', () => {
       expect(call![1]).toBe('#020617');
       vi.restoreAllMocks();
     });
+
+    it('coerces inaccessible readableGreen to accessible default before applying', () => {
+      const setProp = vi.fn();
+      vi.spyOn(document.documentElement.style, 'setProperty').mockImplementation(setProp);
+      applyThemeColors({ ...DEFAULT_THEME_COLORS, readableGreen: '#16a34a' });
+      const call = setProp.mock.calls.find(([prop]) => prop === '--color-readable-green');
+      expect(call).toBeDefined();
+      expect(call![1]).toBe('#15803d');
+      expect(localStorage.getItem(THEME_COLORS_STORAGE_KEY)).toBeNull();
+      vi.restoreAllMocks();
+    });
   });
 });

--- a/src/renderer/lib/themeColors.ts
+++ b/src/renderer/lib/themeColors.ts
@@ -202,12 +202,16 @@ function resolveThemeHex(raw: string | undefined, key: ThemeColorKey): string | 
  * and logs once — never applies partial/unsane strings.
  */
 export function applyThemeColors(colors: Record<ThemeColorKey, string>): void {
+  const merged = { ...colors };
+  if (ensureReadableGreenContrast(merged)) {
+    persistThemeColors(merged);
+  }
   const resolved: Record<ThemeColorKey, string> = { ...DEFAULT_THEME_COLORS };
   for (const key of Object.keys(THEME_CSS_VARS) as ThemeColorKey[]) {
-    const hex = resolveThemeHex(colors[key], key);
+    const hex = resolveThemeHex(merged[key], key);
     if (!hex) {
       console.warn(
-        `[themeColors] applyThemeColors skipped — invalid or non-strict hex key=${sanitizeLogMessage(key)} raw=${sanitizeLogMessage(colors[key])}`,
+        `[themeColors] applyThemeColors skipped — invalid or non-strict hex key=${sanitizeLogMessage(key)} raw=${sanitizeLogMessage(merged[key])}`,
       );
       return;
     }

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -1,12 +1,12 @@
 import { MS_PER_MINUTE } from '../../shared/timeConstants';
 
-export { MS_PER_DAY, MS_PER_HOUR, MS_PER_MINUTE, MS_PER_SECOND } from '../../shared/timeConstants';
-
-/**
- * Compact chat: merged consecutive bubbles from the same sender show a muted timestamp when the gap
- * from the previous message is at least this long (same calendar day; day separators still break groups).
- */
-export const CHAT_COMPACT_CONTINUATION_TIME_GAP_MS = 5 * MS_PER_MINUTE;
+export {
+  CHAT_COMPACT_CONTINUATION_TIME_GAP_MS,
+  MS_PER_DAY,
+  MS_PER_HOUR,
+  MS_PER_MINUTE,
+  MS_PER_SECOND,
+} from '../../shared/timeConstants';
 
 /** MeshCore Ping (`tracePath`) end-to-end cap (queue wait + radio); matches `useMeshCore` `withTimeout`. */
 export const MESHCORE_TRACE_PING_TOTAL_TIMEOUT_MS = 180_000;

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -1572,33 +1572,42 @@ export function useMeshcoreRuntime() {
         setMeshcoreIdentityId(driverStoreId);
       }
 
+      const isSerialInit = meshcoreConnectTypeRef.current === 'serial';
       const getSelfInfoStart = performance.now();
-      const selfInfoPromise = awaitUnlessMeshcoreSetupCancelled(setupGen, conn.getSelfInfo(5000));
-      const getContactsStart = performance.now();
-      const contactsPromise = awaitUnlessMeshcoreSetupCancelled(
-        setupGen,
-        (async () => {
-          if (meshcoreConnectTypeRef.current === 'ble') {
-            await awaitDualNobleBleMeshtasticSettle();
+      let getContactsStart = getSelfInfoStart;
+      let parallelSelfInfoPromise: ReturnType<MeshCoreConnection['getSelfInfo']> | undefined;
+      let parallelContactsPromise: Promise<MeshCoreContactRaw[]> | undefined;
+      if (!isSerialInit) {
+        parallelSelfInfoPromise = awaitUnlessMeshcoreSetupCancelled(
+          setupGen,
+          conn.getSelfInfo(5000),
+        );
+        getContactsStart = performance.now();
+        parallelContactsPromise = awaitUnlessMeshcoreSetupCancelled(
+          setupGen,
+          (async () => {
+            if (meshcoreConnectTypeRef.current === 'ble') {
+              await awaitDualNobleBleMeshtasticSettle();
+            }
+            return withTimeout(conn.getContacts(), MESHCORE_INIT_TIMEOUT_MS, 'getContacts');
+          })(),
+        );
+        const channelsPromise = awaitUnlessMeshcoreSetupCancelled(
+          setupGen,
+          withTimeout(conn.getChannels(), MESHCORE_INIT_TIMEOUT_MS, 'getChannels'),
+        );
+        void (async () => {
+          try {
+            const rawChannels = await channelsPromise;
+            setChannels(
+              rawChannels.map((c) => ({ index: c.channelIdx, name: c.name, secret: c.secret })),
+            );
+          } catch (e) {
+            if (e instanceof DOMException && e.name === 'AbortError') return;
+            console.warn('[useMeshcoreRuntime] getChannels error ' + errLikeToLogString(e));
           }
-          return withTimeout(conn.getContacts(), MESHCORE_INIT_TIMEOUT_MS, 'getContacts');
-        })(),
-      );
-      const channelsPromise = awaitUnlessMeshcoreSetupCancelled(
-        setupGen,
-        withTimeout(conn.getChannels(), MESHCORE_INIT_TIMEOUT_MS, 'getChannels'),
-      );
-      void (async () => {
-        try {
-          const rawChannels = await channelsPromise;
-          setChannels(
-            rawChannels.map((c) => ({ index: c.channelIdx, name: c.name, secret: c.secret })),
-          );
-        } catch (e) {
-          if (e instanceof DOMException && e.name === 'AbortError') return;
-          console.warn('[useMeshcoreRuntime] getChannels error ' + errLikeToLogString(e));
-        }
-      })();
+        })();
+      }
 
       // Show persisted contacts immediately while the radio contact dump runs over BLE.
       const dbCacheStart = performance.now();
@@ -1638,7 +1647,9 @@ export function useMeshcoreRuntime() {
         `[useMeshcoreRuntime] initConn dbCache→UI ${dbCacheMs}ms (${dbCacheNodeCount} nodes)`,
       );
 
-      const rawInfo = await selfInfoPromise;
+      const rawInfo = isSerialInit
+        ? await awaitUnlessMeshcoreSetupCancelled(setupGen, conn.getSelfInfo(5000))
+        : await parallelSelfInfoPromise!;
       const getSelfInfoMs = Math.round(performance.now() - getSelfInfoStart);
       console.debug(`[useMeshcoreRuntime] initConn getSelfInfo ${getSelfInfoMs}ms`);
       const info = enrichMeshCoreSelfInfo(rawInfo);
@@ -1704,7 +1715,15 @@ export function useMeshcoreRuntime() {
         });
       }
 
-      const contactsRaw = await contactsPromise;
+      if (isSerialInit) {
+        getContactsStart = performance.now();
+      }
+      const contactsRaw = isSerialInit
+        ? await awaitUnlessMeshcoreSetupCancelled(
+            setupGen,
+            withTimeout(conn.getContacts(), MESHCORE_INIT_TIMEOUT_MS, 'getContacts'),
+          )
+        : await parallelContactsPromise!;
       const getContactsMs = Math.round(performance.now() - getContactsStart);
       console.debug(
         `[useMeshcoreRuntime] initConn getContacts ${getContactsMs}ms (total ${Math.round(performance.now() - initConnPerfStart)}ms)`,
@@ -1742,6 +1761,23 @@ export function useMeshcoreRuntime() {
       );
       triggerRoomAutoLoginRef.current();
       void deferMeshcoreDbContactMerge(newNodes, previousNodesBaseline);
+
+      if (isSerialInit) {
+        void (async () => {
+          try {
+            const rawChannels = await awaitUnlessMeshcoreSetupCancelled(
+              setupGen,
+              withTimeout(conn.getChannels(), MESHCORE_INIT_TIMEOUT_MS, 'getChannels'),
+            );
+            setChannels(
+              rawChannels.map((c) => ({ index: c.channelIdx, name: c.name, secret: c.secret })),
+            );
+          } catch (e) {
+            if (e instanceof DOMException && e.name === 'AbortError') return;
+            console.warn('[useMeshcoreRuntime] getChannels error ' + errLikeToLogString(e));
+          }
+        })();
+      }
 
       // Re-resolve map/App GPS after nodesRef picks up getSelfInfo advert coords (same tick as setNodes is too early).
       requestAnimationFrame(() => {

--- a/src/shared/timeConstants.ts
+++ b/src/shared/timeConstants.ts
@@ -1,6 +1,13 @@
 /** Time duration constants in milliseconds (main + renderer). */
 export const MS_PER_SECOND = 1_000;
 export const MS_PER_MINUTE = 60_000;
+
+/**
+ * Compact chat: merged consecutive bubbles from the same sender show a muted timestamp when the gap
+ * from the previous message is at least this long (same calendar day; day separators still break groups).
+ */
+export const CHAT_COMPACT_CONTINUATION_TIME_GAP_MS = 5 * MS_PER_MINUTE;
+
 export const MS_PER_HOUR = 3_600_000;
 export const MS_PER_DAY = 86_400_000;
 export const MS_PER_YEAR = 365 * MS_PER_DAY;


### PR DESCRIPTION
## Summary

* **Serial init ordering:** MeshCore USB serial connections now run `getSelfInfo` → `getContacts` → `getChannels` sequentially instead of overlapping init RPCs. UART is single-flight, so parallel calls could fail or leave channels/nodes stale; TCP and BLE still use overlapping init for faster connect.
* **Stale port cleanup:** `createMeshCoreConnection` closes an already-open Web Serial port before opening it, avoiding "port is already open" on reconnect.
* **Serial TX echo filter:** USB serial firmware/adapters can echo companion commands (e.g. DeviceQuery `code=22`) back on RX; `patchMeshcoreCompanionTxEchoFilter` now wraps serial `WebSerialConnection` (and Noble IPC) so meshcore.js no longer logs spurious `unhandled frame` during connect.
* **Protocol badge axe contrast:** Protocol-switcher unread badges use `ProtocolUnreadBadge` — `animate-pulse` on an `aria-hidden` decorative layer while the text label stays fully opaque for WCAG 4.5:1. Adds `hydrateAxeThemeColors` test helper and removes `themeColors` mock from `App.test` so vitest-axe catches real contrast failures.
* **Reaction capture (#577 follow-up):** Unifies tapback reaction capture across linux/darwin/win32 — explicit `reactionCapturePending` session, composer refocus after react/dismiss, window-focus teardown, and darwin/win32 keydown redirect from the hidden reaction input to compose. Clears stale `replyTo` on React; hardens `meshcorePayloadIsTapbackEmojiOnly` so ASCII letters are not sent as tapbacks.
* **Shared timestamp imports:** `ChatPanel` imports `CHAT_COMPACT_CONTINUATION_TIME_GAP_MS` and message timestamp helpers from shared modules (`@/shared/timeConstants`, `@/shared/messageTimestampSkew`) instead of renderer-local paths.
* **Tests:** Serial init-order and stale-port tests; reaction capture tests for linux/darwin/win32; MeshCore init-order AbortError fix; badge axe tests; DeviceQuery echo filter tests.
* **Deps:** Bump `i18next` 26.3.1 → 26.3.2.

## Commits

* `fix: restore sequential MeshCore USB serial init handshake`
* `fix: align ChatPanel imports with shared timestamp modules`
* `chore: bump deps`
* `test: fix unhandled AbortError in MeshCore init-order test`
* `fix: unify reaction capture lifecycle after emoji picker (#577 follow-up)`
* `fix: axe contrast on protocol badges and MeshCore serial TX echo`

## Test plan

- [ ] Connect MeshCore over USB serial — contacts and channels load; no init RPC errors or `unhandled frame: code=22` in console
- [ ] Disconnect and reconnect USB serial — no "port is already open" failure
- [ ] Connect MeshCore over TCP/BLE — init still completes quickly with parallel RPCs
- [ ] Protocol switcher with Meshtastic unread while on MeshCore tab — pulse visible, no axe `color-contrast` serious warnings in dev console
- [ ] Chat compact view timestamps still behave correctly after import path change
- [ ] **win32/darwin:** React → pick emoji → close panel → type without clicking compose → text lands in compose box, no letter reactions
- [ ] **linux:** React → pick emoji → dismiss picker → no stale capture / second emoji-click without re-open
- [ ] `pnpm run test:run` passes