### PR TITLE
test: remediate CodeQL findings for ConnectionPanel and reconnect

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -314,7 +314,9 @@ Not installed by pnpm (install separately when needed):
 | `renderer-logic` | node        | Pure renderer unit tests (no setup)     |
 | `main`           | node        | Main, shared, preload, and script tests |
 
-Worker counts are derived in [`vitest.harness.ts`](../vitest.harness.ts) via `computeVitestMaxWorkers(cpuCount, ratio)`: jsdom workers use `RENDERER_UI_CPU_RATIO` because they are memory-heavy; node workers use `NODE_WORKER_CPU_RATIO`. Both pools floor at `MIN_VITEST_WORKERS`. When tuning worker allocation, change those constants in the harness (not this doc). Shared Vite dependency inline lists (`VITEST_CORE_DEPS`, `VITEST_SERVER_INLINE_DEPS`) also live there — add new deps to the harness when tests need them inlined.
+Worker counts are derived in [`vitest.harness.ts`](../vitest.harness.ts) via `computeVitestMaxWorkers(cpuCount, ratio)`: jsdom workers use `RENDERER_UI_CPU_RATIO` because they are memory-heavy; node workers use `NODE_WORKER_CPU_RATIO`. Both pools floor at `MIN_VITEST_WORKERS` (currently 2) and cap effective CPU count at `MAX_VITEST_CPU_COUNT` (32). When tuning worker allocation, change those constants in the harness (not this doc). Shared Vite dependency inline lists (`VITEST_CORE_DEPS`, `VITEST_SERVER_INLINE_DEPS`) also live there — add new deps to the harness when tests need them inlined.
+
+Monolithic protocol runtimes (`useMeshtasticRuntime`, `useMeshcoreRuntime`) also use **source contract tests** (read `.ts` files and assert wiring strings) where full `renderHook` integration would require heavy BLE/MQTT mocking; see `*.reconnect*.test.ts` beside those runtimes.
 
 Run these quality checks before opening a PR:
 

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -8,7 +8,9 @@ import { axe } from 'vitest-axe';
 import type { SerialPort } from '@/shared/electron-api.types';
 
 import type { FirmwareCheckResult } from '../lib/firmwareCheck';
+import { MESHCORE_IDENTITY_STORAGE_KEY } from '../lib/letsMeshJwt';
 import type { DeviceState } from '../lib/types';
+import { mockConsoleWarn, withMockedConsoleWarn } from '../lib/vitestConsoleMock';
 import ConnectionPanel from './ConnectionPanel';
 
 const disconnectedState: DeviceState = {
@@ -17,6 +19,24 @@ const disconnectedState: DeviceState = {
   reconnectAttempt: 0,
   connectionType: null,
 };
+
+function mockMacNoblePlatform(): {
+  userAgentSpy: ReturnType<typeof vi.spyOn>;
+  restore: () => void;
+} {
+  vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
+  const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
+  userAgentSpy.mockReturnValue(
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+  );
+  return {
+    userAgentSpy,
+    restore: () => {
+      userAgentSpy.mockRestore();
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
+    },
+  };
+}
 
 describe('ConnectionPanel MQTT port clamping', () => {
   it('clamps port to 1 when 0 is entered', async () => {
@@ -104,7 +124,7 @@ describe('ConnectionPanel accessibility', () => {
 describe('ConnectionPanel MQTT connect error', () => {
   it('surfaces error when mqtt.connect rejects', async () => {
     const user = userEvent.setup();
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { spy: consoleWarnSpy, restore } = mockConsoleWarn();
     vi.mocked(window.electronAPI.mqtt.connect).mockRejectedValueOnce(new Error('broker refused'));
 
     render(
@@ -127,7 +147,7 @@ describe('ConnectionPanel MQTT connect error', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringMatching(/\[ConnectionPanel\].*broker refused/s),
     );
-    consoleWarnSpy.mockRestore();
+    restore();
   });
 
   it('does not run LetsMesh preset validation for Meshtastic when meshcore preset was letsmesh', async () => {
@@ -167,7 +187,7 @@ describe('ConnectionPanel MQTT connect error', () => {
 describe('ConnectionPanel BLE error humanization', () => {
   it('shows Windows handshake guidance for MeshCore BLE handshake timeout/disconnect', async () => {
     const user = userEvent.setup();
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { spy: consoleWarnSpy, restore } = mockConsoleWarn();
     const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
     userAgentSpy.mockReturnValue(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124 Safari/537.36',
@@ -199,13 +219,13 @@ describe('ConnectionPanel BLE error humanization', () => {
         /\[ConnectionPanel\].*Bluetooth connected but MeshCore protocol handshake/s,
       ),
     );
-    consoleWarnSpy.mockRestore();
+    restore();
     userAgentSpy.mockRestore();
   });
 
   it('renders object-shaped BLE errors as JSON instead of [object Object]', async () => {
     const user = userEvent.setup();
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { spy: consoleWarnSpy, restore } = mockConsoleWarn();
     const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
     userAgentSpy.mockReturnValue(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124 Safari/537.36',
@@ -235,13 +255,13 @@ describe('ConnectionPanel BLE error humanization', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringMatching(/\[ConnectionPanel\].*"reason":"adapter glitch"/s),
     );
-    consoleWarnSpy.mockRestore();
+    restore();
     userAgentSpy.mockRestore();
   });
 
   it('shows Windows adapter guidance when BLE adapter is unavailable', async () => {
     const user = userEvent.setup();
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { spy: consoleWarnSpy, restore } = mockConsoleWarn();
     const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
     userAgentSpy.mockReturnValue(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124 Safari/537.36',
@@ -271,8 +291,112 @@ describe('ConnectionPanel BLE error humanization', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringMatching(/\[ConnectionPanel\].*Bluetooth adapter is not available/s),
     );
-    consoleWarnSpy.mockRestore();
+    restore();
     userAgentSpy.mockRestore();
+  });
+});
+
+describe('ConnectionPanel Linux BLE auto-connect', () => {
+  function mockLinuxUserAgent(): ReturnType<typeof vi.spyOn> {
+    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
+    userAgentSpy.mockReturnValue(
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+    );
+    return userAgentSpy;
+  }
+
+  it('does not auto-connect BLE on mount when last connection is saved', async () => {
+    const userAgentSpy = mockLinuxUserAgent();
+    const bleId = 'linux-ble-device';
+    const lastConnKey = 'mesh-client:lastConnection:meshtastic';
+    localStorage.setItem(lastConnKey, JSON.stringify({ type: 'ble', bleDeviceId: bleId }));
+    const onAutoConnect = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockClear();
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={onAutoConnect}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Radio Connection')).toBeInTheDocument();
+      });
+      expect(onAutoConnect).not.toHaveBeenCalled();
+      expect(window.electronAPI.startNobleBleScanning).not.toHaveBeenCalled();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+      userAgentSpy.mockRestore();
+    }
+  });
+
+  it('uses Web Bluetooth reconnect path from last-connection card on Linux', async () => {
+    const user = userEvent.setup();
+    const userAgentSpy = mockLinuxUserAgent();
+    const lastConnKey = 'mesh-client:lastConnection:meshtastic';
+    localStorage.setItem(
+      lastConnKey,
+      JSON.stringify({ type: 'ble', bleDeviceId: 'linux-ble-device' }),
+    );
+    const onConnect = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockClear();
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={onConnect}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Reconnect$/i }));
+
+      await waitFor(() => {
+        expect(onConnect).toHaveBeenCalledWith('ble', undefined);
+      });
+      expect(window.electronAPI.startNobleBleScanning).not.toHaveBeenCalled();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+      userAgentSpy.mockRestore();
+    }
+  });
+
+  it('does not start noble scan for meshcore on Linux mount with saved BLE connection', async () => {
+    const userAgentSpy = mockLinuxUserAgent();
+    const lastConnKey = 'mesh-client:lastConnection:meshcore';
+    localStorage.setItem(lastConnKey, JSON.stringify({ type: 'ble', bleDeviceId: 'linux-mc-ble' }));
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockClear();
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshcore"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Radio Connection')).toBeInTheDocument();
+      });
+      expect(window.electronAPI.startNobleBleScanning).not.toHaveBeenCalled();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+      userAgentSpy.mockRestore();
+    }
   });
 });
 
@@ -599,31 +723,33 @@ describe('ConnectionPanel exit actions', () => {
 
   it('shows Quit after connect failure returns to disconnected view', async () => {
     const user = userEvent.setup();
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const onConnect = vi.fn().mockRejectedValue(new Error('Connection refused'));
-    render(
-      <ConnectionPanel
-        state={disconnectedState}
-        onConnect={onConnect}
-        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
-        onDisconnect={vi.fn().mockResolvedValue(undefined)}
-        mqttStatus="disconnected"
-        protocol="meshtastic"
-      />,
-    );
+    await withMockedConsoleWarn(async () => {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={onConnect}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
 
-    const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
-    expect(radioCard).toBeTruthy();
-    await user.click(within(radioCard as HTMLElement).getByRole('radio', { name: /wifi\/http/i }));
-    const hostInput = within(radioCard as HTMLElement).getByLabelText(/device address/i);
-    fireEvent.change(hostInput, { target: { value: '192.168.1.10' } });
-    await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
+      const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
+      expect(radioCard).toBeTruthy();
+      await user.click(
+        within(radioCard as HTMLElement).getByRole('radio', { name: /wifi\/http/i }),
+      );
+      const hostInput = within(radioCard as HTMLElement).getByLabelText(/device address/i);
+      fireEvent.change(hostInput, { target: { value: '192.168.1.10' } });
+      await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /^Quit$/i })).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^Quit$/i })).toBeInTheDocument();
+      });
+      expect(screen.getByText('Radio Connection')).toBeInTheDocument();
     });
-    expect(screen.getByText('Radio Connection')).toBeInTheDocument();
-    consoleWarnSpy.mockRestore();
   });
 
   it('shows Disconnect & Quit on disconnected view when MQTT is connected', () => {
@@ -682,7 +808,6 @@ describe('ConnectionPanel exit actions', () => {
 
   it('shows Quit after HTTP reconnect failure from last-connection card', async () => {
     const user = userEvent.setup();
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const lastConnKey = 'mesh-client:lastConnection:meshtastic';
     localStorage.setItem(
       lastConnKey,
@@ -691,27 +816,28 @@ describe('ConnectionPanel exit actions', () => {
     const onConnect = vi.fn().mockRejectedValue(new Error('Connection refused'));
 
     try {
-      render(
-        <ConnectionPanel
-          state={disconnectedState}
-          onConnect={onConnect}
-          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
-          onDisconnect={vi.fn().mockResolvedValue(undefined)}
-          mqttStatus="disconnected"
-          protocol="meshtastic"
-        />,
-      );
+      await withMockedConsoleWarn(async () => {
+        render(
+          <ConnectionPanel
+            state={disconnectedState}
+            onConnect={onConnect}
+            onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+            onDisconnect={vi.fn().mockResolvedValue(undefined)}
+            mqttStatus="disconnected"
+            protocol="meshtastic"
+          />,
+        );
 
-      await user.click(screen.getByRole('button', { name: /^Reconnect$/i }));
+        await user.click(screen.getByRole('button', { name: /^Reconnect$/i }));
 
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /^Quit$/i })).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByRole('button', { name: /^Quit$/i })).toBeInTheDocument();
+        });
+        expect(onConnect).toHaveBeenCalledWith('http', '192.168.1.10');
+        expect(screen.getByText('Radio Connection')).toBeInTheDocument();
       });
-      expect(onConnect).toHaveBeenCalledWith('http', '192.168.1.10');
-      expect(screen.getByText('Radio Connection')).toBeInTheDocument();
     } finally {
       localStorage.removeItem(lastConnKey);
-      consoleWarnSpy.mockRestore();
     }
   });
 });
