### PR TITLE
fix: stop false MeshCore 1.16 firmware update notification

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -124,8 +124,8 @@ import {
   fetchLatestMeshtasticRelease,
   type FirmwareCheckResult,
   MESHCORE_FIRMWARE_RELEASES_URL,
+  meshCoreFirmwareUpdateAvailable,
   MESHTASTIC_FIRMWARE_RELEASES_URL,
-  parseMeshCoreBuildDate,
   semverGt,
 } from './lib/firmwareCheck';
 import { loadLastConnection } from './lib/lastConnectionStorage';
@@ -3497,8 +3497,7 @@ function FirmwareUpdateNotifier({
     const doCheck =
       protocol === 'meshcore'
         ? fetchLatestMeshCoreRelease().then((release) => {
-            const deviceDate = parseMeshCoreBuildDate(firmwareVersion);
-            const updateAvailable = deviceDate === null || deviceDate < release.publishedAt;
+            const updateAvailable = meshCoreFirmwareUpdateAvailable(firmwareVersion, release);
             return { updateAvailable, release };
           })
         : fetchLatestMeshtasticRelease().then((release) => {

--- a/src/renderer/lib/firmwareCheck.test.ts
+++ b/src/renderer/lib/firmwareCheck.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchLatestMeshCoreRelease,
   fetchLatestMeshtasticRelease,
+  meshCoreFirmwareUpdateAvailable,
+  normalizeMeshCoreVersionTag,
   parseMeshCoreBuildDate,
   semverGt,
 } from './firmwareCheck';
@@ -136,6 +138,8 @@ describe('fetchLatestMeshCoreRelease', () => {
     );
 
     const result = await fetchLatestMeshCoreRelease();
+    // companion-v prefix stripped to semver for display and comparison
+    expect(result.version).toBe('1.14.1');
     // published_at time component must be stripped so same-day device firmware
     // ("20 Mar 2026" → 2026-03-20T00:00:00Z) is not falsely flagged as outdated
     expect(result.publishedAt.toISOString()).toBe('2026-03-20T00:00:00.000Z');
@@ -177,5 +181,69 @@ describe('parseMeshCoreBuildDate', () => {
 
   it('returns null for unrecognized format', () => {
     expect(parseMeshCoreBuildDate('not a date')).toBeNull();
+  });
+
+  it('parses "06-Jun-2026" build date format', () => {
+    const d = parseMeshCoreBuildDate('06-Jun-2026');
+    expect(d).not.toBeNull();
+    expect(d!.toISOString()).toBe('2026-06-06T00:00:00.000Z');
+  });
+
+  it('returns null for semver firmware strings', () => {
+    expect(parseMeshCoreBuildDate('v1.16.0-07a3ca9')).toBeNull();
+    expect(parseMeshCoreBuildDate('1.16')).toBeNull();
+  });
+});
+
+// ─── normalizeMeshCoreVersionTag ──────────────────────────────────
+
+describe('normalizeMeshCoreVersionTag', () => {
+  it('extracts semver from companion release tags', () => {
+    expect(normalizeMeshCoreVersionTag('companion-v1.16.0')).toBe('1.16.0');
+  });
+
+  it('extracts semver from device tags with git suffix', () => {
+    expect(normalizeMeshCoreVersionTag('v1.16.0-07a3ca9')).toBe('1.16.0');
+  });
+});
+
+// ─── meshCoreFirmwareUpdateAvailable ──────────────────────────────
+
+describe('meshCoreFirmwareUpdateAvailable', () => {
+  const release = {
+    version: 'companion-v1.16.0',
+    publishedAt: new Date('2026-06-06T00:00:00.000Z'),
+  };
+
+  it('returns false when device semver matches latest release', () => {
+    expect(meshCoreFirmwareUpdateAvailable('v1.16.0-07a3ca9', release)).toBe(false);
+  });
+
+  it('returns true when release semver is newer', () => {
+    expect(meshCoreFirmwareUpdateAvailable('v1.15.0-abc', release)).toBe(true);
+  });
+
+  it('uses build date comparison for legacy firmware strings', () => {
+    expect(
+      meshCoreFirmwareUpdateAvailable('05 Jun 2026', {
+        version: 'companion-v1.16.0',
+        publishedAt: new Date('2026-06-06T00:00:00.000Z'),
+      }),
+    ).toBe(true);
+    expect(
+      meshCoreFirmwareUpdateAvailable('06 Jun 2026', {
+        version: 'companion-v1.16.0',
+        publishedAt: new Date('2026-06-06T00:00:00.000Z'),
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for unparseable device version (no false positive)', () => {
+    expect(
+      meshCoreFirmwareUpdateAvailable('not a version', {
+        version: 'companion-v1.16.0',
+        publishedAt: new Date('2026-06-06T00:00:00.000Z'),
+      }),
+    ).toBe(false);
   });
 });

--- a/src/renderer/lib/firmwareCheck.ts
+++ b/src/renderer/lib/firmwareCheck.ts
@@ -25,6 +25,42 @@ export function semverGt(remote: string, local: string): boolean {
   return rPat > lPat;
 }
 
+/** Extract semver from MeshCore tags like companion-v1.16.0 or v1.16.0-07a3ca9. */
+export function normalizeMeshCoreVersionTag(tag: string): string {
+  const trimmed = tag.trim();
+  const semverInTag = /v(\d+\.\d+\.\d+|\d+\.\d+)/i.exec(trimmed);
+  if (semverInTag) return semverInTag[1];
+  const bareSemver = /^(\d+\.\d+\.\d+|\d+\.\d+)/.exec(trimmed);
+  if (bareSemver) return bareSemver[1];
+  return trimmed.replace(/^v/i, '');
+}
+
+export function looksLikeMeshCoreSemverVersion(version: string): boolean {
+  const normalized = normalizeMeshCoreVersionTag(version);
+  const parts = normalized.split('.');
+  if (parts.length < 2 || parts.length > 3) return false;
+  return parts.every((part) => /^\d+$/.test(part));
+}
+
+export function meshCoreFirmwareUpdateAvailable(
+  deviceFirmware: string,
+  release: { version: string; publishedAt: Date },
+): boolean {
+  if (
+    looksLikeMeshCoreSemverVersion(deviceFirmware) &&
+    looksLikeMeshCoreSemverVersion(release.version)
+  ) {
+    const deviceSemver = normalizeMeshCoreVersionTag(deviceFirmware);
+    const releaseSemver = normalizeMeshCoreVersionTag(release.version);
+    return semverGt(releaseSemver, deviceSemver);
+  }
+
+  const deviceDate = parseMeshCoreBuildDate(deviceFirmware);
+  if (deviceDate === null) return false;
+
+  return deviceDate < release.publishedAt;
+}
+
 async function fetchWithAbortTimeout(url: string): Promise<Response> {
   const ac = new AbortController();
   const timer = setTimeout(() => {
@@ -68,15 +104,16 @@ export async function fetchLatestMeshCoreRelease(): Promise<{
   const raw = new Date(data.published_at);
   return {
     publishedAt: new Date(Date.UTC(raw.getUTCFullYear(), raw.getUTCMonth(), raw.getUTCDate())),
-    version: data.tag_name.replace(/^v/, ''),
+    version: normalizeMeshCoreVersionTag(data.tag_name),
     releaseUrl: data.html_url,
   };
 }
 
-/** Parses a MeshCore build date string like "19 Feb 2025" into a Date (UTC midnight). */
+/** Parses a MeshCore build date string like "19 Feb 2025" or "06-Jun-2026" into a Date (UTC midnight). */
 export function parseMeshCoreBuildDate(buildDate: string): Date | null {
   const trimmed = buildDate.trim();
   if (!trimmed) return null;
+  if (looksLikeMeshCoreSemverVersion(trimmed)) return null;
   const parsed = new Date(`${trimmed} UTC`);
   if (isNaN(parsed.getTime())) return null;
   return parsed;


### PR DESCRIPTION
## Summary

- MeshCore firmware update checks now compare semver when the device reports version tags like `v1.16.0-07a3ca9` and GitHub publishes `companion-v1.16.0`, instead of treating the semver string as a build date.
- Legacy build-date strings (`19 Feb 2025`, `06-Jun-2026`) still use publish-date comparison as a fallback.
- Unparseable device version strings no longer trigger a false "update available" toast.

## Why

MeshCore 1.16+ stores semver from `deviceQuery` in `firmwareVersion` (overwriting `firmware_build_date`). The old logic called `parseMeshCoreBuildDate` on that semver, got `null`, and treated `null` as outdated—so users already on 1.16 were prompted to update to 1.16.

## Test plan

- [x] `pnpm exec vitest run src/renderer/lib/firmwareCheck.test.ts`
- [ ] Connect a MeshCore radio on firmware 1.16 — no update toast/indicator
- [ ] Connect older firmware with build-date-only reporting — update still shown when release is newer