### PR TITLE
fix: harden USB serial reconnect on lockup and zombie ports

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -267,6 +267,21 @@ This means Chromium still holds the previous Web Serial session (locked streams)
 
 BLE or Wi‑Fi/HTTP avoids this USB serial path when you need a reliable reconnect loop.
 
+### MeshCore / Meshtastic USB serial: app frozen or stuck on "Reconnecting…"
+
+If the UI stops updating but the radio is still powered, Chromium may be holding a **zombie Web Serial session** (streams stalled with no error). mesh-client now:
+
+1. Times out serial `open` / reconnect after **15 seconds** instead of hanging forever.
+2. Treats **3 minutes** without inbound traffic as a dead link (serial watchdog) and starts auto-reconnect.
+3. After **5 failed** auto-reconnect attempts, revokes the stale port permission (`SerialPort.forget()` when supported), clears saved port identity, and shows **Select serial port** in the connection banner (opens the normal port picker).
+
+If auto-recovery does not help:
+
+1. **Quit mesh-client completely** (not only Disconnect), unplug/replug USB if needed, reopen, and use **Select serial port**.
+2. Open **Log → Analyze** after enabling **debug** — look for **USB Serial Reconnect** patterns.
+
+This applies on **Windows, macOS, and Linux** (same Web Serial stack). Linux **permission denied** before the first connect is a separate issue — see [Linux: serial port access denied](#linux-serial-port-access-denied).
+
 ### Connection or transport issues: use Log **Analyze**
 
 Open the **Log** panel (right rail), enable **debug** if needed, reproduce the problem, then click **Analyze**. The app scans recent buffered log lines for patterns (BLE, serial, TCP, MQTT, handshake timeouts, etc.) and lists **suggested next steps**. This complements export/delete: use it before filing an issue so you have concrete log context. Analysis is **heuristic**; treat recommendations as hints, not guarantees.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "leaflet.markercluster": "^1.5.3",
     "lucide-react-motion": "^0.4.0",
     "mgrs": "^2.1.0",
-    "motion": "^12.41.0",
+    "motion": "^12.42.0",
     "mqtt": "^5.15.1",
     "node-forge": "^1.4.0",
     "react-i18next": "^17.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,13 +75,13 @@ importers:
         version: 1.5.3(leaflet@1.9.4)
       lucide-react-motion:
         specifier: ^0.4.0
-        version: 0.4.0(motion@12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.4.0(motion@12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       mgrs:
         specifier: ^2.1.0
         version: 2.1.0
       motion:
-        specifier: ^12.41.0
-        version: 12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^12.42.0
+        version: 12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       mqtt:
         specifier: ^5.15.1
         version: 5.15.1
@@ -382,8 +382,8 @@ packages:
   '@bufbuild/protobuf@2.12.1':
     resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
 
-  '@csstools/color-helpers@6.0.2':
-    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
     engines: {node: '>=20.19.0'}
 
   '@csstools/css-calc@3.2.1':
@@ -393,8 +393,8 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.8':
-    resolution: {integrity: sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==}
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -1603,8 +1603,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.38:
-    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
+  baseline-browser-mapping@2.10.40:
+    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2015,8 +2015,8 @@ packages:
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
 
-  electron-to-chromium@1.5.378:
-    resolution: {integrity: sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==}
+  electron-to-chromium@1.5.379:
+    resolution: {integrity: sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==}
 
   electron-updater@6.8.9:
     resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
@@ -2097,12 +2097,12 @@ packages:
     resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
     engines: {node: '>= 0.4'}
 
-  es-to-primitive@1.3.1:
-    resolution: {integrity: sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==}
+  es-to-primitive@1.3.4:
+    resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.48.1:
-    resolution: {integrity: sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==}
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -2269,8 +2269,8 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
@@ -2348,8 +2348,8 @@ packages:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
-  framer-motion@12.41.0:
-    resolution: {integrity: sha512-OHAMNiCEON1RDBlRGuulsN5AD8ptMjvk5QWfFmYmBLPZ3zFGIJe60kQucQQf4cez1OzQmjYBWDY+dYfISkUdqg==}
+  framer-motion@12.42.0:
+    resolution: {integrity: sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -3249,14 +3249,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  motion-dom@12.41.0:
-    resolution: {integrity: sha512-Lk3J39fOGg6xNr1KRZsN6usDyBf8aP7MEbUPez1VCughHt79OrP7VGqNrPyFL0riaT7WS8t9DRw1M3BHtM/xKw==}
+  motion-dom@12.42.0:
+    resolution: {integrity: sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==}
 
   motion-utils@12.39.0:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
-  motion@12.41.0:
-    resolution: {integrity: sha512-avEDKE22rFPJqDr3Ttk7gMQpeaOmNik60NoJ5T0tj+RBCNvz21D3ArY3l4uitoeQ7eIpDqueWaO3pPYFv8JOVA==}
+  motion@12.42.0:
+    resolution: {integrity: sha512-Qhwvu9sVl5/URSq5CNzwMCpSKK8Uhnrwb6VO977kZyj/wOCS7mWebJUnBoHx5cZU1Zv8a9BD5CSICWKAlrLJgA==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -4121,8 +4121,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.17:
+    resolution: {integrity: sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==}
     engines: {node: '>=18'}
 
   temp-file@3.4.0:
@@ -4581,7 +4581,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -4712,16 +4712,16 @@ snapshots:
 
   '@bufbuild/protobuf@2.12.1': {}
 
-  '@csstools/color-helpers@6.0.2': {}
+  '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 6.0.2
+      '@csstools/color-helpers': 6.1.0
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
@@ -5810,7 +5810,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.16
+      tar: 7.5.17
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       unzipper: 0.12.5
@@ -5937,7 +5937,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.38: {}
+  baseline-browser-mapping@2.10.40: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -5981,9 +5981,9 @@ snapshots:
 
   browserslist@4.28.4:
     dependencies:
-      baseline-browser-mapping: 2.10.38
+      baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.378
+      electron-to-chromium: 1.5.379
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -6366,7 +6366,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-to-chromium@1.5.378: {}
+  electron-to-chromium@1.5.379: {}
 
   electron-updater@6.8.9:
     dependencies:
@@ -6443,7 +6443,7 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
       es-set-tostringtag: 2.1.0
-      es-to-primitive: 1.3.1
+      es-to-primitive: 1.3.4
       function.prototype.name: 1.2.0
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
@@ -6526,15 +6526,16 @@ snapshots:
     dependencies:
       hasown: 2.0.4
 
-  es-to-primitive@1.3.1:
+  es-to-primitive@1.3.4:
     dependencies:
       es-abstract-get: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  es-toolkit@1.48.1: {}
+  es-toolkit@1.49.0: {}
 
   es6-error@4.1.1:
     optional: true
@@ -6777,7 +6778,7 @@ snapshots:
 
   events@3.3.0: {}
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -6857,9 +6858,9 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
-  framer-motion@12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  framer-motion@12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      motion-dom: 12.41.0
+      motion-dom: 12.42.0
       motion-utils: 12.39.0
       tslib: 2.8.1
     optionalDependencies:
@@ -7564,9 +7565,9 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lucide-react-motion@0.4.0(motion@12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  lucide-react-motion@0.4.0(motion@12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      motion: 12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      motion: 12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
@@ -7863,15 +7864,15 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  motion-dom@12.41.0:
+  motion-dom@12.42.0:
     dependencies:
       motion-utils: 12.39.0
 
   motion-utils@12.39.0: {}
 
-  motion@12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  motion@12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      framer-motion: 12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      framer-motion: 12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.7
@@ -7954,7 +7955,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.7.4
-      tar: 7.5.16
+      tar: 7.5.17
       tinyglobby: 0.2.17
       undici: 7.28.0
       which: 6.0.1
@@ -8322,7 +8323,7 @@ snapshots:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
-      es-toolkit: 1.48.1
+      es-toolkit: 1.49.0
       eventemitter3: 5.0.4
       immer: 10.2.0
       react: 19.2.7
@@ -8822,7 +8823,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.16:
+  tar@7.5.17:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -9069,7 +9070,7 @@ snapshots:
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
       es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -79,6 +79,7 @@ import {
 } from './hooks/useProtocolConnection';
 import { useProtocolFacade } from './hooks/useProtocolFacade';
 import { useSendMessage } from './hooks/useSendMessage';
+import { useSerialServiceListeners } from './hooks/useSerialServiceListeners';
 import { useSpellcheckReplaceSync } from './hooks/useSpellcheckReplaceSync';
 import { useTakServer } from './hooks/useTakServer';
 import { ChatPanel, ConnectionPanel, LogPanel, NodeListPanel } from './lazyAppPanels';
@@ -674,6 +675,7 @@ function AppContent({
       onPowerResume: meshcoreRuntime.onPowerResume,
     },
   });
+  useSerialServiceListeners();
   useSpellcheckReplaceSync();
 
   const { meshtastic: meshtasticPanelActions, meshcore: meshcorePanelActions } =
@@ -1802,6 +1804,7 @@ function AppContent({
     if (reconnectInFlightRef.current) return;
     reconnectInFlightRef.current = true;
 
+    const serialNeedsReselect = activeConnectionView.state.serialNeedsReselect ?? false;
     const lastStored = loadLastConnection(protocol);
     const lastType =
       activeConnectionView.state.connectionType ?? lastStored?.type ?? ('ble' as const);
@@ -1812,6 +1815,15 @@ function AppContent({
           const finish = () => {
             reconnectInFlightRef.current = false;
           };
+
+          if (serialNeedsReselect && lastType === 'serial') {
+            void protocolConnect(protocol, 'serial')
+              .catch((err: unknown) => {
+                logRfReconnectFailure('[App] handleReconnect serial reselect failed', err);
+              })
+              .finally(finish);
+            return;
+          }
 
           void reconnectRfFromLastConnection(protocol, lastType, {
             connectBleAutomatic: (bleDeviceId) =>
@@ -1838,6 +1850,7 @@ function AppContent({
       });
   }, [
     activeConnectionView.state.connectionType,
+    activeConnectionView.state.serialNeedsReselect,
     meshcoreConnection,
     meshtasticConnection,
     protocol,
@@ -2172,6 +2185,8 @@ function AppContent({
         <ConnectionBanner
           status={activeConnectionView.state.status}
           connectionLoss={deviceLoss}
+          serialNeedsReselect={activeConnectionView.state.serialNeedsReselect}
+          connectionType={activeConnectionView.state.connectionType}
           reconnectAttempt={activeConnectionView.state.reconnectAttempt}
           onReconnect={handleReconnect}
         />
@@ -3547,15 +3562,43 @@ function FirmwareUpdateNotifier({
 function ConnectionBanner({
   status,
   connectionLoss,
+  serialNeedsReselect,
+  connectionType,
   reconnectAttempt,
   onReconnect,
 }: {
   status: string;
   connectionLoss?: boolean;
+  serialNeedsReselect?: boolean;
+  connectionType?: string | null;
   reconnectAttempt?: number;
   onReconnect: () => void;
 }) {
   const { t } = useTranslation();
+
+  if (
+    status === 'disconnected' &&
+    connectionLoss &&
+    serialNeedsReselect &&
+    connectionType === 'serial'
+  ) {
+    return (
+      <div className="flex items-center justify-between border-b border-red-700 bg-red-900/80 px-4 py-2">
+        <div className="flex items-center gap-2">
+          <span className="text-red-400">⚠</span>
+          <span className="text-sm text-red-200">{t('connectionBanner.serialReselect')}</span>
+        </div>
+        <button
+          type="button"
+          onClick={onReconnect}
+          aria-label={t('connectionBanner.serialReselectAction')}
+          className="text-sm font-medium text-red-300 underline hover:text-red-100"
+        >
+          {t('connectionBanner.serialReselectAction')}
+        </button>
+      </div>
+    );
+  }
 
   if (status === 'disconnected' && connectionLoss) {
     return (

--- a/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
+++ b/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
@@ -169,6 +169,7 @@ export function attachMeshcoreLegacyConnEvents(
     teardownMeshcoreConnEventListeners,
     meshcorePreviousNodesBaselineForBuild,
     handleConnectionLostRef,
+    bumpLastDataReceived,
   } = ctx;
 
   /** PacketRouter + meshcoreIngest own parsed room posts when identity is bound. */
@@ -186,8 +187,12 @@ export function attachMeshcoreLegacyConnEvents(
   }[] = [];
   const onMeshcoreConn = (event: string | number, handler: (...args: unknown[]) => void) => {
     if (protocolOwnedEvents.has(event)) return;
-    conn.on(event, handler);
-    meshcorePersistentListenerRegs.push({ event, handler });
+    const wrapped = (...args: unknown[]) => {
+      bumpLastDataReceived?.();
+      handler(...args);
+    };
+    conn.on(event, wrapped);
+    meshcorePersistentListenerRegs.push({ event, handler: wrapped });
   };
 
   const logTransportLineAsDevice = (line: string) => {

--- a/src/renderer/hooks/meshcore/meshcoreLegacyConnEventsCtx.ts
+++ b/src/renderer/hooks/meshcore/meshcoreLegacyConnEventsCtx.ts
@@ -68,4 +68,5 @@ export interface MeshcoreLegacyConnEventsCtx {
   teardownMeshcoreConnEventListeners: (opts?: { driverDisconnect?: boolean }) => void;
   meshcorePreviousNodesBaselineForBuild: () => Map<number, MeshNode>;
   handleConnectionLostRef: RefObject<() => void>;
+  bumpLastDataReceived?: () => void;
 }

--- a/src/renderer/hooks/useConnectionView.ts
+++ b/src/renderer/hooks/useConnectionView.ts
@@ -8,6 +8,7 @@ function deviceStateFromStore(record: ConnectionRecord): DeviceState {
   return {
     status: record.status,
     connectionLoss: record.connectionLoss,
+    serialNeedsReselect: record.serialNeedsReselect,
     myNodeNum: record.myNodeNum,
     connectionType: record.connectionType,
     reconnectAttempt: record.reconnectAttempt,

--- a/src/renderer/hooks/useProtocolConnection.ts
+++ b/src/renderer/hooks/useProtocolConnection.ts
@@ -36,6 +36,7 @@ function deviceStateFromConnection(conn: ReturnType<typeof useConnectionByProtoc
     batteryPercent: conn.batteryPercent,
     batteryCharging: conn.batteryCharging,
     connectionLoss: conn.connectionLoss,
+    serialNeedsReselect: conn.serialNeedsReselect,
   };
 }
 

--- a/src/renderer/hooks/useSerialServiceListeners.ts
+++ b/src/renderer/hooks/useSerialServiceListeners.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+import { routeSerialServiceDisconnect } from '../lib/serialDisconnectRouter';
+import { attachSerialServiceDisconnectListener } from '../lib/serialPortRecovery';
+
+/** Mount once from App.tsx — global Web Serial unplug detection for both protocols. */
+export function useSerialServiceListeners(): void {
+  useEffect(() => {
+    return attachSerialServiceDisconnectListener(routeSerialServiceDisconnect);
+  }, []);
+}

--- a/src/renderer/lib/connection.serial-cleanup.test.ts
+++ b/src/renderer/lib/connection.serial-cleanup.test.ts
@@ -3,6 +3,7 @@ import { TransportWebSerial } from '@meshtastic/transport-web-serial';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeSerialPortIfOpen, reconnectSerial, safeDisconnect } from './connection';
+import { SERIAL_OPEN_TIMEOUT_MS } from './serialPortRecovery';
 
 vi.mock('@meshtastic/transport-web-serial', () => ({
   TransportWebSerial: {
@@ -84,6 +85,30 @@ describe('connection serial cleanup', () => {
 
     expect(port.close).toHaveBeenCalledTimes(1);
     expect(TransportWebSerial.createFromPort).toHaveBeenCalledWith(port, 115200);
+  });
+
+  it('reconnectSerial rejects when createFromPort hangs past serial open timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const port = makeMockSerialPort({ portId: 'saved-port' });
+      Object.defineProperty(navigator, 'serial', {
+        configurable: true,
+        value: {
+          getPorts: vi.fn().mockResolvedValue([port]),
+        },
+      });
+      localStorage.setItem('mesh-client:lastSerialPort', 'saved-port');
+      vi.mocked(TransportWebSerial.createFromPort).mockImplementation(() => new Promise(() => {}));
+
+      const reconnectPromise = reconnectSerial('saved-port');
+      const rejection = expect(reconnectPromise).rejects.toThrow(
+        /Meshtastic serial reconnect timed out/,
+      );
+      await vi.advanceTimersByTimeAsync(SERIAL_OPEN_TIMEOUT_MS);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('safeDisconnect closes underlying serial port after device.disconnect', async () => {

--- a/src/renderer/lib/connection.ts
+++ b/src/renderer/lib/connection.ts
@@ -11,6 +11,7 @@ import {
   getMeshtasticStreamsDiagnostics,
   logMeshtasticSerialStreamDiagnostics,
 } from './connectionWebStreams';
+import { SERIAL_OPEN_TIMEOUT_MS, withSerialTransportTimeout } from './serialPortRecovery';
 import {
   getPortSignature,
   persistSerialPortIdentity,
@@ -267,7 +268,6 @@ export async function createConnection(
           ...getMeshtasticStreamsDiagnostics(),
         })}`,
       );
-      const SERIAL_CONNECT_TIMEOUT_MS = 15_000;
       const serialApi = navigator.serial;
       const origRequestPort = serialApi.requestPort.bind(serialApi);
       let capturedSerialPort: SerialPort | null = null;
@@ -281,9 +281,9 @@ export async function createConnection(
         const serialTimeoutPromise = new Promise<never>((_, reject) =>
           setTimeout(() => {
             reject(
-              new Error(`Serial connection timed out after ${SERIAL_CONNECT_TIMEOUT_MS / 1000}s`),
+              new Error(`Serial connection timed out after ${SERIAL_OPEN_TIMEOUT_MS / 1000}s`),
             );
-          }, SERIAL_CONNECT_TIMEOUT_MS),
+          }, SERIAL_OPEN_TIMEOUT_MS),
         );
         try {
           transport = await Promise.race([serialPromise, serialTimeoutPromise]);
@@ -408,7 +408,10 @@ export async function reconnectSerial(lastPortId?: string | null): Promise<MeshD
   );
   let transport: Awaited<ReturnType<typeof TransportWebSerial.createFromPort>>;
   try {
-    transport = await TransportWebSerial.createFromPort(port, 115200);
+    transport = await withSerialTransportTimeout(
+      TransportWebSerial.createFromPort(port, 115200),
+      'Meshtastic serial reconnect',
+    );
   } catch (err) {
     console.warn(
       `[connection] TransportWebSerial.createFromPort failed ${err instanceof Error ? err.message : String(err)}`,

--- a/src/renderer/lib/drivers/ConnectionDriver.ts
+++ b/src/renderer/lib/drivers/ConnectionDriver.ts
@@ -305,6 +305,17 @@ export class ConnectionDriver {
   getSlot(transportId: string): TransportSlot | undefined {
     return this.slots.get(transportId);
   }
+
+  /** Latest inbound activity timestamp for an identity's RF transport (excludes MQTT). */
+  getLastDataAtForIdentity(identityId: IdentityId): number | null {
+    let latest = 0;
+    for (const slot of this.slots.values()) {
+      if (slot.identityId === identityId && slot.type !== 'mqtt') {
+        latest = Math.max(latest, slot.lastDataAt);
+      }
+    }
+    return latest > 0 ? latest : null;
+  }
 }
 
 export const connectionDriver = new ConnectionDriver();

--- a/src/renderer/lib/meshcore/meshcoreSerialTransportLoss.ts
+++ b/src/renderer/lib/meshcore/meshcoreSerialTransportLoss.ts
@@ -1,0 +1,87 @@
+import type { Connection } from '@liamcottle/meshcore.js';
+
+import { errLikeToLogString } from '../errLikeToLogString';
+import {
+  createSerializedWritableStream,
+  isMeshtasticTransportLostError,
+} from '../meshtastic/meshtasticTransportLossDetection';
+
+/** Neutral alias — same heuristics apply to Web Serial write/read failures. */
+export const isWebSerialTransportLostError = isMeshtasticTransportLostError;
+
+/** Resolve underlying Web Serial port from a MeshCore WebSerialConnection handle. */
+export function getSerialPortFromMeshcoreConnection(conn: unknown): SerialPort | null {
+  const candidate = conn as { port?: SerialPort; connection?: SerialPort };
+  if (candidate?.port && typeof candidate.port.close === 'function') {
+    return candidate.port;
+  }
+  if (candidate?.connection && typeof candidate.connection.close === 'function') {
+    return candidate.connection;
+  }
+  return null;
+}
+
+type MeshcoreWritableConn = Connection & { writable: WritableStream<Uint8Array> };
+
+/**
+ * Detect serial unplug and write failures on MeshCore Web Serial connections.
+ * Complements SDK `disconnected` when streams stall without emitting an event.
+ */
+export function attachMeshcoreSerialTransportLossWatch(
+  conn: MeshcoreWritableConn,
+  onConnectionLost: () => void,
+): () => void {
+  const cleanups: (() => void)[] = [];
+  let notified = false;
+
+  const notify = (source: string, err?: unknown) => {
+    if (notified) return;
+    notified = true;
+    console.warn(
+      `[meshcoreSerialTransportLoss] serial link lost (${source})` +
+        (err ? `: ${errLikeToLogString(err)}` : ''),
+    );
+    onConnectionLost();
+  };
+
+  const port = getSerialPortFromMeshcoreConnection(conn);
+  const portWithDisconnect = port;
+  if (portWithDisconnect && typeof portWithDisconnect.addEventListener === 'function') {
+    const onDisconnect = () => {
+      notify('serial-disconnect');
+    };
+    portWithDisconnect.addEventListener('disconnect', onDisconnect);
+    cleanups.push(() => {
+      portWithDisconnect.removeEventListener('disconnect', onDisconnect);
+    });
+  }
+
+  if (conn.writable) {
+    const wrapped = createSerializedWritableStream(conn.writable, (err: unknown) => {
+      notify('write-failure', err);
+    });
+    Object.defineProperty(conn, 'writable', {
+      configurable: true,
+      writable: true,
+      value: wrapped,
+    });
+    cleanups.push(() => {
+      try {
+        const inner = port?.writable;
+        if (inner) {
+          Object.defineProperty(conn, 'writable', {
+            configurable: true,
+            writable: true,
+            value: inner,
+          });
+        }
+      } catch {
+        // catch-no-log-ok restore writable after teardown
+      }
+    });
+  }
+
+  return () => {
+    for (const cleanup of cleanups) cleanup();
+  };
+}

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
@@ -139,14 +139,13 @@ export function attachMeshtasticTransportLossWatch(
 
   if (type === 'serial') {
     const port = getSerialPortFromMeshTransport(device.transport);
-    const portWithDisconnect = port as (SerialPort & EventTarget) | null;
-    if (portWithDisconnect && typeof portWithDisconnect.addEventListener === 'function') {
+    if (port && typeof port.addEventListener === 'function') {
       const onDisconnect = () => {
         notify('serial-disconnect');
       };
-      portWithDisconnect.addEventListener('disconnect', onDisconnect);
+      port.addEventListener('disconnect', onDisconnect);
       cleanups.push(() => {
-        portWithDisconnect.removeEventListener('disconnect', onDisconnect);
+        port.removeEventListener('disconnect', onDisconnect);
       });
     }
   }

--- a/src/renderer/lib/protocols/meshcore/MeshCoreTransport.ts
+++ b/src/renderer/lib/protocols/meshcore/MeshCoreTransport.ts
@@ -9,6 +9,7 @@ import { patchMeshcoreCompanionTxEchoFilter } from '../../meshcoreCompanionTxEch
 import { MeshcoreWebBluetoothConnection } from '../../meshcoreWebBluetoothConnection';
 import { createSerializedWritableStream } from '../../meshtastic/meshtasticTransportLossDetection';
 import { parseTcpAddress } from '../../parseTcpAddress';
+import { openSerialPortWithTimeout } from '../../serialPortRecovery';
 import { persistSerialPortIdentity, selectGrantedSerialPort } from '../../serialPortSignature';
 import { TransportWebBluetoothIpc } from '../../transportWebBluetoothIpc';
 import type { NobleBleSessionId } from '../../types';
@@ -188,12 +189,14 @@ export function patchMeshcoreWebSerialWritable(
 
 async function openSerialPort(port: SerialPort): Promise<Connection> {
   persistSerialPortIdentity(port);
-  await (port as unknown as { open(opts: object): Promise<void> }).open({ baudRate: 115200 });
+  await openSerialPortWithTimeout(port, 115200, 'MeshCore serial open');
   const rawWritable = port.writable;
   const conn = new (WebSerialConnection as unknown as new (port: unknown) => MeshcoreWebSerialConn)(
     port,
   );
-  patchMeshcoreWebSerialWritable(conn, rawWritable);
+  if (rawWritable) {
+    patchMeshcoreWebSerialWritable(conn, rawWritable);
+  }
   patchMeshcoreCompanionTxEchoFilter(conn);
   return conn;
 }

--- a/src/renderer/lib/serialDisconnectRouter.ts
+++ b/src/renderer/lib/serialDisconnectRouter.ts
@@ -1,0 +1,42 @@
+import { serialPortMatchesPersistedIdentity } from './serialPortRecovery';
+
+export interface SerialDisconnectTarget {
+  isSerialConnected: () => boolean;
+  onDisconnected: () => void;
+}
+
+let meshtasticSerialDisconnectTarget: SerialDisconnectTarget | null = null;
+let meshcoreSerialDisconnectTarget: SerialDisconnectTarget | null = null;
+
+/** Debounce duplicate per-port + global service disconnect notifications. */
+let lastSerialDisconnectNotifyAt = 0;
+const SERIAL_DISCONNECT_DEBOUNCE_MS = 500;
+
+export function registerMeshtasticSerialDisconnectTarget(
+  target: SerialDisconnectTarget | null,
+): void {
+  meshtasticSerialDisconnectTarget = target;
+}
+
+export function registerMeshcoreSerialDisconnectTarget(
+  target: SerialDisconnectTarget | null,
+): void {
+  meshcoreSerialDisconnectTarget = target;
+}
+
+export function routeSerialServiceDisconnect(port: SerialPort): void {
+  if (!serialPortMatchesPersistedIdentity(port)) return;
+  const now = Date.now();
+  if (now - lastSerialDisconnectNotifyAt < SERIAL_DISCONNECT_DEBOUNCE_MS) return;
+
+  let notified = false;
+  const tryNotify = (target: SerialDisconnectTarget | null) => {
+    if (notified || !target?.isSerialConnected()) return;
+    notified = true;
+    lastSerialDisconnectNotifyAt = now;
+    target.onDisconnected();
+  };
+
+  tryNotify(meshtasticSerialDisconnectTarget);
+  tryNotify(meshcoreSerialDisconnectTarget);
+}

--- a/src/renderer/lib/serialPortRecovery.test.ts
+++ b/src/renderer/lib/serialPortRecovery.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  attachSerialServiceDisconnectListener,
+  clearPersistedSerialPortIdentity,
+  forgetGrantedSerialPortBestEffort,
+  openSerialPortWithTimeout,
+  SERIAL_OPEN_TIMEOUT_MS,
+  serialPortMatchesPersistedIdentity,
+  withSerialTransportTimeout,
+} from './serialPortRecovery';
+import { LAST_SERIAL_PORT_KEY, LAST_SERIAL_PORT_SIGNATURE_KEY } from './serialPortSignature';
+
+describe('serialPortRecovery', () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    storage.clear();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      clear: () => {
+        storage.clear();
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('openSerialPortWithTimeout rejects when open hangs', async () => {
+    const port = {
+      open: vi.fn(() => new Promise<void>(() => {})),
+    } as unknown as SerialPort;
+
+    const openPromise = openSerialPortWithTimeout(port, 115200, 'test open');
+    const rejection = expect(openPromise).rejects.toThrow(/test open timed out/);
+    await vi.advanceTimersByTimeAsync(SERIAL_OPEN_TIMEOUT_MS);
+    await rejection;
+  });
+
+  it('withSerialTransportTimeout resolves when promise settles in time', async () => {
+    await expect(withSerialTransportTimeout(Promise.resolve('ok'), 'transport')).resolves.toBe(
+      'ok',
+    );
+  });
+
+  it('clearPersistedSerialPortIdentity removes stored keys', () => {
+    localStorage.setItem(LAST_SERIAL_PORT_KEY, 'p1');
+    localStorage.setItem(LAST_SERIAL_PORT_SIGNATURE_KEY, '{"usbVendorId":1}');
+    clearPersistedSerialPortIdentity();
+    expect(localStorage.getItem(LAST_SERIAL_PORT_KEY)).toBeNull();
+    expect(localStorage.getItem(LAST_SERIAL_PORT_SIGNATURE_KEY)).toBeNull();
+  });
+
+  it('serialPortMatchesPersistedIdentity matches portId', () => {
+    localStorage.setItem(LAST_SERIAL_PORT_KEY, 'port-a');
+    const port = {
+      portId: 'port-a',
+      getInfo: () => ({}),
+    } as SerialPort & { portId: string };
+    expect(serialPortMatchesPersistedIdentity(port)).toBe(true);
+  });
+
+  it('forgetGrantedSerialPortBestEffort calls forget when port exposes it', async () => {
+    const forget = vi.fn().mockResolvedValue(undefined);
+    await forgetGrantedSerialPortBestEffort({ forget } as unknown as SerialPort);
+    expect(forget).toHaveBeenCalledTimes(1);
+  });
+
+  it('attachSerialServiceDisconnectListener invokes handler on disconnect', () => {
+    const port = { close: vi.fn() } as unknown as SerialPort;
+    const handler = vi.fn();
+    const remove = vi.fn();
+    const addEventListener = vi.fn();
+    Object.defineProperty(navigator, 'serial', {
+      configurable: true,
+      value: { addEventListener, removeEventListener: remove },
+    });
+
+    const cleanup = attachSerialServiceDisconnectListener(handler);
+    expect(addEventListener).toHaveBeenCalledWith('disconnect', expect.any(Function));
+
+    const listener = addEventListener.mock.calls[0][1] as (event: Event) => void;
+    listener({ target: port } as unknown as Event);
+    expect(handler).toHaveBeenCalledWith(port);
+
+    cleanup();
+    expect(remove).toHaveBeenCalledWith('disconnect', listener);
+  });
+});

--- a/src/renderer/lib/serialPortRecovery.ts
+++ b/src/renderer/lib/serialPortRecovery.ts
@@ -1,0 +1,103 @@
+import { withTimeout } from '../../shared/withTimeout';
+import {
+  getPortSignature,
+  LAST_SERIAL_PORT_KEY,
+  LAST_SERIAL_PORT_SIGNATURE_KEY,
+  loadLastSerialPortId,
+  loadLastSerialPortSignature,
+  signaturesEqual,
+} from './serialPortSignature';
+
+/** Match Meshtastic initial connect timeout in connection.ts */
+export const SERIAL_OPEN_TIMEOUT_MS = 15_000;
+
+/** Shared serial silence thresholds (Meshtastic + MeshCore watchdog). */
+export const SERIAL_STALE_THRESHOLD_MS = 120_000;
+export const SERIAL_DEAD_THRESHOLD_MS = 180_000;
+export const SERIAL_WATCHDOG_INTERVAL_MS = 15_000;
+
+export function withSerialTransportTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return withTimeout(promise, SERIAL_OPEN_TIMEOUT_MS, label);
+}
+
+export async function openSerialPortWithTimeout(
+  port: SerialPort,
+  baudRate: number,
+  label = 'Serial port open',
+): Promise<void> {
+  await withTimeout(port.open({ baudRate }), SERIAL_OPEN_TIMEOUT_MS, label);
+}
+
+export function isSerialPortForgetSupported(port?: SerialPort | null): boolean {
+  if (!port) return false;
+  return typeof (port as SerialPort & { forget?: () => Promise<void> }).forget === 'function';
+}
+
+/** Revoke Web Serial permission for a stale port; best-effort when API is absent. */
+export async function forgetGrantedSerialPortBestEffort(port: SerialPort | null): Promise<void> {
+  if (!port) return;
+  const portWithForget = port as SerialPort & { forget?: () => Promise<void> };
+  if (typeof portWithForget.forget !== 'function') {
+    console.debug('[serialPortRecovery] SerialPort.forget not supported — skipping');
+    return;
+  }
+  try {
+    await portWithForget.forget();
+    console.debug('[serialPortRecovery] forgot serial port permission');
+  } catch (e) {
+    console.warn(
+      `[serialPortRecovery] forget failed ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+export async function escalateSerialReconnectExhaustion(
+  port: SerialPort | null | undefined,
+): Promise<void> {
+  await forgetGrantedSerialPortBestEffort(port ?? null);
+  clearPersistedSerialPortIdentity();
+}
+
+export function clearPersistedSerialPortIdentity(): void {
+  try {
+    localStorage.removeItem(LAST_SERIAL_PORT_KEY);
+    localStorage.removeItem(LAST_SERIAL_PORT_SIGNATURE_KEY);
+  } catch {
+    // catch-no-log-ok localStorage unavailable
+  }
+}
+
+export function serialPortMatchesPersistedIdentity(port: SerialPort): boolean {
+  const portId = (port as SerialPort & { portId?: string }).portId;
+  const lastPortId = loadLastSerialPortId();
+  if (lastPortId && portId && portId === lastPortId) return true;
+  const lastSignature = loadLastSerialPortSignature();
+  if (lastSignature && signaturesEqual(lastSignature, getPortSignature(port))) return true;
+  return false;
+}
+
+export type SerialServiceDisconnectHandler = (port: SerialPort) => void;
+
+/**
+ * Listen for any granted port disconnect at the Serial service level.
+ * Returns cleanup; no-op when Web Serial is unavailable.
+ */
+export function attachSerialServiceDisconnectListener(
+  onPortDisconnected: SerialServiceDisconnectHandler,
+): () => void {
+  const serial = navigator.serial;
+  if (!serial || typeof serial.addEventListener !== 'function') {
+    return () => {};
+  }
+
+  const handler = (event: Event) => {
+    const target = event.target;
+    if (!target || typeof (target as SerialPort).close !== 'function') return;
+    onPortDisconnected(target as SerialPort);
+  };
+
+  serial.addEventListener('disconnect', handler);
+  return () => {
+    serial.removeEventListener('disconnect', handler);
+  };
+}

--- a/src/renderer/lib/types.ts
+++ b/src/renderer/lib/types.ts
@@ -433,6 +433,8 @@ export interface DeviceState {
   status: 'disconnected' | 'connecting' | 'connected' | 'configured' | 'stale' | 'reconnecting';
   /** True when the last drop was unexpected (not manual disconnect). */
   connectionLoss?: boolean;
+  /** Serial auto-reconnect exhausted; user must re-select the USB serial port. */
+  serialNeedsReselect?: boolean;
   myNodeNum: number;
   connectionType: ConnectionType | null;
   reconnectAttempt?: number;

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Připojení ztraceno — rádio odpojeno",
     "staleLoss": "Připojení může být ztraceno — v poslední době nebyla přijata žádná data",
     "reconnect": "Znovu připojit",
-    "reconnectingAttempt": "Opětovné připojení... Pokus {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Opětovné připojení... Pokus {{attempt}}/{{max}}",
+    "serialReselect": "Ztráta sériového připojení USB — vyberte zařízení znovu",
+    "serialReselectAction": "Výběr sériového portu"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Maximální počet pokusů o opětovné připojení MQTT",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Verbindung unterbrochen — Funkverbindung getrennt",
     "staleLoss": "Verbindung kann verloren gehen — in letzter Zeit wurden keine Daten empfangen",
     "reconnect": "Erneut verbinden",
-    "reconnectingAttempt": "Wiederverbinden… Versuch {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Wiederverbinden… Versuch {{attempt}}/{{max}}",
+    "serialReselect": "USB-Seriellverbindung unterbrochen — wählen Sie Ihr Gerät erneut aus",
+    "serialReselectAction": "Serielle Schnittstelle auswählen"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Max. MQTT-Wiederverbindungsversuche",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Connection lost — radio disconnected",
     "staleLoss": "Connection may be lost — no data received recently",
     "reconnect": "Reconnect",
-    "reconnectingAttempt": "Reconnecting… attempt {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Reconnecting… attempt {{attempt}}/{{max}}",
+    "serialReselect": "USB serial connection lost — select your device again",
+    "serialReselectAction": "Select serial port"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Max MQTT reconnect attempts",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Conexión perdida — radio desconectada",
     "staleLoss": "La conexión puede perderse: no se han recibido datos recientemente",
     "reconnect": "Reconectar",
-    "reconnectingAttempt": "Volviendo a conectar… intento {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Volviendo a conectar… intento {{attempt}}/{{max}}",
+    "serialReselect": "Conexión serie USB perdida — seleccione su dispositivo de nuevo",
+    "serialReselectAction": "Seleccionar porto serie"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Intentos de reconexión MQTT máximos",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Connexion perdue — radio déconnectée",
     "staleLoss": "La connexion peut être perdue — aucune donnée reçue récemment",
     "reconnect": "Reconnecter",
-    "reconnectingAttempt": "Reconnexion... tentative {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Reconnexion... tentative {{attempt}}/{{max}}",
+    "serialReselect": "Connexion série USB perdue — sélectionnez à nouveau votre appareil",
+    "serialReselectAction": "Sélectionner le port série"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Nombre maximal de tentatives de reconnexion MQTT",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Koneksi terputus — radio terputus",
     "staleLoss": "Koneksi mungkin terputus — tidak ada data yang diterima baru - baru ini",
     "reconnect": "Sambung ulang",
-    "reconnectingAttempt": "Menghubungkan kembali… upaya {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Menghubungkan kembali… upaya {{attempt}}/{{max}}",
+    "serialReselect": "Koneksi serial USB terputus — pilih perangkat Anda lagi",
+    "serialReselectAction": "Pilih port serial"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Upaya penyambungan kembali MQTT maks",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Connessione persa — radio scollegata",
     "staleLoss": "La connessione potrebbe essere persa — nessun dato ricevuto di recente",
     "reconnect": "Connessione",
-    "reconnectingAttempt": "Riconnessione in corso... tentativo {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Riconnessione in corso... tentativo {{attempt}}/{{max}}",
+    "serialReselect": "Connessione seriale USB persa — seleziona di nuovo il tuo dispositivo",
+    "serialReselectAction": "Selezionare la Porta Seriale."
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Numero massimo di tentativi di riconnessione MQTT",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "接続が切断されました—無線が切断されました",
     "staleLoss": "接続が失われる可能性があります—最近受信したデータはありません",
     "reconnect": "再接続",
-    "reconnectingAttempt": "再接続中… {{attempt}}/{{max}} 回目"
+    "reconnectingAttempt": "再接続中… {{attempt}}/{{max}} 回目",
+    "serialReselect": "USBシリアル接続が失われました—デバイスを再度選択してください",
+    "serialReselectAction": "シリアルポートを選択"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "MQTT 再接続の最大試行回数",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "연결 끊김 — 라디오 연결이 끊어짐",
     "staleLoss": "연결이 끊어질 수 있습니다 — 최근 수신된 데이터가 없습니다",
     "reconnect": "재접속",
-    "reconnectingAttempt": "다시 연결 중… 시도 {{attempt}}/{{max}}"
+    "reconnectingAttempt": "다시 연결 중… 시도 {{attempt}}/{{max}}",
+    "serialReselect": "USB 직렬 연결 끊김 — 장치를 다시 선택하십시오",
+    "serialReselectAction": "직렬 포트 선택"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "최대 MQTT 재연결 시도",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Verbinding verbroken — radio losgekoppeld",
     "staleLoss": "De verbinding kan verloren gaan — er zijn onlangs geen gegevens ontvangen",
     "reconnect": "Opnieuw verbinden",
-    "reconnectingAttempt": "Opnieuw verbinden… poging {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Opnieuw verbinden… poging {{attempt}}/{{max}}",
+    "serialReselect": "USB seriële verbinding verbroken — selecteer uw apparaat opnieuw",
+    "serialReselectAction": "Seriële poort selecteren"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Max. MQTT-pogingen om opnieuw verbinding te maken",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Utracono połączenie — rozłączono radio",
     "staleLoss": "Połączenie może zostać utracone — brak danych otrzymanych ostatnio",
     "reconnect": "Połącz ponownie",
-    "reconnectingAttempt": "Ponowne łączenie… próba {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Ponowne łączenie… próba {{attempt}}/{{max}}",
+    "serialReselect": "Utracono połączenie szeregowe USB — wybierz ponownie swoje urządzenie",
+    "serialReselectAction": "Wybierz port szeregowy"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Maksymalna liczba prób ponownego połączenia MQTT",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Conexão perdida — rádio desconectado",
     "staleLoss": "A conexão pode ser perdida — nenhum dado recebido recentemente",
     "reconnect": "Reconectar",
-    "reconnectingAttempt": "Reconectando… tentativa {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Reconectando… tentativa {{attempt}}/{{max}}",
+    "serialReselect": "Conexão serial USB perdida — selecione seu dispositivo novamente",
+    "serialReselectAction": "Selecionar porta serial"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Tentativas máximas de reconexão do MQTT",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Соединение потеряно — радио отключено",
     "staleLoss": "Соединение может быть потеряно — данные не получены в последнее время",
     "reconnect": "Перепідключення",
-    "reconnectingAttempt": "Повторное подключение… попытка {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Повторное подключение… попытка {{attempt}}/{{max}}",
+    "serialReselect": "Последовательное USB-соединение потеряно — выберите устройство еще раз",
+    "serialReselectAction": "Выберите последовательный порт"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Максимальное количество попыток переподключения MQTT",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "Bağlantı kesildi — radyo bağlantısı kesildi",
     "staleLoss": "Bağlantı kaybolabilir — yakın zamanda veri alınmadı",
     "reconnect": "Yeniden bağlanınız",
-    "reconnectingAttempt": "Yeniden bağlanıyor… {{attempt}}/{{max}} denemesi"
+    "reconnectingAttempt": "Yeniden bağlanıyor… {{attempt}}/{{max}} denemesi",
+    "serialReselect": "USB seri bağlantısı kesildi — cihazınızı tekrar seçin",
+    "serialReselectAction": "COM… seri portunu seçin"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Maksimum MQTT yeniden bağlanma denemesi",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "З 'єднання втрачено — радіо роз' єднано",
     "staleLoss": "З 'єднання може бути втрачено — нещодавно не було отримано жодних даних",
     "reconnect": "Повторно під’єднати",
-    "reconnectingAttempt": "Повторне підключення… спроба {{attempt}}/{{max}}"
+    "reconnectingAttempt": "Повторне підключення… спроба {{attempt}}/{{max}}",
+    "serialReselect": "Серійне з 'єднання USB втрачено — виберіть пристрій знову",
+    "serialReselectAction": "Виберіть послідовний порт"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Максимальна кількість спроб повторного підключення MQTT",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -400,7 +400,9 @@
     "disconnectedLoss": "连接断开—无线电断开",
     "staleLoss": "连接可能丢失—最近未收到任何数据",
     "reconnect": "重新连接",
-    "reconnectingAttempt": "正在重新连接… 尝试 {{attempt}}/{{max}}"
+    "reconnectingAttempt": "正在重新连接… 尝试 {{attempt}}/{{max}}",
+    "serialReselect": "USB串行连接丢失—请重新选择您的设备",
+    "serialReselectAction": "选择串行端口"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "最大MQTT重新连接尝试次数",

--- a/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
@@ -39,6 +39,16 @@ describe('useMeshcoreRuntime auto-reconnect (regression)', () => {
     expect(RUNTIME_SOURCE).toContain('handleMeshcoreConnectionLostRef.current()');
     expect(RUNTIME_SOURCE).toContain('power resume — resetting reconnect budget');
   });
+
+  it('escalates serial reconnect exhaustion with forget and re-select UI flag', () => {
+    expect(RUNTIME_SOURCE).toMatch(
+      /meshcoreReconnectAttemptRef\.current >= MESHCORE_MAX_RECONNECT_ATTEMPTS[\s\S]{0,500}escalateSerialReconnectExhaustion/,
+    );
+    expect(RUNTIME_SOURCE).toContain('serialNeedsReselect');
+    expect(RUNTIME_SOURCE).toContain('attachMeshcoreSerialTransportLossWatch');
+    expect(RUNTIME_SOURCE).toContain('startMeshcoreSerialWatchdog');
+    expect(RUNTIME_SOURCE).toContain('registerMeshcoreSerialDisconnectTarget');
+  });
 });
 
 describe('meshcoreLegacyConnEvents disconnected handler (regression)', () => {

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -117,6 +117,7 @@ import {
   replaceMeshcorePubKeyRegistry,
   setMeshcorePubKeyRegistryRefSync,
 } from '../lib/meshcore/meshcorePubKeyRegistry';
+import { attachMeshcoreSerialTransportLossWatch } from '../lib/meshcore/meshcoreSerialTransportLoss';
 import {
   buildMeshcoreOutboundTapbackWire,
   MESHCORE_TXT_TYPE_CLI_DATA,
@@ -265,6 +266,13 @@ import {
   type RepeaterCommandService,
 } from '../lib/repeaterCommandService';
 import { createRepeaterRemoteRpcQueue } from '../lib/repeaterRemoteRpcQueue';
+import { registerMeshcoreSerialDisconnectTarget } from '../lib/serialDisconnectRouter';
+import {
+  escalateSerialReconnectExhaustion,
+  SERIAL_DEAD_THRESHOLD_MS,
+  SERIAL_STALE_THRESHOLD_MS,
+  SERIAL_WATCHDOG_INTERVAL_MS,
+} from '../lib/serialPortRecovery';
 import { LAST_SERIAL_PORT_KEY } from '../lib/serialPortSignature';
 import { registerMeshcoreSession } from '../lib/sessions/meshcoreSession';
 import { getStoredMeshProtocol } from '../lib/storedMeshProtocol';
@@ -413,10 +421,14 @@ export function useMeshcoreRuntime() {
     httpAddress?: string;
     blePeripheralId?: string;
     serialPortId?: string | null;
+    serialPort?: SerialPort | null;
   } | null>(null);
   const meshcoreReconnectAttemptRef = useRef(0);
   const meshcoreReconnectGenerationRef = useRef(0);
   const meshcoreIsReconnectingRef = useRef(false);
+  const meshcoreLastDataReceivedRef = useRef<number>(Date.now());
+  const meshcoreSerialWatchdogRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const meshcoreSerialLossCleanupRef = useRef<(() => void) | null>(null);
   const handleMeshcoreConnectionLostRef = useRef<() => void>(() => {});
   const attemptMeshcoreReconnectRef = useRef<() => Promise<void>>(async () => {});
   /** Incremented on `disconnect()` so in-flight `initConn` can abort instead of timing out. */
@@ -618,6 +630,7 @@ export function useMeshcoreRuntime() {
         return updated;
       });
     }
+    meshcoreLastDataReceivedRef.current = Date.now();
   }, [state.myNodeNum]);
 
   const buildNodesFromContactsRef = useRef<
@@ -1407,6 +1420,66 @@ export function useMeshcoreRuntime() {
     return Promise.resolve();
   }, []);
 
+  const bumpMeshcoreLastDataReceived = useCallback(() => {
+    meshcoreLastDataReceivedRef.current = Date.now();
+    setState((s) => {
+      if (s.status === 'stale') {
+        return { ...s, status: 'configured', lastDataReceived: Date.now() };
+      }
+      return s;
+    });
+  }, []);
+
+  const stopMeshcoreSerialWatchdog = useCallback(() => {
+    if (meshcoreSerialWatchdogRef.current) {
+      clearInterval(meshcoreSerialWatchdogRef.current);
+      meshcoreSerialWatchdogRef.current = null;
+    }
+    meshcoreSerialLossCleanupRef.current?.();
+    meshcoreSerialLossCleanupRef.current = null;
+  }, []);
+
+  const startMeshcoreSerialWatchdog = useCallback(
+    (conn: MeshCoreConnection) => {
+      if (meshcoreConnectionParamsRef.current?.rfType !== 'serial') return;
+      stopMeshcoreSerialWatchdog();
+      meshcoreLastDataReceivedRef.current = Date.now();
+      meshcoreSerialLossCleanupRef.current = attachMeshcoreSerialTransportLossWatch(
+        conn as unknown as Connection & { writable: WritableStream<Uint8Array> },
+        () => {
+          if (meshcoreIsReconnectingRef.current) return;
+          handleMeshcoreConnectionLostRef.current();
+        },
+      );
+      meshcoreSerialWatchdogRef.current = setInterval(() => {
+        if (meshcoreIsReconnectingRef.current) return;
+        if (meshcoreConnectionParamsRef.current?.rfType !== 'serial') return;
+        const identityId =
+          meshcoreIdentityIdRef.current ?? meshcorePendingDriverIdentityRef.current;
+        const driverLast = identityId
+          ? connectionDriver.getLastDataAtForIdentity(identityId)
+          : null;
+        const lastAt = Math.max(meshcoreLastDataReceivedRef.current, driverLast ?? 0);
+        const elapsed = Date.now() - lastAt;
+        if (elapsed > SERIAL_DEAD_THRESHOLD_MS) {
+          console.warn(
+            `[useMeshcoreRuntime] watchdog: serial dead for ${elapsed}ms, triggering reconnect`,
+          );
+          handleMeshcoreConnectionLostRef.current();
+        } else if (elapsed > SERIAL_STALE_THRESHOLD_MS) {
+          console.warn(`[useMeshcoreRuntime] watchdog: serial stale for ${elapsed}ms`);
+          setState((s) => {
+            if (s.status === 'configured' || s.status === 'connected') {
+              return { ...s, status: 'stale', lastDataReceived: lastAt };
+            }
+            return s;
+          });
+        }
+      }, SERIAL_WATCHDOG_INTERVAL_MS);
+    },
+    [stopMeshcoreSerialWatchdog],
+  );
+
   const meshcoreLegacyConnEventsCtx = useMemo<MeshcoreLegacyConnEventsCtx>(
     () => ({
       meshcoreIdentityIdRef,
@@ -1448,12 +1521,14 @@ export function useMeshcoreRuntime() {
       teardownMeshcoreConnEventListeners,
       meshcorePreviousNodesBaselineForBuild,
       handleConnectionLostRef: handleMeshcoreConnectionLostRef,
+      bumpLastDataReceived: bumpMeshcoreLastDataReceived,
     }),
     [
       addMessage,
       addCliHistoryEntry,
       teardownMeshcoreConnEventListeners,
       meshcorePreviousNodesBaselineForBuild,
+      bumpMeshcoreLastDataReceived,
     ],
   );
 
@@ -1668,6 +1743,7 @@ export function useMeshcoreRuntime() {
         myNodeNum: myNodeId,
         status: 'configured',
         connectionLoss: false,
+        serialNeedsReselect: false,
       }));
       if (getStoredMeshProtocol() === 'meshcore') {
         useDiagnosticsStore.getState().migrateForeignLoraFromZero(myNodeId);
@@ -1969,6 +2045,7 @@ export function useMeshcoreRuntime() {
         myNodeNum: 0,
         connectionType: type === 'tcp' ? 'http' : type,
         connectionLoss: false,
+        serialNeedsReselect: false,
       });
       if (type === 'ble') bleConnectInProgressRef.current = true;
     },
@@ -2000,6 +2077,14 @@ export function useMeshcoreRuntime() {
       meshcoreConnEventListenersTeardownRef.current = setupEventListeners(conn);
       await initConn(conn, setupGen, { driverIdentityId });
       if (type === 'serial') {
+        const serialPort =
+          meshcoreConnectionParamsRef.current?.serialPort ??
+          (conn as { port?: SerialPort }).port ??
+          null;
+        if (meshcoreConnectionParamsRef.current) {
+          meshcoreConnectionParamsRef.current.serialPort = serialPort;
+        }
+        startMeshcoreSerialWatchdog(conn);
         const portId = localStorage.getItem(LAST_SERIAL_PORT_KEY);
         const nodeName = selfInfoRef.current?.name?.trim() || null;
         if (portId && nodeName) {
@@ -2018,7 +2103,7 @@ export function useMeshcoreRuntime() {
         }
       }
     },
-    [initConn, setupEventListeners],
+    [initConn, setupEventListeners, startMeshcoreSerialWatchdog],
   );
 
   const handleRfConnectFailure = useCallback(
@@ -2088,6 +2173,7 @@ export function useMeshcoreRuntime() {
       setMeshcoreCliHistories(new Map());
       setMeshcoreCliErrors(new Map());
       meshcoreClearAllRoomSessions();
+      stopMeshcoreSerialWatchdog();
       setEnvironmentTelemetry([]);
       setState(INITIAL_STATE);
       if (meshcoreStatsPollRef.current) {
@@ -2102,7 +2188,7 @@ export function useMeshcoreRuntime() {
       prevStatsTimestampRef.current = null;
       bleConnectInProgressRef.current = false;
     },
-    [teardownMeshcoreConnEventListeners, reloadMeshcoreNodesFromDb],
+    [teardownMeshcoreConnEventListeners, reloadMeshcoreNodesFromDb, stopMeshcoreSerialWatchdog],
   );
 
   const attemptMeshcoreReconnect = useCallback(async () => {
@@ -2115,11 +2201,16 @@ export function useMeshcoreRuntime() {
     if (meshcoreReconnectAttemptRef.current >= MESHCORE_MAX_RECONNECT_ATTEMPTS) {
       meshcoreIsReconnectingRef.current = false;
       meshcoreReconnectAttemptRef.current = 0;
+      stopMeshcoreSerialWatchdog();
+      if (params.rfType === 'serial') {
+        await escalateSerialReconnectExhaustion(params.serialPort ?? null);
+      }
       setState((s) => ({
         ...s,
         status: 'disconnected',
-        connectionType: null,
+        connectionType: params.rfType === 'serial' ? 'serial' : null,
         connectionLoss: true,
+        serialNeedsReselect: params.rfType === 'serial',
       }));
       return;
     }
@@ -2182,6 +2273,11 @@ export function useMeshcoreRuntime() {
       );
       meshcoreReconnectAttemptRef.current = 0;
       meshcoreIsReconnectingRef.current = false;
+      setState((s) => ({
+        ...s,
+        serialNeedsReselect: false,
+        connectionLoss: false,
+      }));
     } catch (err) {
       if (opened?.driverIdentityId) {
         await connectionDriver.disconnect(opened.driverIdentityId).catch((e: unknown) => {
@@ -2196,7 +2292,7 @@ export function useMeshcoreRuntime() {
       );
       void attemptMeshcoreReconnectRef.current();
     }
-  }, [attachRfSession, prepareRfConnect]);
+  }, [attachRfSession, prepareRfConnect, stopMeshcoreSerialWatchdog]);
 
   attemptMeshcoreReconnectRef.current = attemptMeshcoreReconnect;
 
@@ -2285,6 +2381,7 @@ export function useMeshcoreRuntime() {
           httpAddress: type === 'tcp' ? tcpHost : undefined,
           blePeripheralId: type === 'ble' ? blePeripheralId : undefined,
           serialPortId: type === 'serial' ? localStorage.getItem(LAST_SERIAL_PORT_KEY) : undefined,
+          serialPort: null,
         };
         meshcoreReconnectAttemptRef.current = 0;
         meshcoreIsReconnectingRef.current = false;
@@ -2394,6 +2491,7 @@ export function useMeshcoreRuntime() {
           meshcoreConnectionParamsRef.current = {
             rfType: 'serial',
             serialPortId: lastSerialPortId ?? localStorage.getItem(LAST_SERIAL_PORT_KEY),
+            serialPort: null,
           };
           meshcoreReconnectAttemptRef.current = 0;
           meshcoreIsReconnectingRef.current = false;
@@ -5570,6 +5668,7 @@ export function useMeshcoreRuntime() {
     setConnection(meshcoreIdentityId, {
       status: state.status,
       connectionLoss: state.connectionLoss,
+      serialNeedsReselect: state.serialNeedsReselect,
       myNodeNum: state.myNodeNum,
       connectionType: state.connectionType,
       reconnectAttempt: state.reconnectAttempt,
@@ -5645,6 +5744,14 @@ export function useMeshcoreRuntime() {
       copyMeshcorePubKeyRegistryToRefs(pubKeyMapRef.current, pubKeyPrefixMapRef.current);
     });
     return () => setMeshcorePubKeyRegistryRefSync(null);
+  }, []);
+
+  useEffect(() => {
+    registerMeshcoreSerialDisconnectTarget({
+      isSerialConnected: () => meshcoreConnectionParamsRef.current?.rfType === 'serial',
+      onDisconnected: () => handleMeshcoreConnectionLostRef.current(),
+    });
+    return () => registerMeshcoreSerialDisconnectTarget(null);
   }, []);
 
   useEffect(() => {

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -38,8 +38,11 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
       /reconnectAttemptRef\.current >= MAX_RECONNECT_ATTEMPTS[\s\S]{0,400}stopWatchdog/,
     );
     expect(SOURCE).toMatch(
-      /reconnectAttemptRef\.current >= MAX_RECONNECT_ATTEMPTS[\s\S]{0,400}deviceRef\.current = null/,
+      /reconnectAttemptRef\.current >= MAX_RECONNECT_ATTEMPTS[\s\S]{0,2000}deviceRef\.current = null/,
     );
+    expect(SOURCE).toContain('escalateSerialReconnectExhaustion');
+    expect(SOURCE).toContain('serialNeedsReselect');
+    expect(SOURCE).toContain('registerMeshtasticSerialDisconnectTarget');
   });
 
   it('clears reconnect refs in handleRfConnectFailure', () => {

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -66,7 +66,7 @@ import {
   mergeAppSettingsPartial,
 } from '../lib/appSettingsStorage';
 import { MAX_IN_MEMORY_CHAT_MESSAGES, trimChatMessagesToMax } from '../lib/chatInMemoryBuffer';
-import { safeDisconnect } from '../lib/connection';
+import { getSerialPortFromMeshTransport, safeDisconnect } from '../lib/connection';
 import { validateCoords } from '../lib/coordUtils';
 import {
   getMergedNodesForForeignLoraDiagnostics,
@@ -146,6 +146,8 @@ import type { MeshtasticRawPacketEntry } from '../lib/rawPacketLogConstants';
 import { reactionGlyphFromPicker } from '../lib/reactions';
 import { enrichMeshtasticReplyPreviews, resolveMeshtasticWireReplyId } from '../lib/replyPreview';
 import { rfConnectionTransportOpts } from '../lib/rfConnectionTypes';
+import { registerMeshtasticSerialDisconnectTarget } from '../lib/serialDisconnectRouter';
+import { escalateSerialReconnectExhaustion } from '../lib/serialPortRecovery';
 import { loadLastSerialPortId } from '../lib/serialPortSignature';
 import {
   clearMeshtasticOutboundTempId,
@@ -212,7 +214,7 @@ const BROADCAST_ADDR = 0xffffffff;
 const BLE_STALE_THRESHOLD_MS = 90_000; // 90s — show warning
 const BLE_DEAD_THRESHOLD_MS = 180_000; // 3min — trigger reconnect
 const SERIAL_STALE_THRESHOLD_MS = 120_000; // 2min
-const SERIAL_DEAD_THRESHOLD_MS = 300_000; // 5min
+const SERIAL_DEAD_THRESHOLD_MS = 180_000; // 3min — align with BLE/HTTP
 // HTTP: align closer to BLE thresholds so WiFi behaves similarly for staleness/reconnect.
 const HTTP_STALE_THRESHOLD_MS = 90_000; // 90s — show warning
 const HTTP_DEAD_THRESHOLD_MS = 180_000; // 3min — trigger reconnect
@@ -307,6 +309,7 @@ export function useMeshtasticRuntime() {
     httpAddress?: string;
     blePeripheralId?: string;
     lastSerialPortId?: string | null;
+    serialPort?: SerialPort | null;
   } | null>(null);
   const isReconnectingRef = useRef<boolean>(false);
   const reconnectGenerationRef = useRef<number>(0);
@@ -1857,14 +1860,21 @@ export function useMeshtasticRuntime() {
       cleanupSubscriptions();
       stopWatchdog();
       stopGpsInterval();
+      const exhaustedParams = connectionParamsRef.current;
+      const exhaustedSerialPort =
+        exhaustedParams?.type === 'serial' ? (exhaustedParams.serialPort ?? null) : null;
+      if (exhaustedParams?.type === 'serial') {
+        await escalateSerialReconnectExhaustion(exhaustedSerialPort);
+      }
       deviceRef.current = null;
       meshtasticDriverConnectedRef.current = false;
       meshtasticPendingDriverIdentityRef.current = null;
       setState((s) => ({
         ...s,
         status: 'disconnected',
-        connectionType: null,
+        connectionType: exhaustedParams?.type === 'serial' ? 'serial' : null,
         connectionLoss: true,
+        serialNeedsReselect: exhaustedParams?.type === 'serial',
         batteryPercent: undefined,
         batteryCharging: undefined,
       }));
@@ -1929,8 +1939,18 @@ export function useMeshtasticRuntime() {
       console.debug(
         `[useMeshtasticRuntime] Reconnect succeeded on attempt ${reconnectAttemptRef.current}`,
       );
+      if (params.type === 'serial' && connectionParamsRef.current && opened?.device) {
+        connectionParamsRef.current.serialPort = getSerialPortFromMeshTransport(
+          opened.device.transport,
+        );
+      }
       reconnectAttemptRef.current = 0;
       isReconnectingRef.current = false;
+      setState((s) => ({
+        ...s,
+        serialNeedsReselect: false,
+        connectionLoss: false,
+      }));
     } catch (err) {
       const failedDriverIdentity =
         opened?.driverIdentityId ??
@@ -2012,6 +2032,7 @@ export function useMeshtasticRuntime() {
         httpAddress,
         blePeripheralId,
         lastSerialPortId: resolvedSerialPortId,
+        serialPort: null,
       };
       reconnectAttemptRef.current = 0;
       isReconnectingRef.current = false;
@@ -2021,6 +2042,7 @@ export function useMeshtasticRuntime() {
         status: 'connecting',
         connectionType: type,
         connectionLoss: false,
+        serialNeedsReselect: false,
         batteryPercent: undefined,
         batteryCharging: undefined,
       }));
@@ -2049,6 +2071,11 @@ export function useMeshtasticRuntime() {
         );
       }
       deviceRef.current = activeDevice;
+      if (type === 'serial' && connectionParamsRef.current) {
+        connectionParamsRef.current.serialPort = getSerialPortFromMeshTransport(
+          activeDevice.transport,
+        );
+      }
       wireSubscriptions(activeDevice, type, { driverIdentityId });
 
       // Show persisted nodes immediately while NodeDB configure replays over BLE/serial.
@@ -3781,6 +3808,7 @@ export function useMeshtasticRuntime() {
     setConnection(meshtasticIdentityId, {
       status: state.status,
       connectionLoss: state.connectionLoss,
+      serialNeedsReselect: state.serialNeedsReselect,
       myNodeNum: state.myNodeNum,
       connectionType: state.connectionType,
       reconnectAttempt: state.reconnectAttempt,
@@ -3792,6 +3820,14 @@ export function useMeshtasticRuntime() {
       mqttStatus,
     });
   }, [meshtasticIdentityId, state, mqttStatus]);
+
+  useEffect(() => {
+    registerMeshtasticSerialDisconnectTarget({
+      isSerialConnected: () => connectionParamsRef.current?.type === 'serial',
+      onDisconnected: () => handleConnectionLostRef.current(),
+    });
+    return () => registerMeshtasticSerialDisconnectTarget(null);
+  }, []);
 
   useEffect(() => {
     registerMeshtasticSession({

--- a/src/renderer/stores/connectionStore.ts
+++ b/src/renderer/stores/connectionStore.ts
@@ -18,6 +18,8 @@ export interface ConnectionRecord {
   mqttStatus: MQTTStatus;
   /** True when the last drop was unexpected (not manual disconnect). */
   connectionLoss?: boolean;
+  /** Serial auto-reconnect exhausted; user must pick the port again via requestPort(). */
+  serialNeedsReselect?: boolean;
   reconnectAttempt: number;
   myNodeNum: number;
   lastDataReceivedAt?: Date;

--- a/src/renderer/types/web-serial.d.ts
+++ b/src/renderer/types/web-serial.d.ts
@@ -2,22 +2,43 @@
  * Minimal Web Serial API declarations for TypeScript.
  * See https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API
  */
-interface SerialPort {
-  readonly readable: ReadableStream<Uint8Array>;
-  readonly writable: WritableStream<Uint8Array>;
+interface SerialPort extends EventTarget {
+  readonly readable: ReadableStream<Uint8Array> | null;
+  readonly writable: WritableStream<Uint8Array> | null;
   open(options: { baudRate: number }): Promise<void>;
   close(): Promise<void>;
+  forget(): Promise<void>;
   getInfo(): {
     serialNumber?: string;
     usbVendorId?: number;
     usbProductId?: number;
     bluetoothServiceClassId?: string;
   };
+  addEventListener(
+    type: 'connect' | 'disconnect',
+    listener: (event: Event) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: 'connect' | 'disconnect',
+    listener: (event: Event) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
 }
 
-interface Serial {
+interface Serial extends EventTarget {
   getPorts(): Promise<SerialPort[]>;
   requestPort(options?: { filters?: unknown[] }): Promise<SerialPort>;
+  addEventListener(
+    type: 'connect' | 'disconnect',
+    listener: (event: Event) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: 'connect' | 'disconnect',
+    listener: (event: Event) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
 }
 
 interface Navigator {


### PR DESCRIPTION
## Summary

- **Serial recovery layer** (`serialPortRecovery.ts`, `serialDisconnectRouter.ts`): 15s open/reconnect timeouts, `SerialPort.forget()` escalation after repeated failures, persisted port identity cleanup, and global `navigator.serial` unplug routing for both Meshtastic and MeshCore.
- **Watchdogs & transport loss**: MeshCore serial watchdog (120s stale / 180s dead), transport-loss detection on Web Serial writes, and inbound activity tracking; Meshtastic serial dead threshold aligned to 3 minutes.
- **Reconnect UX**: After five failed auto-reconnect attempts, sets `serialNeedsReselect` and shows a connection banner with **Select serial port** that opens `requestPort()` instead of looping on `getPorts()`.
- **Docs**: Platform-neutral recovery steps in `docs/troubleshooting.md`.
- **Deps**: Bump `motion` to ^12.42.0 (transitive lockfile updates).

Zombie Web Serial sessions could hang reconnect indefinitely and force users to quit the app; bounded timeouts, watchdogs, `forget`, and re-select UI recover without OS-specific code paths.

## Commits

- `fix: harden USB serial reconnect on lockup and zombie ports`
- `chore: bump deps`

## Test plan

- [ ] Connect Meshtastic over USB serial; disconnect cable — auto-reconnect should recover or escalate to re-select banner after repeated failures.
- [ ] Connect MeshCore over USB serial; verify inbound traffic resets serial watchdog (no false reconnect while active).
- [ ] Simulate stalled serial open (or wait past 15s) — reconnect should fail with timeout instead of hanging forever.
- [ ] After 5 failed reconnects, confirm banner shows **Select serial port** and opens the normal port picker.
- [ ] Run `pnpm run test:run` — `serialPortRecovery.test.ts`, `connection.serial-cleanup.test.ts`, and runtime reconnect tests pass.
- [ ] Verify on Windows, macOS, and Linux (shared Web Serial stack).