@@ -719,10 +845,7 @@ describe('ConnectionPanel exit actions', () => {
 describe('ConnectionPanel BLE noble manual connect', () => {
   it('starts noble scan on manual Connect even when a last BLE device is saved', async () => {
     const user = userEvent.setup();
-    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
-    userAgentSpy.mockReturnValue(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
-    );
+    const { restore } = mockMacNoblePlatform();
     const lastConnKey = 'mesh-client:lastConnection:meshtastic';
     localStorage.setItem(
       lastConnKey,
@@ -771,17 +894,14 @@ describe('ConnectionPanel BLE noble manual connect', () => {
       expect(onConnect).not.toHaveBeenCalled();
     } finally {
       localStorage.removeItem(lastConnKey);
-      userAgentSpy.mockRestore();
+      restore();
     }
   });
 });
 
 describe('ConnectionPanel BLE noble auto-connect', () => {
   it('calls onAutoConnect with saved peripheral id without waiting for renderer discovery', async () => {
-    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
-    userAgentSpy.mockReturnValue(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
-    );
+    const { restore } = mockMacNoblePlatform();
     const bleId = 'ble-known-device';
     const lastConnKey = 'mesh-client:lastConnection:meshtastic';
     localStorage.setItem(lastConnKey, JSON.stringify({ type: 'ble', bleDeviceId: bleId }));
@@ -806,17 +926,14 @@ describe('ConnectionPanel BLE noble auto-connect', () => {
       expect(window.electronAPI.startNobleBleScanning).not.toHaveBeenCalled();
     } finally {
       localStorage.removeItem(lastConnKey);
-      userAgentSpy.mockRestore();
+      restore();
     }
   });
 });
 
 describe('ConnectionPanel meshcore shared Meshtastic BLE auto-connect', () => {
   it('skips meshcore noble scan when last BLE device matches Meshtastic', async () => {
-    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
-    userAgentSpy.mockReturnValue(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
-    );
+    const { restore } = mockMacNoblePlatform();
     const sharedId = 'shared-ble-peripheral';
     const mcConnKey = 'mesh-client:lastConnection:meshcore';
     const mtBleKey = 'mesh-client:lastBleDevice:meshtastic';
@@ -842,17 +959,14 @@ describe('ConnectionPanel meshcore shared Meshtastic BLE auto-connect', () => {
     } finally {
       localStorage.removeItem(mcConnKey);
       localStorage.removeItem(mtBleKey);
-      userAgentSpy.mockRestore();
+      restore();
     }
   });
 });
 
 describe('ConnectionPanel serial auto-connect BLE fallback', () => {
   it('falls back to noble BLE scan when serial auto-connect fails and lastBleDevice exists', async () => {
-    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
-    userAgentSpy.mockReturnValue(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
-    );
+    const { restore } = mockMacNoblePlatform();
     const lastConnKey = 'mesh-client:lastConnection:meshcore';
     const lastBleKey = 'mesh-client:lastBleDevice:meshcore';
     localStorage.setItem(lastConnKey, JSON.stringify({ type: 'serial', serialPortId: 'port-1' }));
@@ -890,15 +1004,12 @@ describe('ConnectionPanel serial auto-connect BLE fallback', () => {
     } finally {
       localStorage.removeItem(lastConnKey);
       localStorage.removeItem(lastBleKey);
-      userAgentSpy.mockRestore();
+      restore();
     }
   });
 
   it('does not fall back to noble BLE when serial fails but BLE id is shared with Meshtastic', async () => {
-    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
-    userAgentSpy.mockReturnValue(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124 Safari/537.36',
-    );
+    const { restore } = mockMacNoblePlatform();
     const sharedId = 'shared-ble-device';
     const lastConnKey = 'mesh-client:lastConnection:meshcore';
     localStorage.setItem(lastConnKey, JSON.stringify({ type: 'serial', serialPortId: 'port-1' }));
@@ -929,7 +1040,7 @@ describe('ConnectionPanel serial auto-connect BLE fallback', () => {
       localStorage.removeItem(lastConnKey);
       localStorage.removeItem('mesh-client:lastBleDevice:meshcore');
       localStorage.removeItem('mesh-client:lastBleDevice:meshtastic');
-      userAgentSpy.mockRestore();
+      restore();
     }
   });
 });
@@ -963,32 +1074,32 @@ describe('ConnectionPanel MeshCore TCP port field', () => {
 
   it('passes host:port to onConnect when a custom port is set', async () => {
     const user = userEvent.setup();
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const onConnect = vi.fn().mockResolvedValue(undefined);
-    render(
-      <ConnectionPanel
-        state={disconnectedState}
-        onConnect={onConnect}
-        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
-        onDisconnect={vi.fn().mockResolvedValue(undefined)}
-        mqttStatus="disconnected"
-        protocol="meshcore"
-      />,
-    );
+    await withMockedConsoleWarn(async () => {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={onConnect}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshcore"
+        />,
+      );
 
-    const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
-    expect(radioCard).toBeTruthy();
+      const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
+      expect(radioCard).toBeTruthy();
 
-    const tcpBtn = within(radioCard as HTMLElement).getByRole('radio', { name: /tcp\/ip/i });
-    await user.click(tcpBtn);
+      const tcpBtn = within(radioCard as HTMLElement).getByRole('radio', { name: /tcp\/ip/i });
+      await user.click(tcpBtn);
 
-    const portInput = within(radioCard as HTMLElement).getByLabelText(/^Port$/i);
-    fireEvent.change(portInput, { target: { value: '5001' } });
+      const portInput = within(radioCard as HTMLElement).getByLabelText(/^Port$/i);
+      fireEvent.change(portInput, { target: { value: '5001' } });
 
-    await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
+      await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
 
-    expect(onConnect).toHaveBeenCalledWith('http', 'localhost:5001');
-    consoleWarnSpy.mockRestore();
+      expect(onConnect).toHaveBeenCalledWith('http', 'localhost:5001');
+    });
   });
 
   it.each([
@@ -997,30 +1108,30 @@ describe('ConnectionPanel MeshCore TCP port field', () => {
     ['abc', 'localhost:5000'],
   ])('falls back to port 5000 for invalid port %s', async (badPort, expectedAddress) => {
     const user = userEvent.setup();
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const onConnect = vi.fn().mockResolvedValue(undefined);
-    render(
-      <ConnectionPanel
-        state={disconnectedState}
-        onConnect={onConnect}
-        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
-        onDisconnect={vi.fn().mockResolvedValue(undefined)}
-        mqttStatus="disconnected"
-        protocol="meshcore"
-      />,
-    );
+    await withMockedConsoleWarn(async () => {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={onConnect}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshcore"
+        />,
+      );
 
-    const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
-    const tcpBtn = within(radioCard as HTMLElement).getByRole('radio', { name: /tcp\/ip/i });
-    await user.click(tcpBtn);
+      const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
+      const tcpBtn = within(radioCard as HTMLElement).getByRole('radio', { name: /tcp\/ip/i });
+      await user.click(tcpBtn);
 
-    const portInput = within(radioCard as HTMLElement).getByLabelText(/^Port$/i);
-    fireEvent.change(portInput, { target: { value: badPort } });
+      const portInput = within(radioCard as HTMLElement).getByLabelText(/^Port$/i);
+      fireEvent.change(portInput, { target: { value: badPort } });
 
-    await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
+      await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
 
-    expect(onConnect).toHaveBeenCalledWith('http', expectedAddress);
-    consoleWarnSpy.mockRestore();
+      expect(onConnect).toHaveBeenCalledWith('http', expectedAddress);
+    });
   });
 });
 
@@ -1054,6 +1165,7 @@ describe('ConnectionPanel Meshtastic MQTT autoLaunch persistence', () => {
 describe('ConnectionPanel MQTT channel PSKs', () => {
   const KEY_A = '1PG7OiApB1nwvP+rz05pAQ==';
   const KEY_B = 'AAAAAAAAAAAAAAAAAAAAAA==';
+  const INVALID_LENGTH_PSK = btoa(String.fromCharCode(...new Uint8Array(20).fill(2)));
 
   function renderMeshtasticMqtt() {
     return render(
@@ -1110,5 +1222,108 @@ describe('ConnectionPanel MQTT channel PSKs', () => {
       const saved = JSON.parse(localStorage.getItem('mesh-client:mqttSettings') ?? '{}');
       expect(saved.channelPsks).toEqual([KEY_A, KEY_B]);
     });
+  });
+
+  it('shows invalid length warning after blur', async () => {
+    const user = userEvent.setup();
+    renderMeshtasticMqtt();
+
+    const textarea = document.getElementById('mqtt-channel-psks') as HTMLTextAreaElement;
+    await user.clear(textarea);
+    await user.type(textarea, INVALID_LENGTH_PSK);
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Each key must decode to 16 bytes \(AES-128\) or 32 bytes \(AES-256\)/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows invalid base64 warning after blur', async () => {
+    const user = userEvent.setup();
+    renderMeshtasticMqtt();
+
+    const textarea = document.getElementById('mqtt-channel-psks') as HTMLTextAreaElement;
+    await user.clear(textarea);
+    await user.type(textarea, 'not!!!base64');
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid base64 on a channel PSK line/)).toBeInTheDocument();
+    });
+  });
+
+  it('clears validation warning when draft is edited', async () => {
+    const user = userEvent.setup();
+    renderMeshtasticMqtt();
+
+    const textarea = document.getElementById('mqtt-channel-psks') as HTMLTextAreaElement;
+    await user.clear(textarea);
+    await user.type(textarea, INVALID_LENGTH_PSK);
+    fireEvent.blur(textarea);
+    await waitFor(() => {
+      expect(screen.getByText(/Each key must decode to 16 bytes/)).toBeInTheDocument();
+    });
+
+    await user.type(textarea, 'x');
+    await waitFor(() => {
+      expect(screen.queryByText(/Each key must decode to 16 bytes/)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('ConnectionPanel LetsMesh username sync', () => {
+  const PUB_HEX = 'a'.repeat(64);
+
+  function renderMeshcoreLetsMesh() {
+    return render(
+      <ConnectionPanel
+        state={disconnectedState}
+        onConnect={vi.fn().mockResolvedValue(undefined)}
+        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+        onDisconnect={vi.fn().mockResolvedValue(undefined)}
+        mqttStatus="disconnected"
+        protocol="meshcore"
+      />,
+    );
+  }
+
+  it('populates username from identity on mount and after debounced identity updates', async () => {
+    localStorage.setItem('mesh-client:mqttPreset:meshcore', 'letsmesh');
+    localStorage.setItem(MESHCORE_IDENTITY_STORAGE_KEY, JSON.stringify({ public_key: PUB_HEX }));
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
+
+    try {
+      renderMeshcoreLetsMesh();
+
+      const usernameInput = await screen.findByLabelText<HTMLInputElement>(/^Username$/i);
+      expect(usernameInput.value).toBe(`v1_${PUB_HEX.toUpperCase()}`);
+
+      const callsBeforeBurst = getItemSpy.mock.calls.filter(
+        ([key]) => key === MESHCORE_IDENTITY_STORAGE_KEY,
+      ).length;
+
+      act(() => {
+        window.dispatchEvent(new Event('meshclient:meshcoreIdentityUpdated'));
+        window.dispatchEvent(new Event('meshclient:meshcoreIdentityUpdated'));
+        window.dispatchEvent(new Event('meshclient:meshcoreIdentityUpdated'));
+      });
+
+      await waitFor(
+        () => {
+          const callsAfterBurst = getItemSpy.mock.calls.filter(
+            ([key]) => key === MESHCORE_IDENTITY_STORAGE_KEY,
+          ).length;
+          expect(callsAfterBurst - callsBeforeBurst).toBeLessThanOrEqual(2);
+        },
+        { timeout: 500 },
+      );
+      expect(usernameInput.value).toBe(`v1_${PUB_HEX.toUpperCase()}`);
+    } finally {
+      localStorage.removeItem('mesh-client:mqttPreset:meshcore');
+      localStorage.removeItem(MESHCORE_IDENTITY_STORAGE_KEY);
+      getItemSpy.mockRestore();
+    }
   });
 });

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react-hooks/set-state-in-effect, react-hooks/refs */
-import type { TFunction } from 'i18next';
 import { PARENT_HOVER_ATTR } from 'lucide-react-motion';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,8 +23,13 @@ import {
 import { formatMeshtasticNodeId } from '@/shared/nodeNameUtils';
 import { clampTcpPort, parseTcpPortFromString } from '@/shared/tcpPort';
 
-import { MESHCORE_SETUP_ABORT_MESSAGE } from '../lib/bleConnectErrors';
 import { reconnectBleWithScan } from '../lib/bleReconnectHelper';
+import {
+  humanizeBleError,
+  humanizeHttpError,
+  humanizeSerialError,
+} from '../lib/connectionPanelErrorHumanize';
+import { runConnectionPanelStorageMigrations } from '../lib/connectionPanelStorageMigrations';
 import type { FirmwareCheckResult } from '../lib/firmwareCheck';
 import {
   letsMeshPresetConfigurationDeviation,
@@ -92,193 +96,6 @@ function lastBleDeviceKey(p: MeshProtocol) {
 
 function lastConnectionKey(p: MeshProtocol) {
   return `mesh-client:lastConnection:${p}`;
-}
-
-function humanizeSerialError(err: unknown, t: TFunction): string {
-  const msg = err instanceof Error ? err.message : String(err);
-  const isWindows = navigator.userAgent.toLowerCase().includes('windows');
-  if (/access denied|permission|not allowed/i.test(msg)) {
-    const hint = isWindows
-      ? t('connectionPanel.humanize.serial.accessDeniedWindowsHint')
-      : t('connectionPanel.humanize.serial.accessDeniedLinuxHint');
-    return t('connectionPanel.humanize.prefixedHint', { message: msg, hint });
-  }
-  if (/no port|not found|disconnected|device not found/i.test(msg)) {
-    return t('connectionPanel.humanize.prefixedHint', {
-      message: msg,
-      hint: t('connectionPanel.humanize.serial.disconnectedHint'),
-    });
-  }
-  if (/timed out/i.test(msg)) {
-    return t('connectionPanel.humanize.prefixedHint', {
-      message: msg,
-      hint: t('connectionPanel.humanize.serial.timeoutHint'),
-    });
-  }
-  if (/already open|locked stream|cannot cancel a locked/i.test(msg)) {
-    return t('connectionPanel.humanize.prefixedHint', {
-      message: msg,
-      hint: t('connectionPanel.humanize.serial.portStillOpenHint'),
-    });
-  }
-  return msg;
-}
-
-function hostFromAddressInput(address: string): string {
-  const raw = address.trim();
-  if (!raw) return '';
-  try {
-    return new URL(raw.includes('://') ? raw : `http://${raw}`).hostname.toLowerCase();
-  } catch {
-    // catch-no-log-ok user-typed host/IP without scheme
-    return raw.split('/')[0]?.split(':')[0]?.toLowerCase() ?? '';
-  }
-}
-
-function isMeshtasticLocalAddress(address: string): boolean {
-  const host = hostFromAddressInput(address);
-  return host === 'meshtastic.local' || host.endsWith('.meshtastic.local');
-}
-
-function humanizeHttpError(address: string, err: unknown, t: TFunction): string {
-  const msg = err instanceof Error ? err.message : String(err);
-  const isMdns = isMeshtasticLocalAddress(address);
-  const isWindows = navigator.userAgent.toLowerCase().includes('windows');
-  if (/timed out|timeout|aborted/i.test(msg)) {
-    const hint = isMdns
-      ? isWindows
-        ? t('connectionPanel.humanize.http.timeoutMdnsWindows')
-        : t('connectionPanel.humanize.http.timeoutMdnsNonWindows')
-      : t('connectionPanel.humanize.http.timeoutGeneric');
-    return t('connectionPanel.humanize.prefixedHint', { message: msg, hint });
-  }
-  if (/401|403|unauthorized/i.test(msg)) {
-    return t('connectionPanel.humanize.prefixedHint', {
-      message: msg,
-      hint: t('connectionPanel.humanize.http.unauthorizedHint'),
-    });
-  }
-  if (/econnrefused|connection refused|failed to fetch|network/i.test(msg)) {
-    return t('connectionPanel.humanize.prefixedHint', {
-      message: msg,
-      hint: t('connectionPanel.humanize.http.econnrefusedHint'),
-    });
-  }
-  if (isMdns) {
-    const suffix = isWindows
-      ? t('connectionPanel.humanize.http.suffixMdnsWindows')
-      : t('connectionPanel.humanize.http.suffixMdnsNonWindows');
-    return t('connectionPanel.humanize.prefixedHint', { message: msg, hint: suffix });
-  }
-  return msg;
-}
-
-function humanizeBleError(err: unknown, t: TFunction): string {
-  if (
-    err instanceof DOMException &&
-    err.name === 'AbortError' &&
-    err.message === MESHCORE_SETUP_ABORT_MESSAGE
-  ) {
-    return '';
-  }
-  const msg =
-    err instanceof Error
-      ? err.message
-      : typeof err === 'string'
-        ? err
-        : (() => {
-            try {
-              return JSON.stringify(err);
-            } catch {
-              // catch-no-log-ok stringify fallback for arbitrary renderer error shapes
-              return String(err);
-            }
-          })();
-  const isWindows = navigator.userAgent.toLowerCase().includes('windows');
-  const isLinux = navigator.userAgent.toLowerCase().includes('linux');
-  if (msg.includes('Bluetooth adapter not found') || msg.includes('adapter is not available')) {
-    const hint = isWindows
-      ? t('connectionPanel.humanize.ble.adapterWindowsHint')
-      : isLinux
-        ? t('connectionPanel.humanize.ble.adapterLinuxHint')
-        : t('connectionPanel.humanize.ble.adapterGenericHint');
-    return t('connectionPanel.humanize.prefixedHint', { message: msg, hint });
-  }
-  if (msg.includes('SecurityError') || msg.includes('not allowed to access')) {
-    return t('connectionPanel.humanize.prefixedHint', {
-      message: msg,
-      hint: t('connectionPanel.humanize.ble.securityPermissionHint'),
-    });
-  }
-  if (msg.includes('GATT Server is disconnected')) {
-    return t('connectionPanel.humanize.prefixedHint', {
-      message: msg,
-      hint: t('connectionPanel.humanize.ble.gattDisconnectedHint'),
-    });
-  }
-  // Web Bluetooth on Linux: "GATT Error: Not supported" means the device requires pairing
-  // before GATT operations are allowed. This is common with Meshtastic devices.
-  if (msg.includes('GATT Error: Not supported')) {
-    let enhanced = `${msg} ${t('connectionPanel.humanize.ble.gattNotSupportedBase')}`;
-    if (isLinux) {
-      enhanced += t('connectionPanel.humanize.ble.gattNotSupportedLinuxPin');
-    }
-    return enhanced;
-  }
-  // Check error.name directly for DOMException types that indicate pairing issues
-  if (err instanceof DOMException) {
-    if (err.name === 'SecurityError') {
-      let enhanced = t('connectionPanel.humanize.ble.authFailedBase', { message: err.message });
-      if (isLinux) {
-        enhanced += t('connectionPanel.humanize.ble.authFailedLinuxPin');
-      }
-      return enhanced;
-    }
-    if (err.name === 'NetworkError') {
-      let enhanced = t('connectionPanel.humanize.ble.networkFailedBase', { message: err.message });
-      if (isLinux) {
-        enhanced += t('connectionPanel.humanize.ble.networkFailedLinuxHint');
-      } else {
-        enhanced += t('connectionPanel.humanize.ble.networkFailedNonLinuxHint');
-      }
-      return enhanced;
-    }
-  }
-  // Web Bluetooth on Linux: connection failed often means device not paired properly
-  if (msg.includes('Connection Error: Connection attempt failed')) {
-    let enhanced = `${msg} ${t('connectionPanel.humanize.ble.connectionAttemptFailedBase')}`;
-    if (isLinux) {
-      enhanced += t('connectionPanel.humanize.ble.connectionAttemptFailedLinuxHint');
-    }
-    return enhanced;
-  }
-  if (/Bluetooth connected but MeshCore protocol handshake did not complete/i.test(msg)) {
-    let enhanced = `${msg} ${t('connectionPanel.humanize.ble.meshcoreHandshakeHint')}`;
-    if (isWindows) {
-      enhanced += t('connectionPanel.humanize.ble.meshcoreHandshakeWindowsExtra');
-    }
-    return enhanced;
-  }
-  if (/Bluetooth connection timed out while opening MeshCore over Noble IPC/i.test(msg)) {
-    let enhanced = `${msg} ${t('connectionPanel.humanize.ble.meshcoreHandshakeHint')}`;
-    if (isWindows) {
-      enhanced += t('connectionPanel.humanize.ble.meshcoreHandshakeWindowsExtra');
-    }
-    return enhanced;
-  }
-  const isDarwin = !isLinux && !isWindows;
-  if (
-    isDarwin &&
-    (/BLE connectAsync timed out/i.test(msg) ||
-      /BLE peripheral not found/i.test(msg) ||
-      /unknown peripheral/i.test(msg))
-  ) {
-    return t('connectionPanel.humanize.prefixedHint', {
-      message: msg,
-      hint: t('connectionPanel.humanize.ble.macWakeRecoveryHint'),
-    });
-  }
-  return msg;
 }
 
 function shouldShowLinuxRePairFromBleError(err: unknown, bleErrMsg: string): boolean {
@@ -430,38 +247,9 @@ function MqttGlobeStatusIcon({ status }: { status: MQTTStatus }) {
   return <MqttGlobeIcon className={`h-5 w-5 ${color}`} />;
 }
 
-function migrateMqttSettingsOnce(): void {
-  if (localStorage.getItem('mesh-client:mqttSettings:meshcore') !== null) return;
-  const raw = localStorage.getItem('mesh-client:mqttSettings');
-  if (!raw) return;
-  const parsed = parseStoredJson<Partial<MQTTSettings>>(raw, 'migrateMqttSettingsOnce');
-  if (!parsed) return;
-  if (typeof parsed.topicPrefix === 'string' && parsed.topicPrefix.startsWith('meshcore')) {
-    localStorage.setItem('mesh-client:mqttSettings:meshcore', raw);
-    localStorage.removeItem('mesh-client:mqttSettings');
-  }
-}
-migrateMqttSettingsOnce();
-
-function migrateMeshcoreTopicIataOnce(): void {
-  const MIGRATION_KEY = 'mesh-client:migrated:meshcore-topic-iata-v1';
-  if (localStorage.getItem(MIGRATION_KEY) !== null) return;
-  const raw = localStorage.getItem('mesh-client:mqttSettings:meshcore');
-  if (raw) {
-    const parsed = parseStoredJson<Partial<MQTTSettings>>(raw, 'migrateMeshcoreTopicIataOnce');
-    if (parsed?.topicPrefix === 'meshcore' && typeof parsed.server === 'string') {
-      const iata = parsed.server.trim() === COLORADO_MESH_HOST ? 'DEN' : 'test';
-      localStorage.setItem(
-        'mesh-client:mqttSettings:meshcore',
-        JSON.stringify({ ...parsed, topicPrefix: `meshcore/${iata}` }),
-      );
-    }
-  }
-  localStorage.setItem(MIGRATION_KEY, '1');
-}
-migrateMeshcoreTopicIataOnce();
-
 const MESHCORE_MQTT_SETTINGS_KEY = 'mesh-client:mqttSettings:meshcore';
+
+const LETS_MESH_USERNAME_SYNC_DEBOUNCE_MS = 100;
 
 function persistMqttSettingsIfChanged(key: string, settings: MQTTSettings): void {
   const serialized = JSON.stringify(settings);
@@ -521,6 +309,12 @@ export default function ConnectionPanel({
 }: Props) {
   const { t } = useTranslation();
   const parentIconTrigger = useParentIconTrigger();
+  const letsMeshUsernameSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    runConnectionPanelStorageMigrations();
+  }, []);
+
   const [connectionType, setConnectionType] = useState<ConnectionType>('ble');
   const [httpAddress, setHttpAddress] = useState(() => {
     const last = loadLastConnection(protocol);
@@ -702,10 +496,23 @@ export default function ConnectionPanel({
       if (!u) return;
       setMeshcoreMqttSettings((prev) => (prev.username === u ? prev : { ...prev, username: u }));
     };
+    const scheduleSync = () => {
+      if (letsMeshUsernameSyncTimerRef.current) {
+        clearTimeout(letsMeshUsernameSyncTimerRef.current);
+      }
+      letsMeshUsernameSyncTimerRef.current = setTimeout(() => {
+        letsMeshUsernameSyncTimerRef.current = null;
+        syncLetsMeshUsername();
+      }, LETS_MESH_USERNAME_SYNC_DEBOUNCE_MS);
+    };
     syncLetsMeshUsername();
-    window.addEventListener('meshclient:meshcoreIdentityUpdated', syncLetsMeshUsername);
+    window.addEventListener('meshclient:meshcoreIdentityUpdated', scheduleSync);
     return () => {
-      window.removeEventListener('meshclient:meshcoreIdentityUpdated', syncLetsMeshUsername);
+      window.removeEventListener('meshclient:meshcoreIdentityUpdated', scheduleSync);
+      if (letsMeshUsernameSyncTimerRef.current) {
+        clearTimeout(letsMeshUsernameSyncTimerRef.current);
+        letsMeshUsernameSyncTimerRef.current = null;
+      }
     };
   }, [protocol, meshcorePreset]);
 

--- a/src/renderer/lib/bleReconnectHelper.test.ts
+++ b/src/renderer/lib/bleReconnectHelper.test.ts
@@ -4,16 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BLE_RECONNECT_SCAN_TIMEOUT_MS, reconnectBleWithScan } from './bleReconnectHelper';
 
 describe('reconnectBleWithScan', () => {
-  const originalUa = navigator.userAgent;
   let discoveredCb: ((device: { deviceId: string; name: string }) => void) | null = null;
 
   beforeEach(() => {
-    Object.defineProperty(navigator, 'userAgent', {
-      value: 'Macintosh',
-      configurable: true,
-    });
     discoveredCb = null;
     vi.useFakeTimers();
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
     window.electronAPI.startNobleBleScanning = vi.fn().mockResolvedValue(undefined);
     window.electronAPI.stopNobleBleScanning = vi.fn().mockResolvedValue(undefined);
     window.electronAPI.onNobleBleDeviceDiscovered = vi.fn((cb) => {
@@ -25,12 +21,11 @@ describe('reconnectBleWithScan', () => {
   });
 
   afterEach(() => {
-    Object.defineProperty(navigator, 'userAgent', { value: originalUa, configurable: true });
     vi.useRealTimers();
   });
 
   it('connects immediately on Linux without Noble scan', async () => {
-    Object.defineProperty(navigator, 'userAgent', { value: 'Linux', configurable: true });
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
     const connect = vi.fn().mockResolvedValue(undefined);
     await reconnectBleWithScan('meshtastic', 'ble-1', connect);
     expect(connect).toHaveBeenCalledTimes(1);
@@ -60,6 +55,51 @@ describe('reconnectBleWithScan', () => {
     expect(window.electronAPI.stopNobleBleScanning).toHaveBeenCalledWith('meshtastic');
   });
 
+  it('ignores discovery events for other device ids until target appears', async () => {
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('peripheral not in cache'))
+      .mockResolvedValueOnce(undefined);
+    const promise = reconnectBleWithScan('meshtastic', 'ble-target', connect);
+    await vi.waitFor(() => {
+      expect(window.electronAPI.startNobleBleScanning).toHaveBeenCalled();
+    });
+    discoveredCb?.({ deviceId: 'ble-other', name: 'Other' });
+    expect(connect).toHaveBeenCalledTimes(1);
+    discoveredCb?.({ deviceId: 'ble-target', name: 'Radio' });
+    await promise;
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects when connect fails after discovery', async () => {
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('peripheral not in cache'))
+      .mockRejectedValueOnce(new Error('connect failed after discovery'));
+    const promise = reconnectBleWithScan('meshtastic', 'ble-1', connect);
+    await vi.waitFor(() => {
+      expect(window.electronAPI.startNobleBleScanning).toHaveBeenCalled();
+    });
+    discoveredCb?.({ deviceId: 'ble-1', name: 'Radio' });
+    await expect(promise).rejects.toThrow('connect failed after discovery');
+    expect(window.electronAPI.stopNobleBleScanning).toHaveBeenCalledWith('meshtastic');
+  });
+
+  it('ignores duplicate discovery after first match settles', async () => {
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('peripheral not in cache'))
+      .mockResolvedValueOnce(undefined);
+    const promise = reconnectBleWithScan('meshtastic', 'ble-1', connect);
+    await vi.waitFor(() => {
+      expect(window.electronAPI.startNobleBleScanning).toHaveBeenCalled();
+    });
+    discoveredCb?.({ deviceId: 'ble-1', name: 'Radio' });
+    discoveredCb?.({ deviceId: 'ble-1', name: 'Radio' });
+    await promise;
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects after scan timeout when peripheral never appears', async () => {
     const connect = vi.fn().mockRejectedValue(new Error('peripheral not in cache'));
     const promise = reconnectBleWithScan('meshtastic', 'ble-1', connect, {
@@ -83,15 +123,9 @@ describe('reconnectBleWithScan', () => {
 
   it('evaluates Linux vs Noble at call time (not module import)', async () => {
     vi.resetModules();
-    Object.defineProperty(navigator, 'userAgent', {
-      value: 'Mozilla/5.0 (X11; Linux x86_64)',
-      configurable: true,
-    });
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
     const { reconnectBleWithScan: reconnectAtCallTime } = await import('./bleReconnectHelper');
-    Object.defineProperty(navigator, 'userAgent', {
-      value: 'Macintosh',
-      configurable: true,
-    });
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
     const connect = vi
       .fn()
       .mockRejectedValueOnce(new Error('peripheral not in cache'))

--- a/src/renderer/lib/bleReconnectHelper.ts
+++ b/src/renderer/lib/bleReconnectHelper.ts
@@ -8,8 +8,9 @@ export const BLE_RECONNECT_SCAN_TIMEOUT_MS = 30_000;
 /** Noble wait-for-peripheral + scan fallback; ConnectionPanel must not use a shorter UI timeout. */
 export const BLE_NOBLE_AUTO_CONNECT_MAX_MS = 30_000 + BLE_RECONNECT_SCAN_TIMEOUT_MS + 15_000;
 
-const isLinuxPlatform = (): boolean =>
-  typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('linux');
+function isLinuxPlatform(): boolean {
+  return typeof window !== 'undefined' && window.electronAPI.getPlatform() === 'linux';
+}
 
 /**
  * Noble macOS/Windows: connect immediately (main process uses knownPeripherals cache),
@@ -41,12 +42,16 @@ export async function reconnectBleWithScan(
   const timeoutMs = opts?.scanTimeoutMs ?? BLE_RECONNECT_SCAN_TIMEOUT_MS;
 
   return new Promise<void>((resolve, reject) => {
-    let settled = false;
+    const abortController = new AbortController();
+    const { signal } = abortController;
     let scanTimeout: ReturnType<typeof setTimeout> | null = null;
     let offDiscovered: (() => void) | null = null;
 
     const cleanup = () => {
-      if (scanTimeout != null) clearTimeout(scanTimeout);
+      if (scanTimeout != null) {
+        clearTimeout(scanTimeout);
+        scanTimeout = null;
+      }
       offDiscovered?.();
       offDiscovered = null;
       void window.electronAPI.stopNobleBleScanning(sessionId).catch((e: unknown) => {
@@ -55,14 +60,15 @@ export async function reconnectBleWithScan(
     };
 
     const finish = (fn: () => void) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
+      if (signal.aborted) return;
+      abortController.abort();
       fn();
     };
 
+    signal.addEventListener('abort', cleanup, { once: true });
+
     offDiscovered = window.electronAPI.onNobleBleDeviceDiscovered((device) => {
-      if (device.deviceId !== peripheralId) return;
+      if (signal.aborted || device.deviceId !== peripheralId) return;
       finish(() => {
         void connect().then(resolve).catch(reject);
       });

--- a/src/renderer/lib/connectionPanelErrorHumanize.test.ts
+++ b/src/renderer/lib/connectionPanelErrorHumanize.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import type { TFunction } from 'i18next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MESHCORE_SETUP_ABORT_MESSAGE } from './bleConnectErrors';
+import {
+  hostFromAddressInput,
+  humanizeBleError,
+  humanizeHttpError,
+  humanizeSerialError,
+  isMeshtasticLocalAddress,
+} from './connectionPanelErrorHumanize';
+
+function mockT(): TFunction {
+  return ((key: string, opts?: Record<string, unknown>) => {
+    if (key === 'connectionPanel.humanize.prefixedHint' && opts) {
+      return `${opts.message as string} — ${opts.hint as string}`;
+    }
+    if (opts?.message) {
+      return `${key}:${opts.message as string}`;
+    }
+    return key;
+  }) as TFunction;
+}
+
+function setUserAgent(ua: string): void {
+  vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(ua);
+}
+
+const UA = {
+  windows: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+  linux: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+  darwin: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/537.36',
+};
+
+describe('hostFromAddressInput / isMeshtasticLocalAddress', () => {
+  it('parses host from bare IP and mdns hostname', () => {
+    expect(hostFromAddressInput('192.168.1.10')).toBe('192.168.1.10');
+    expect(hostFromAddressInput('http://meshtastic.local')).toBe('meshtastic.local');
+    expect(isMeshtasticLocalAddress('meshtastic.local')).toBe(true);
+    expect(isMeshtasticLocalAddress('node.meshtastic.local')).toBe(true);
+    expect(isMeshtasticLocalAddress('192.168.1.10')).toBe(false);
+  });
+});
+
+describe('humanizeSerialError', () => {
+  const t = mockT();
+
+  it.each([
+    ['windows', UA.windows, 'access denied', 'accessDeniedWindowsHint'],
+    ['linux', UA.linux, 'permission denied', 'accessDeniedLinuxHint'],
+    ['any', UA.linux, 'device not found', 'disconnectedHint'],
+    ['any', UA.linux, 'connection timed out', 'timeoutHint'],
+    ['any', UA.linux, 'port is already open', 'portStillOpenHint'],
+  ] as const)('maps %s serial error "%s"', (_label, ua, message, hintKey) => {
+    setUserAgent(ua);
+    const result = humanizeSerialError(new Error(message), t);
+    expect(result).toContain(message);
+    expect(result).toContain(`connectionPanel.humanize.serial.${hintKey}`);
+  });
+
+  it('returns raw message when no pattern matches', () => {
+    setUserAgent(UA.linux);
+    expect(humanizeSerialError(new Error('unknown serial fault'), t)).toBe('unknown serial fault');
+  });
+});
+
+describe('humanizeHttpError', () => {
+  const t = mockT();
+
+  it.each([
+    [
+      'mdns windows timeout',
+      UA.windows,
+      'meshtastic.local',
+      'request timed out',
+      'timeoutMdnsWindows',
+    ],
+    ['mdns non-windows timeout', UA.linux, 'meshtastic.local', 'timeout', 'timeoutMdnsNonWindows'],
+    ['ip timeout', UA.linux, '192.168.1.10', 'aborted', 'timeoutGeneric'],
+    ['unauthorized', UA.linux, '192.168.1.10', '401 unauthorized', 'unauthorizedHint'],
+    ['refused', UA.linux, '192.168.1.10', 'ECONNREFUSED', 'econnrefusedHint'],
+  ] as const)('%s', (_label, ua, address, message, hintKey) => {
+    setUserAgent(ua);
+    const result = humanizeHttpError(address, new Error(message), t);
+    expect(result).toContain(message);
+    expect(result).toContain(`connectionPanel.humanize.http.${hintKey}`);
+  });
+
+  it('adds mdns suffix on non-timeout errors for mdns addresses', () => {
+    setUserAgent(UA.windows);
+    const result = humanizeHttpError('meshtastic.local', new Error('weird failure'), t);
+    expect(result).toContain('suffixMdnsWindows');
+  });
+
+  it('returns raw message for generic IP errors', () => {
+    setUserAgent(UA.linux);
+    expect(humanizeHttpError('192.168.1.10', new Error('weird failure'), t)).toBe('weird failure');
+  });
+});
+
+describe('humanizeBleError', () => {
+  const t = mockT();
+
+  it('suppresses MeshCore setup AbortError', () => {
+    setUserAgent(UA.linux);
+    const err = new DOMException(MESHCORE_SETUP_ABORT_MESSAGE, 'AbortError');
+    expect(humanizeBleError(err, t)).toBe('');
+  });
+
+  it('stringifies object errors', () => {
+    setUserAgent(UA.windows);
+    expect(humanizeBleError({ reason: 'adapter glitch' }, t)).toContain(
+      '"reason":"adapter glitch"',
+    );
+  });
+
+  it.each([
+    ['windows adapter', UA.windows, 'Bluetooth adapter is not available', 'adapterWindowsHint'],
+    ['linux adapter', UA.linux, 'Bluetooth adapter not found', 'adapterLinuxHint'],
+    ['darwin adapter', UA.darwin, 'adapter is not available', 'adapterGenericHint'],
+  ] as const)('%s', (_label, ua, message, hintKey) => {
+    setUserAgent(ua);
+    const result = humanizeBleError(new Error(message), t);
+    expect(result).toContain(`connectionPanel.humanize.ble.${hintKey}`);
+  });
+
+  it('handles SecurityError in message', () => {
+    setUserAgent(UA.linux);
+    const result = humanizeBleError(new Error('SecurityError: not allowed to access'), t);
+    expect(result).toContain('securityPermissionHint');
+  });
+
+  it('handles GATT disconnected', () => {
+    setUserAgent(UA.linux);
+    const result = humanizeBleError(new Error('GATT Server is disconnected'), t);
+    expect(result).toContain('gattDisconnectedHint');
+  });
+
+  it('handles GATT not supported with Linux PIN hint', () => {
+    setUserAgent(UA.linux);
+    const result = humanizeBleError(new Error('GATT Error: Not supported'), t);
+    expect(result).toContain('gattNotSupportedBase');
+    expect(result).toContain('gattNotSupportedLinuxPin');
+  });
+
+  it('handles DOMException SecurityError with Linux PIN', () => {
+    setUserAgent(UA.linux);
+    const err = new DOMException('pairing required', 'SecurityError');
+    const result = humanizeBleError(err, t);
+    expect(result).toContain('authFailedBase');
+    expect(result).toContain('authFailedLinuxPin');
+  });
+
+  it('handles DOMException NetworkError on Linux vs non-Linux', () => {
+    setUserAgent(UA.linux);
+    const linuxResult = humanizeBleError(new DOMException('failed', 'NetworkError'), t);
+    expect(linuxResult).toContain('networkFailedLinuxHint');
+
+    setUserAgent(UA.windows);
+    const winResult = humanizeBleError(new DOMException('failed', 'NetworkError'), t);
+    expect(winResult).toContain('networkFailedNonLinuxHint');
+  });
+
+  it('handles connection attempt failed with Linux hint', () => {
+    setUserAgent(UA.linux);
+    const result = humanizeBleError(new Error('Connection Error: Connection attempt failed'), t);
+    expect(result).toContain('connectionAttemptFailedLinuxHint');
+  });
+
+  it('handles MeshCore handshake with Windows extra', () => {
+    setUserAgent(UA.windows);
+    const result = humanizeBleError(
+      new Error(
+        'Bluetooth connected but MeshCore protocol handshake did not complete before disconnect/timeout.',
+      ),
+      t,
+    );
+    expect(result).toContain('meshcoreHandshakeHint');
+    expect(result).toContain('meshcoreHandshakeWindowsExtra');
+  });
+
+  it('handles Noble IPC timeout with Windows extra', () => {
+    setUserAgent(UA.windows);
+    const result = humanizeBleError(
+      new Error('Bluetooth connection timed out while opening MeshCore over Noble IPC'),
+      t,
+    );
+    expect(result).toContain('meshcoreHandshakeWindowsExtra');
+  });
+
+  it('handles Darwin wake recovery hints', () => {
+    setUserAgent(UA.darwin);
+    const result = humanizeBleError(new Error('BLE connectAsync timed out'), t);
+    expect(result).toContain('macWakeRecoveryHint');
+  });
+});
+
+describe('humanizeBleError userAgent cleanup', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores userAgent spy between tests', () => {
+    setUserAgent(UA.windows);
+    expect(humanizeBleError(new Error('Bluetooth adapter not found'), mockT())).toContain(
+      'adapterWindowsHint',
+    );
+  });
+});

--- a/src/renderer/lib/connectionPanelErrorHumanize.ts
+++ b/src/renderer/lib/connectionPanelErrorHumanize.ts
@@ -1,0 +1,186 @@
+import type { TFunction } from 'i18next';
+
+import { MESHCORE_SETUP_ABORT_MESSAGE } from './bleConnectErrors';
+
+export function hostFromAddressInput(address: string): string {
+  const raw = address.trim();
+  if (!raw) return '';
+  try {
+    return new URL(raw.includes('://') ? raw : `http://${raw}`).hostname.toLowerCase();
+  } catch {
+    // catch-no-log-ok user-typed host/IP without scheme
+    return raw.split('/')[0]?.split(':')[0]?.toLowerCase() ?? '';
+  }
+}
+
+export function isMeshtasticLocalAddress(address: string): boolean {
+  const host = hostFromAddressInput(address);
+  return host === 'meshtastic.local' || host.endsWith('.meshtastic.local');
+}
+
+export function humanizeSerialError(err: unknown, t: TFunction): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  const isWindows = navigator.userAgent.toLowerCase().includes('windows');
+  if (/access denied|permission|not allowed/i.test(msg)) {
+    const hint = isWindows
+      ? t('connectionPanel.humanize.serial.accessDeniedWindowsHint')
+      : t('connectionPanel.humanize.serial.accessDeniedLinuxHint');
+    return t('connectionPanel.humanize.prefixedHint', { message: msg, hint });
+  }
+  if (/no port|not found|disconnected|device not found/i.test(msg)) {
+    return t('connectionPanel.humanize.prefixedHint', {
+      message: msg,
+      hint: t('connectionPanel.humanize.serial.disconnectedHint'),
+    });
+  }
+  if (/timed out/i.test(msg)) {
+    return t('connectionPanel.humanize.prefixedHint', {
+      message: msg,
+      hint: t('connectionPanel.humanize.serial.timeoutHint'),
+    });
+  }
+  if (/already open|locked stream|cannot cancel a locked/i.test(msg)) {
+    return t('connectionPanel.humanize.prefixedHint', {
+      message: msg,
+      hint: t('connectionPanel.humanize.serial.portStillOpenHint'),
+    });
+  }
+  return msg;
+}
+
+export function humanizeHttpError(address: string, err: unknown, t: TFunction): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  const isMdns = isMeshtasticLocalAddress(address);
+  const isWindows = navigator.userAgent.toLowerCase().includes('windows');
+  if (/timed out|timeout|aborted/i.test(msg)) {
+    const hint = isMdns
+      ? isWindows
+        ? t('connectionPanel.humanize.http.timeoutMdnsWindows')
+        : t('connectionPanel.humanize.http.timeoutMdnsNonWindows')
+      : t('connectionPanel.humanize.http.timeoutGeneric');
+    return t('connectionPanel.humanize.prefixedHint', { message: msg, hint });
+  }
+  if (/401|403|unauthorized/i.test(msg)) {
+    return t('connectionPanel.humanize.prefixedHint', {
+      message: msg,
+      hint: t('connectionPanel.humanize.http.unauthorizedHint'),
+    });
+  }
+  if (/econnrefused|connection refused|failed to fetch|network/i.test(msg)) {
+    return t('connectionPanel.humanize.prefixedHint', {
+      message: msg,
+      hint: t('connectionPanel.humanize.http.econnrefusedHint'),
+    });
+  }
+  if (isMdns) {
+    const suffix = isWindows
+      ? t('connectionPanel.humanize.http.suffixMdnsWindows')
+      : t('connectionPanel.humanize.http.suffixMdnsNonWindows');
+    return t('connectionPanel.humanize.prefixedHint', { message: msg, hint: suffix });
+  }
+  return msg;
+}
+
+export function humanizeBleError(err: unknown, t: TFunction): string {
+  if (
+    err instanceof DOMException &&
+    err.name === 'AbortError' &&
+    err.message === MESHCORE_SETUP_ABORT_MESSAGE
+  ) {
+    return '';
+  }
+  const msg =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : (() => {
+            try {
+              return JSON.stringify(err);
+            } catch {
+              // catch-no-log-ok stringify fallback for arbitrary renderer error shapes
+              return String(err);
+            }
+          })();
+  const isWindows = navigator.userAgent.toLowerCase().includes('windows');
+  const isLinux = navigator.userAgent.toLowerCase().includes('linux');
+  if (msg.includes('Bluetooth adapter not found') || msg.includes('adapter is not available')) {
+    const hint = isWindows
+      ? t('connectionPanel.humanize.ble.adapterWindowsHint')
+      : isLinux
+        ? t('connectionPanel.humanize.ble.adapterLinuxHint')
+        : t('connectionPanel.humanize.ble.adapterGenericHint');
+    return t('connectionPanel.humanize.prefixedHint', { message: msg, hint });
+  }
+  if (msg.includes('SecurityError') || msg.includes('not allowed to access')) {
+    return t('connectionPanel.humanize.prefixedHint', {
+      message: msg,
+      hint: t('connectionPanel.humanize.ble.securityPermissionHint'),
+    });
+  }
+  if (msg.includes('GATT Server is disconnected')) {
+    return t('connectionPanel.humanize.prefixedHint', {
+      message: msg,
+      hint: t('connectionPanel.humanize.ble.gattDisconnectedHint'),
+    });
+  }
+  if (msg.includes('GATT Error: Not supported')) {
+    let enhanced = `${msg} ${t('connectionPanel.humanize.ble.gattNotSupportedBase')}`;
+    if (isLinux) {
+      enhanced += t('connectionPanel.humanize.ble.gattNotSupportedLinuxPin');
+    }
+    return enhanced;
+  }
+  if (err instanceof DOMException) {
+    if (err.name === 'SecurityError') {
+      let enhanced = t('connectionPanel.humanize.ble.authFailedBase', { message: err.message });
+      if (isLinux) {
+        enhanced += t('connectionPanel.humanize.ble.authFailedLinuxPin');
+      }
+      return enhanced;
+    }
+    if (err.name === 'NetworkError') {
+      let enhanced = t('connectionPanel.humanize.ble.networkFailedBase', { message: err.message });
+      if (isLinux) {
+        enhanced += t('connectionPanel.humanize.ble.networkFailedLinuxHint');
+      } else {
+        enhanced += t('connectionPanel.humanize.ble.networkFailedNonLinuxHint');
+      }
+      return enhanced;
+    }
+  }
+  if (msg.includes('Connection Error: Connection attempt failed')) {
+    let enhanced = `${msg} ${t('connectionPanel.humanize.ble.connectionAttemptFailedBase')}`;
+    if (isLinux) {
+      enhanced += t('connectionPanel.humanize.ble.connectionAttemptFailedLinuxHint');
+    }
+    return enhanced;
+  }
+  if (/Bluetooth connected but MeshCore protocol handshake did not complete/i.test(msg)) {
+    let enhanced = `${msg} ${t('connectionPanel.humanize.ble.meshcoreHandshakeHint')}`;
+    if (isWindows) {
+      enhanced += t('connectionPanel.humanize.ble.meshcoreHandshakeWindowsExtra');
+    }
+    return enhanced;
+  }
+  if (/Bluetooth connection timed out while opening MeshCore over Noble IPC/i.test(msg)) {
+    let enhanced = `${msg} ${t('connectionPanel.humanize.ble.meshcoreHandshakeHint')}`;
+    if (isWindows) {
+      enhanced += t('connectionPanel.humanize.ble.meshcoreHandshakeWindowsExtra');
+    }
+    return enhanced;
+  }
+  const isDarwin = !isLinux && !isWindows;
+  if (
+    isDarwin &&
+    (/BLE connectAsync timed out/i.test(msg) ||
+      /BLE peripheral not found/i.test(msg) ||
+      /unknown peripheral/i.test(msg))
+  ) {
+    return t('connectionPanel.humanize.prefixedHint', {
+      message: msg,
+      hint: t('connectionPanel.humanize.ble.macWakeRecoveryHint'),
+    });
+  }
+  return msg;
+}

--- a/src/renderer/lib/connectionPanelStorageMigrations.test.ts
+++ b/src/renderer/lib/connectionPanelStorageMigrations.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  LEGACY_MQTT_SETTINGS_KEY,
+  MESHCORE_MQTT_SETTINGS_KEY,
+  MESHCORE_TOPIC_IATA_MIGRATION_KEY,
+  runConnectionPanelStorageMigrations,
+} from './connectionPanelStorageMigrations';
+import { COLORADO_MESH_HOST } from './letsMeshJwt';
+
+const store = new Map<string, string>();
+
+beforeEach(() => {
+  store.clear();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  });
+});
+
+describe('runConnectionPanelStorageMigrations', () => {
+  it('moves legacy meshcore mqtt blob from mesh-client:mqttSettings to meshcore key', () => {
+    const legacy = JSON.stringify({
+      server: 'mqtt.example.com',
+      topicPrefix: 'meshcore/test',
+      port: 1883,
+    });
+    localStorage.setItem(LEGACY_MQTT_SETTINGS_KEY, legacy);
+
+    runConnectionPanelStorageMigrations();
+
+    expect(localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY)).toBe(legacy);
+    expect(localStorage.getItem(LEGACY_MQTT_SETTINGS_KEY)).toBeNull();
+  });
+
+  it('does not move legacy blob when topicPrefix is not meshcore', () => {
+    const legacy = JSON.stringify({ server: 'mqtt.example.com', topicPrefix: 'msh/US' });
+    localStorage.setItem(LEGACY_MQTT_SETTINGS_KEY, legacy);
+
+    runConnectionPanelStorageMigrations();
+
+    expect(localStorage.getItem(LEGACY_MQTT_SETTINGS_KEY)).toBe(legacy);
+    expect(localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY)).toBeNull();
+  });
+
+  it('migrates meshcore topicPrefix to IATA for Colorado Mesh host', () => {
+    localStorage.setItem(
+      MESHCORE_MQTT_SETTINGS_KEY,
+      JSON.stringify({ server: COLORADO_MESH_HOST, topicPrefix: 'meshcore', port: 443 }),
+    );
+
+    runConnectionPanelStorageMigrations();
+
+    const parsed = JSON.parse(localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY) ?? '{}') as {
+      topicPrefix?: string;
+    };
+    expect(parsed.topicPrefix).toBe('meshcore/DEN');
+    expect(localStorage.getItem(MESHCORE_TOPIC_IATA_MIGRATION_KEY)).toBe('1');
+  });
+
+  it('migrates meshcore topicPrefix to test IATA for non-Colorado hosts', () => {
+    localStorage.setItem(
+      MESHCORE_MQTT_SETTINGS_KEY,
+      JSON.stringify({ server: 'mqtt.example.com', topicPrefix: 'meshcore', port: 1883 }),
+    );
+
+    runConnectionPanelStorageMigrations();
+
+    const parsed = JSON.parse(localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY) ?? '{}') as {
+      topicPrefix?: string;
+    };
+    expect(parsed.topicPrefix).toBe('meshcore/test');
+  });
+
+  it('sets migration marker even when meshcore settings are absent', () => {
+    runConnectionPanelStorageMigrations();
+    expect(localStorage.getItem(MESHCORE_TOPIC_IATA_MIGRATION_KEY)).toBe('1');
+  });
+
+  it('is idempotent on second call', () => {
+    localStorage.setItem(
+      MESHCORE_MQTT_SETTINGS_KEY,
+      JSON.stringify({ server: COLORADO_MESH_HOST, topicPrefix: 'meshcore', port: 443 }),
+    );
+    runConnectionPanelStorageMigrations();
+    const afterFirst = localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY);
+
+    runConnectionPanelStorageMigrations();
+
+    expect(localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY)).toBe(afterFirst);
+  });
+});

--- a/src/renderer/lib/connectionPanelStorageMigrations.ts
+++ b/src/renderer/lib/connectionPanelStorageMigrations.ts
@@ -1,0 +1,43 @@
+import { COLORADO_MESH_HOST } from './letsMeshJwt';
+import { parseStoredJson } from './parseStoredJson';
+import type { MQTTSettings } from './types';
+
+const LEGACY_MQTT_SETTINGS_KEY = 'mesh-client:mqttSettings';
+const MESHCORE_MQTT_SETTINGS_KEY = 'mesh-client:mqttSettings:meshcore';
+const MESHCORE_TOPIC_IATA_MIGRATION_KEY = 'mesh-client:migrated:meshcore-topic-iata-v1';
+
+function migrateMqttSettingsOnce(): void {
+  if (localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY) !== null) return;
+  const raw = localStorage.getItem(LEGACY_MQTT_SETTINGS_KEY);
+  if (!raw) return;
+  const parsed = parseStoredJson<Partial<MQTTSettings>>(raw, 'migrateMqttSettingsOnce');
+  if (!parsed) return;
+  if (typeof parsed.topicPrefix === 'string' && parsed.topicPrefix.startsWith('meshcore')) {
+    localStorage.setItem(MESHCORE_MQTT_SETTINGS_KEY, raw);
+    localStorage.removeItem(LEGACY_MQTT_SETTINGS_KEY);
+  }
+}
+
+function migrateMeshcoreTopicIataOnce(): void {
+  if (localStorage.getItem(MESHCORE_TOPIC_IATA_MIGRATION_KEY) !== null) return;
+  const raw = localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY);
+  if (raw) {
+    const parsed = parseStoredJson<Partial<MQTTSettings>>(raw, 'migrateMeshcoreTopicIataOnce');
+    if (parsed?.topicPrefix === 'meshcore' && typeof parsed.server === 'string') {
+      const iata = parsed.server.trim() === COLORADO_MESH_HOST ? 'DEN' : 'test';
+      localStorage.setItem(
+        MESHCORE_MQTT_SETTINGS_KEY,
+        JSON.stringify({ ...parsed, topicPrefix: `meshcore/${iata}` }),
+      );
+    }
+  }
+  localStorage.setItem(MESHCORE_TOPIC_IATA_MIGRATION_KEY, '1');
+}
+
+/** Idempotent localStorage migrations for ConnectionPanel MQTT settings. */
+export function runConnectionPanelStorageMigrations(): void {
+  migrateMqttSettingsOnce();
+  migrateMeshcoreTopicIataOnce();
+}
+
+export { LEGACY_MQTT_SETTINGS_KEY, MESHCORE_MQTT_SETTINGS_KEY, MESHCORE_TOPIC_IATA_MIGRATION_KEY };

--- a/src/renderer/lib/meshtasticMqttSettingsStorage.ts
+++ b/src/renderer/lib/meshtasticMqttSettingsStorage.ts
@@ -14,7 +14,7 @@ const PSK_RECOVERY_FLAG = 'mesh-client:migrated:meshtastic-psk-recovery-v1';
 type MqttSettingsWithPsks = Partial<MQTTSettings> & { channelPsks?: string[] };
 
 /**
- * Legacy `migrateMqttSettingsOnce` moved the entire JSON blob to the MeshCore key when
+ * Legacy `connectionPanelStorageMigrations` moved the entire JSON blob to the MeshCore key when
  * topicPrefix started with "meshcore", leaving Meshtastic manual PSK lines unreachable.
  */
 function recoverMeshtasticChannelPsksFromLegacyMigration(): void {

--- a/src/renderer/lib/rfReconnectHelper.test.ts
+++ b/src/renderer/lib/rfReconnectHelper.test.ts
@@ -50,17 +50,12 @@ describe('reconnectRfFromLastConnection', () => {
   });
 
   it('on Linux uses direct BLE connect (Web Bluetooth user gesture path)', async () => {
-    const ua = navigator.userAgent;
-    Object.defineProperty(navigator, 'userAgent', {
-      value: 'Linux',
-      configurable: true,
-    });
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
     localStorage.setItem(
       STORAGE_KEY('meshtastic'),
       JSON.stringify({ type: 'ble', bleDeviceId: 'ble-1' }),
     );
     await reconnectRfFromLastConnection('meshtastic', 'ble', handlers);
-    Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true });
     expect(handlers.connectBleDirect).toHaveBeenCalledWith('ble-1');
     expect(handlers.connectBleAutomatic).not.toHaveBeenCalled();
   });

--- a/src/renderer/lib/rfReconnectHelper.ts
+++ b/src/renderer/lib/rfReconnectHelper.ts
@@ -9,7 +9,7 @@ import {
 import type { ConnectionType, MeshProtocol } from './types';
 
 const isLinuxPlatform = (): boolean =>
-  typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('linux');
+  typeof window !== 'undefined' && window.electronAPI.getPlatform() === 'linux';
 
 export interface RfReconnectHandlers {
   /** Noble scan + connectAutomatic, or Web Bluetooth connectAutomatic (Linux). */

--- a/src/renderer/lib/sourceContractTestHelpers.test.ts
+++ b/src/renderer/lib/sourceContractTestHelpers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractBalancedBlock,
+  extractIfBlockBody,
+  extractUseCallbackBody,
+} from './sourceContractTestHelpers';
+
+describe('sourceContractTestHelpers', () => {
+  it('extractBalancedBlock returns inner text for nested braces', () => {
+    const source = 'fn() { outer { inner { deep } } tail }';
+    const openIndex = source.indexOf('{');
+    expect(extractBalancedBlock(source, openIndex)).toBe(' outer { inner { deep } } tail ');
+  });
+
+  it('extractBalancedBlock throws on unbalanced input', () => {
+    expect(() => extractBalancedBlock('if (x) { no close', 7)).toThrow(/Unbalanced braces/);
+  });
+
+  it('extractIfBlockBody finds conditional block bodies', () => {
+    const source = `
+      if (foo === 'bar') {
+        doThing();
+      }
+      if (other) { ignored(); }
+    `;
+    expect(extractIfBlockBody(source, "foo === 'bar'")).toContain('doThing()');
+    expect(extractIfBlockBody(source, 'missing')).toBe('');
+  });
+
+  it('extractUseCallbackBody finds callback bodies', () => {
+    const source = `
+      const handleRfConnectFailure = useCallback((err: unknown) => {
+        isReconnectingRef.current = false;
+        reconnectGenerationRef.current += 1;
+      }, []);
+    `;
+    const body = extractUseCallbackBody(source, 'handleRfConnectFailure');
+    expect(body).toContain('isReconnectingRef.current = false');
+    expect(body).toContain('reconnectGenerationRef.current += 1');
+  });
+
+  it('extractUseCallbackBody returns empty string when marker is missing', () => {
+    expect(extractUseCallbackBody('const x = 1;', 'missing')).toBe('');
+  });
+});

--- a/src/renderer/lib/sourceContractTestHelpers.ts
+++ b/src/renderer/lib/sourceContractTestHelpers.ts
@@ -1,0 +1,33 @@
+/** Returns the inner text of a `{ ... }` block starting at `openBraceIndex`. */
+export function extractBalancedBlock(source: string, openBraceIndex: number): string {
+  let depth = 0;
+  for (let i = openBraceIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(openBraceIndex + 1, i);
+    }
+  }
+  throw new Error(`Unbalanced braces at index ${openBraceIndex}`);
+}
+
+export function extractIfBlockBody(source: string, condition: string): string {
+  const marker = `if (${condition})`;
+  const ifIndex = source.indexOf(marker);
+  if (ifIndex === -1) return '';
+  const braceIndex = source.indexOf('{', ifIndex);
+  if (braceIndex === -1) return '';
+  return extractBalancedBlock(source, braceIndex);
+}
+
+export function extractUseCallbackBody(source: string, name: string): string {
+  const marker = `const ${name} = useCallback(`;
+  const start = source.indexOf(marker);
+  if (start === -1) return '';
+  const arrowIndex = source.indexOf('=> {', start);
+  if (arrowIndex === -1) return '';
+  const braceIndex = source.indexOf('{', arrowIndex);
+  if (braceIndex === -1) return '';
+  return extractBalancedBlock(source, braceIndex);
+}

--- a/src/renderer/lib/vitestConsoleMock.ts
+++ b/src/renderer/lib/vitestConsoleMock.ts
@@ -1,0 +1,28 @@
+import type { MockInstance } from 'vitest';
+import { vi } from 'vitest';
+
+export interface ConsoleWarnMock {
+  spy: MockInstance<(message?: unknown, ...optionalParams: unknown[]) => void>;
+  restore: () => void;
+}
+
+/** Suppresses console.warn for the duration of a test; always restores on completion. */
+export function mockConsoleWarn(): ConsoleWarnMock {
+  const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  return {
+    spy,
+    restore: () => {
+      spy.mockRestore();
+    },
+  };
+}
+
+/** Runs fn with console.warn suppressed; restores the spy even when fn throws. */
+export async function withMockedConsoleWarn(fn: () => void | Promise<void>): Promise<void> {
+  const { restore } = mockConsoleWarn();
+  try {
+    await fn();
+  } finally {
+    restore();
+  }
+}

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -1,45 +1,21 @@
 // @vitest-environment jsdom
+/**
+ * Source contract tests for useMeshtasticRuntime reconnect hardening.
+ *
+ * Full renderHook integration of useMeshtasticRuntime requires extensive BLE/MQTT/IPC
+ * mocking; these tests lock reconnect invariants (suspend backoff, generation bump, RF
+ * verify order, exhaustion cleanup) cheaply. Prefer behavioral tests for new features;
+ * extend contracts only for regression-critical wiring.
+ */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { extractIfBlockBody, extractUseCallbackBody } from '../lib/sourceContractTestHelpers';
+
 const TEST_DIR = import.meta.dirname ?? __dirname;
 const SOURCE = readFileSync(join(TEST_DIR, 'useMeshtasticRuntime.ts'), 'utf-8');
-
-/** Returns the inner text of a `{ ... }` block starting at `openBraceIndex`. */
-function extractBalancedBlock(source: string, openBraceIndex: number): string {
-  let depth = 0;
-  for (let i = openBraceIndex; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) return source.slice(openBraceIndex + 1, i);
-    }
-  }
-  throw new Error(`Unbalanced braces at index ${openBraceIndex}`);
-}
-
-function extractIfBlockBody(source: string, condition: string): string {
-  const marker = `if (${condition})`;
-  const ifIndex = source.indexOf(marker);
-  if (ifIndex === -1) return '';
-  const braceIndex = source.indexOf('{', ifIndex);
-  if (braceIndex === -1) return '';
-  return extractBalancedBlock(source, braceIndex);
-}
-
-function extractUseCallbackBody(source: string, name: string): string {
-  const marker = `const ${name} = useCallback(`;
-  const start = source.indexOf(marker);
-  if (start === -1) return '';
-  const arrowIndex = source.indexOf('=> {', start);
-  if (arrowIndex === -1) return '';
-  const braceIndex = source.indexOf('{', arrowIndex);
-  if (braceIndex === -1) return '';
-  return extractBalancedBlock(source, braceIndex);
-}
 
 describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
   it('uses suspend-aware delayUnlessSuspended for reconnect backoff', () => {

--- a/vitest.harness.test.ts
+++ b/vitest.harness.test.ts
@@ -56,4 +56,21 @@ describe('vitest.harness', () => {
       expect(VITEST_SERVER_INLINE_DEPS).toContain(dep);
     }
   });
+
+  it('MIN_VITEST_WORKERS is a positive integer', () => {
+    expect(Number.isInteger(MIN_VITEST_WORKERS)).toBe(true);
+    expect(MIN_VITEST_WORKERS).toBeGreaterThan(0);
+  });
+
+  it('computeVitestMaxWorkers with ratio exactly 1.0', () => {
+    expect(computeVitestMaxWorkers(8, 1)).toBe(8);
+    expect(computeVitestMaxWorkers(1, 1)).toBe(MIN_VITEST_WORKERS);
+  });
+
+  it('computeVitestMaxWorkers at exactly MAX_VITEST_CPU_COUNT boundary', () => {
+    expect(computeVitestMaxWorkers(MAX_VITEST_CPU_COUNT, 1)).toBe(MAX_VITEST_CPU_COUNT);
+    expect(computeVitestMaxWorkers(MAX_VITEST_CPU_COUNT, RENDERER_UI_CPU_RATIO)).toBe(
+      Math.floor(MAX_VITEST_CPU_COUNT * RENDERER_UI_CPU_RATIO),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Add shared `vitestConsoleMock` helper and refactor `ConnectionPanel.test.tsx` console.warn spies for consistent cleanup.
- Extract `connectionPanelErrorHumanize` and `connectionPanelStorageMigrations` into testable lib modules; run migrations from a mount effect instead of module load.
- Expand ConnectionPanel coverage: Linux Web Bluetooth auto-connect/reconnect paths, MQTT channel PSK validation UI, LetsMesh username debounced identity sync.
- Switch `bleReconnectHelper` / `rfReconnectHelper` Linux detection to `electronAPI.getPlatform()`; refactor Noble scan lifecycle to `AbortController`.
- Extract `sourceContractTestHelpers` with unit tests and document reconnect hardening source-contract rationale.
- Add `vitest.harness` boundary tests and note worker floor/cap + source contract tests in `docs/development-environment.md`.

## Test plan

- [x] `pnpm exec vitest run src/renderer/components/ConnectionPanel.test.tsx`
- [x] `pnpm exec vitest run src/renderer/lib/connectionPanelErrorHumanize.test.ts`
- [x] `pnpm exec vitest run src/renderer/lib/connectionPanelStorageMigrations.test.ts`
- [x] `pnpm exec vitest run src/renderer/lib/bleReconnectHelper.test.ts`
- [x] `pnpm exec vitest run src/renderer/lib/rfReconnectHelper.test.ts`
- [x] `pnpm exec vitest run src/renderer/lib/sourceContractTestHelpers.test.ts`
- [x] `pnpm exec vitest run src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts`
- [x] `pnpm exec vitest run vitest.harness.test.ts`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`