### PR TITLE
fix: Noble BLE auto-connect direct connect and manual scan races

### DIFF
--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -716,6 +716,66 @@ describe('ConnectionPanel exit actions', () => {
   });
 });
 
+describe('ConnectionPanel BLE noble manual connect', () => {
+  it('starts noble scan on manual Connect even when a last BLE device is saved', async () => {
+    const user = userEvent.setup();
+    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
+    userAgentSpy.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+    );
+    const lastConnKey = 'mesh-client:lastConnection:meshtastic';
+    localStorage.setItem(
+      lastConnKey,
+      JSON.stringify({ type: 'ble', bleDeviceId: 'previously-paired-radio' }),
+    );
+    const onAutoConnect = vi.fn().mockResolvedValue(undefined);
+    const onConnect = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockClear();
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={onConnect}
+          onAutoConnect={onAutoConnect}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(onAutoConnect).toHaveBeenCalledWith(
+          'ble',
+          undefined,
+          undefined,
+          'previously-paired-radio',
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByRole('radiogroup', { name: 'Connection Type' })).toBeInTheDocument();
+      });
+
+      vi.mocked(window.electronAPI.startNobleBleScanning).mockClear();
+
+      const connectionField = screen
+        .getByRole('radiogroup', { name: 'Connection Type' })
+        .closest('fieldset')?.parentElement;
+      expect(connectionField).toBeTruthy();
+      await user.click(within(connectionField!).getByRole('radio', { name: /Bluetooth/i }));
+      await user.click(within(connectionField!).getByRole('button', { name: /^Connect$/i }));
+
+      await waitFor(() => {
+        expect(window.electronAPI.startNobleBleScanning).toHaveBeenCalledWith('meshtastic');
+      });
+      expect(onConnect).not.toHaveBeenCalled();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+      userAgentSpy.mockRestore();
+    }
+  });
+});
+
 describe('ConnectionPanel BLE noble auto-connect', () => {
   it('calls onAutoConnect with saved peripheral id without waiting for renderer discovery', async () => {
     const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -716,6 +716,41 @@ describe('ConnectionPanel exit actions', () => {
   });
 });
 
+describe('ConnectionPanel BLE noble auto-connect', () => {
+  it('calls onAutoConnect with saved peripheral id without waiting for renderer discovery', async () => {
+    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
+    userAgentSpy.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+    );
+    const bleId = 'ble-known-device';
+    const lastConnKey = 'mesh-client:lastConnection:meshtastic';
+    localStorage.setItem(lastConnKey, JSON.stringify({ type: 'ble', bleDeviceId: bleId }));
+    const onAutoConnect = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockClear();
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={onAutoConnect}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(onAutoConnect).toHaveBeenCalledWith('ble', undefined, undefined, bleId);
+      });
+      expect(window.electronAPI.startNobleBleScanning).not.toHaveBeenCalled();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+      userAgentSpy.mockRestore();
+    }
+  });
+});
+
 describe('ConnectionPanel meshcore shared Meshtastic BLE auto-connect', () => {
   it('skips meshcore noble scan when last BLE device matches Meshtastic', async () => {
     const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -22,6 +22,7 @@ import { formatMeshtasticNodeId } from '@/shared/nodeNameUtils';
 import { clampTcpPort, parseTcpPortFromString } from '@/shared/tcpPort';
 
 import { MESHCORE_SETUP_ABORT_MESSAGE } from '../lib/bleConnectErrors';
+import { reconnectBleWithScan } from '../lib/bleReconnectHelper';
 import type { FirmwareCheckResult } from '../lib/firmwareCheck';
 import {
   letsMeshPresetConfigurationDeviation,
@@ -1513,9 +1514,23 @@ export default function ConnectionPanel({
       isAutoConnectingRef.current = true;
       setIsAutoConnecting(true);
       setConnecting(true);
-      setConnectionStage('connectionPanel.stageScanningLast');
+      setConnectionStage('connectionPanel.stageConnecting');
       startAutoConnectTimeout();
-      void window.electronAPI.startNobleBleScanning(protocol).catch(onAutoConnectFailed);
+      // Try direct connect first (main process waitForPeripheralDuringScan); scan only on failure.
+      void reconnectBleWithScan(protocol, lastBleId, () =>
+        onAutoConnectRef.current('ble', undefined, undefined, lastBleId),
+      )
+        .then(() => {
+          if (autoConnectTimeoutRef.current) {
+            clearTimeout(autoConnectTimeoutRef.current);
+            autoConnectTimeoutRef.current = null;
+          }
+          isAutoConnectingRef.current = false;
+          setIsAutoConnecting(false);
+          setConnecting(false);
+          setConnectionStage('');
+        })
+        .catch(onAutoConnectFailed);
       return true;
     };
 
@@ -1568,9 +1583,8 @@ export default function ConnectionPanel({
       });
     } else if (lc.type === 'ble') {
       if (lastBleId && !isLinux) {
-        // Noble: auto-scan on startup — no user gesture required.
-        // onNobleBleDeviceDiscovered will auto-connect when the known device appears.
-        // On Linux, Web Bluetooth requires a user gesture; skip auto-scan and let user click Connect.
+        // Noble: direct connect with saved peripheral id (main process scans if needed).
+        // On Linux, Web Bluetooth requires a user gesture; skip auto-connect and let user click Connect.
         if (skipMeshcoreSharedMeshtasticBleAutoConnect()) return;
         startBleNobleAutoConnect();
       }
@@ -1628,9 +1642,8 @@ export default function ConnectionPanel({
             }
           });
         } else {
-          // Noble: start scanning — no user gesture required.
-          // onNobleBleDeviceDiscovered will auto-connect when the known device appears.
-          setConnectionStage('connectionPanel.stageScanningLast');
+          const bleDeviceId = lastConnection.bleDeviceId;
+          setConnectionStage('connectionPanel.stageConnecting');
           if (autoConnectTimeoutRef.current) {
             clearTimeout(autoConnectTimeoutRef.current);
             autoConnectTimeoutRef.current = null;
@@ -1643,18 +1656,31 @@ export default function ConnectionPanel({
             setConnecting(false);
             setConnectionStage('');
           }, 30_000);
-          void window.electronAPI.startNobleBleScanning(protocol).catch((err: unknown) => {
-            if (autoConnectTimeoutRef.current) {
-              clearTimeout(autoConnectTimeoutRef.current);
-              autoConnectTimeoutRef.current = null;
-            }
-            isAutoConnectingRef.current = false;
-            setIsAutoConnecting(false);
-            const bleErrMsg = humanizeBleError(err, t);
-            if (bleErrMsg) setError(bleErrMsg);
-            setConnecting(false);
-            setConnectionStage('');
-          });
+          void reconnectBleWithScan(protocol, bleDeviceId, () =>
+            onConnect('ble', undefined, bleDeviceId),
+          )
+            .then(() => {
+              if (autoConnectTimeoutRef.current) {
+                clearTimeout(autoConnectTimeoutRef.current);
+                autoConnectTimeoutRef.current = null;
+              }
+              isAutoConnectingRef.current = false;
+              setIsAutoConnecting(false);
+              setConnecting(false);
+              setConnectionStage('');
+            })
+            .catch((err: unknown) => {
+              if (autoConnectTimeoutRef.current) {
+                clearTimeout(autoConnectTimeoutRef.current);
+                autoConnectTimeoutRef.current = null;
+              }
+              isAutoConnectingRef.current = false;
+              setIsAutoConnecting(false);
+              const bleErrMsg = humanizeBleError(err, t);
+              if (bleErrMsg) setError(bleErrMsg);
+              setConnecting(false);
+              setConnectionStage('');
+            });
         }
       }
     } else if (lastConnection.type === 'http') {

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -8,7 +8,10 @@ import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import { ConnectionIcon, MqttGlobeIcon } from '@/renderer/lib/icons/connectionIcons';
 import { useParentIconTrigger } from '@/renderer/lib/icons/iconMotionContext';
 import { SpinnerIcon, SpinnerIconLg } from '@/renderer/lib/icons/spinnerIcon';
-import { meshcoreTargetsSharedMeshtasticBlePeripheral } from '@/renderer/lib/meshcoreDualNobleBleInit';
+import {
+  isRendererNobleBlePlatform,
+  meshcoreTargetsSharedMeshtasticBlePeripheral,
+} from '@/renderer/lib/meshcoreDualNobleBleInit';
 import { markMqttUserDisconnect } from '@/renderer/lib/mqttDisconnectIntent';
 import { mqttUsesTls } from '@/renderer/lib/mqttTls';
 import { parseTcpAddress } from '@/renderer/lib/parseTcpAddress';
@@ -61,6 +64,7 @@ import {
 } from '../lib/meshtasticMqttTlsMigration';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import { LAST_SERIAL_PORT_KEY } from '../lib/serialPortSignature';
+import { STARTUP_MESHCORE_BLE_AUTOCONNECT_STAGGER_MS } from '../lib/timeConstants';
 import type {
   ConnectionType,
   DeviceState,
@@ -784,6 +788,7 @@ export default function ConnectionPanel({
   );
   const autoConnectFiredRef = useRef(false);
   const autoConnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const meshcoreBleAutoConnectStaggerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isAutoConnectingRef = useRef(false);
   const [isAutoConnecting, setIsAutoConnecting] = useState(false);
   // Tracks BLE device name at selection time, used when saving LastConnection
@@ -1249,29 +1254,6 @@ export default function ConnectionPanel({
     setConnectionStage('connectionPanel.stagePleaseWait');
 
     if (connectionType === 'ble') {
-      if (!isLinux) {
-        const lastBleId = lastConnection?.bleDeviceId ?? loadLastBleDevice(protocol);
-        if (lastBleId) {
-          setConnectionType('ble');
-          setConnectionStage('connectionPanel.stageConnecting');
-          try {
-            await onConnect('ble', undefined, lastBleId);
-            setConnecting(false);
-            setConnectionStage('');
-            return;
-          } catch (err) {
-            console.warn(
-              '[ConnectionPanel] handleConnect last-device reconnect failed ' +
-                errLikeToLogString(err),
-            );
-            const bleErrMsg = humanizeBleError(err, t);
-            if (bleErrMsg) setError(bleErrMsg);
-            setConnecting(false);
-            setConnectionStage('');
-            return;
-          }
-        }
-      }
       if (isLinux) {
         console.debug('[ConnectionPanel] handleConnect Linux BLE path');
         setConnectionStage('connectionPanel.stageSelectBluetoothDots');
@@ -1315,7 +1297,8 @@ export default function ConnectionPanel({
           return;
         }
       }
-      // Noble: start scanning — actual connection triggered when user selects a device
+      // Noble (macOS/Windows): manual Connect always opens the scanner so the user can pick any device.
+      // Reconnect to the last device uses handleReconnect / startup auto-connect instead.
       setConnectionStage('connectionPanel.stageScanning');
       try {
         await window.electronAPI.startNobleBleScanning(protocol);
@@ -1350,7 +1333,7 @@ export default function ConnectionPanel({
       setConnecting(false);
       setConnectionStage('');
     }
-  }, [connectionType, activeHostAddress, onConnect, protocol, isLinux, t, lastConnection]);
+  }, [connectionType, activeHostAddress, onConnect, protocol, isLinux, t]);
 
   const handleCancelConnection = useCallback(async () => {
     isAutoConnectingRef.current = false;
@@ -1515,16 +1498,11 @@ export default function ConnectionPanel({
       setIsAutoConnecting(true);
       setConnecting(true);
       setConnectionStage('connectionPanel.stageConnecting');
-      startAutoConnectTimeout();
-      // Try direct connect first (main process waitForPeripheralDuringScan); scan only on failure.
+      // reconnectBleWithScan owns failure timing (wait + scan); do not use the 30s serial timeout here.
       void reconnectBleWithScan(protocol, lastBleId, () =>
         onAutoConnectRef.current('ble', undefined, undefined, lastBleId),
       )
         .then(() => {
-          if (autoConnectTimeoutRef.current) {
-            clearTimeout(autoConnectTimeoutRef.current);
-            autoConnectTimeoutRef.current = null;
-          }
           isAutoConnectingRef.current = false;
           setIsAutoConnecting(false);
           setConnecting(false);
@@ -1583,10 +1561,23 @@ export default function ConnectionPanel({
       });
     } else if (lc.type === 'ble') {
       if (lastBleId && !isLinux) {
-        // Noble: direct connect with saved peripheral id (main process scans if needed).
-        // On Linux, Web Bluetooth requires a user gesture; skip auto-connect and let user click Connect.
-        if (skipMeshcoreSharedMeshtasticBleAutoConnect()) return;
-        startBleNobleAutoConnect();
+        const runBleAutoConnect = () => {
+          if (skipMeshcoreSharedMeshtasticBleAutoConnect()) return;
+          startBleNobleAutoConnect();
+        };
+        const meshtasticBlePending =
+          protocol === 'meshcore' &&
+          isRendererNobleBlePlatform() &&
+          loadLastConnection('meshtastic')?.type === 'ble' &&
+          Boolean(loadLastConnection('meshtastic')?.bleDeviceId);
+        if (meshtasticBlePending) {
+          meshcoreBleAutoConnectStaggerRef.current = setTimeout(() => {
+            meshcoreBleAutoConnectStaggerRef.current = null;
+            runBleAutoConnect();
+          }, STARTUP_MESHCORE_BLE_AUTOCONNECT_STAGGER_MS);
+        } else {
+          runBleAutoConnect();
+        }
       }
     }
     // HTTP: do not auto-trigger — show one-click reconnect card instead
@@ -1596,6 +1587,9 @@ export default function ConnectionPanel({
   useEffect(
     () => () => {
       if (autoConnectTimeoutRef.current) clearTimeout(autoConnectTimeoutRef.current);
+      if (meshcoreBleAutoConnectStaggerRef.current) {
+        clearTimeout(meshcoreBleAutoConnectStaggerRef.current);
+      }
     },
     [],
   );
@@ -1644,36 +1638,16 @@ export default function ConnectionPanel({
         } else {
           const bleDeviceId = lastConnection.bleDeviceId;
           setConnectionStage('connectionPanel.stageConnecting');
-          if (autoConnectTimeoutRef.current) {
-            clearTimeout(autoConnectTimeoutRef.current);
-            autoConnectTimeoutRef.current = null;
-          }
-          autoConnectTimeoutRef.current = setTimeout(() => {
-            console.warn('[ConnectionPanel] auto-connect timed out after 30s');
-            isAutoConnectingRef.current = false;
-            setIsAutoConnecting(false);
-            setError(t('connectionPanel.error.autoConnectTimeout'));
-            setConnecting(false);
-            setConnectionStage('');
-          }, 30_000);
           void reconnectBleWithScan(protocol, bleDeviceId, () =>
             onConnect('ble', undefined, bleDeviceId),
           )
             .then(() => {
-              if (autoConnectTimeoutRef.current) {
-                clearTimeout(autoConnectTimeoutRef.current);
-                autoConnectTimeoutRef.current = null;
-              }
               isAutoConnectingRef.current = false;
               setIsAutoConnecting(false);
               setConnecting(false);
               setConnectionStage('');
             })
             .catch((err: unknown) => {
-              if (autoConnectTimeoutRef.current) {
-                clearTimeout(autoConnectTimeoutRef.current);
-                autoConnectTimeoutRef.current = null;
-              }
               isAutoConnectingRef.current = false;
               setIsAutoConnecting(false);
               const bleErrMsg = humanizeBleError(err, t);

--- a/src/renderer/lib/bleReconnectHelper.ts
+++ b/src/renderer/lib/bleReconnectHelper.ts
@@ -5,6 +5,9 @@ import type { MeshProtocol } from './types';
 
 export const BLE_RECONNECT_SCAN_TIMEOUT_MS = 30_000;
 
+/** Noble wait-for-peripheral + scan fallback; ConnectionPanel must not use a shorter UI timeout. */
+export const BLE_NOBLE_AUTO_CONNECT_MAX_MS = 30_000 + BLE_RECONNECT_SCAN_TIMEOUT_MS + 15_000;
+
 const isLinuxPlatform = (): boolean =>
   typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('linux');
 

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -178,6 +178,9 @@ export const POWER_RESUME_MESHCORE_MESHTASTIC_SETTLE_MS = 30_000;
 /** Poll interval inside `awaitDualNobleBleMeshtasticSettle`. */
 export const MESHCORE_DUAL_NOBLE_BLE_POLL_MS = 200;
 
+/** Stagger MeshCore Noble BLE startup auto-connect after Meshtastic (dual-protocol adapter contention). */
+export const STARTUP_MESHCORE_BLE_AUTOCONNECT_STAGGER_MS = 8_000;
+
 /** BlueZ is slower than macOS CBCentralManager — requestDevice / reuse granted device. */
 export const MESHCORE_WEB_BLUETOOTH_REQUEST_DEVICE_TIMEOUT_MS = 60_000;
 

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -4,7 +4,42 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-const SOURCE = readFileSync(join(__dirname, '../runtime/useMeshtasticRuntime.ts'), 'utf-8');
+const TEST_DIR = import.meta.dirname ?? __dirname;
+const SOURCE = readFileSync(join(TEST_DIR, 'useMeshtasticRuntime.ts'), 'utf-8');
+
+/** Returns the inner text of a `{ ... }` block starting at `openBraceIndex`. */
+function extractBalancedBlock(source: string, openBraceIndex: number): string {
+  let depth = 0;
+  for (let i = openBraceIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(openBraceIndex + 1, i);
+    }
+  }
+  throw new Error(`Unbalanced braces at index ${openBraceIndex}`);
+}
+
+function extractIfBlockBody(source: string, condition: string): string {
+  const marker = `if (${condition})`;
+  const ifIndex = source.indexOf(marker);
+  if (ifIndex === -1) return '';
+  const braceIndex = source.indexOf('{', ifIndex);
+  if (braceIndex === -1) return '';
+  return extractBalancedBlock(source, braceIndex);
+}
+
+function extractUseCallbackBody(source: string, name: string): string {
+  const marker = `const ${name} = useCallback(`;
+  const start = source.indexOf(marker);
+  if (start === -1) return '';
+  const arrowIndex = source.indexOf('=> {', start);
+  if (arrowIndex === -1) return '';
+  const braceIndex = source.indexOf('{', arrowIndex);
+  if (braceIndex === -1) return '';
+  return extractBalancedBlock(source, braceIndex);
+}
 
 describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
   it('uses suspend-aware delayUnlessSuspended for reconnect backoff', () => {
@@ -31,25 +66,24 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
   });
 
   it('cleans up device and watchdog when reconnect budget is exhausted', () => {
-    expect(SOURCE).toMatch(
-      /reconnectAttemptRef\.current >= MAX_RECONNECT_ATTEMPTS[\s\S]{0,400}cleanupSubscriptions/,
+    const exhaustionBlock = extractIfBlockBody(
+      SOURCE,
+      'reconnectAttemptRef.current >= MAX_RECONNECT_ATTEMPTS',
     );
-    expect(SOURCE).toMatch(
-      /reconnectAttemptRef\.current >= MAX_RECONNECT_ATTEMPTS[\s\S]{0,400}stopWatchdog/,
-    );
-    expect(SOURCE).toMatch(
-      /reconnectAttemptRef\.current >= MAX_RECONNECT_ATTEMPTS[\s\S]{0,2000}deviceRef\.current = null/,
-    );
+    expect(exhaustionBlock.length).toBeGreaterThan(0);
+    expect(exhaustionBlock).toContain('cleanupSubscriptions()');
+    expect(exhaustionBlock).toContain('stopWatchdog()');
+    expect(exhaustionBlock).toContain('deviceRef.current = null');
     expect(SOURCE).toContain('escalateSerialReconnectExhaustion');
     expect(SOURCE).toContain('serialNeedsReselect');
     expect(SOURCE).toContain('registerMeshtasticSerialDisconnectTarget');
   });
 
   it('clears reconnect refs in handleRfConnectFailure', () => {
-    expect(SOURCE).toMatch(/handleRfConnectFailure[\s\S]{0,400}isReconnectingRef\.current = false/);
-    expect(SOURCE).toMatch(
-      /handleRfConnectFailure[\s\S]{0,400}reconnectGenerationRef\.current \+= 1/,
-    );
+    const failureBlock = extractUseCallbackBody(SOURCE, 'handleRfConnectFailure');
+    expect(failureBlock.length).toBeGreaterThan(0);
+    expect(failureBlock).toContain('isReconnectingRef.current = false');
+    expect(failureBlock).toContain('reconnectGenerationRef.current += 1');
   });
 
   it('exports power suspend/resume handlers for usePowerRecovery', () => {

--- a/vitest.harness.test.ts
+++ b/vitest.harness.test.ts
@@ -23,7 +23,14 @@ describe('vitest.harness', () => {
     expect(computeVitestMaxWorkers(8, 0)).toBe(MIN_VITEST_WORKERS);
     expect(computeVitestMaxWorkers(8, -0.5)).toBe(MIN_VITEST_WORKERS);
     expect(computeVitestMaxWorkers(Number.NaN, RENDERER_UI_CPU_RATIO)).toBe(MIN_VITEST_WORKERS);
+    expect(computeVitestMaxWorkers(8, Number.NaN)).toBe(MIN_VITEST_WORKERS);
     expect(computeVitestMaxWorkers(8, Number.POSITIVE_INFINITY)).toBe(MIN_VITEST_WORKERS);
+    expect(computeVitestMaxWorkers(8, Number.NEGATIVE_INFINITY)).toBe(MIN_VITEST_WORKERS);
+  });
+
+  it('computeVitestMaxWorkers floors very small ratios to MIN_VITEST_WORKERS', () => {
+    expect(computeVitestMaxWorkers(MAX_VITEST_CPU_COUNT, 0.01)).toBe(MIN_VITEST_WORKERS);
+    expect(computeVitestMaxWorkers(1, 0.01)).toBe(MIN_VITEST_WORKERS);
   });
 
   it('computeVitestMaxWorkers caps ratio above 1', () => {


### PR DESCRIPTION
## Summary

- **Direct connect before scan:** Noble BLE startup auto-connect and reconnect card now route through `reconnectBleWithScan`, so the main process connects via `waitForPeripheralDuringScan` instead of waiting only for renderer IPC discovery events. Fixes false offline timeouts when Bluetooth is on but the saved device never appears in the renderer scan list.
- **Manual Connect opens scanner:** On macOS/Windows, manual Connect always starts Noble scanning so users can pick a different radio; reconnect to the last device uses startup auto-connect or the reconnect card instead.
- **Timeout race fix:** Removes the ConnectionPanel 30s auto-connect timeout from Noble paths; `reconnectBleWithScan` owns wait + scan timing (documented `BLE_NOBLE_AUTO_CONNECT_MAX_MS`).
- **Dual-protocol stagger:** MeshCore startup BLE auto-connect waits 8s when Meshtastic also has a saved BLE device, reducing adapter contention on dual-protocol setups.
- **Tests:** ConnectionPanel regression tests for manual scan-with-saved-device and auto-connect direct-connect; hardened `useMeshtasticRuntime` reconnect regression tests and vitest harness edge-case coverage.

## Test plan

- [ ] macOS/Windows: app startup with saved Meshtastic BLE device auto-connects without requiring scan picker
- [ ] macOS/Windows: manual Connect with saved BLE device opens scanner (does not silently reconnect to last device)
- [ ] Reconnect card for saved BLE device connects without false 30s timeout while radio is reachable
- [ ] Dual-protocol: Meshtastic + MeshCore both with saved BLE — Meshtastic connects first, MeshCore auto-connect follows after stagger
- [ ] `pnpm run test:run` — ConnectionPanel, reconnect-hardening, vitest.harness tests pass