### PR TITLE
Fix Flatpak Wayland launch, MeshCore queue badge, Reticulum DMs by address, and CodeQL findings

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -14,6 +14,8 @@ jobs:
   flatpak:
     name: Flatpak (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    env:
+      RS_RETICULUM_REF: 6d2b28475321bc15c8f60796513d8878b47ed3ab
     permissions:
       contents: read
     strategy:
@@ -22,14 +24,42 @@ jobs:
         include:
           - arch: x86_64
             runner: ubuntu-latest
+            cargo_target: x86_64-unknown-linux-gnu
           - arch: aarch64
             runner: ubuntu-24.04-arm
+            cargo_target: aarch64-unknown-linux-gnu
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
       options: --privileged
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Clone Ratspeak stack (rsReticulum, rsLXMF)
+        run: |
+          RNS_DIR="${GITHUB_WORKSPACE}/../rsReticulum"
+          PATCH="${GITHUB_WORKSPACE}/reticulum-sidecar/patches/rsReticulum-packet-tap.patch"
+          git clone https://github.com/ratspeak/rsReticulum.git "${RNS_DIR}"
+          git -C "${RNS_DIR}" checkout "${RS_RETICULUM_REF}"
+          git -C "${RNS_DIR}" apply --check "${PATCH}"
+          git -C "${RNS_DIR}" apply "${PATCH}"
+          git clone --depth 1 https://github.com/ratspeak/rsLXMF.git "${GITHUB_WORKSPACE}/../rsLXMF"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          targets: ${{ matrix.cargo_target }}
+
+      - name: Install Reticulum sidecar Linux build deps
+        run: apt-get update && apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Build Reticulum sidecar for Flatpak payload
+        working-directory: reticulum-sidecar
+        run: |
+          cargo build --release --target "${{ matrix.cargo_target }}" \
+            --features rns-stack,rns-ble,rns-rnode-tcp
+          install -Dm755 \
+            "target/${{ matrix.cargo_target }}/release/mesh-client-reticulum" \
+            "${GITHUB_WORKSPACE}/resources/reticulum-sidecar/mesh-client-reticulum"
 
       - name: Generate offline pnpm sources
         run: |
@@ -47,6 +77,31 @@ jobs:
           branch: stable
           cache-key: flatpak-builder-${{ matrix.arch }}-${{ github.sha }}
           upload-artifact: true
+
+      - name: Smoke test Flatpak install
+        run: |
+          set -euo pipefail
+          flatpak run --command=sh org.coloradomesh.MeshClient -c \
+            'test -x /app/lib/mesh-client/electron/electron;
+            test -f /app/lib/mesh-client/resources/reticulum-sidecar/mesh-client-reticulum'
+
+          set +e
+          out=$(dbus-run-session xvfb-run -a timeout 20s flatpak run org.coloradomesh.MeshClient 2>&1)
+          code=$?
+          set -e
+          printf '%s\n' "$out"
+          echo "$out" | grep -q 'mesh-client: missing' && exit 1
+          echo "$out" | grep -qi 'No usable sandbox' && exit 1
+          echo "$out" | grep -qi 'zypak-wrapper: line' && exit 1
+          # 124 = timeout (app stayed alive long enough); other exits may occur on teardown
+          if [ "$code" -eq 124 ]; then
+            exit 0
+          fi
+          # Immediate wrapper/zypak failure usually exits in under 2s with code 1
+          if [ "$code" -eq 1 ] && [ "$(printf '%s' "$out" | wc -c)" -lt 200 ]; then
+            echo "Flatpak launch failed immediately (exit $code)" >&2
+            exit 1
+          fi
 
   publish:
     name: Publish to GitHub Release

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -256,6 +256,18 @@ flatpak-node-generator pnpm pnpm-lock.yaml -o flatpak/generated-sources.json
 
 Offline install inside the Flatpak sandbox uses `scripts/flatpak-pnpm-install.mjs`, which retries transient `@jsr/_tmp_*` rename races (same root cause as Windows `dist:win` hoisted installs).
 
+**3b. Bundle Reticulum sidecar** (required for Reticulum tab in the Flatpak; CI does this automatically)
+
+The manifest copies `resources/` into the app, including `resources/reticulum-sidecar/mesh-client-reticulum`. Before `flatpak-builder`, build the sidecar and install the binary there:
+
+```bash
+pnpm run reticulum:sidecar:build
+install -Dm755 reticulum-sidecar/target/debug/mesh-client-reticulum \
+  resources/reticulum-sidecar/mesh-client-reticulum
+```
+
+For a release-quality local Flatpak, use `cargo build --release` with `rns-stack,rns-ble,rns-rnode-tcp` (see [Reticulum sidecar](#reticulum-sidecar-optional)).
+
 **4. Build and install locally**
 
 ```bash
@@ -289,6 +301,8 @@ flatpak run org.coloradomesh.MeshClient
 ```
 
 **Runtime issues** (GPU, VMware guests): see [Flatpak: `vmwgfx: driver missing` (VMware on macOS)](troubleshooting.md#flatpak-vmwgfx-driver-missing-vmware-on-macos).
+
+**Launch failures on Arch/CachyOS Wayland**: see [Flatpak: immediate exit on Arch / CachyOS / Wayland (#598)](troubleshooting.md#flatpak-immediate-exit-on-arch--cachyos--wayland-598).
 
 **Lint the manifest** before submitting to Flathub:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -782,7 +782,9 @@ With **Wi‑Fi off** or **airplane mode** on, using a **packaged** build if poss
 
 **Queue badge stuck at `Q: 255/256`**:
 
-- Usually means the companion radio outbound queue is nearly full, or (on older builds) CORE stats were mis-parsed. Enable debug logging and export logs if the badge stays red for minutes with no traffic; look for `[useMeshcoreRuntime] high queue depth=`.
+- Usually means the companion radio outbound queue is nearly full. Enable debug logging and export logs if the badge stays red for minutes with no traffic; look for `[useMeshcoreRuntime] high queue depth=`.
+- Some **HTTP/TCP** companions pad the legacy 7-byte STATS CORE frame to 9 bytes with `raw[7]=0` and `raw[8]=0xff` (padding sentinel). mesh-client treats that signature as 7-byte layout (`queue_len` at byte 6). If chat send/receive works but the badge is red with `rawHex` ending in `0000ff`, upgrade to a build that includes this fix ([#600](https://github.com/Colorado-Mesh/mesh-client/issues/600)).
+- On older builds, CORE stats could also be mis-parsed (false `Q: 255/256` with normal traffic).
 
 **Windows packaged updater: `Cannot find module 'semver'`**:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -205,6 +205,44 @@ flatpak install --user ./org.coloradomesh.MeshClient-aarch64.flatpak # or -x86_6
 flatpak run org.coloradomesh.MeshClient
 ```
 
+### Flatpak: immediate exit on Arch / CachyOS / Wayland (#598)
+
+**Symptom**: `flatpak run org.coloradomesh.MeshClient` prints `Command failed` right after `Running 'bwrap … -- mesh-client'` with no window. Common on **Arch, CachyOS, KDE Plasma 6, and Hyprland** (pure Wayland). The AppImage from the same release often works.
+
+**Cause**: The Flatpak sandbox mounts an empty `/tmp/.X11-unix`, so Electron cannot fall back to X11 unless the wrapper passes Wayland/Ozone flags. Older bundles also omitted Chromium sandbox flags and `TMPDIR` setup that zypak expects.
+
+The log line `F: /lib32 does not exist in runtime` is **harmless** on x86_64-only runtimes — not the failure cause.
+
+**Fix**:
+
+1. Reinstall the latest `.flatpak` from [GitHub Releases](https://github.com/Colorado-Mesh/mesh-client/releases) (bundles after the #598 fix include an updated wrapper).
+2. Run with debug logging if it still fails:
+   ```bash
+   ZYPAK_DEBUG=1 flatpak run org.coloradomesh.MeshClient
+   ```
+3. Inspect the installed payload:
+   ```bash
+   flatpak run --command=sh org.coloradomesh.MeshClient
+   # inside sandbox:
+   ls -l /app/lib/mesh-client/electron/electron
+   ls -l /app/lib/mesh-client/resources/reticulum-sidecar/mesh-client-reticulum
+   /app/bin/mesh-client --help 2>&1 | head
+   ```
+
+**Workarounds**:
+
+```bash
+MESH_CLIENT_DISABLE_GPU=1 flatpak run org.coloradomesh.MeshClient
+```
+
+**Reinstall**:
+
+```bash
+flatpak uninstall --user org.coloradomesh.MeshClient
+flatpak install --user ./org.coloradomesh.MeshClient-x86_64.flatpak
+flatpak run org.coloradomesh.MeshClient
+```
+
 ### Linux development: SIGILL during `pnpm install`
 
 **Symptom**: `electron exited with signal SIGILL` during install/rebuild (common in sandboxes or VMs without instructions the prebuilt Electron binary expects).

--- a/flatpak/mesh-client-wrapper.sh
+++ b/flatpak/mesh-client-wrapper.sh
@@ -1,6 +1,22 @@
 #!/bin/sh
 # Electron2 BaseApp provides zypak-wrapper; Chromium binary comes from node_modules/electron.
+set -eu
+
+APP_ROOT=/app/lib/mesh-client
+ELECTRON="${APP_ROOT}/electron/electron"
+# package.json "main"; launch via "." from APP_ROOT
+MAIN_REL=dist-electron/main/index.js
+
 export TMPDIR="${XDG_RUNTIME_DIR:-/tmp}/app/${FLATPAK_ID:-org.coloradomesh.MeshClient}"
+mkdir -p "$TMPDIR"
+export CHROME_WRAPPER=/app/bin/mesh-client
+
+for path in "$ELECTRON" "${APP_ROOT}/${MAIN_REL}" "${APP_ROOT}/package.json"; do
+  if [ ! -e "$path" ]; then
+    echo "mesh-client: missing ${path}" >&2
+    exit 1
+  fi
+done
 
 # VMware guests need vmwgfx/3D enabled in the VM (especially macOS hosts); see docs/troubleshooting.md.
 # When vmwgfx is present but Mesa DRI fails in the Flatpak sandbox, auto software rendering.
@@ -20,11 +36,11 @@ if [ "${MESH_CLIENT_DISABLE_GPU:-}" = "1" ]; then
   gpu_args=--disable-gpu
 fi
 
-cd /app/lib/mesh-client || exit 1
-if [ -n "$gpu_args" ]; then
-  exec zypak-wrapper /app/lib/mesh-client/electron/electron \
-    "$gpu_args" \
-    /app/lib/mesh-client/dist-electron/main/index.js "$@"
+electron_args=--disable-setuid-sandbox
+if [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
+  electron_args="${electron_args} --ozone-platform-hint=wayland"
 fi
-exec zypak-wrapper /app/lib/mesh-client/electron/electron \
-  /app/lib/mesh-client/dist-electron/main/index.js "$@"
+
+cd "$APP_ROOT"
+# shellcheck disable=SC2086
+exec zypak-wrapper "$ELECTRON" $gpu_args $electron_args . "$@"

--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -28,6 +28,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --env=NODE_ENV=production
   - --env=ELECTRON_IS_DEV=0
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 
 modules:
   - name: mesh-client

--- a/reticulum-sidecar/src/stack/topology.rs
+++ b/reticulum-sidecar/src/stack/topology.rs
@@ -69,18 +69,14 @@ pub fn build_topology(peers: &[PeerRow]) -> (Vec<PeerRow>, Vec<TopologyEdge>) {
 /// When a relay is only referenced as `via` (not its own path-table row), link it to self.
 fn infer_self_to_via_edges(edges: &mut Vec<TopologyEdge>, edge_keys: &mut HashSet<(String, String)>) {
     let mut has_incoming = HashSet::new();
+    let mut non_self_sources = HashSet::new();
     for edge in edges.iter() {
         has_incoming.insert(edge.target.clone());
+        if edge.source != SELF_ID {
+            non_self_sources.insert(edge.source.clone());
+        }
     }
-    let vias: Vec<String> = edges
-        .iter()
-        .filter(|e| e.source != SELF_ID)
-        .map(|e| e.source.clone())
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .filter(|via| !has_incoming.contains(via))
-        .collect();
-    for via in vias {
+    for via in non_self_sources.into_iter().filter(|via| !has_incoming.contains(via)) {
         let key = (SELF_ID.into(), via.clone());
         if edge_keys.insert(key) {
             edges.push(TopologyEdge {

--- a/reticulum-sidecar/src/stack/via.rs
+++ b/reticulum-sidecar/src/stack/via.rs
@@ -1,5 +1,7 @@
 //! Reticulum LXMF transport classification (RF / TCP / network).
 
+use std::collections::HashMap;
+
 use super::types::InterfaceRow;
 
 /// Classify an RNS interface name or UI type into a transport marker.
@@ -39,18 +41,42 @@ fn live_matches_config(live_row: &InterfaceRow, cfg: &InterfaceRow) -> bool {
 /// Union config with live RNS stats: every configured interface is returned; live rows
 /// overlay status/enabled when names match. Config-only rows (e.g. failed USB open) stay
 /// visible with `status: down`.
+fn find_live_index_for_config(
+    cfg: &InterfaceRow,
+    live: &[InterfaceRow],
+    live_by_id: &HashMap<String, usize>,
+    live_by_name: &HashMap<String, usize>,
+) -> Option<usize> {
+    let mut candidates = Vec::with_capacity(2);
+    if let Some(&idx) = live_by_id.get(&cfg.id) {
+        candidates.push(idx);
+    }
+    if let Some(&idx) = live_by_name.get(&cfg.name) {
+        candidates.push(idx);
+    }
+    candidates
+        .into_iter()
+        .filter(|&idx| live_matches_config(&live[idx], cfg))
+        .min()
+}
+
 pub fn merge_live_interfaces_with_config(
     config: &[InterfaceRow],
     live: Vec<InterfaceRow>,
 ) -> Vec<InterfaceRow> {
     let mut merged: Vec<InterfaceRow> = Vec::with_capacity(config.len().max(live.len()));
+    let mut live_by_id: HashMap<String, usize> = HashMap::new();
+    let mut live_by_name: HashMap<String, usize> = HashMap::new();
+    for (idx, row) in live.iter().enumerate() {
+        live_by_id.entry(row.id.clone()).or_insert(idx);
+        live_by_name.entry(row.name.clone()).or_insert(idx);
+    }
+    let mut matched_live = vec![false; live.len()];
 
     for cfg in config {
-        if let Some(mut live_row) = live
-            .iter()
-            .find(|l| live_matches_config(l, cfg))
-            .cloned()
-        {
+        if let Some(idx) = find_live_index_for_config(cfg, &live, &live_by_id, &live_by_name) {
+            matched_live[idx] = true;
+            let mut live_row = live[idx].clone();
             live_row.id = cfg.id.clone();
             live_row.iface_type = cfg.iface_type.clone();
             live_row.host = cfg.host.clone();
@@ -78,8 +104,8 @@ pub fn merge_live_interfaces_with_config(
         }
     }
 
-    for live_row in live {
-        if !config.iter().any(|c| live_matches_config(&live_row, c)) {
+    for (idx, live_row) in live.into_iter().enumerate() {
+        if !matched_live[idx] {
             merged.push(live_row);
         }
     }

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -191,6 +191,31 @@ function checkManifestBranchAndElectronPayload(pkg) {
     });
   }
 
+  if (!yaml.includes('ELECTRON_OZONE_PLATFORM_HINT=auto')) {
+    violations.push({
+      file: rel,
+      message: 'manifest finish-args must set ELECTRON_OZONE_PLATFORM_HINT=auto for Wayland/X11',
+    });
+  }
+
+  return violations;
+}
+
+function checkManifestReticulumSidecarPayload() {
+  const violations = [];
+  if (!fs.existsSync(MANIFEST)) return violations;
+
+  const yaml = fs.readFileSync(MANIFEST, 'utf8');
+  const rel = path.relative(ROOT, MANIFEST);
+
+  if (!yaml.includes('cp -a dist dist-electron node_modules resources /app/lib/mesh-client/')) {
+    violations.push({
+      file: rel,
+      message:
+        'manifest must copy resources/ into /app/lib/mesh-client/ (Reticulum sidecar under resources/reticulum-sidecar/)',
+    });
+  }
+
   return violations;
 }
 
@@ -207,11 +232,54 @@ function checkWrapperLaunchPaths() {
   if (!sh.includes(EXPECTED_MAIN)) {
     violations.push({
       file: rel,
-      message: `wrapper must launch ${EXPECTED_MAIN} (package.json "main")`,
+      message: `wrapper must reference ${EXPECTED_MAIN} (package.json "main") for preflight`,
     });
   }
 
-  if (!sh.includes(EXPECTED_ELECTRON)) {
+  if (!sh.includes('mkdir -p "$TMPDIR"')) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must mkdir -p TMPDIR under XDG_RUNTIME_DIR/app/$FLATPAK_ID',
+    });
+  }
+
+  if (!sh.includes('CHROME_WRAPPER=/app/bin/mesh-client')) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must set CHROME_WRAPPER=/app/bin/mesh-client for zypak re-exec',
+    });
+  }
+
+  if (!sh.includes('--disable-setuid-sandbox')) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must pass --disable-setuid-sandbox (zypak owns Chromium sandboxing)',
+    });
+  }
+
+  if (!sh.includes('XDG_SESSION_TYPE') || !sh.includes('--ozone-platform-hint=wayland')) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must pass --ozone-platform-hint=wayland when XDG_SESSION_TYPE is wayland',
+    });
+  }
+
+  if (!/exec zypak-wrapper[^\n]* \. "\$@"/.test(sh)) {
+    violations.push({
+      file: rel,
+      message: 'wrapper must launch via zypak-wrapper … . "$@" from APP_ROOT (package.json dir)',
+    });
+  }
+
+  if (sh.includes('dist-electron/main/index.js "$@"')) {
+    violations.push({
+      file: rel,
+      message:
+        'wrapper must not pass dist-electron/main/index.js as argv; launch with "." from APP_ROOT',
+    });
+  }
+
+  if (!sh.includes(EXPECTED_ELECTRON) && !sh.includes('${APP_ROOT}/electron/electron')) {
     violations.push({
       file: rel,
       message: `wrapper must invoke bundled Chromium at ${EXPECTED_ELECTRON}`,
@@ -317,6 +385,7 @@ function main() {
     ...checkManifestAppId(),
     ...checkManifestPnpmVersion(PKG_JSON),
     ...checkManifestBranchAndElectronPayload(PKG_JSON),
+    ...checkManifestReticulumSidecarPayload(),
     ...checkWrapperLaunchPaths(),
     ...checkDesktopStartupWMClass(PKG_JSON),
   ];

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -20,11 +20,26 @@ fi
 # Usage: get_version "<lockfile-key>"
 # Example: get_version "@jsr/meshtastic__core" -> "2.6.6"
 get_version() {
-  grep -E "^  '?$1@" "$LOCKFILE" \
-    | grep -v '(' \
-    | head -1 \
-    | sed "s/.*@//; s/'//; s/:\$//" \
-    || echo ""
+  local key="$1"
+  if [ -z "$key" ]; then
+    echo ''
+    return 0
+  fi
+  if ! command -v node > /dev/null 2>&1; then
+    echo "Error: node is required to parse ${LOCKFILE}." >&2
+    return 1
+  fi
+  node - "$key" "$LOCKFILE" << 'EOF'
+const fs = require('node:fs');
+
+const key = process.argv[2];
+const lockfile = process.argv[3];
+const lock = fs.readFileSync(lockfile, 'utf8');
+const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const re = new RegExp(`^  ['"]?${escaped}@([^'":]+)['"]?:`, 'm');
+const match = lock.match(re);
+process.stdout.write(match?.[1] ?? '');
+EOF
 }
 
 # Get resolved rustc version (empty if not installed)

--- a/src/main/identityVault.test.ts
+++ b/src/main/identityVault.test.ts
@@ -67,4 +67,18 @@ describe('identityVault', () => {
     expect(blocked.ok).toBe(false);
     expect(blocked.error).toMatch(/too many unlock attempts/i);
   });
+
+  it('serializes concurrent unlock attempts for accurate rate limiting', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-vault-'));
+    setIdentityVaultPathForTests(path.join(tmpDir, 'identity-vault.json'));
+    await setIdentityVaultPasscode('vault-pass-9999', '{"identity":"backup"}');
+    lockIdentityVault();
+
+    const attempts = await Promise.all(
+      Array.from({ length: 6 }, () => unlockIdentityVault('wrong-pass')),
+    );
+    const blocked = attempts.filter((res) => res.error?.match(/too many unlock attempts/i));
+    expect(blocked).toHaveLength(1);
+    expect(attempts.filter((res) => !res.ok)).toHaveLength(6);
+  });
 });

--- a/src/main/identityVault.ts
+++ b/src/main/identityVault.ts
@@ -40,6 +40,16 @@ const UNLOCK_MAX_ATTEMPTS = 5;
 const UNLOCK_WINDOW_MS = 60_000;
 let unlockAttemptWindowStart = 0;
 let unlockAttemptCount = 0;
+let unlockMutexTail: Promise<void> = Promise.resolve();
+
+function withUnlockMutex<T>(fn: () => Promise<T>): Promise<T> {
+  const result = unlockMutexTail.then(fn, fn);
+  unlockMutexTail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
 
 function checkUnlockRateLimit(): string | null {
   const now = Date.now();
@@ -58,6 +68,7 @@ function checkUnlockRateLimit(): string | null {
 export function resetIdentityVaultUnlockRateLimitForTests(): void {
   unlockAttemptWindowStart = 0;
   unlockAttemptCount = 0;
+  unlockMutexTail = Promise.resolve();
 }
 
 /** Test hook: override vault file path (null restores default). */
@@ -211,22 +222,24 @@ export async function setIdentityVaultPasscode(
 }
 
 export async function unlockIdentityVault(passcode: string): Promise<IdentityVaultActionResult> {
-  const rateError = checkUnlockRateLimit();
-  if (rateError) return { ok: false, error: rateError };
-  const envelope = readEnvelopeFromDisk();
-  if (!envelope) return { ok: false, error: 'vault not configured' };
-  try {
-    unlockedSecret = await decryptVaultSecret(passcode, envelope);
-    unlockAttemptCount = 0;
-    return { ok: true };
-  } catch (err) {
-    unlockedSecret = null;
-    // catch-no-log-ok wrong passcode returned to IPC caller as { ok: false, error }
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
+  return withUnlockMutex(async () => {
+    const rateError = checkUnlockRateLimit();
+    if (rateError) return { ok: false, error: rateError };
+    const envelope = readEnvelopeFromDisk();
+    if (!envelope) return { ok: false, error: 'vault not configured' };
+    try {
+      unlockedSecret = await decryptVaultSecret(passcode, envelope);
+      unlockAttemptCount = 0;
+      return { ok: true };
+    } catch (err) {
+      unlockedSecret = null;
+      // catch-no-log-ok wrong passcode returned to IPC caller as { ok: false, error }
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  });
 }
 
 export function lockIdentityVault(): IdentityVaultActionResult {

--- a/src/main/reticulum-proxy-path.ts
+++ b/src/main/reticulum-proxy-path.ts
@@ -21,7 +21,9 @@ function isReticulumTransportQueryGetPath(normalized: string): boolean {
   );
 }
 
-export function reticulumProxyGetTimeoutMs(apiPath: string): number {
+const proxyGetTimeoutCache = new Map<string, number>();
+
+function computeReticulumProxyGetTimeoutMs(apiPath: string): number {
   const trimmed = apiPath.trim();
   const pathOnly = trimmed.split('?')[0] ?? trimmed;
   const normalized = pathOnly.startsWith('/') ? pathOnly : `/${pathOnly}`;
@@ -35,6 +37,14 @@ export function reticulumProxyGetTimeoutMs(apiPath: string): number {
     return RETICULUM_TRANSPORT_QUERY_GET_TIMEOUT_MS;
   }
   return RETICULUM_PROXY_GET_TIMEOUT_MS;
+}
+
+export function reticulumProxyGetTimeoutMs(apiPath: string): number {
+  const cached = proxyGetTimeoutCache.get(apiPath);
+  if (cached !== undefined) return cached;
+  const timeout = computeReticulumProxyGetTimeoutMs(apiPath);
+  proxyGetTimeoutCache.set(apiPath, timeout);
+  return timeout;
 }
 
 /**

--- a/src/main/reticulum-sidecar-path.test.ts
+++ b/src/main/reticulum-sidecar-path.test.ts
@@ -1,3 +1,4 @@
+import { app } from 'electron';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -5,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('electron', () => ({
   app: {
-    getAppPath: () => '/virtual/app',
+    getAppPath: vi.fn(() => '/virtual/app'),
     isPackaged: false,
     getPath: () => '/tmp/mesh-client-test',
   },
@@ -38,6 +39,7 @@ describe('reticulum-sidecar-path', () => {
 
   afterEach(() => {
     spawnMock.mockReset();
+    vi.mocked(app.getAppPath).mockReturnValue('/virtual/app');
     if (tmpDir) {
       fs.rmSync(tmpDir, { recursive: true, force: true });
       tmpDir = '';
@@ -62,6 +64,17 @@ describe('reticulum-sidecar-path', () => {
     fs.writeFileSync(binary, '');
 
     expect(resolveSidecarBinaryPath([tmpDir])).toBe(binary);
+  });
+
+  it('resolveSidecarBinaryPath prefers resources/reticulum-sidecar under app path (Flatpak)', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-reticulum-flatpak-'));
+    const appRoot = path.join(tmpDir, 'lib', 'mesh-client');
+    const bundled = path.join(appRoot, 'resources', 'reticulum-sidecar', sidecarBinaryName());
+    fs.mkdirSync(path.dirname(bundled), { recursive: true });
+    fs.writeFileSync(bundled, 'flatpak-sidecar');
+
+    vi.mocked(app.getAppPath).mockReturnValue(appRoot);
+    expect(resolveSidecarBinaryPath()).toBe(bundled);
   });
 
   it('sidecarBinaryIsStale returns true when Rust source is newer than binary', () => {

--- a/src/main/reticulum-sidecar-path.ts
+++ b/src/main/reticulum-sidecar-path.ts
@@ -38,6 +38,13 @@ export function resolveSidecarBinaryPath(extraRoots: string[] = []): string {
     if (fs.existsSync(bundled)) return bundled;
   }
 
+  try {
+    const appBundled = path.join(app.getAppPath(), 'resources', 'reticulum-sidecar', name);
+    if (fs.existsSync(appBundled)) return appBundled;
+  } catch {
+    // catch-no-log-ok app path unavailable in unit tests without electron ready
+  }
+
   const projectDir = findReticulumSidecarProjectDir(extraRoots);
   if (projectDir) {
     for (const profile of ['debug', 'release'] as const) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -178,6 +178,7 @@ import { protocolHeaderBorderClass } from './lib/protocolTheme';
 import { useRadioProvider } from './lib/radio/providerFactory';
 import type { ReticulumRawPacketEntry } from './lib/rawPacketLogConstants';
 import { repairMeshtasticReplyPreviews } from './lib/replyPreview';
+import { openReticulumDmFromHash } from './lib/reticulum/reticulumDestinationInput';
 import { logRfReconnectFailure, reconnectRfFromLastConnection } from './lib/rfReconnectHelper';
 import { getStoredMeshProtocol, MESH_PROTOCOL_STORAGE_KEY } from './lib/storedMeshProtocol';
 import {
@@ -2075,6 +2076,14 @@ function AppContent() {
     setActiveTab(1); // Switch to Chat tab
   }, []);
 
+  const handleOpenReticulumDmByHash = useCallback(
+    (hash: string) => {
+      const nodeId = openReticulumDmFromHash(hash);
+      handleMessageNode(nodeId);
+    },
+    [handleMessageNode],
+  );
+
   const handleOpenRoom = useCallback(
     (nodeNum: number) => {
       setPendingRoomTarget(nodeNum);
@@ -2591,7 +2600,7 @@ function AppContent() {
                       capabilities.hasNomadNetworkPanel ? (
                         <ErrorBoundary>
                           <Suspense fallback={<PanelSkeleton />}>
-                            <NomadNetworkPanel />
+                            <NomadNetworkPanel onOpenDm={handleOpenReticulumDmByHash} />
                           </Suspense>
                         </ErrorBoundary>
                       ) : null}

--- a/src/renderer/components/ChatPanel.test.tsx
+++ b/src/renderer/components/ChatPanel.test.tsx
@@ -10,8 +10,11 @@ import type { ChatMessage, MeshNode } from '../lib/types';
 import ChatPanel from './ChatPanel';
 import { ToastProvider } from './Toast';
 
-async function waitForComposer(): Promise<HTMLElement> {
-  return screen.findByRole('textbox');
+async function waitForComposer(): Promise<HTMLTextAreaElement> {
+  const boxes = await screen.findAllByRole('textbox');
+  const textarea = boxes.find((el): el is HTMLTextAreaElement => el.tagName === 'TEXTAREA');
+  if (!textarea) throw new Error('Chat composer textarea not found');
+  return textarea;
 }
 
 vi.mock('../lib/chatNotifications', () => ({ playMessageNotification: vi.fn() }));
@@ -3555,7 +3558,9 @@ describe('ChatPanel reticulum dm-only chat', () => {
       </ToastProvider>,
     );
     expect(
-      screen.getByText('No conversations yet — open a contact from the Nodes tab.'),
+      screen.getByText(
+        'No conversations yet — enter an address or open a contact from the Nodes tab.',
+      ),
     ).toBeInTheDocument();
     const input = await waitForComposer();
     expect(input).toBeDisabled();
@@ -3564,9 +3569,48 @@ describe('ChatPanel reticulum dm-only chat', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Reticulum chat is direct message only. Pick a contact above or open one from the Nodes tab.',
+        'Reticulum chat is direct message only. Pick a contact above, enter an address, or open one from the Nodes tab.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('opens DM tab when a valid destination hash is entered', async () => {
+    const user = userEvent.setup();
+    const hash = '368f994c056de0d8882855eb0d627497';
+    const peerId = parseInt(hash.slice(0, 12), 16) >>> 0;
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ToastProvider>
+        <ChatPanel {...reticulumProps} onSend={onSend} />
+      </ToastProvider>,
+    );
+    const addressInput = screen.getByLabelText('Destination address');
+    await user.type(addressInput, hash);
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    const composer = await waitForComposer();
+    expect(composer).not.toBeDisabled();
+    await user.type(composer, 'hello');
+    await user.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith('hello', 0, peerId, undefined);
+    });
+  });
+
+  it('shows validation error for invalid destination hash', async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ChatPanel {...reticulumProps} />
+      </ToastProvider>,
+    );
+    const addressInput = screen.getByLabelText('Destination address');
+    await user.type(addressInput, 'not-a-valid-hash');
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(
+      screen.getByText('Enter a valid 32-character destination hash or lxmf:// address.'),
+    ).toBeInTheDocument();
+    const composer = await waitForComposer();
+    expect(composer).toBeDisabled();
   });
 
   it('hides message history when no DM tab is selected', () => {
@@ -3592,7 +3636,7 @@ describe('ChatPanel reticulum dm-only chat', () => {
     expect(screen.queryByText('prior hello')).not.toBeInTheDocument();
     expect(
       screen.getByText(
-        'Reticulum chat is direct message only. Pick a contact above or open one from the Nodes tab.',
+        'Reticulum chat is direct message only. Pick a contact above, enter an address, or open one from the Nodes tab.',
       ),
     ).toBeInTheDocument();
   });

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -48,6 +48,10 @@ import {
 import { normalizeReticulumNodeId } from '@/renderer/lib/reticulum/destHash';
 import { parseReticulumAttachmentPayload } from '@/renderer/lib/reticulum/parseReticulumAttachmentPayload';
 import { reticulumMessageMatchesDmPeer } from '@/renderer/lib/reticulum/reticulumChatDmFilter';
+import {
+  openReticulumDmFromHash,
+  parseReticulumDestinationInput,
+} from '@/renderer/lib/reticulum/reticulumDestinationInput';
 import { writeClipboardText } from '@/renderer/lib/writeClipboardText';
 import type { ChatExportMessage } from '@/shared/electron-api.types';
 import { formatIsoDate, formatIsoDateTime } from '@/shared/formatIsoDate';
@@ -616,6 +620,8 @@ function ChatPanel({
   const openDmTabsRef = useRef(openDmTabs);
   openDmTabsRef.current = openDmTabs;
   const [activeDmNode, setActiveDmNode] = useState<number | null>(null);
+  const [dmAddressInput, setDmAddressInput] = useState('');
+  const [dmAddressError, setDmAddressError] = useState<string | null>(null);
   const [dismissedDmTabs, setDismissedDmTabs] = useState<Record<number, number>>(() => {
     const raw = localStorage.getItem(dismissedDmTabsStorageKey(protocol));
     const parsed = parseStoredJson<Record<string, number>>(raw, 'ChatPanel dismissedDmTabs');
@@ -1374,6 +1380,18 @@ function ChatPanel({
     setViewMode('dm');
   }, []);
 
+  const submitDmByAddress = useCallback(() => {
+    const parsed = parseReticulumDestinationInput(dmAddressInput);
+    if (!parsed) {
+      setDmAddressError(t('chatPanel.dmAddressInvalid'));
+      return;
+    }
+    setDmAddressError(null);
+    const nodeId = openReticulumDmFromHash(parsed);
+    setDmAddressInput('');
+    openDmTo(nodeId);
+  }, [dmAddressInput, openDmTo, t]);
+
   // Close a DM tab
   const closeDmTab = useCallback(
     (nodeNum: number) => {
@@ -1909,6 +1927,43 @@ function ChatPanel({
           })
         )}
       </div>
+
+      {protocol === 'reticulum' && dmOnlyChat ? (
+        <div className="mb-2 flex min-w-0 flex-wrap items-center gap-1">
+          <input
+            type="text"
+            value={dmAddressInput}
+            onChange={(e) => {
+              setDmAddressInput(e.target.value);
+              if (dmAddressError) setDmAddressError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                submitDmByAddress();
+              }
+            }}
+            placeholder={t('chatPanel.dmAddressPlaceholder')}
+            aria-label={t('chatPanel.dmAddressAria')}
+            aria-invalid={dmAddressError != null}
+            spellCheck={false}
+            className="bg-secondary-dark/80 focus:border-brand-green/50 min-w-0 flex-1 rounded border border-gray-600/50 px-2 py-1 font-mono text-xs text-gray-200 focus:outline-none sm:max-w-md"
+          />
+          <button
+            type="button"
+            disabled={!dmAddressInput.trim()}
+            onClick={submitDmByAddress}
+            className="bg-secondary-dark text-muted shrink-0 rounded border border-gray-600/50 px-2.5 py-1 text-xs hover:text-gray-200 disabled:opacity-40"
+          >
+            {t('chatPanel.openDmByAddress')}
+          </button>
+          {dmAddressError ? (
+            <span className="w-full text-[10px] text-red-400" role="alert">
+              {dmAddressError}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
 
       {/* Search bar */}
       {showSearch && (

--- a/src/renderer/components/NomadMicronPageView.test.tsx
+++ b/src/renderer/components/NomadMicronPageView.test.tsx
@@ -1,8 +1,10 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import NomadMicronPageView from './NomadMicronPageView';
+
+const LXMF_HASH = '368f994c056de0d8882855eb0d627497';
 
 describe('NomadMicronPageView', () => {
   const defaultProps = {
@@ -10,6 +12,7 @@ describe('NomadMicronPageView', () => {
     selectedHash: 'abc1234567890abcdef1234567890ab',
     onNavigate: vi.fn(),
     onDownloadFile: vi.fn(),
+    onOpenDm: vi.fn(),
   };
 
   it('does not mount script tags from malicious micron markup', () => {
@@ -42,5 +45,28 @@ describe('NomadMicronPageView', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('opens DM for lxmf:// links instead of navigating', () => {
+    const onOpenDm = vi.fn();
+    const onNavigate = vi.fn();
+    const markup = `\`[Contact\`lxmf://${LXMF_HASH}\`*]\``;
+    render(
+      <NomadMicronPageView
+        {...defaultProps}
+        onOpenDm={onOpenDm}
+        onNavigate={onNavigate}
+        content={markup}
+      />,
+    );
+    const link = document.querySelector<HTMLElement>('[data-action="openNode"]');
+    expect(link).not.toBeNull();
+    const href = link?.getAttribute('href');
+    const title = link?.getAttribute('title');
+    const dataDest = link?.getAttribute('data-destination');
+    expect(href ?? title ?? dataDest).toBeTruthy();
+    fireEvent.click(link!);
+    expect(onOpenDm).toHaveBeenCalledWith(LXMF_HASH);
+    expect(onNavigate).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/components/NomadMicronPageView.tsx
+++ b/src/renderer/components/NomadMicronPageView.tsx
@@ -7,6 +7,10 @@ import {
   parseNomadNetworkLinkUrl,
   renderNomadMicronPage,
 } from '@/renderer/lib/nomad/micronParser';
+import {
+  isReticulumLxmfLink,
+  parseReticulumLxmfLinkUrl,
+} from '@/renderer/lib/reticulum/reticulumDestinationInput';
 
 interface NomadMicronPageViewProps {
   content: string;
@@ -14,6 +18,7 @@ interface NomadMicronPageViewProps {
   selectedHash: string;
   onNavigate: (hash: string, path: string) => void;
   onDownloadFile: (hash: string, path: string) => void;
+  onOpenDm?: (destinationHash: string) => void;
 }
 
 export default function NomadMicronPageView({
@@ -22,6 +27,7 @@ export default function NomadMicronPageView({
   selectedHash,
   onNavigate,
   onDownloadFile,
+  onOpenDm,
 }: NomadMicronPageViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -29,6 +35,12 @@ export default function NomadMicronPageView({
     (destination: string) => {
       if (isExternalHttpUrl(destination)) {
         window.open(destination, '_blank', 'noopener,noreferrer');
+        return;
+      }
+
+      const lxmfHash = parseReticulumLxmfLinkUrl(destination);
+      if (lxmfHash) {
+        onOpenDm?.(lxmfHash);
         return;
       }
 
@@ -42,7 +54,7 @@ export default function NomadMicronPageView({
       }
       onNavigate(hash, parsed.path);
     },
-    [defaultPagePath, onDownloadFile, onNavigate, selectedHash],
+    [defaultPagePath, onDownloadFile, onNavigate, onOpenDm, selectedHash],
   );
 
   useEffect(() => {
@@ -55,8 +67,12 @@ export default function NomadMicronPageView({
     for (const element of links) {
       const onActivate = (event: Event) => {
         event.preventDefault();
-        const destination =
-          element.getAttribute('data-destination') ?? element.getAttribute('href') ?? '';
+        const href = element.getAttribute('href') ?? '';
+        const title = element.getAttribute('title') ?? '';
+        const dataDestination = element.getAttribute('data-destination') ?? '';
+        // micron-parser strips lxmf:// from data-destination; href/title keep the scheme.
+        const lxmfSource = [href, title].find((v) => v && isReticulumLxmfLink(v));
+        const destination = (lxmfSource ?? dataDestination) || href;
         if (!destination) return;
         handleNomadLink(destination);
       };

--- a/src/renderer/components/NomadNetworkPanel.test.tsx
+++ b/src/renderer/components/NomadNetworkPanel.test.tsx
@@ -126,4 +126,39 @@ describe('NomadNetworkPanel', () => {
 
     expect(toggleFavorite).toHaveBeenCalledWith('abc1234567890', false);
   });
+
+  it('calls onOpenDm when Message button is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenDm = vi.fn();
+    isReticulumSidecarRunning.mockResolvedValue(true);
+    const fetchNomadPage = vi.fn().mockResolvedValue({
+      ok: true,
+      content: 'hello',
+      content_type: 'text/plain',
+    });
+    useNomadNetworkStore.setState({
+      fetchNomadPage,
+      nodes: new Map([
+        [
+          'abc1234567890abcdef1234567890ab',
+          {
+            destination_hash: 'abc1234567890abcdef1234567890ab',
+            display_name: 'Test Node',
+            favorited: false,
+          },
+        ],
+      ]),
+    });
+
+    render(<NomadNetworkPanel onOpenDm={onOpenDm} />);
+    await user.click(screen.getByRole('button', { name: 'nomadNetwork.openNode' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'nomadNetwork.sendMessageAria' }),
+      ).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'nomadNetwork.sendMessageAria' }));
+    expect(onOpenDm).toHaveBeenCalledWith('abc1234567890abcdef1234567890ab');
+  });
 });

--- a/src/renderer/components/NomadNetworkPanel.tsx
+++ b/src/renderer/components/NomadNetworkPanel.tsx
@@ -39,7 +39,11 @@ function matchesSearch(node: NomadNodeRow, query: string): boolean {
   return name.includes(q) || hash.includes(q);
 }
 
-export default function NomadNetworkPanel() {
+export default function NomadNetworkPanel({
+  onOpenDm,
+}: {
+  onOpenDm?: (destinationHash: string) => void;
+}) {
   const { t } = useTranslation();
   const nodes = useNomadNetworkStore((s) => s.nodes);
   const lastRefreshAt = useNomadNetworkStore((s) => s.lastRefreshAt);
@@ -311,6 +315,22 @@ export default function NomadNetworkPanel() {
                   </span>
                 ) : null}
                 <div className="ml-auto flex flex-wrap gap-1">
+                  {onOpenDm ? (
+                    <button
+                      type="button"
+                      disabled={!sidecarRunning}
+                      className="rounded border border-purple-600 px-2 py-1 text-xs text-purple-300 hover:bg-purple-900/30 disabled:opacity-40"
+                      aria-label={t('nomadNetwork.sendMessageAria', {
+                        name:
+                          selectedNode.display_name ?? selectedNode.destination_hash.slice(0, 16),
+                      })}
+                      onClick={() => {
+                        onOpenDm(selectedNode.destination_hash);
+                      }}
+                    >
+                      {t('nomadNetwork.sendMessage')}
+                    </button>
+                  ) : null}
                   <button
                     type="button"
                     className="rounded border border-gray-600 px-2 py-1 text-xs text-gray-200 hover:bg-slate-800"
@@ -414,6 +434,7 @@ export default function NomadNetworkPanel() {
                       onDownloadFile={(hash, path) => {
                         void downloadNodeFile(hash, path);
                       }}
+                      onOpenDm={onOpenDm}
                     />
                   ) : (
                     <pre className="font-mono text-xs leading-relaxed whitespace-pre-wrap text-gray-200">

--- a/src/renderer/lib/meshcoreCoreStatsQueue.test.ts
+++ b/src/renderer/lib/meshcoreCoreStatsQueue.test.ts
@@ -7,8 +7,21 @@ describe('queueLenFromMeshCoreCoreStatsRaw', () => {
     const raw = new Uint8Array(9);
     raw[6] = 0x05;
     raw[7] = 0x01;
-    raw[8] = 3;
-    expect(queueLenFromMeshCoreCoreStatsRaw(raw, 5)).toBe(3);
+    raw[8] = 7;
+    expect(queueLenFromMeshCoreCoreStatsRaw(raw, 5)).toBe(7);
+  });
+
+  it('ignores 0xff byte-8 padding on HTTP/TCP 7-byte-padded CORE stats', () => {
+    const raw = Uint8Array.from([0, 0, 0xec, 0xeb, 0, 0, 0, 0, 0xff]);
+    expect(queueLenFromMeshCoreCoreStatsRaw(raw, 0)).toBe(0);
+  });
+
+  it('does not treat byte 8 as padding when byte 7 is non-zero', () => {
+    const raw = new Uint8Array(9);
+    raw[6] = 0x05;
+    raw[7] = 0x01;
+    raw[8] = 0xff;
+    expect(queueLenFromMeshCoreCoreStatsRaw(raw, 5)).toBe(0xff);
   });
 
   it('uses last byte for legacy 7-byte payload', () => {

--- a/src/renderer/lib/meshcoreCoreStatsQueue.ts
+++ b/src/renderer/lib/meshcoreCoreStatsQueue.ts
@@ -12,6 +12,10 @@ export function queueLenFromMeshCoreCoreStatsRaw(
     return meshcoreJsParsedQueueLen;
   }
   if (raw.length >= 9) {
+    // HTTP/TCP companions may pad 7-byte CORE stats; byte 8 is 0xff sentinel, queue at byte 6.
+    if (raw[8] === 0xff && raw[7] === 0 && raw[6] === meshcoreJsParsedQueueLen) {
+      return raw[6];
+    }
     return raw[8];
   }
   if (raw.length >= 7) {

--- a/src/renderer/lib/reticulum/reticulumDestinationInput.test.ts
+++ b/src/renderer/lib/reticulum/reticulumDestinationInput.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveReticulumDestinationHash } from './destHash';
+import {
+  isReticulumLxmfLink,
+  openReticulumDmFromHash,
+  parseReticulumDestinationInput,
+  parseReticulumLxmfLinkUrl,
+} from './reticulumDestinationInput';
+
+const HASH = '368f994c056de0d8882855eb0d627497';
+
+describe('parseReticulumDestinationInput', () => {
+  it('parses bare 32-char hex', () => {
+    expect(parseReticulumDestinationInput(HASH)).toBe(HASH);
+    expect(parseReticulumDestinationInput(HASH.toUpperCase())).toBe(HASH);
+  });
+
+  it('parses lxmf:// scheme', () => {
+    expect(parseReticulumDestinationInput(`lxmf://${HASH}`)).toBe(HASH);
+  });
+
+  it('parses lxmf@ shorthand', () => {
+    expect(parseReticulumDestinationInput(`lxmf@${HASH}`)).toBe(HASH);
+  });
+
+  it('parses lxmf.delivery@ aspect', () => {
+    expect(parseReticulumDestinationInput(`lxmf.delivery@${HASH}`)).toBe(HASH);
+  });
+
+  it('strips angle brackets and quotes', () => {
+    expect(parseReticulumDestinationInput(`<${HASH}>`)).toBe(HASH);
+    expect(parseReticulumDestinationInput(`"${HASH}"`)).toBe(HASH);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(parseReticulumDestinationInput('')).toBeNull();
+    expect(parseReticulumDestinationInput('not-a-hash')).toBeNull();
+    expect(parseReticulumDestinationInput('abc')).toBeNull();
+    expect(parseReticulumDestinationInput('lxmf://tooshort')).toBeNull();
+  });
+});
+
+describe('isReticulumLxmfLink', () => {
+  it('detects lxmf schemes and aspects', () => {
+    expect(isReticulumLxmfLink(`lxmf://${HASH}`)).toBe(true);
+    expect(isReticulumLxmfLink(`lxmf@${HASH}`)).toBe(true);
+    expect(isReticulumLxmfLink(`lxmf.delivery@${HASH}`)).toBe(true);
+  });
+
+  it('does not treat bare hash as lxmf link', () => {
+    expect(isReticulumLxmfLink(HASH)).toBe(false);
+    expect(isReticulumLxmfLink(`${HASH}:/page/index.mu`)).toBe(false);
+  });
+});
+
+describe('parseReticulumLxmfLinkUrl', () => {
+  it('parses lxmf links only', () => {
+    expect(parseReticulumLxmfLinkUrl(`lxmf://${HASH}`)).toBe(HASH);
+    expect(parseReticulumLxmfLinkUrl(HASH)).toBeNull();
+  });
+});
+
+describe('openReticulumDmFromHash', () => {
+  it('registers hash and returns node id', () => {
+    const nodeId = openReticulumDmFromHash(HASH);
+    expect(nodeId).toBeGreaterThan(0);
+    expect(resolveReticulumDestinationHash(nodeId)).toBe(HASH);
+  });
+
+  it('throws on invalid hash', () => {
+    expect(() => openReticulumDmFromHash('bad')).toThrow('Invalid Reticulum destination hash');
+  });
+});

--- a/src/renderer/lib/reticulum/reticulumDestinationInput.ts
+++ b/src/renderer/lib/reticulum/reticulumDestinationInput.ts
@@ -1,0 +1,75 @@
+import { registerReticulumDestinationHash, reticulumHashToNodeId } from './destHash';
+
+const RETICULUM_HASH_RE = /^[a-f0-9]{32}$/;
+
+/** Strip optional angle brackets or quotes around pasted addresses. */
+function stripWrappers(raw: string): string {
+  let s = raw.trim();
+  if (
+    (s.startsWith('<') && s.endsWith('>')) ||
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    s = s.slice(1, -1).trim();
+  }
+  return s;
+}
+
+/**
+ * Parse user-entered Reticulum destination input into a normalized 32-char hex hash.
+ * Accepts lxmf://, lxmf@, lxmf.delivery@, and bare 32-char hex.
+ */
+export function parseReticulumDestinationInput(raw: string): string | null {
+  const trimmed = stripWrappers(raw);
+  if (!trimmed) return null;
+
+  const lower = trimmed.toLowerCase();
+
+  if (lower.startsWith('lxmf://')) {
+    const hash = lower.slice('lxmf://'.length).replace(/[^a-f0-9]/g, '');
+    return RETICULUM_HASH_RE.test(hash) ? hash : null;
+  }
+
+  if (lower.startsWith('lxmf.delivery@')) {
+    const hash = lower.slice('lxmf.delivery@'.length).replace(/[^a-f0-9]/g, '');
+    return RETICULUM_HASH_RE.test(hash) ? hash : null;
+  }
+
+  if (lower.startsWith('lxmf@')) {
+    const hash = lower.slice('lxmf@'.length).replace(/[^a-f0-9]/g, '');
+    return RETICULUM_HASH_RE.test(hash) ? hash : null;
+  }
+
+  const bare = lower.replace(/[^a-f0-9]/g, '');
+  return RETICULUM_HASH_RE.test(bare) ? bare : null;
+}
+
+/**
+ * Returns true when a Micron link URL explicitly targets an LXMF destination
+ * (not a bare nomad page hash).
+ */
+export function isReticulumLxmfLink(url: string): boolean {
+  const trimmed = url.trim().toLowerCase();
+  return (
+    trimmed.startsWith('lxmf://') ||
+    trimmed.startsWith('lxmf@') ||
+    trimmed.startsWith('lxmf.delivery@')
+  );
+}
+
+/** Parse an lxmf-schemed Micron link into a destination hash, or null. */
+export function parseReticulumLxmfLinkUrl(url: string): string | null {
+  if (!isReticulumLxmfLink(url)) return null;
+  return parseReticulumDestinationInput(url);
+}
+
+/** Register hash in the runtime registry and return the uint32 node id for chat stores. */
+export function openReticulumDmFromHash(hash: string): number {
+  const normalized = parseReticulumDestinationInput(hash);
+  if (!normalized) {
+    throw new Error('Invalid Reticulum destination hash');
+  }
+  const nodeId = reticulumHashToNodeId(normalized);
+  registerReticulumDestinationHash(nodeId, normalized);
+  return nodeId;
+}

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Nepřipojeno — zprávy jsou pouze pro čtení",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Zmínit návrhy"
+    "mentionSuggestionsAria": "Zmínit návrhy",
+    "openDmByAddress": "OTEVŘENO",
+    "dmAddressPlaceholder": "Cílový hash nebo lxmf://…",
+    "dmAddressAria": "Cílová adresa retikula",
+    "dmAddressInvalid": "Zadejte platný 32znakový cílový hash nebo adresu lxmf://."
   },
   "chatPayload": {
     "mention": "Zmínit {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Zobrazit naformátovanou stránku",
     "fileDownloading": "Stahování souboru…",
     "fileDownloadFailed": "Nepodařilo se stáhnout soubor: {{error}}",
-    "fileDownloadInProgress": "Stahování souboru již probíhá."
+    "fileDownloadInProgress": "Stahování souboru již probíhá.",
+    "sendMessage": "Zpráva",
+    "sendMessageAria": "Odeslat zprávu na {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Celková distribuce",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Nicht verbunden – Nachrichten sind schreibgeschützt",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Erwähnen Sie Vorschläge"
+    "mentionSuggestionsAria": "Erwähnen Sie Vorschläge",
+    "openDmByAddress": "Offen",
+    "dmAddressPlaceholder": "Ziel-Hash oder lxmf://…",
+    "dmAddressAria": "Retikulum-Zieladresse",
+    "dmAddressInvalid": "Geben Sie einen gültigen 32-stelligen Ziel-Hash oder eine lxmf://-Adresse ein."
   },
   "chatPayload": {
     "mention": "Erwähne {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Formatierte Seite anzeigen",
     "fileDownloading": "Datei wird heruntergeladen…",
     "fileDownloadFailed": "Datei konnte nicht heruntergeladen werden: {{error}}",
-    "fileDownloadInProgress": "Ein Datei-Download ist bereits im Gange."
+    "fileDownloadInProgress": "Ein Datei-Download ist bereits im Gange.",
+    "sendMessage": "Nachricht",
+    "sendMessageAria": "Nachricht an {{name}} senden"
   },
   "packetDistribution": {
     "overallDistribution": "Gesamtverteilung",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -411,9 +411,13 @@
     "composePlaceholderDefault": "Enter message here",
     "composePlaceholderSelectDm": "Select a contact above to start a DM…",
     "selectDmFirst": "Select a DM recipient before sending.",
-    "emptySelectDm": "Reticulum chat is direct message only. Pick a contact above or open one from the Nodes tab.",
+    "emptySelectDm": "Reticulum chat is direct message only. Pick a contact above, enter an address, or open one from the Nodes tab.",
     "noDmConversations": "No conversations yet",
-    "noDmConversationsReticulum": "No conversations yet — open a contact from the Nodes tab.",
+    "noDmConversationsReticulum": "No conversations yet — enter an address or open a contact from the Nodes tab.",
+    "openDmByAddress": "Open",
+    "dmAddressPlaceholder": "Hash or lxmf://…",
+    "dmAddressAria": "Destination address",
+    "dmAddressInvalid": "Enter a valid 32-character destination hash or lxmf:// address.",
     "sendFailed": "Send failed",
     "queueButton": "Queue",
     "replyingTo": "Replying to",
@@ -2288,7 +2292,9 @@
     "hideSource": "Show formatted page",
     "fileDownloading": "Downloading file…",
     "fileDownloadFailed": "Failed to download file: {{error}}",
-    "fileDownloadInProgress": "A file download is already in progress."
+    "fileDownloadInProgress": "A file download is already in progress.",
+    "sendMessage": "Message",
+    "sendMessageAria": "Send message to {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Overall Distribution",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "No conectado: los mensajes son de solo lectura",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Mencionar sugerencias"
+    "mentionSuggestionsAria": "Mencionar sugerencias",
+    "openDmByAddress": "Abierto",
+    "dmAddressPlaceholder": "Hash de destino o lxmf://…",
+    "dmAddressAria": "Dirección de destino del retículo",
+    "dmAddressInvalid": "Introduzca un hash de destino válido de 32 caracteres o una dirección lxmf://."
   },
   "chatPayload": {
     "mention": "Mencionar {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Mostrar página formateada",
     "fileDownloading": "Descargando archivo…",
     "fileDownloadFailed": "No se pudo descargar el archivo: {{error}}",
-    "fileDownloadInProgress": "Ya hay una descarga de archivos en curso."
+    "fileDownloadInProgress": "Ya hay una descarga de archivos en curso.",
+    "sendMessage": "Mensaje",
+    "sendMessageAria": "Enviar mensaje a {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Distribución general",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Non connecté : les messages sont en lecture seule",
     "starredDm": "DM : {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Mentionner des suggestions"
+    "mentionSuggestionsAria": "Mentionner des suggestions",
+    "openDmByAddress": "Ouvrir",
+    "dmAddressPlaceholder": "Hachage de destination ou lxmf://…",
+    "dmAddressAria": "Adresse de destination du réticulum",
+    "dmAddressInvalid": "Entrez un hachage de destination valide de 32 caractères ou une adresse lxmf://."
   },
   "chatPayload": {
     "mention": "Mention {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Afficher la page formatée",
     "fileDownloading": "Téléchargement du fichier…",
     "fileDownloadFailed": "Échec du téléchargement du fichier : {{error}}",
-    "fileDownloadInProgress": "Un téléchargement de fichier est déjà en cours."
+    "fileDownloadInProgress": "Un téléchargement de fichier est déjà en cours.",
+    "sendMessage": "Message",
+    "sendMessageAria": "Envoyer un message à {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Répartition globale",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Tidak tersambung — pesan hanya dapat dibaca",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Sebutkan saran"
+    "mentionSuggestionsAria": "Sebutkan saran",
+    "openDmByAddress": "Membuka",
+    "dmAddressPlaceholder": "Hash tujuan atau lxmf://…",
+    "dmAddressAria": "Alamat tujuan retikulum",
+    "dmAddressInvalid": "Masukkan hash tujuan 32 karakter atau alamat lxmf:// yang valid."
   },
   "chatPayload": {
     "mention": "Sebutkan {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Tampilkan halaman yang diformat",
     "fileDownloading": "Mengunduh berkas…",
     "fileDownloadFailed": "Gagal mengunduh file: {{error}}",
-    "fileDownloadInProgress": "Pengunduhan file sedang berlangsung."
+    "fileDownloadInProgress": "Pengunduhan file sedang berlangsung.",
+    "sendMessage": "Pesan",
+    "sendMessageAria": "Kirim pesan ke {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Distribusi Keseluruhan",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Non connesso: i messaggi sono di sola lettura",
     "starredDm": "DM: {{name}}",
     "starredChannel": "cap{{channel}}",
-    "mentionSuggestionsAria": "Menziona suggerimenti"
+    "mentionSuggestionsAria": "Menziona suggerimenti",
+    "openDmByAddress": "Aprire",
+    "dmAddressPlaceholder": "Hash di destinazione o lxmf://…",
+    "dmAddressAria": "Indirizzo di destinazione del reticolo",
+    "dmAddressInvalid": "Inserisci un hash di destinazione valido di 32 caratteri o un indirizzo lxmf://."
   },
   "chatPayload": {
     "mention": "Menziona {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Mostra la pagina formattata",
     "fileDownloading": "Download del file…",
     "fileDownloadFailed": "Impossibile scaricare il file: {{error}}",
-    "fileDownloadInProgress": "È già in corso il download di un file."
+    "fileDownloadInProgress": "È già in corso il download di un file.",
+    "sendMessage": "Messaggio",
+    "sendMessageAria": "Invia messaggio a {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Distribuzione complessiva",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "接続されていません - メッセージは読み取り専用です",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "提案について言及する"
+    "mentionSuggestionsAria": "提案について言及する",
+    "openDmByAddress": "開ける",
+    "dmAddressPlaceholder": "宛先ハッシュまたは lxmf://…",
+    "dmAddressAria": "レチクルの宛先アドレス",
+    "dmAddressInvalid": "有効な 32 文字の宛先ハッシュまたは lxmf:// アドレスを入力します。"
   },
   "chatPayload": {
     "mention": "{{label}} について言及してください",
@@ -2317,7 +2321,9 @@
     "hideSource": "フォーマットされたページを表示",
     "fileDownloading": "ファイルをダウンロード中…",
     "fileDownloadFailed": "ファイルのダウンロードに失敗しました: {{error}}",
-    "fileDownloadInProgress": "ファイルのダウンロードはすでに進行中です。"
+    "fileDownloadInProgress": "ファイルのダウンロードはすでに進行中です。",
+    "sendMessage": "メッセージ",
+    "sendMessageAria": "{{name}} にメッセージを送信"
   },
   "packetDistribution": {
     "overallDistribution": "全体の分布",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "연결되지 않음 — 메시지는 읽기 전용입니다.",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "멘션 제안"
+    "mentionSuggestionsAria": "멘션 제안",
+    "openDmByAddress": "열려 있는",
+    "dmAddressPlaceholder": "대상 해시 또는 lxmf://…",
+    "dmAddressAria": "레티큘럼 목적지 주소",
+    "dmAddressInvalid": "유효한 32자 대상 해시 또는 lxmf:// 주소를 입력하세요."
   },
   "chatPayload": {
     "mention": "{{label}}을(를) 언급하세요",
@@ -2317,7 +2321,9 @@
     "hideSource": "서식이 지정된 페이지 표시",
     "fileDownloading": "파일 다운로드 중…",
     "fileDownloadFailed": "파일 다운로드 실패: {{error}}",
-    "fileDownloadInProgress": "파일 다운로드가 이미 진행 중입니다."
+    "fileDownloadInProgress": "파일 다운로드가 이미 진행 중입니다.",
+    "sendMessage": "메시지",
+    "sendMessageAria": "{{name}}에 메시지 보내기"
   },
   "packetDistribution": {
     "overallDistribution": "전체 분포",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Niet verbonden: berichten zijn alleen-lezen",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Noem suggesties"
+    "mentionSuggestionsAria": "Noem suggesties",
+    "openDmByAddress": "Open",
+    "dmAddressPlaceholder": "Bestemmingshash of lxmf://…",
+    "dmAddressAria": "Bestemmingsadres van Reticulum",
+    "dmAddressInvalid": "Voer een geldig bestemmingshash- of lxmf://-adres van 32 tekens in."
   },
   "chatPayload": {
     "mention": "Vermeld {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Toon opgemaakte pagina",
     "fileDownloading": "Bestand downloaden…",
     "fileDownloadFailed": "Kan bestand niet downloaden: {{error}}",
-    "fileDownloadInProgress": "Er wordt al een bestand gedownload."
+    "fileDownloadInProgress": "Er wordt al een bestand gedownload.",
+    "sendMessage": "Bericht",
+    "sendMessageAria": "Stuur bericht naar {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Algemene distributie",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Brak połączenia — wiadomości są tylko do odczytu",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Wspomnij o sugestiach"
+    "mentionSuggestionsAria": "Wspomnij o sugestiach",
+    "openDmByAddress": "Otwarte",
+    "dmAddressPlaceholder": "Hash docelowy lub lxmf://…",
+    "dmAddressAria": "Adres docelowy siateczki",
+    "dmAddressInvalid": "Wprowadź prawidłowy 32-znakowy skrót docelowy lub adres lxmf://."
   },
   "chatPayload": {
     "mention": "Wspomnij o {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Pokaż sformatowaną stronę",
     "fileDownloading": "Pobieram plik…",
     "fileDownloadFailed": "Nie udało się pobrać pliku: {{error}}",
-    "fileDownloadInProgress": "Pobieranie pliku już trwa."
+    "fileDownloadInProgress": "Pobieranie pliku już trwa.",
+    "sendMessage": "Wiadomość",
+    "sendMessageAria": "Wyślij wiadomość do {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Ogólna dystrybucja",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Não conectado – as mensagens são somente leitura",
     "starredDm": "Mestre: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Mencionar sugestões"
+    "mentionSuggestionsAria": "Mencionar sugestões",
+    "openDmByAddress": "Abrir",
+    "dmAddressPlaceholder": "Hash de destino ou lxmf://…",
+    "dmAddressAria": "Endereço de destino do retículo",
+    "dmAddressInvalid": "Insira um hash de destino válido de 32 caracteres ou um endereço lxmf://."
   },
   "chatPayload": {
     "mention": "Mencionar {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Mostrar página formatada",
     "fileDownloading": "Baixando arquivo…",
     "fileDownloadFailed": "Falha ao baixar arquivo: {{error}}",
-    "fileDownloadInProgress": "Um download de arquivo já está em andamento."
+    "fileDownloadInProgress": "Um download de arquivo já está em andamento.",
+    "sendMessage": "Mensagem",
+    "sendMessageAria": "Enviar mensagem para {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Distribuição Geral",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Не подключено — сообщения доступны только для чтения.",
     "starredDm": "ДМ: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Упоминание предложений"
+    "mentionSuggestionsAria": "Упоминание предложений",
+    "openDmByAddress": "Открыть",
+    "dmAddressPlaceholder": "Хэш назначения или lxmf://…",
+    "dmAddressAria": "Адрес назначения ретикулума",
+    "dmAddressInvalid": "Введите действительный 32-значный хэш пункта назначения или адрес lxmf://."
   },
   "chatPayload": {
     "mention": "Упоминание {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Показать отформатированную страницу",
     "fileDownloading": "Загрузка файла…",
     "fileDownloadFailed": "Не удалось загрузить файл: {{error}}.",
-    "fileDownloadInProgress": "Загрузка файла уже идет."
+    "fileDownloadInProgress": "Загрузка файла уже идет.",
+    "sendMessage": "Сообщение",
+    "sendMessageAria": "Отправить сообщение {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Общее распределение",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Bağlı değil — mesajlar salt okunurdur",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Bahsetme önerileri"
+    "mentionSuggestionsAria": "Bahsetme önerileri",
+    "openDmByAddress": "Açık",
+    "dmAddressPlaceholder": "Hedef karması veya lxmf://…",
+    "dmAddressAria": "Retikulum hedef adresi",
+    "dmAddressInvalid": "32 karakterlik geçerli bir hedef karması veya lxmf:// adresi girin."
   },
   "chatPayload": {
     "mention": "{{label}}'dan bahsedin",
@@ -2317,7 +2321,9 @@
     "hideSource": "Biçimlendirilmiş sayfayı göster",
     "fileDownloading": "Dosya indiriliyor…",
     "fileDownloadFailed": "Dosya indirilemedi: {{error}}",
-    "fileDownloadInProgress": "Bir dosya indirme işlemi zaten devam ediyor."
+    "fileDownloadInProgress": "Bir dosya indirme işlemi zaten devam ediyor.",
+    "sendMessage": "Mesaj",
+    "sendMessageAria": "{{name}} adresine mesaj gönder"
   },
   "packetDistribution": {
     "overallDistribution": "Genel Dağıtım",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "Не підключено — повідомлення доступні лише для читання",
     "starredDm": "DM: {{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "Згадайте пропозиції"
+    "mentionSuggestionsAria": "Згадайте пропозиції",
+    "openDmByAddress": "ВІДЧИНЕНО",
+    "dmAddressPlaceholder": "Хеш призначення або lxmf://…",
+    "dmAddressAria": "Адреса призначення ретикулуму",
+    "dmAddressInvalid": "Введіть дійсний 32-символьний хеш призначення або адресу lxmf://."
   },
   "chatPayload": {
     "mention": "Згадайте {{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "Показати відформатовану сторінку",
     "fileDownloading": "Завантаження файлу…",
     "fileDownloadFailed": "Не вдалося завантажити файл: {{error}}",
-    "fileDownloadInProgress": "Завантаження файлу вже триває."
+    "fileDownloadInProgress": "Завантаження файлу вже триває.",
+    "sendMessage": "повідомлення",
+    "sendMessageAria": "Надіслати повідомлення до {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "Загальний розподіл",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -478,7 +478,11 @@
     "readOnlyDisconnected": "未连接 — 消息是只读的",
     "starredDm": "DM：{{name}}",
     "starredChannel": "ch{{channel}}",
-    "mentionSuggestionsAria": "提及建议"
+    "mentionSuggestionsAria": "提及建议",
+    "openDmByAddress": "打开",
+    "dmAddressPlaceholder": "目标哈希或 lxmf://...",
+    "dmAddressAria": "网状目标地址",
+    "dmAddressInvalid": "输入有效的 32 字符目标哈希或 lxmf:// 地址。"
   },
   "chatPayload": {
     "mention": "提及{{label}}",
@@ -2317,7 +2321,9 @@
     "hideSource": "显示格式化页面",
     "fileDownloading": "正在下载文件...",
     "fileDownloadFailed": "下载文件失败：{{error}}",
-    "fileDownloadInProgress": "文件下载已在进行中。"
+    "fileDownloadInProgress": "文件下载已在进行中。",
+    "sendMessage": "信息",
+    "sendMessageAria": "发送消息至 {{name}}"
   },
   "packetDistribution": {
     "overallDistribution": "总体分布",


### PR DESCRIPTION
## Summary

This branch bundles four commits on top of `main`:

- **Reticulum DMs by destination address** — Parse bare hex, `lxmf://`, and `lxmf@` aspect shorthands; open DMs from Chat (address field below DM tabs) and from Nomad Network (Message toolbar + `lxmf://` Micron link clicks) without visiting the Nodes tab first.
- **MeshCore HTTP companion queue badge (#600)** — Ignore STATS CORE 0xff byte-8 padding on 9-byte HTTP/TCP frames so companions no longer show a permanent red `Q: 255/256` badge when traffic is healthy.
- **CodeQL performance and concurrency** — Single-pass Reticulum topology edge inference, indexed interface merge, cached Reticulum proxy GET timeouts, serialized identity-vault unlock rate limiting, and robust pnpm lockfile version parsing in `scripts/update.sh`.
- **Flatpak launch on Arch/CachyOS Wayland (#598)** — Harden `mesh-client-wrapper.sh` (TMPDIR, zypak/Wayland flags, Chromium sandbox), bundle Reticulum sidecar in CI and local Flatpak builds, extend `check:flatpak`, and document troubleshooting.

## Test plan

- [ ] **Reticulum Chat** — Paste a bare destination hash and `lxmf://` URL in the Chat address field; confirm a DM tab opens without using Nodes.
- [ ] **Nomad Network** — Click **Message** on a peer and an `lxmf://` link in a Micron page; confirm Chat opens the correct DM.
- [ ] **MeshCore HTTP companion** — Connect over HTTP/TCP; confirm queue badge reflects real depth (not stuck at 255/256).
- [ ] **Identity vault** — Rapid wrong passcode attempts still hit rate limit under concurrent unlock IPC.
- [ ] **Flatpak (Linux)** — Build/install latest bundle; `flatpak run org.coloradomesh.MeshClient` launches on Wayland (Arch/CachyOS/KDE/Hyprland); Reticulum sidecar binary present under `resources/reticulum-sidecar/`.
- [ ] `pnpm run check:flatpak`, `pnpm run test:run` (CI covers these on the branch).

Fixes #598, #600