### PR TITLE
refactor: harden i18n quality checks and vitest harness edge cases

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -314,7 +314,7 @@ Not installed by pnpm (install separately when needed):
 | `renderer-logic` | node        | Pure renderer unit tests (no setup)     |
 | `main`           | node        | Main, shared, preload, and script tests |
 
-Worker counts are derived in [`vitest.harness.ts`](../vitest.harness.ts): jsdom workers use `RENDERER_UI_CPU_RATIO` (0.5) because they are memory-heavy; node workers use `NODE_WORKER_CPU_RATIO` (0.75). Both pools floor at `MIN_VITEST_WORKERS` (2). Shared Vite dependency inline lists (`VITEST_CORE_DEPS`, `VITEST_SERVER_INLINE_DEPS`) also live there — add new deps to the harness when tests need them inlined.
+Worker counts are derived in [`vitest.harness.ts`](../vitest.harness.ts) via `computeVitestMaxWorkers(cpuCount, ratio)`: jsdom workers use `RENDERER_UI_CPU_RATIO` because they are memory-heavy; node workers use `NODE_WORKER_CPU_RATIO`. Both pools floor at `MIN_VITEST_WORKERS`. When tuning worker allocation, change those constants in the harness (not this doc). Shared Vite dependency inline lists (`VITEST_CORE_DEPS`, `VITEST_SERVER_INLINE_DEPS`) also live there — add new deps to the harness when tests need them inlined.
 
 Run these quality checks before opening a PR:
 

