### PR TITLE
fix: skip MeshCore BLE auto-connect when sharing Meshtastic peripheral

### DIFF
--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -716,6 +716,129 @@ describe('ConnectionPanel exit actions', () => {
   });
 });
 
+describe('ConnectionPanel meshcore shared Meshtastic BLE auto-connect', () => {
+  it('skips meshcore noble scan when last BLE device matches Meshtastic', async () => {
+    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
+    userAgentSpy.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+    );
+    const sharedId = 'shared-ble-peripheral';
+    const mcConnKey = 'mesh-client:lastConnection:meshcore';
+    const mtBleKey = 'mesh-client:lastBleDevice:meshtastic';
+    localStorage.setItem(mcConnKey, JSON.stringify({ type: 'ble', bleDeviceId: sharedId }));
+    localStorage.setItem(mtBleKey, sharedId);
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockClear();
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshcore"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(window.electronAPI.startNobleBleScanning).not.toHaveBeenCalled();
+      });
+    } finally {
+      localStorage.removeItem(mcConnKey);
+      localStorage.removeItem(mtBleKey);
+      userAgentSpy.mockRestore();
+    }
+  });
+});
+
+describe('ConnectionPanel serial auto-connect BLE fallback', () => {
+  it('falls back to noble BLE scan when serial auto-connect fails and lastBleDevice exists', async () => {
+    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
+    userAgentSpy.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+    );
+    const lastConnKey = 'mesh-client:lastConnection:meshcore';
+    const lastBleKey = 'mesh-client:lastBleDevice:meshcore';
+    localStorage.setItem(lastConnKey, JSON.stringify({ type: 'serial', serialPortId: 'port-1' }));
+    localStorage.setItem(lastBleKey, 'ble-device-abc');
+    const onAutoConnect = vi
+      .fn()
+      .mockRejectedValue(new Error('Serial auto-connect failed (radio did not respond)'));
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockResolvedValue(undefined);
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={onAutoConnect}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshcore"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(onAutoConnect).toHaveBeenCalledWith('serial', undefined, 'port-1');
+      });
+      await waitFor(() => {
+        expect(window.electronAPI.startNobleBleScanning).toHaveBeenCalledWith('meshcore');
+      });
+
+      const migrated = JSON.parse(localStorage.getItem(lastConnKey) ?? '{}') as {
+        type?: string;
+        bleDeviceId?: string;
+      };
+      expect(migrated.type).toBe('ble');
+      expect(migrated.bleDeviceId).toBe('ble-device-abc');
+    } finally {
+      localStorage.removeItem(lastConnKey);
+      localStorage.removeItem(lastBleKey);
+      userAgentSpy.mockRestore();
+    }
+  });
+
+  it('does not fall back to noble BLE when serial fails but BLE id is shared with Meshtastic', async () => {
+    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
+    userAgentSpy.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+    );
+    const sharedId = 'shared-ble-device';
+    const lastConnKey = 'mesh-client:lastConnection:meshcore';
+    localStorage.setItem(lastConnKey, JSON.stringify({ type: 'serial', serialPortId: 'port-1' }));
+    localStorage.setItem('mesh-client:lastBleDevice:meshcore', sharedId);
+    localStorage.setItem('mesh-client:lastBleDevice:meshtastic', sharedId);
+    const onAutoConnect = vi
+      .fn()
+      .mockRejectedValue(new Error('Serial auto-connect failed (radio did not respond)'));
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockClear();
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={onAutoConnect}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshcore"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(onAutoConnect).toHaveBeenCalledWith('serial', undefined, 'port-1');
+      });
+      expect(window.electronAPI.startNobleBleScanning).not.toHaveBeenCalled();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+      localStorage.removeItem('mesh-client:lastBleDevice:meshcore');
+      localStorage.removeItem('mesh-client:lastBleDevice:meshtastic');
+      userAgentSpy.mockRestore();
+    }
+  });
+});
+
 describe('ConnectionPanel MeshCore TCP port field', () => {
   it('renders host and port inputs with default port 5000 when TCP/IP is selected', async () => {
     const user = userEvent.setup();

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -8,6 +8,7 @@ import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import { ConnectionIcon, MqttGlobeIcon } from '@/renderer/lib/icons/connectionIcons';
 import { useParentIconTrigger } from '@/renderer/lib/icons/iconMotionContext';
 import { SpinnerIcon, SpinnerIconLg } from '@/renderer/lib/icons/spinnerIcon';
+import { meshcoreTargetsSharedMeshtasticBlePeripheral } from '@/renderer/lib/meshcoreDualNobleBleInit';
 import { markMqttUserDisconnect } from '@/renderer/lib/mqttDisconnectIntent';
 import { mqttUsesTls } from '@/renderer/lib/mqttTls';
 import { parseTcpAddress } from '@/renderer/lib/parseTcpAddress';
@@ -925,6 +926,13 @@ export default function ConnectionPanel({
       });
       if (isAutoConnectingRef.current) {
         const lastId = lastConnection?.bleDeviceId ?? loadLastBleDevice(protocol);
+        if (
+          protocol === 'meshcore' &&
+          lastId &&
+          meshcoreTargetsSharedMeshtasticBlePeripheral(lastId)
+        ) {
+          return;
+        }
         if (lastId && device.deviceId === lastId) {
           if (autoConnectTimeoutRef.current) {
             clearTimeout(autoConnectTimeoutRef.current);
@@ -1445,6 +1453,8 @@ export default function ConnectionPanel({
 
     autoConnectFiredRef.current = true;
 
+    const lastBleId = lc.bleDeviceId ?? loadLastBleDevice(protocol);
+
     const startAutoConnectTimeout = () => {
       if (autoConnectTimeoutRef.current) clearTimeout(autoConnectTimeoutRef.current);
       autoConnectTimeoutRef.current = setTimeout(() => {
@@ -1469,6 +1479,47 @@ export default function ConnectionPanel({
       setConnectionStage('');
     };
 
+    const startBleNobleAutoConnect = (): boolean => {
+      if (!lastBleId || isLinux) return false;
+      setConnectionType('ble');
+      isAutoConnectingRef.current = true;
+      setIsAutoConnecting(true);
+      setConnecting(true);
+      setConnectionStage('connectionPanel.stageScanningLast');
+      startAutoConnectTimeout();
+      void window.electronAPI.startNobleBleScanning(protocol).catch(onAutoConnectFailed);
+      return true;
+    };
+
+    const skipMeshcoreSharedMeshtasticBleAutoConnect = (): boolean => {
+      if (protocol !== 'meshcore' || !meshcoreTargetsSharedMeshtasticBlePeripheral(lastBleId)) {
+        return false;
+      }
+      console.debug(
+        `[ConnectionPanel] meshcore BLE auto-connect skipped — same peripheral as Meshtastic (${lastBleId})`,
+      );
+      if (autoConnectTimeoutRef.current) {
+        clearTimeout(autoConnectTimeoutRef.current);
+        autoConnectTimeoutRef.current = null;
+      }
+      isAutoConnectingRef.current = false;
+      setIsAutoConnecting(false);
+      setConnecting(false);
+      setConnectionStage('');
+      return true;
+    };
+
+    const migrateLastConnectionToBle = (bleDeviceId: string) => {
+      const bleLast: LastConnection = {
+        type: 'ble',
+        bleDeviceId,
+        bleDeviceName:
+          lc.bleDeviceName ?? lastConnectionBleDeviceNameFallbackRef.current ?? undefined,
+      };
+      saveLastConnection(protocol, bleLast);
+      setLastConnection(bleLast);
+    };
+
     if (lc.type === 'serial') {
       setConnectionType('serial');
       isAutoConnectingRef.current = true;
@@ -1476,21 +1527,24 @@ export default function ConnectionPanel({
       setConnecting(true);
       setConnectionStage('connectionPanel.stagePleaseWait');
       startAutoConnectTimeout();
-      void onAutoConnectRef
-        .current('serial', undefined, lc.serialPortId)
-        .catch(onAutoConnectFailed);
+      void onAutoConnectRef.current('serial', undefined, lc.serialPortId).catch((err: unknown) => {
+        if (lastBleId && !isLinux) {
+          console.warn(
+            `[ConnectionPanel] serial auto-connect failed for ${protocol}; falling back to BLE noble scan: ${errLikeToLogString(err)}`,
+          );
+          migrateLastConnectionToBle(lastBleId);
+          if (skipMeshcoreSharedMeshtasticBleAutoConnect()) return;
+          if (startBleNobleAutoConnect()) return;
+        }
+        onAutoConnectFailed(err);
+      });
     } else if (lc.type === 'ble') {
-      setConnectionType('ble');
-      if (lc.bleDeviceId && !isLinux) {
+      if (lastBleId && !isLinux) {
         // Noble: auto-scan on startup — no user gesture required.
         // onNobleBleDeviceDiscovered will auto-connect when the known device appears.
         // On Linux, Web Bluetooth requires a user gesture; skip auto-scan and let user click Connect.
-        isAutoConnectingRef.current = true;
-        setIsAutoConnecting(true);
-        setConnecting(true);
-        setConnectionStage('connectionPanel.stageScanningLast');
-        startAutoConnectTimeout();
-        void window.electronAPI.startNobleBleScanning(protocol).catch(onAutoConnectFailed);
+        if (skipMeshcoreSharedMeshtasticBleAutoConnect()) return;
+        startBleNobleAutoConnect();
       }
     }
     // HTTP: do not auto-trigger — show one-click reconnect card instead

--- a/src/renderer/hooks/useMeshcoreRuntime.serial-cleanup.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.serial-cleanup.test.tsx
@@ -169,6 +169,31 @@ describe('useMeshcoreRuntime serial cleanup', () => {
     serialConnCloseMock.mockResolvedValue(undefined);
   });
 
+  it('connectAutomatic maps bare meshcore.js reject() to a readable serial error', async () => {
+    const port = makeMockSerialPort('auto-port');
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: {
+        getPorts: vi.fn().mockResolvedValue([port]),
+      },
+    });
+    serialConnGetSelfInfoMock.mockRejectedValue(undefined);
+
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useMeshcoreRuntime());
+
+    await expect(
+      act(async () => {
+        await result.current.connectAutomatic('serial', undefined, 'auto-port');
+      }),
+    ).rejects.toThrow('Serial auto-connect failed (radio did not respond)');
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/connectAutomatic serial error.*Serial auto-connect failed/),
+    );
+    consoleWarnSpy.mockRestore();
+  });
+
   it('connectAutomatic closes raw port even when connection close throws', async () => {
     const port = makeMockSerialPort('auto-port');
     Object.defineProperty(navigator, 'serial', {

--- a/src/renderer/hooks/useProtocolConnection.test.ts
+++ b/src/renderer/hooks/useProtocolConnection.test.ts
@@ -72,7 +72,10 @@ describe('useProtocolConnect (driver-first)', () => {
       'configure failed',
     );
 
-    expect(meshtastic.handleRfConnectFailure).toHaveBeenCalledWith('id-meshtastic-driver');
+    expect(meshtastic.handleRfConnectFailure).toHaveBeenCalledWith(
+      'id-meshtastic-driver',
+      expect.objectContaining({ message: 'configure failed' }),
+    );
     expect(meshtastic.attachRfSession).toHaveBeenCalled();
   });
 
@@ -86,7 +89,10 @@ describe('useProtocolConnect (driver-first)', () => {
       'driver connect failed',
     );
 
-    expect(meshtastic.handleRfConnectFailure).toHaveBeenCalledWith(undefined);
+    expect(meshtastic.handleRfConnectFailure).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ message: 'driver connect failed' }),
+    );
     expect(meshtastic.attachRfSession).not.toHaveBeenCalled();
   });
 

--- a/src/renderer/hooks/useProtocolConnection.ts
+++ b/src/renderer/hooks/useProtocolConnection.ts
@@ -83,7 +83,7 @@ export function useProtocolConnect() {
         driverIdentityId = await driverConnect('meshtastic', params);
         await meshtastic.attachRfSession(driverIdentityId, type);
       } catch (err) {
-        await meshtastic.handleRfConnectFailure(driverIdentityId);
+        await meshtastic.handleRfConnectFailure(driverIdentityId, err);
         throw err;
       }
     },

--- a/src/renderer/lib/meshcoreDualNobleBleInit.test.ts
+++ b/src/renderer/lib/meshcoreDualNobleBleInit.test.ts
@@ -4,6 +4,7 @@ import { useConnectionStore } from '../stores/connectionStore';
 import { useIdentityStore } from '../stores/identityStore';
 import {
   awaitDualNobleBleMeshtasticSettle,
+  meshcoreTargetsSharedMeshtasticBlePeripheral,
   meshtasticNobleBleConfigureBusy,
   needsSequentialMeshcoreRadioInit,
 } from './meshcoreDualNobleBleInit';
@@ -103,5 +104,14 @@ describe('meshcoreDualNobleBleInit', () => {
     // jsdom reports non-Linux in CI; Noble path when platform is macOS/Windows.
     const bleSequential = needsSequentialMeshcoreRadioInit('ble');
     expect(typeof bleSequential).toBe('boolean');
+  });
+
+  it('meshcoreTargetsSharedMeshtasticBlePeripheral when both remember the same BLE id', () => {
+    localStorage.setItem('mesh-client:lastBleDevice:meshtastic', 'shared-peripheral');
+    localStorage.setItem('mesh-client:lastBleDevice:meshcore', 'shared-peripheral');
+    expect(meshcoreTargetsSharedMeshtasticBlePeripheral('shared-peripheral')).toBe(true);
+    expect(meshcoreTargetsSharedMeshtasticBlePeripheral('other-peripheral')).toBe(false);
+    localStorage.removeItem('mesh-client:lastBleDevice:meshtastic');
+    localStorage.removeItem('mesh-client:lastBleDevice:meshcore');
   });
 });

--- a/src/renderer/lib/meshcoreDualNobleBleInit.ts
+++ b/src/renderer/lib/meshcoreDualNobleBleInit.ts
@@ -1,5 +1,6 @@
 import { getConnection } from '../stores/connectionStore';
 import { useIdentityStore } from '../stores/identityStore';
+import { resolveLastBlePeripheralId } from './lastConnectionStorage';
 import {
   MESHCORE_DUAL_NOBLE_BLE_GET_CONTACTS_DEFER_MS,
   MESHCORE_DUAL_NOBLE_BLE_POLL_MS,
@@ -41,6 +42,18 @@ export function meshtasticNobleBleConfigureBusy(): boolean {
     if (conn.status === 'connecting' || conn.status === 'connected') return true;
   }
   return false;
+}
+
+/**
+ * MeshCore and Meshtastic cannot hold separate Noble GATT sessions to the same peripheral.
+ * Skip MeshCore BLE auto-connect when it targets the same device as Meshtastic RF.
+ */
+export function meshcoreTargetsSharedMeshtasticBlePeripheral(
+  meshcoreBlePeripheralId: string | null | undefined,
+): boolean {
+  if (!meshcoreBlePeripheralId) return false;
+  const meshtasticBleId = resolveLastBlePeripheralId('meshtastic');
+  return Boolean(meshtasticBleId && meshtasticBleId === meshcoreBlePeripheralId);
 }
 
 /**

--- a/src/renderer/lib/sessions/meshtasticSession.ts
+++ b/src/renderer/lib/sessions/meshtasticSession.ts
@@ -9,7 +9,7 @@ export interface MeshtasticSessionApi {
     lastSerialPortId?: string | null,
   ) => Promise<void>;
   attachRfSession: (driverIdentityId: string, type: ConnectionType) => Promise<void>;
-  handleRfConnectFailure: (driverIdentityId?: string) => Promise<void>;
+  handleRfConnectFailure: (driverIdentityId?: string, reason?: unknown) => Promise<void>;
   finalizeDriverDisconnect: (opts?: { disconnectDriver?: boolean }) => Promise<void>;
   /** Meshtastic chat send (RF and MQTT-only via TransportManager). */
   sendChatMessage: (

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -2403,10 +2403,16 @@ export function useMeshcoreRuntime() {
             err.name === 'AbortError' &&
             err.message === MESHCORE_SETUP_ABORT_MESSAGE;
           if (!isSetupAbort) {
-            console.error(
-              '[useMeshcoreRuntime] connectAutomatic serial error',
-              serializeErrorLike(err) || err,
+            const normalized = normalizeMeshCoreError(
+              err,
+              'Serial auto-connect failed (radio did not respond)',
             );
+            const stage = opened ? 'attachRfSession' : 'openMeshCoreTransport';
+            console.warn(
+              `[useMeshcoreRuntime] connectAutomatic serial error stage=${stage} ${errLikeToLogString(normalized)} raw=${errLikeToLogString(err)}`,
+            );
+            await handleRfConnectFailure('serial', opened?.driverIdentityId);
+            throw normalized;
           }
           await handleRfConnectFailure('serial', opened?.driverIdentityId);
           throw err;

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -2092,9 +2092,12 @@ export function useMeshtasticRuntime() {
   );
 
   const handleRfConnectFailure = useCallback(
-    async (driverIdentityId?: string): Promise<void> => {
+    async (driverIdentityId?: string, reason?: unknown): Promise<void> => {
       clearConfigureTimeout();
-      console.error('[useMeshtasticRuntime] Connection failed');
+      console.error(
+        '[useMeshtasticRuntime] Connection failed: ' +
+          errLikeToLogString(reason ?? new Error('unknown connection failure')),
+      );
       isReconnectingRef.current = false;
       reconnectGenerationRef.current += 1;
       cleanupSubscriptions();
@@ -2198,8 +2201,7 @@ export function useMeshtasticRuntime() {
         });
         await attachRfSession(opened.driverIdentityId, type, opened.device);
       } catch (err) {
-        console.error('[useMeshtasticRuntime] Connection failed: ' + errLikeToLogString(err));
-        await handleRfConnectFailure(opened?.driverIdentityId);
+        await handleRfConnectFailure(opened?.driverIdentityId, err);
         throw err;
       }
     },
@@ -2233,8 +2235,7 @@ export function useMeshtasticRuntime() {
         });
         await attachRfSession(opened.driverIdentityId, type, opened.device);
       } catch (err) {
-        console.error('[useMeshtasticRuntime] Auto-connect failed: ' + errLikeToLogString(err));
-        await handleRfConnectFailure(opened?.driverIdentityId);
+        await handleRfConnectFailure(opened?.driverIdentityId, err);
         throw err;
       }
     },


### PR DESCRIPTION
## Summary

When both MeshCore and Meshtastic tabs are configured for the same BLE radio, the dual-protocol auto-connect flow was attempting to open a second Noble GATT connection to an already-connected peripheral. Noble cannot hold concurrent GATT sessions to the same device, so this caused connect failures and UI thrash.

Additionally improves serial auto-connect resilience by falling back to BLE scanning when serial fails and a known BLE device exists.

## Changes

### MeshCore BLE auto-connect skip
- **`meshcoreDualNobleBleInit.ts`** — new `meshcoreTargetsSharedMeshtasticBlePeripheral()` compares the MeshCore target BLE peripheral id against the last Meshtastic BLE device in localStorage. If they match, MeshCore skips its own auto-connect.
- **`ConnectionPanel.tsx`** — guards both the Noble device-discovered handler and the `autoConnectFired` path with the shared-peripheral check. On hit, logs a debug message, clears the timeout, and returns to idle without attempting a scan.

### Serial auto-connect → BLE fallback
- **`ConnectionPanel.tsx`** — when serial auto-connect fails and a known BLE device id exists (non-Linux), the panel now:
  1. Logs a warning with the serial error
  2. Migrates the stored `LastConnection` from `{type:"serial"}` to `{type:"ble", bleDeviceId:...}`
  3. Falls through to the shared-peripheral guard (skip if Meshtastic owns it)
  4. Otherwise initiates a Noble BLE scan for that device

### Better MeshCore serial error messages
- **`useMeshcoreRuntime.ts`** — bare `meshcore.js` rejections (e.g. `undefined` from `getSelfInfo` timeout) are now normalized via `normalizeMeshCoreError` into a readable `"Serial auto-connect failed (radio did not respond)"` before being thrown up to `ConnectionPanel`. This gives users (and the fallback logic) a meaningful error instead of a cryptic `undefined`.

### Pass `reason` through `handleRfConnectFailure`
- **`meshtasticSession.ts`** — interface signature updated to accept an optional `reason?: unknown`.
- **`useMeshtasticRuntime.ts`** — both `connectRadio` and `connectAutomatic` now pass the caught error through to `handleRfConnectFailure`, which logs it instead of the previous opaque `"Connection failed"` message.
- **`useProtocolConnection.ts`** — the driver-first connect path now also forwards the error.
- Test assertions updated to expect the error object.

## Testing

- **`ConnectionPanel.test.tsx`** — 3 new cases:
  - Skips MeshCore noble scan when last BLE device matches Meshtastic
  - Falls back to BLE noble scan when serial fails and last BLE device is known
  - Does not fall back to BLE when serial fails but BLE id is shared with Meshtastic
- **`meshcoreDualNobleBleInit.test.ts`** — 1 new case for `meshcoreTargetsSharedMeshtasticBlePeripheral`
- **`useMeshcoreRuntime.serial-cleanup.test.tsx`** — 1 new case verifying bare rejections map to readable serial error
- **`useProtocolConnection.test.ts`** — 2 existing assertions updated to expect error passthrough