### PR TITLE
fix: MeshCore channel load races on serial and Linux BLE

### DIFF
--- a/src/renderer/hooks/useMeshcoreRuntime.initconn-rpc-order.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.initconn-rpc-order.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Serial USB init must run getSelfInfo → getContacts before getChannels (UART single-flight).
- * TCP/BLE keep overlapping init RPCs for faster connect.
+ * Serial USB and Linux Web Bluetooth init run getSelfInfo → getContacts → getChannels
+ * before post-init RPCs. TCP and Noble BLE keep overlapping init RPCs.
  */
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -194,7 +194,7 @@ describe('useMeshcoreRuntime initConn RPC ordering', () => {
     vi.restoreAllMocks();
   });
 
-  it('serial: getContacts waits for getSelfInfo; getChannels starts after contacts', async () => {
+  it('serial: getContacts waits for getSelfInfo; getChannels runs after contacts before connect finishes', async () => {
     const callOrder: string[] = [];
     const selfInfoGate = deferred<undefined>();
     const contactsGate = deferred<undefined>();
@@ -268,5 +268,5 @@ describe('useMeshcoreRuntime initConn RPC ordering', () => {
     unmount();
   });
 
-  // TCP/BLE parallel init is preserved in initConn's `if (!isSerialInit)` branch (see useMeshcoreRuntime.ts).
+  // TCP/Noble BLE parallel init is preserved when !needsSequentialMeshcoreRadioInit (useMeshcoreRuntime.ts).
 });

--- a/src/renderer/hooks/useMeshcoreRuntime.stats.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.stats.test.tsx
@@ -259,7 +259,7 @@ describe('useMeshcoreRuntime stats parsing', () => {
     expect(getStatsPacketsMock).toHaveBeenCalled();
   });
 
-  it('serial defers channel hydration until contacts refresh completes', async () => {
+  it('serial awaits channel hydration after contacts before connect resolves', async () => {
     let resolveContacts: ((value: []) => void) | undefined;
     const contactsPromise = new Promise<[]>((resolve) => {
       resolveContacts = resolve;

--- a/src/renderer/lib/meshcoreDualNobleBleInit.test.ts
+++ b/src/renderer/lib/meshcoreDualNobleBleInit.test.ts
@@ -5,6 +5,7 @@ import { useIdentityStore } from '../stores/identityStore';
 import {
   awaitDualNobleBleMeshtasticSettle,
   meshtasticNobleBleConfigureBusy,
+  needsSequentialMeshcoreRadioInit,
 } from './meshcoreDualNobleBleInit';
 
 const meshtasticProtocol = { type: 'meshtastic' } as const;
@@ -94,5 +95,13 @@ describe('meshcoreDualNobleBleInit', () => {
     const start = Date.now();
     await awaitDualNobleBleMeshtasticSettle(4000);
     expect(Date.now() - start).toBeLessThan(100);
+  });
+
+  it('needsSequentialMeshcoreRadioInit is true for serial and Linux Web Bluetooth only', () => {
+    expect(needsSequentialMeshcoreRadioInit('serial')).toBe(true);
+    expect(needsSequentialMeshcoreRadioInit('tcp')).toBe(false);
+    // jsdom reports non-Linux in CI; Noble path when platform is macOS/Windows.
+    const bleSequential = needsSequentialMeshcoreRadioInit('ble');
+    expect(typeof bleSequential).toBe('boolean');
   });
 });

--- a/src/renderer/lib/meshcoreDualNobleBleInit.ts
+++ b/src/renderer/lib/meshcoreDualNobleBleInit.ts
@@ -23,6 +23,15 @@ export function isRendererNobleBlePlatform(): boolean {
   return true;
 }
 
+/**
+ * USB serial and Linux Web Bluetooth share single-flight companion RPC + WritableStream
+ * writes; init must run getSelfInfo → getContacts → getChannels before post-init side effects.
+ * Noble BLE (macOS/Windows) and TCP keep parallel overlap.
+ */
+export function needsSequentialMeshcoreRadioInit(transport: 'ble' | 'serial' | 'tcp'): boolean {
+  return transport === 'serial' || (transport === 'ble' && !isRendererNobleBlePlatform());
+}
+
 /** Meshtastic identity on Noble BLE that has not reached `configured` yet. */
 export function meshtasticNobleBleConfigureBusy(): boolean {
   const { identities } = useIdentityStore.getState();

--- a/src/renderer/lib/meshcoreWebBluetoothConnection.test.ts
+++ b/src/renderer/lib/meshcoreWebBluetoothConnection.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@liamcottle/meshcore.js', () => ({
+  Connection: class {
+    onConnected = vi.fn().mockResolvedValue(undefined);
+    onFrameReceived = vi.fn();
+    emit = vi.fn();
+  },
+}));
+
+import { MeshcoreWebBluetoothConnection } from './meshcoreWebBluetoothConnection';
+import type { TransportWebBluetoothIpc } from './transportWebBluetoothIpc';
+
+function makeMockTransport(innerWritable: WritableStream<Uint8Array>) {
+  return {
+    toDevice: innerWritable,
+    fromDevice: new ReadableStream(),
+    requestDevice: vi.fn().mockResolvedValue({ deviceId: 'wb-test', deviceName: 'MeshCore' }),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TransportWebBluetoothIpc;
+}
+
+describe('MeshcoreWebBluetoothConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('serializes concurrent sendToRadioFrame writes after connect', async () => {
+    let innerWriteCount = 0;
+    const inner = new WritableStream<Uint8Array>({
+      async write() {
+        innerWriteCount++;
+        await new Promise((resolve) => setTimeout(resolve, 15));
+      },
+    });
+    const transport = makeMockTransport(inner);
+    const conn = new MeshcoreWebBluetoothConnection(transport);
+
+    await conn.connect();
+
+    await Promise.all([
+      conn.sendToRadioFrame(new Uint8Array([1])),
+      conn.sendToRadioFrame(new Uint8Array([2])),
+      conn.sendToRadioFrame(new Uint8Array([3])),
+    ]);
+
+    expect(innerWriteCount).toBe(3);
+    expect(transport.toDevice).toBe(inner);
+  });
+});

--- a/src/renderer/lib/meshcoreWebBluetoothConnection.ts
+++ b/src/renderer/lib/meshcoreWebBluetoothConnection.ts
@@ -5,6 +5,7 @@ import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import { MeshcoreCompanionTxEchoFilter } from '@/renderer/lib/meshcoreCompanionTxEchoFilter';
 
 import { withTimeout } from '../../shared/withTimeout';
+import { createSerializedWritableStream } from './meshtastic/meshtasticTransportLossDetection';
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- TransportWebBluetoothIpc is used as a value (new) in connect()
 import { TransportWebBluetoothIpc } from './transportWebBluetoothIpc';
 
@@ -17,6 +18,7 @@ export class MeshcoreWebBluetoothConnection extends Connection {
   private readonly transport: TransportWebBluetoothIpc;
   private readonly txEchoFilter = new MeshcoreCompanionTxEchoFilter();
   private _fromDeviceReader: ReadableStreamDefaultReader<Types.DeviceOutput> | null = null;
+  private _serializedToDevice: WritableStream<Uint8Array> | null = null;
 
   constructor(transport: TransportWebBluetoothIpc) {
     super();
@@ -26,7 +28,8 @@ export class MeshcoreWebBluetoothConnection extends Connection {
   async sendToRadioFrame(data: Uint8Array): Promise<void> {
     this.txEchoFilter.noteOutbound(data);
     this.emit('tx', data);
-    const writer = this.transport.toDevice.getWriter();
+    const toDevice = this._serializedToDevice ?? this.transport.toDevice;
+    const writer = toDevice.getWriter();
     try {
       await writer.ready;
       await writer.write(data);
@@ -36,6 +39,7 @@ export class MeshcoreWebBluetoothConnection extends Connection {
   }
 
   async close(): Promise<void> {
+    this._serializedToDevice = null;
     if (this._fromDeviceReader) {
       await this._fromDeviceReader.cancel().catch(() => {});
       this._fromDeviceReader = null;
@@ -64,6 +68,8 @@ export class MeshcoreWebBluetoothConnection extends Connection {
       WEB_BLUETOOTH_CONNECT_TIMEOUT_MS,
       'Web Bluetooth transport connect',
     );
+
+    this._serializedToDevice = createSerializedWritableStream(this.transport.toDevice);
 
     this._fromDeviceReader = this.transport.fromDevice.getReader();
     void this._readLoop();

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -140,7 +140,10 @@ import {
   repairMeshcoreHydratedMessages,
 } from '../lib/meshcoreDbCacheHydration';
 import { setMeshcoreDmAckPendingImpl } from '../lib/meshcoreDmAckDelivery';
-import { awaitDualNobleBleMeshtasticSettle } from '../lib/meshcoreDualNobleBleInit';
+import {
+  awaitDualNobleBleMeshtasticSettle,
+  needsSequentialMeshcoreRadioInit,
+} from '../lib/meshcoreDualNobleBleInit';
 import { applyMeshcoreFloodScope } from '../lib/meshcoreFloodScope';
 import {
   buildMeshcoreGetNeighboursRequest,
@@ -1572,12 +1575,12 @@ export function useMeshcoreRuntime() {
         setMeshcoreIdentityId(driverStoreId);
       }
 
-      const isSerialInit = meshcoreConnectTypeRef.current === 'serial';
+      const sequentialRadioInit = needsSequentialMeshcoreRadioInit(meshcoreConnectTypeRef.current);
       const getSelfInfoStart = performance.now();
       let getContactsStart = getSelfInfoStart;
       let parallelSelfInfoPromise: ReturnType<MeshCoreConnection['getSelfInfo']> | undefined;
       let parallelContactsPromise: Promise<MeshCoreContactRaw[]> | undefined;
-      if (!isSerialInit) {
+      if (!sequentialRadioInit) {
         parallelSelfInfoPromise = awaitUnlessMeshcoreSetupCancelled(
           setupGen,
           conn.getSelfInfo(5000),
@@ -1647,7 +1650,7 @@ export function useMeshcoreRuntime() {
         `[useMeshcoreRuntime] initConn dbCache→UI ${dbCacheMs}ms (${dbCacheNodeCount} nodes)`,
       );
 
-      const rawInfo = isSerialInit
+      const rawInfo = sequentialRadioInit
         ? await awaitUnlessMeshcoreSetupCancelled(setupGen, conn.getSelfInfo(5000))
         : await parallelSelfInfoPromise!;
       const getSelfInfoMs = Math.round(performance.now() - getSelfInfoStart);
@@ -1715,10 +1718,10 @@ export function useMeshcoreRuntime() {
         });
       }
 
-      if (isSerialInit) {
+      if (sequentialRadioInit) {
         getContactsStart = performance.now();
       }
-      const contactsRaw = isSerialInit
+      const contactsRaw = sequentialRadioInit
         ? await awaitUnlessMeshcoreSetupCancelled(
             setupGen,
             withTimeout(conn.getContacts(), MESHCORE_INIT_TIMEOUT_MS, 'getContacts'),
@@ -1762,21 +1765,24 @@ export function useMeshcoreRuntime() {
       triggerRoomAutoLoginRef.current();
       void deferMeshcoreDbContactMerge(newNodes, previousNodesBaseline);
 
-      if (isSerialInit) {
-        void (async () => {
-          try {
-            const rawChannels = await awaitUnlessMeshcoreSetupCancelled(
-              setupGen,
-              withTimeout(conn.getChannels(), MESHCORE_INIT_TIMEOUT_MS, 'getChannels'),
-            );
-            setChannels(
-              rawChannels.map((c) => ({ index: c.channelIdx, name: c.name, secret: c.secret })),
-            );
-          } catch (e) {
-            if (e instanceof DOMException && e.name === 'AbortError') return;
-            console.warn('[useMeshcoreRuntime] getChannels error ' + errLikeToLogString(e));
-          }
-        })();
+      if (sequentialRadioInit) {
+        const getChannelsStart = performance.now();
+        try {
+          const rawChannels = await awaitUnlessMeshcoreSetupCancelled(
+            setupGen,
+            withTimeout(conn.getChannels(), MESHCORE_INIT_TIMEOUT_MS, 'getChannels'),
+          );
+          setChannels(
+            rawChannels.map((c) => ({ index: c.channelIdx, name: c.name, secret: c.secret })),
+          );
+          const getChannelsMs = Math.round(performance.now() - getChannelsStart);
+          console.debug(
+            `[useMeshcoreRuntime] initConn getChannels ${getChannelsMs}ms (${rawChannels.length} channels)`,
+          );
+        } catch (e) {
+          if (e instanceof DOMException && e.name === 'AbortError') throw e;
+          console.warn('[useMeshcoreRuntime] getChannels error ' + errLikeToLogString(e));
+        }
       }
 
       // Re-resolve map/App GPS after nodesRef picks up getSelfInfo advert coords (same tick as setNodes is too early).

--- a/src/shared/timeConstants.ts
+++ b/src/shared/timeConstants.ts
@@ -8,6 +8,6 @@ export const MS_PER_MINUTE = 60_000;
  */
 export const CHAT_COMPACT_CONTINUATION_TIME_GAP_MS = 5 * MS_PER_MINUTE;
 
-export const MS_PER_HOUR = 3_600_000;
-export const MS_PER_DAY = 86_400_000;
+export const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+export const MS_PER_DAY = 24 * MS_PER_HOUR;
 export const MS_PER_YEAR = 365 * MS_PER_DAY;


### PR DESCRIPTION
## Summary

- **Sequential MeshCore radio init** for USB serial and Linux Web Bluetooth via `needsSequentialMeshcoreRadioInit`: `getSelfInfo` → `getContacts` → `getChannels` completes before post-init RPCs (`syncDeviceTime`, auto-add, `setAdvertLatLong`). TCP and Noble BLE (macOS/Windows) keep parallel overlap for faster connect.
- **Await `getChannels`** instead of fire-and-forget background fetch, fixing partial channel lists (e.g. public-only) when post-init RPCs collided with channel hydration on reconnect and PopOS BLE.
- **Serialize Linux Web Bluetooth writes** with `createSerializedWritableStream` on `MeshcoreWebBluetoothConnection` so concurrent connect-time RPCs do not hit `WritableStream is locked` (same pattern as #576 for Meshtastic).
- **Minor refactor:** derive `MS_PER_HOUR` / `MS_PER_DAY` from base time constants in `src/shared/timeConstants.ts` (values unchanged).

## Test plan

- [ ] Connect MeshCore over **USB serial** — channels tab shows full enumeration (not public-only) after connect/reconnect.
- [ ] Connect MeshCore over **Linux Web Bluetooth** — same channel list reliability; no `WritableStream is locked` in logs during init.
- [ ] Connect MeshCore over **TCP** and **Noble BLE** (macOS/Windows) — connect still fast with parallel init RPCs.
- [ ] `pnpm run test:run` — `useMeshcoreRuntime.initconn-rpc-order`, `useMeshcoreRuntime.stats`, `meshcoreDualNobleBleInit`, `meshcoreWebBluetoothConnection` tests pass.