--- a/scripts/check-i18n-quality.mjs
+++ b/scripts/check-i18n-quality.mjs
@@ -906,13 +906,18 @@ export const ELLIPSIS_HYGIENE_LEAF_KEYS = new Set(['channelLoading', 'savingChan
 export const CAT_PH_PLACEHOLDER_RE = /__\s*PH\s*\d/i;
 
 /** i18next interpolation names in appearance order (for duplicate names, set dedupes). */
+const placeholderNameSetCache = new Map();
+
 export function placeholderNameSet(s) {
+  const cached = placeholderNameSetCache.get(s);
+  if (cached) return cached;
   const re = /\{\{\s*([^}]+?)\s*\}\}/g;
   const out = new Set();
   let m;
   while ((m = re.exec(s))) {
     out.add(m[1]);
   }
+  placeholderNameSetCache.set(s, out);
   return out;
 }
 
@@ -1027,13 +1032,16 @@ export function protectedBrandIssues(enVal, val, brands = PROTECTED_BRANDS) {
 }
 
 /**
- * @param {LocaleStringContext} ctx
- * @returns {string[]} Human-readable issue descriptions (empty if OK).
+ * @typedef {{ locale: string, flatKey: string, val: string, enVal: string, leafKey: string }} LocaleQualityCtx
  */
-export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
-  const issues = [];
-  const leafKey = flatKey.split('.').pop() ?? flatKey;
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkCatEncodingAndMeshtasticIssues(ctx) {
+  const { locale, flatKey, val, enVal } = ctx;
+  const issues = [];
   if (CAT_PH_PLACEHOLDER_RE.test(val)) {
     issues.push('CAT/XLIFF __ PH __ placeholder residue is not allowed');
   }
@@ -1084,7 +1092,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
   ) {
     issues.push('French "chaîne(s)" means broadcast channel; use "canal/canaux" for mesh channels');
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkMustTranslateAndFormFieldIssues(ctx) {
+  const { locale, val, enVal, leafKey } = ctx;
+  const issues = [];
   if (locale !== 'en' && MUST_TRANSLATE_LEAF_KEYS.has(leafKey) && val === enVal) {
     issues.push(`"${leafKey}" is still identical to English — translate the UI text`);
   }
@@ -1141,7 +1158,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
   ) {
     issues.push('use Unicode ellipsis (…) instead of ASCII dots when English uses …');
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkRadioPanelChannelIssues(ctx) {
+  const { locale, flatKey, val, leafKey } = ctx;
+  const issues = [];
   if (flatKey === RETRY_REMOTE_CHANNELS_KEY) {
     for (const { re, hint } of RETRY_REMOTE_CHANNELS_FORBIDDEN[locale] ?? []) {
       if (re.test(val)) {
@@ -1153,7 +1179,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
   if (locale === 'nl' && leafKey === 'channelLoadFailed' && /\bmislukte\b/i.test(val)) {
     issues.push('use past participle "mislukt" for failed-state labels, not "mislukte"');
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkRoomsPanelFalseFriendIssues(ctx) {
+  const { locale, flatKey, val } = ctx;
+  const issues = [];
   if (isMeshcoreRoomUiKey(flatKey)) {
     for (const { re, hint } of ROOMS_PANEL_FALSE_FRIENDS[locale] ?? []) {
       if (re.test(val)) {
@@ -1165,7 +1200,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
   if (locale === 'ja' && flatKey === 'nodesPanel.meshcoreTypeRoom' && /部屋/.test(val)) {
     issues.push('roomsPanel false friend: use "ルーム" for MeshCore Room type, not hotel 部屋');
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkMeshAdvertAndRawPacketLogIssues(ctx) {
+  const { locale, flatKey, val, enVal } = ctx;
+  const issues = [];
   const shouldCheckMeshAdvertCommercial =
     isMeshAdvertCommercialCheckKey(flatKey) ||
     (locale === 'nl' && isMeshAdvertUiKey(flatKey, enVal));
@@ -1207,7 +1251,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
       }
     }
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkRoomsGuestPasswordAndNlMeshIssues(ctx) {
+  const { locale, flatKey, val, enVal } = ctx;
+  const issues = [];
   if (
     locale !== 'en' &&
     flatKey === `${ROOMS_PANEL_PREFIX}guestPasswordPlaceholder` &&
@@ -1225,7 +1278,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
     const gaasIssue = nlMeshGaasIssue(enVal, val);
     if (gaasIssue) issues.push(gaasIssue);
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkMqttWifiAndScriptIssues(ctx) {
+  const { locale, flatKey, val, enVal } = ctx;
+  const issues = [];
   if (isMqttProxyUiKey(flatKey)) {
     for (const { re, hint } of MQTT_PROXY_LEGAL_FALSE_FRIENDS) {
       if (re.test(val)) {
@@ -1250,7 +1312,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
   if (!CJK_LOCALES.has(locale) && CJK_SCRIPT_RE.test(val) && !CJK_SCRIPT_RE.test(enVal)) {
     issues.push('wrong-script contamination (CJK characters in a non-CJK locale)');
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkRoomsPanelTranslationIssues(ctx) {
+  const { locale, flatKey, val, enVal, leafKey } = ctx;
+  const issues = [];
   if (
     locale !== 'en' &&
     flatKey.startsWith(ROOMS_PANEL_PREFIX) &&
@@ -1317,7 +1388,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
   ) {
     issues.push('unreadPosts uses "Nowość" (novelty) — use "nowe" or "nowych" for unread count');
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkChatPanelIssues(ctx) {
+  const { locale, flatKey, val, enVal, leafKey } = ctx;
+  const issues = [];
   if (
     locale !== 'en' &&
     flatKey.startsWith('chatPanel.composeLimit.') &&
@@ -1361,7 +1441,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
       }
     }
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkRoomsPanelMembersIssues(ctx) {
+  const { locale, flatKey, val, enVal, leafKey } = ctx;
+  const issues = [];
   if (
     locale !== 'en' &&
     flatKey.startsWith(ROOMS_PANEL_PREFIX) &&
@@ -1558,7 +1647,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
       );
     }
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkAppPanelReduceMotionAndBrandIssues(ctx) {
+  const { locale, flatKey, val, enVal } = ctx;
+  const issues = [];
   if (flatKey === REDUCE_MOTION_DESC_KEY && enVal.includes('Loading spinners')) {
     for (const { re, hint } of REDUCE_MOTION_LOADING_SPINNER_FALSE_FRIENDS[locale] ?? []) {
       if (re.test(val)) {
@@ -1594,7 +1692,16 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
   if (enVal.includes('mesh-client') && MESH_CLIENT_LOWERCASE_SPACED_RE.test(val)) {
     issues.push('use "mesh-client" without spaces around the hyphen (not "mesh - client")');
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkMeshcoreOpenWireIssues(ctx) {
+  const { locale, flatKey, val, enVal, leafKey } = ctx;
+  const issues = [];
   if (locale !== 'en' && isMeshcoreOpenWireUiLeafKey(leafKey) && val === enVal) {
     issues.push(`"${leafKey}" is still identical to English — translate the UI text`);
   }
@@ -1706,13 +1813,31 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
   ) {
     issues.push('debugSnapshotCopied uses English "clipboard" — use "papan klip"');
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkUkrainianApostropheIssues(ctx) {
+  const { locale, val } = ctx;
+  const issues = [];
   if (locale === 'uk' && UK_BROKEN_APOSTROPHE_RE.test(val)) {
     issues.push(
       "Ukrainian apostrophe words must not have a space before ' (e.g. з'єднання, not з 'єднання)",
     );
   }
+  return issues;
+}
 
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkMeshcoreReactionAndConnectionIssues(ctx) {
+  const { locale, flatKey, val, enVal, leafKey } = ctx;
+  const issues = [];
   if (
     locale !== 'en' &&
     flatKey.startsWith('chatPanel.') &&
@@ -1775,6 +1900,37 @@ export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
     }
   }
 
+  return issues;
+}
+
+const LOCALE_STRING_QUALITY_CHECKS = [
+  checkCatEncodingAndMeshtasticIssues,
+  checkMustTranslateAndFormFieldIssues,
+  checkRadioPanelChannelIssues,
+  checkRoomsPanelFalseFriendIssues,
+  checkMeshAdvertAndRawPacketLogIssues,
+  checkRoomsGuestPasswordAndNlMeshIssues,
+  checkMqttWifiAndScriptIssues,
+  checkRoomsPanelTranslationIssues,
+  checkChatPanelIssues,
+  checkRoomsPanelMembersIssues,
+  checkAppPanelReduceMotionAndBrandIssues,
+  checkMeshcoreOpenWireIssues,
+  checkUkrainianApostropheIssues,
+  checkMeshcoreReactionAndConnectionIssues,
+];
+
+/**
+ * @param {LocaleStringContext} ctx
+ * @returns {string[]} Human-readable issue descriptions (empty if OK).
+ */
+export function localeStringQualityIssues({ locale, flatKey, val, enVal }) {
+  const leafKey = flatKey.split('.').pop() ?? flatKey;
+  const qualityCtx = { locale, flatKey, val, enVal, leafKey };
+  const issues = [];
+  for (const check of LOCALE_STRING_QUALITY_CHECKS) {
+    issues.push(...check(qualityCtx));
+  }
   return issues;
 }
 

--- a/scripts/check-i18n-quality.test.mjs
+++ b/scripts/check-i18n-quality.test.mjs
@@ -633,6 +633,12 @@ describe('localeStringQualityIssues', () => {
 });
 
 describe('interpolationPlaceholderIssues', () => {
+  it('memoizes placeholderNameSet for identical strings', async () => {
+    const { placeholderNameSet } = await import('./check-i18n-quality.mjs');
+    const text = 'Hello {{name}} and {{count}}';
+    expect(placeholderNameSet(text)).toBe(placeholderNameSet(text));
+  });
+
   it('flags missing {{count}} when CAT left __ PH0 __ residue', () => {
     const issues = interpolationPlaceholderIssues(
       'Logging in to {{count}} rooms (one at a time)…',

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -36,7 +36,8 @@ import {
 } from './check-i18n-quality.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const LOCALES_DIR = join(__dirname, '../src/renderer/locales');
+const LOCALES_DIR =
+  process.env.MESH_CLIENT_LOCALES_DIR ?? join(__dirname, '../src/renderer/locales');
 
 /** Log copy for opaque rooms-hello-* codes from check-i18n-quality.mjs (kept here for CodeQL). */
 const ROOMS_HELLO_FALSE_FRIEND_LOG = {
@@ -73,6 +74,25 @@ function formatLocaleQualityIssueForLog(issue) {
 }
 const SRC_DIR = join(__dirname, '../src/renderer');
 const EN_FILE = join(LOCALES_DIR, 'en/translation.json');
+
+function failLocalesDirAccess(err) {
+  const reason = err instanceof Error ? err.message : String(err);
+  console.error(
+    `Error: locales directory is missing or inaccessible: ${LOCALES_DIR} (${reason}). ` +
+      'Ensure src/renderer/locales exists and is readable.',
+  );
+  process.exit(1);
+}
+
+function readLocalesDirEntries() {
+  try {
+    return readdirSync(LOCALES_DIR);
+  } catch (err) {
+    failLocalesDirAccess(err);
+  }
+}
+
+readLocalesDirEntries();
 
 function flatten(obj, prefix = '') {
   const out = {};
@@ -228,7 +248,7 @@ for (const file of files) {
 }
 
 // ── 2. Check completeness across locale files (warn only — rate limits can leave gaps) ──
-const localeDirs = readdirSync(LOCALES_DIR).filter((d) => {
+const localeDirs = readLocalesDirEntries().filter((d) => {
   const full = join(LOCALES_DIR, d);
   return statSync(full).isDirectory() && d !== 'en';
 });

--- a/scripts/check-i18n.test.mjs
+++ b/scripts/check-i18n.test.mjs
@@ -44,3 +44,22 @@ describe('check-i18n locale fixtures', () => {
     expect(() => JSON.parse('{not json')).toThrow();
   });
 });
+
+describe('check-i18n locales directory access', () => {
+  it('fails with a helpful message when LOCALES_DIR is missing', async () => {
+    const { spawnSync } = await import('node:child_process');
+    const { join, dirname } = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+    const scriptDir = dirname(fileURLToPath(import.meta.url));
+    const missingLocales = join(scriptDir, '__missing_locales_dir__');
+    const result = spawnSync(process.execPath, ['scripts/check-i18n.mjs'], {
+      cwd: join(scriptDir, '..'),
+      env: { ...process.env, MESH_CLIENT_LOCALES_DIR: missingLocales },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(1);
+    const output = `${result.stderr}\n${result.stdout}`;
+    expect(output).toContain('locales directory is missing or inaccessible');
+    expect(output).toContain(missingLocales);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -123,6 +123,7 @@ const RENDERER_LOGIC_EXCLUDE = [
   'src/renderer/stores/watchedNodesStore.test.ts',
 ];
 
+/** Glob in renderer-logic include; excluded from renderer-ui via RENDERER_UI_EXCLUDE filter below */
 const RENDERER_LOGIC_LIB_GLOB = 'src/renderer/lib/**/*.test.ts';
 
 /** Lib tests that need jsdom/setup — excluded from renderer-logic, routed to renderer-ui */
@@ -206,6 +207,7 @@ export default defineConfig({
           globals: true,
           environment: 'node',
           include: RENDERER_LOGIC_INCLUDE,
+          // RENDERER_LOGIC_LIB_GLOB in include matches all lib tests; exclude routes jsdom cases to renderer-ui.
           exclude: RENDERER_LOGIC_EXCLUDE,
           pool: 'threads',
           maxWorkers: nodeWorkers,

--- a/vitest.harness.test.ts
+++ b/vitest.harness.test.ts
@@ -16,6 +16,20 @@ describe('vitest.harness', () => {
     expect(computeVitestMaxWorkers(8, NODE_WORKER_CPU_RATIO)).toBe(6);
   });
 
+  it('computeVitestMaxWorkers returns MIN_VITEST_WORKERS for invalid inputs', () => {
+    expect(computeVitestMaxWorkers(0, RENDERER_UI_CPU_RATIO)).toBe(MIN_VITEST_WORKERS);
+    expect(computeVitestMaxWorkers(-4, NODE_WORKER_CPU_RATIO)).toBe(MIN_VITEST_WORKERS);
+    expect(computeVitestMaxWorkers(8, 0)).toBe(MIN_VITEST_WORKERS);
+    expect(computeVitestMaxWorkers(8, -0.5)).toBe(MIN_VITEST_WORKERS);
+    expect(computeVitestMaxWorkers(Number.NaN, RENDERER_UI_CPU_RATIO)).toBe(MIN_VITEST_WORKERS);
+    expect(computeVitestMaxWorkers(8, Number.POSITIVE_INFINITY)).toBe(MIN_VITEST_WORKERS);
+  });
+
+  it('computeVitestMaxWorkers caps ratio above 1', () => {
+    expect(computeVitestMaxWorkers(8, 2)).toBe(8);
+    expect(computeVitestMaxWorkers(4, 1.5)).toBe(4);
+  });
+
   it('renderer-ui uses a lower CPU ratio than node workers', () => {
     expect(RENDERER_UI_CPU_RATIO).toBeLessThan(NODE_WORKER_CPU_RATIO);
   });

--- a/vitest.harness.ts
+++ b/vitest.harness.ts
@@ -8,7 +8,11 @@ export const RENDERER_UI_CPU_RATIO = 0.5;
 export const NODE_WORKER_CPU_RATIO = 0.75;
 
 export function computeVitestMaxWorkers(cpuCount: number, ratio: number): number {
-  return Math.max(MIN_VITEST_WORKERS, Math.floor(cpuCount * ratio));
+  if (!Number.isFinite(cpuCount) || !Number.isFinite(ratio) || cpuCount <= 0 || ratio <= 0) {
+    return MIN_VITEST_WORKERS;
+  }
+  const boundedRatio = Math.min(ratio, 1);
+  return Math.max(MIN_VITEST_WORKERS, Math.floor(cpuCount * boundedRatio));
 }
 
 /** Shared deps inlined for Vite SSR optimizeDeps and server.deps.inline. */


### PR DESCRIPTION
## Summary

- Refactors `localeStringQualityIssues` into 14 focused checker functions coordinated via `LOCALE_STRING_QUALITY_CHECKS`, and memoizes `placeholderNameSet` for repeated scans across thousands of locale keys.
- Improves `check-i18n` startup diagnostics when `src/renderer/locales` is missing or unreadable (`readLocalesDirEntries`, `MESH_CLIENT_LOCALES_DIR` test override).
- Hardens `computeVitestMaxWorkers` for invalid/zero inputs and ratios above 1, with new harness tests.
- Documents Vitest worker constants in `development-environment.md` by reference to `vitest.harness.ts` instead of hardcoded literals; clarifies `RENDERER_LOGIC_LIB_GLOB` and why `renderer-logic` still needs `exclude` alongside the lib test glob.

## Test plan

- [x] `pnpm exec vitest run scripts/check-i18n-quality.test.mjs scripts/check-i18n.test.mjs vitest.harness.test.ts`
- [x] Full `pnpm run test:run` (pre-commit)
- [x] `pnpm run lint` and `pnpm run typecheck` (pre-commit)