### PR TITLE
fix: Flatpak sidecar CI and actionlint installer

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -7,12 +7,10 @@ on:
     tags: ['v*']
 
 jobs:
-  # Both arches use the flathub-infra container (Flathub remote, flatpak-builder, privileged
-  # system installs). aarch64 uses GitHub's native ARM runners — do not build on bare
-  # ubuntu-latest with apt flatpak; that lacks --privileged and fails with
-  # "Flatpak system operation Deploy not allowed for user".
-  flatpak:
-    name: Flatpak (${{ matrix.arch }})
+  # Sidecar is built on bare Ubuntu runners (apt). The flathub-infra Flatpak container is a
+  # minimal freedesktopsdk/sdk rootfs with no apt/dnf — host cargo builds cannot install deps there.
+  reticulum-sidecar:
+    name: Reticulum sidecar (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     env:
       RS_RETICULUM_REF: 6d2b28475321bc15c8f60796513d8878b47ed3ab
@@ -28,10 +26,6 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
             cargo_target: aarch64-unknown-linux-gnu
-    container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
-      options: --privileged
-
     steps:
       - uses: actions/checkout@v6
 
@@ -50,8 +44,7 @@ jobs:
           targets: ${{ matrix.cargo_target }}
 
       - name: Install Reticulum sidecar Linux build deps
-        # flathub-infra container is Fedora-based (dnf), not Debian (apt).
-        run: dnf install -y dbus-devel pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
       - name: Build Reticulum sidecar for Flatpak payload
         working-directory: reticulum-sidecar
@@ -61,6 +54,42 @@ jobs:
           install -Dm755 \
             "target/${{ matrix.cargo_target }}/release/mesh-client-reticulum" \
             "${GITHUB_WORKSPACE}/resources/reticulum-sidecar/mesh-client-reticulum"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: mesh-client-reticulum-${{ matrix.arch }}
+          path: resources/reticulum-sidecar/mesh-client-reticulum
+          retention-days: 1
+
+  # Both arches use the flathub-infra container (Flathub remote, flatpak-builder, privileged
+  # system installs). aarch64 uses GitHub's native ARM runners — do not build on bare
+  # ubuntu-latest with apt flatpak; that lacks --privileged and fails with
+  # "Flatpak system operation Deploy not allowed for user".
+  flatpak:
+    name: Flatpak (${{ matrix.arch }})
+    needs: reticulum-sidecar
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: mesh-client-reticulum-${{ matrix.arch }}
+          path: resources/reticulum-sidecar
 
       - name: Generate offline pnpm sources
         run: |

--- a/scripts/install-actionlint.mjs
+++ b/scripts/install-actionlint.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { promises as fs } from 'node:fs';
+import { createWriteStream, promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -40,7 +40,7 @@ async function downloadToFile(url, destinationPath) {
   if (!res.ok) {
     throw new Error(`Failed to download: ${res.status} ${res.statusText}`);
   }
-  const file = fs.createWriteStream(destinationPath);
+  const file = createWriteStream(destinationPath);
   // Pipe the response body stream into the file.
   await pipeline(res.body, file);
 }


### PR DESCRIPTION
## Summary

- Split `flatpak.yaml` into a `reticulum-sidecar` job (bare Ubuntu runners + `apt`) and the existing privileged `flatpak` job; pass per-arch sidecar artifacts into the Flatpak build.
- Fix `pnpm run setup:actionlint` by importing `createWriteStream` from `node:fs` (not available on `fs.promises`).

Fixes the failing **Install Reticulum sidecar Linux build deps** step on Flatpak CI (run 28625957023). The flathub-infra container has no `apt` or `dnf`; the sidecar must be built on the host runner.

## Test plan

- [ ] **Build Flatpak** workflow passes for x86_64 and aarch64 (`reticulum-sidecar` + `flatpak` jobs)
- [ ] Smoke test finds `mesh-client-reticulum` in the built bundle
- [ ] `pnpm run setup:actionlint` downloads and installs actionlint successfully