### PR TITLE
fix: use dnf for Reticulum sidecar deps in Flatpak CI

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -50,7 +50,8 @@ jobs:
           targets: ${{ matrix.cargo_target }}
 
       - name: Install Reticulum sidecar Linux build deps
-        run: apt-get update && apt-get install -y libdbus-1-dev pkg-config
+        # flathub-infra container is Fedora-based (dnf), not Debian (apt).
+        run: dnf install -y dbus-devel pkg-config
 
       - name: Build Reticulum sidecar for Flatpak payload
         working-directory: reticulum-sidecar


### PR DESCRIPTION
## Summary

- Fix Flatpak workflow failure in "Install Reticulum sidecar Linux build deps" by using `dnf install dbus-devel pkg-config` instead of `apt-get`.
- The `ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08` container is Fedora-based and does not ship `apt-get`, which caused both x86_64 and aarch64 jobs to exit 127 in [run 28625426005](https://github.com/Colorado-Mesh/mesh-client/actions/runs/28625426005).

## Test plan

- [ ] Re-run **Build Flatpak (no release)** workflow on this branch and confirm both matrix jobs pass the sidecar build-deps step.
- [ ] Confirm Reticulum sidecar builds and is copied into `resources/reticulum-sidecar/` before flatpak-builder runs.