### PR TITLE
chore: sync reticulum-sidecar Cargo.lock for rns-interface deps

### DIFF
--- a/reticulum-sidecar/Cargo.lock
+++ b/reticulum-sidecar/Cargo.lock
@@ -1604,6 +1604,7 @@ dependencies = [
  "objc2-foundation",
  "rand 0.8.6",
  "rns-crypto",
+ "rns-identity",
  "rns-transport",
  "rns-wire",
  "serde",


### PR DESCRIPTION
## Summary

- Add `rns-identity` to the `rns-interface` dependency block in `reticulum-sidecar/Cargo.lock`.

Follow-up to #605: a local `rns-stack` sidecar build resolved the sibling `rsReticulum` graph and updated the lockfile. CI builds without `--locked`, so the drift did not block merge but would reappear on every local full-stack build.

## Test plan

- [x] Pre-commit hooks (lint, typecheck, full test suite)
- [x] Diff is a single lockfile line — no source changes