### PR TITLE
fix: harden long MeshCore sessions against RPC races and memory growth

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -110,6 +110,18 @@ After the lid closes or the Mac sleeps, mesh-client pauses reconnect backoff and
 - **BLE stack stuck after wake** (`unknown peripheral`, `connectAsync timed out`, `peripheral not found` in the app log): **Quit mesh-client fully** (Cmd+Q), toggle **Bluetooth off → on** in System Settings (or power-cycle the radios), reopen the app, wait ~5 seconds, then use **Connect** on the Connection tab.
 - **MQTT-only:** Transient errors such as `ENETDOWN` or `ENETUNREACH` after wake should recover automatically.
 
+### Long-running sessions (multi-day uptime)
+
+If mesh-client stays open for **days** on a busy mesh (especially **MeshCore BLE-only** with hundreds of repeaters):
+
+- **Restart the app every 1–2 days** to limit main-process uptime (reduces risk of native BLE / V8 edge cases after ~72h).
+- **MeshCore:** enable **contact cap** (~500) and **auto-prune by age** in App settings; avoid bulk repeater status/neighbors refresh when not needed.
+- **Meshtastic:** enable **node cap** and **auto-prune** in App settings.
+- **Reticulum:** restart the sidecar/stack periodically on always-on nodes; message retention prunes run at startup and every 6 hours while the app is open.
+- If the app crashes, save **`~/Library/Logs/DiagnosticReports/Mesh-client-*.ips`** (macOS) before relaunching. Main-process crashes often show `EXC_BREAKPOINT` during a timer/GC; include the `.ips` and exported log when reporting.
+
+After **24 hours** of uptime, the main process logs periodic **long-session health** lines (`[main] long-session health …`) with memory and BLE session state.
+
 ### Windows sleep / wake and auto-reconnect
 
 After sleep or hibernate, mesh-client uses the same resume path as macOS: reconnect backoff and MQTT I/O pause until the OS resumes. Expect roughly **4 seconds** after wake before Meshtastic RF auto-reconnect runs, then MeshCore about **8 seconds** later (plus up to **30 seconds** while MeshCore waits for Meshtastic Noble configure to finish when both use BLE over Noble IPC).

--- a/patches/@liamcottle__meshcore.js@1.13.0.patch
+++ b/patches/@liamcottle__meshcore.js@1.13.0.patch
@@ -1,8 +1,24 @@
+diff --git a/src/buffer_reader.js b/src/buffer_reader.js
+index 9142fbc9fda24c07082d63ced24117a35b29dc93..2f8cf2d68d1c32c1d7cc489f33527c9ad89545d4 100644
+--- a/src/buffer_reader.js
++++ b/src/buffer_reader.js
+@@ -24,7 +24,10 @@ class BufferReader {
+     }
+ 
+     readString() {
+-        return new TextDecoder().decode(this.readRemainingBytes());
++        const bytes = this.readRemainingBytes();
++        const nullIdx = bytes.indexOf(0);
++        const slice = nullIdx >= 0 ? bytes.subarray(0, nullIdx) : bytes;
++        return new TextDecoder().decode(slice);
+     }
+ 
+     readCString(maxLength) {
 diff --git a/src/connection/connection.js b/src/connection/connection.js
-index af6f6d670adc0948d3453df34acbbde46c1b4250..0000000000000000000000000000000000000000 100644
+index af6f6d670adc0948d3453df34acbbde46c1b4250..337c18dbf16796a21c9834578589a583a6364f42 100644
 --- a/src/connection/connection.js
 +++ b/src/connection/connection.js
-@@ -231,7 +231,10 @@
+@@ -231,7 +231,10 @@ class Connection extends EventEmitter {
          const data = new BufferWriter();
          data.writeByte(Constants.CommandCodes.SendLogin);
          data.writeBytes(publicKey); // 32 bytes - id of repeater or room server
@@ -14,11 +30,10 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..00000000000000000000000000000000
          await this.sendToRadioFrame(data.toBytes());
      }
  
-@@ -338,6 +341,14 @@
-         data.writeByte(manualAddContacts); // 0 or 1
+@@ -338,6 +341,14 @@ class Connection extends EventEmitter {
          await this.sendToRadioFrame(data.toBytes());
      }
-+
+ 
 +    async sendCommandSetPathHashMode(mode) {
 +        const data = new BufferWriter();
 +        data.writeByte(61); // CMD_SET_PATH_HASH_MODE (companion_radio v1.14+)
@@ -26,10 +41,11 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..00000000000000000000000000000000
 +        data.writeByte(mode);
 +        await this.sendToRadioFrame(data.toBytes());
 +    }
- 
++
      onFrameReceived(frame) {
  
-@@ -400,6 +411,8 @@
+         // emit received frame
+@@ -400,6 +411,8 @@ class Connection extends EventEmitter {
              this.onRawDataPush(bufferReader);
          } else if(responseCode === Constants.PushCodes.LoginSuccess){
              this.onLoginSuccessPush(bufferReader);
@@ -38,7 +54,21 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..00000000000000000000000000000000
          } else if(responseCode === Constants.PushCodes.StatusResponse){
              this.onStatusResponsePush(bufferReader);
          } else if(responseCode === Constants.PushCodes.LogRxData){
-@@ -459,6 +472,13 @@
+@@ -412,8 +425,12 @@ class Connection extends EventEmitter {
+             this.onNewAdvertPush(bufferReader);
+         } else if(responseCode === Constants.PushCodes.BinaryResponse){
+             this.onBinaryResponsePush(bufferReader);
++        } else if(responseCode === 25){
++            // AUTOADD_CONFIG — handled in mesh-client app rx path; ignore in library
++        } else if(responseCode === 0x8F){
++            // Unknown push (0x8F) — firmware ahead of library; drop silently
+         } else {
+-            console.log(`unhandled frame: code=${responseCode}`, frame);
++            console.debug(`unhandled frame: code=${responseCode}`);
+         }
+ 
+     }
+@@ -459,6 +476,13 @@ class Connection extends EventEmitter {
          });
      }
  
@@ -52,7 +82,7 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..00000000000000000000000000000000
      onStatusResponsePush(bufferReader) {
          this.emit(Constants.PushCodes.StatusResponse, {
              reserved: bufferReader.readByte(), // reserved
-@@ -494,15 +514,25 @@
+@@ -494,15 +518,25 @@ class Connection extends EventEmitter {
      onTraceDataPush(bufferReader) {
          const reserved = bufferReader.readByte();
          const pathLen = bufferReader.readUInt8();
@@ -84,7 +114,7 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..00000000000000000000000000000000
          });
      }
  
-@@ -582,11 +612,30 @@
+@@ -582,11 +616,30 @@ class Connection extends EventEmitter {
      }
  
      onDeviceInfoResponse(bufferReader) {
@@ -119,7 +149,7 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..00000000000000000000000000000000
          });
      }
  
-@@ -2375,6 +2424,33 @@
+@@ -2375,6 +2428,33 @@ class Connection extends EventEmitter {
          });
      }
  
@@ -153,19 +183,3 @@ index af6f6d670adc0948d3453df34acbbde46c1b4250..00000000000000000000000000000000
      async setAutoAddContacts() {
          return await this.setOtherParams(false);
      }
-diff --git a/src/buffer_reader.js b/src/buffer_reader.js
-index 9142fbc9fda24c07082d63ced24117a35b29dc93..0000000000000000000000000000000000000000 100644
---- a/src/buffer_reader.js
-+++ b/src/buffer_reader.js
-@@ -24,7 +24,10 @@
-     }
- 
-     readString() {
--        return new TextDecoder().decode(this.readRemainingBytes());
-+        const bytes = this.readRemainingBytes();
-+        const nullIdx = bytes.indexOf(0);
-+        const slice = nullIdx >= 0 ? bytes.subarray(0, nullIdx) : bytes;
-+        return new TextDecoder().decode(slice);
-     }
- 
-     readCString(maxLength) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74
     path: patches/@jsr__meshtastic__transport-web-serial@0.2.5.patch
   '@liamcottle/meshcore.js@1.13.0':
-    hash: f528c684e6fa62ca944c1db885ea30b3c4ec3a144c4b1aa23f6ce0bbfe814955
+    hash: ce165f5116fc9db3cb5f87a52651e8c75efee9ab7dfa9a572c077f6161d17eca
     path: patches/@liamcottle__meshcore.js@1.13.0.patch
   '@stoprocent/noble@2.5.5':
     hash: df0ff44bd608a879ac16e7fc8965eb3ba8cade13f8d4b64c330d475bd722dcca
@@ -127,7 +127,7 @@ importers:
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
       '@liamcottle/meshcore.js':
         specifier: ^1.13.0
-        version: 1.13.0(patch_hash=f528c684e6fa62ca944c1db885ea30b3c4ec3a144c4b1aa23f6ce0bbfe814955)
+        version: 1.13.0(patch_hash=ce165f5116fc9db3cb5f87a52651e8c75efee9ab7dfa9a572c077f6161d17eca)
       '@meshtastic/core':
         specifier: npm:@jsr/meshtastic__core@^2.6.6
         version: '@jsr/meshtastic__core@2.6.6(patch_hash=714af0fd567c3a11b0ee94c68743dce951b199d388f217bd3cb5770a7b3e278a)(buffer@6.0.3)'
@@ -5100,7 +5100,7 @@ snapshots:
     transitivePeerDependencies:
       - buffer
 
-  '@liamcottle/meshcore.js@1.13.0(patch_hash=f528c684e6fa62ca944c1db885ea30b3c4ec3a144c4b1aa23f6ce0bbfe814955)':
+  '@liamcottle/meshcore.js@1.13.0(patch_hash=ce165f5116fc9db3cb5f87a52651e8c75efee9ab7dfa9a572c077f6161d17eca)':
     dependencies:
       '@noble/curves': 1.9.7
       serialport: 13.0.0

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5754,6 +5754,17 @@ void app.whenReady().then(() => {
     }
     createWindow();
 
+    const MAIN_PROCESS_HEALTH_LOG_INTERVAL_MS = 60 * 60 * 1000;
+    const MAIN_PROCESS_HEALTH_UPTIME_THRESHOLD_SEC = 24 * 60 * 60;
+    setInterval(() => {
+      if (process.uptime() < MAIN_PROCESS_HEALTH_UPTIME_THRESHOLD_SEC) return;
+      const mem = process.memoryUsage();
+      const ble = nobleBleManager.getLongSessionHealthSnapshot();
+      console.debug(
+        `[main] long-session health uptimeSec=${Math.floor(process.uptime())} rss=${mem.rss} heapUsed=${mem.heapUsed} ble=${JSON.stringify(ble)}`,
+      );
+    }, MAIN_PROCESS_HEALTH_LOG_INTERVAL_MS).unref();
+
     setupAppMenu();
 
     // ─── Power monitor: notify renderer on suspend/resume ──────────

--- a/src/main/ipc/reticulum-db-handlers.ts
+++ b/src/main/ipc/reticulum-db-handlers.ts
@@ -311,6 +311,31 @@ export function registerReticulumDbIpcHandlers({ ipcMain }: ReticulumDbIpcDeps):
     }
   });
 
+  ipcMain.handle('db:pruneReticulumMessagesByCount', (event, maxCount: number) => {
+    try {
+      assertIpcSender(event, 'db:pruneReticulumMessagesByCount');
+      const db = getDbForIpc('db:pruneReticulumMessagesByCount');
+      if (!db) return { changes: 0 };
+      if (typeof maxCount !== 'number' || maxCount < 100 || !Number.isFinite(maxCount)) {
+        return { changes: 0 };
+      }
+      const cap = Math.floor(maxCount);
+      const result = db
+        .prepareOnce(
+          'DELETE FROM reticulum_messages WHERE id NOT IN (SELECT id FROM reticulum_messages ORDER BY timestamp DESC, id DESC LIMIT ?)',
+        )
+        .run(cap);
+      if (result.changes > 0) {
+        console.debug(
+          `[IPC] db:pruneReticulumMessagesByCount: pruned ${result.changes} messages, keeping newest ${cap}`,
+        );
+      }
+      return { changes: Number(result.changes) };
+    } catch (err) {
+      finishDbIpcHandler('db:pruneReticulumMessagesByCount', err);
+    }
+  });
+
   ipcMain.handle('db:vacuumReticulumTables', (event) => {
     try {
       assertIpcSender(event, 'db:vacuumReticulumTables');

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -526,6 +526,21 @@ export class NobleBleManager extends EventEmitter {
     return false;
   }
 
+  /** Snapshot for long-session main-process health logs. */
+  getLongSessionHealthSnapshot(): {
+    meshcoreConnected: boolean;
+    meshtasticConnected: boolean;
+    bleSessionActive: boolean;
+    scanningActive: boolean;
+  } {
+    return {
+      meshcoreConnected: this.isConnected('meshcore'),
+      meshtasticConnected: this.isConnected('meshtastic'),
+      bleSessionActive: this.isBleSessionActive(),
+      scanningActive: this.scanningActive,
+    };
+  }
+
   /**
    * Returns the scan filter for the current set of requesters.
    * - meshtastic only → filter by known Meshtastic service UUID (cleaner results)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -65,6 +65,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('db:pruneMessagesByCount', maxCount),
     pruneMeshcoreMessagesByCount: (maxCount: number) =>
       ipcRenderer.invoke('db:pruneMeshcoreMessagesByCount', maxCount),
+    pruneReticulumMessagesByCount: (maxCount: number) =>
+      ipcRenderer.invoke('db:pruneReticulumMessagesByCount', maxCount),
     deleteNodesBatch: (nodeIds: number[]) => ipcRenderer.invoke('db:deleteNodesBatch', nodeIds),
     clearMessagesByChannel: (channel: number) =>
       ipcRenderer.invoke('db:clearMessagesByChannel', channel),

--- a/src/renderer/hooks/useAppStartupDbPrune.ts
+++ b/src/renderer/hooks/useAppStartupDbPrune.ts
@@ -1,10 +1,20 @@
 import { useEffect } from 'react';
 
-import { runStartupDbPrune } from '@/renderer/lib/startupDbPrune';
+import {
+  runSessionDbPrune,
+  runStartupDbPrune,
+  SESSION_DB_PRUNE_INTERVAL_MS,
+} from '@/renderer/lib/startupDbPrune';
 
-/** Run SQLite retention prune once per session, then invoke post-prune hydration. */
+/** Run SQLite retention prune once at startup, then every {@link SESSION_DB_PRUNE_INTERVAL_MS}. */
 export function useAppStartupDbPrune(onAfterPrune: () => void): void {
   useEffect(() => {
     void runStartupDbPrune().then(onAfterPrune);
+    const intervalId = setInterval(() => {
+      void runSessionDbPrune();
+    }, SESSION_DB_PRUNE_INTERVAL_MS);
+    return () => {
+      clearInterval(intervalId);
+    };
   }, [onAfterPrune]);
 }

--- a/src/renderer/lib/devElectronApiStub.ts
+++ b/src/renderer/lib/devElectronApiStub.ts
@@ -36,6 +36,7 @@ export function createDevElectronApiStub(): typeof window.electronAPI {
       pruneNodesByCount: async () => ({ changes: 0 }),
       pruneMessagesByCount: async () => ({ changes: 0 }),
       pruneMeshcoreMessagesByCount: async () => ({ changes: 0 }),
+      pruneReticulumMessagesByCount: async () => ({ changes: 0 }),
       deleteNodesBatch: async () => 0,
       clearMessagesByChannel: noopAsync,
       getMessageChannels: async () => [],

--- a/src/renderer/lib/meshcorePathHashMode.test.ts
+++ b/src/renderer/lib/meshcorePathHashMode.test.ts
@@ -28,11 +28,11 @@ describe('meshcorePathHashMode', () => {
 
   it('sets path hash mode and waits for Ok', async () => {
     const conn = {
-      on: vi.fn(),
-      off: vi.fn(),
-      once: vi.fn((event: string | number, cb: () => void) => {
+      on: vi.fn((event: string | number, cb: () => void) => {
         if (event === 0) queueMicrotask(cb);
       }),
+      off: vi.fn(),
+      once: vi.fn(),
       sendToRadioFrame: vi.fn().mockResolvedValue(undefined),
     };
     await setMeshcorePathHashModeOnRadio(conn, 1);

--- a/src/renderer/lib/meshcorePathHashMode.ts
+++ b/src/renderer/lib/meshcorePathHashMode.ts
@@ -27,21 +27,29 @@ export function setMeshcorePathHashModeOnRadio(
   mode: MeshcorePathHashMode,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const onOk = () => {
+    let settled = false;
+    const cleanup = (): void => {
       conn.off(MC_RESP_OK, onOk);
       conn.off(MC_RESP_ERR, onErr);
+    };
+    const onOk = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
       resolve();
     };
-    const onErr = () => {
-      conn.off(MC_RESP_OK, onOk);
-      conn.off(MC_RESP_ERR, onErr);
+    const onErr = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
       reject(new Error('radio rejected path hash mode'));
     };
-    conn.once(MC_RESP_OK, onOk);
-    conn.once(MC_RESP_ERR, onErr);
+    conn.on(MC_RESP_OK, onOk);
+    conn.on(MC_RESP_ERR, onErr);
     void conn.sendToRadioFrame(buildSetPathHashModeFrame(mode)).catch((err: unknown) => {
-      conn.off(MC_RESP_OK, onOk);
-      conn.off(MC_RESP_ERR, onErr);
+      if (settled) return;
+      settled = true;
+      cleanup();
       reject(err instanceof Error ? err : new Error(String(err)));
     });
   });

--- a/src/renderer/lib/meshcoreRepeaterLoginRpc.ts
+++ b/src/renderer/lib/meshcoreRepeaterLoginRpc.ts
@@ -1,0 +1,114 @@
+import {
+  buildSendLoginFrame,
+  MC_PUSH_LOGIN_FAIL,
+  MC_PUSH_LOGIN_SUCCESS,
+  MC_RESP_ERR,
+  MC_RESP_SENT,
+  type MeshcoreRepeaterLoginResponse,
+  type MeshcoreRepeaterRpcConnection,
+  normalizePubKeyPrefix,
+  prefixToHex,
+  pubKeyPrefixesEqual,
+  unknownToError,
+} from './meshcoreRepeaterRpcCommon';
+
+/** Default extra timeout added to radio estTimeout for repeater admin login. */
+export const MESHCORE_REPEATER_LOGIN_EXTRA_TIMEOUT_MS = 10_000;
+
+/**
+ * Resilient repeater admin login: keeps listening for LoginSuccess until prefix matches or timeout.
+ * Replaces meshcore.js `login()` which uses `once(LoginSuccess)` and drops mismatched pushes.
+ */
+export function runMeshcoreRepeaterLogin(
+  conn: MeshcoreRepeaterRpcConnection,
+  contactPublicKey: Uint8Array,
+  password: string,
+  extraTimeoutMs: number = MESHCORE_REPEATER_LOGIN_EXTRA_TIMEOUT_MS,
+): Promise<MeshcoreRepeaterLoginResponse> {
+  const expectedPrefix = contactPublicKey.subarray(0, 6);
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let responseTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = (): void => {
+      if (responseTimeoutId !== undefined) {
+        clearTimeout(responseTimeoutId);
+        responseTimeoutId = undefined;
+      }
+      conn.off(MC_RESP_SENT, onSent);
+      conn.off(MC_RESP_ERR, onErr);
+      conn.off(MC_PUSH_LOGIN_SUCCESS, onLoginSuccess);
+      conn.off(MC_PUSH_LOGIN_FAIL, onLoginFail);
+    };
+
+    const fail = (e: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (e === 'timeout') {
+        reject(new Error('timeout'));
+        return;
+      }
+      reject(unknownToError(e, 'repeater login failed'));
+    };
+
+    const succeed = (response: MeshcoreRepeaterLoginResponse): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(response);
+    };
+
+    const onLoginSuccess = (response: unknown): void => {
+      const r = response as MeshcoreRepeaterLoginResponse;
+      const prefix = normalizePubKeyPrefix(r.pubKeyPrefix);
+      if (!prefix) return;
+      if (!pubKeyPrefixesEqual(expectedPrefix, prefix)) {
+        console.debug(
+          `[meshcoreRepeaterLoginRpc] LoginSuccess prefix mismatch expected=${prefixToHex(expectedPrefix)} got=${prefixToHex(prefix)}`,
+        );
+        return;
+      }
+      succeed(r);
+    };
+
+    const onLoginFail = (response: unknown): void => {
+      const r = response as MeshcoreRepeaterLoginResponse;
+      const prefix = normalizePubKeyPrefix(r.pubKeyPrefix);
+      if (!prefix) return;
+      if (!pubKeyPrefixesEqual(expectedPrefix, prefix)) {
+        console.debug(
+          `[meshcoreRepeaterLoginRpc] LoginFail prefix mismatch expected=${prefixToHex(expectedPrefix)} got=${prefixToHex(prefix)}`,
+        );
+        return;
+      }
+      fail(new Error('repeater login rejected (wrong password or ACL denied)'));
+    };
+
+    const onSent = (response: unknown): void => {
+      conn.off(MC_RESP_SENT, onSent);
+      conn.off(MC_RESP_ERR, onErr);
+      const r = response as { estTimeout?: number };
+      const estTimeout = (r.estTimeout ?? 0) + extraTimeoutMs;
+      responseTimeoutId = setTimeout(() => {
+        fail('timeout');
+      }, estTimeout);
+    };
+
+    const onErr = (): void => {
+      fail(new Error('radio rejected repeater login'));
+    };
+
+    conn.on(MC_PUSH_LOGIN_SUCCESS, onLoginSuccess);
+    conn.on(MC_PUSH_LOGIN_FAIL, onLoginFail);
+    conn.on(MC_RESP_SENT, onSent);
+    conn.on(MC_RESP_ERR, onErr);
+
+    void conn
+      .sendToRadioFrame(buildSendLoginFrame(contactPublicKey, password))
+      .catch((err: unknown) => {
+        fail(err);
+      });
+  });
+}

--- a/src/renderer/lib/meshcoreRepeaterRpc.test.ts
+++ b/src/renderer/lib/meshcoreRepeaterRpc.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runMeshcoreRepeaterLogin } from './meshcoreRepeaterLoginRpc';
+import {
+  MC_PUSH_LOGIN_SUCCESS,
+  MC_PUSH_STATUS_RESPONSE,
+  MC_PUSH_TELEMETRY_RESPONSE,
+  MC_RESP_ERR,
+  MC_RESP_SENT,
+  parseRepeaterStatsFromStatusData,
+} from './meshcoreRepeaterRpcCommon';
+import { runMeshcoreRepeaterStatusRequest } from './meshcoreRepeaterStatusRpc';
+import { runMeshcoreRepeaterTelemetryRequest } from './meshcoreRepeaterTelemetryRpc';
+
+function makePubKey(seed: number): Uint8Array {
+  const key = new Uint8Array(32);
+  key[0] = seed & 0xff;
+  for (let i = 1; i < 32; i++) {
+    key[i] = (seed + i) & 0xff;
+  }
+  return key;
+}
+
+function createMockConn(): {
+  on: (event: string | number, cb: (...args: unknown[]) => void) => void;
+  off: (event: string | number, cb: (...args: unknown[]) => void) => void;
+  sendToRadioFrame: (data: Uint8Array) => Promise<void>;
+  emit: (event: string | number, payload?: unknown) => void;
+  sentFrames: Uint8Array[];
+} {
+  const handlers = new Map<string | number, Set<(...args: unknown[]) => void>>();
+  const sentFrames: Uint8Array[] = [];
+
+  return {
+    sentFrames,
+    on(event, cb) {
+      let set = handlers.get(event);
+      if (!set) {
+        set = new Set();
+        handlers.set(event, set);
+      }
+      set.add(cb);
+    },
+    off(event, cb) {
+      handlers.get(event)?.delete(cb);
+    },
+    sendToRadioFrame(data) {
+      sentFrames.push(data);
+      return Promise.resolve();
+    },
+    emit(event, payload) {
+      for (const cb of handlers.get(event) ?? []) {
+        cb(payload);
+      }
+    },
+  };
+}
+
+function buildStatusData(): Uint8Array {
+  const buf = new ArrayBuffer(48);
+  const view = new DataView(buf);
+  let o = 0;
+  view.setUint16(o, 3700, true);
+  o += 2;
+  view.setUint16(o, 2, true);
+  o += 2;
+  view.setInt16(o, -95, true);
+  o += 2;
+  view.setInt16(o, -80, true);
+  o += 2;
+  for (let i = 0; i < 8; i++) {
+    view.setUint32(o, 100 + i, true);
+    o += 4;
+  }
+  view.setUint16(o, 1, true);
+  o += 2;
+  view.setInt16(o, 8, true);
+  o += 2;
+  view.setUint16(o, 0, true);
+  o += 2;
+  view.setUint16(o, 0, true);
+  return new Uint8Array(buf);
+}
+
+describe('parseRepeaterStatsFromStatusData', () => {
+  it('parses LE fields matching meshcore.js layout', () => {
+    const stats = parseRepeaterStatsFromStatusData(buildStatusData());
+    expect(stats.batt_milli_volts).toBe(3700);
+    expect(stats.curr_tx_queue_len).toBe(2);
+    expect(stats.last_snr).toBe(8);
+  });
+});
+
+describe('runMeshcoreRepeaterLogin', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('succeeds when wrong-prefix LoginSuccess arrives before the matching one', async () => {
+    const conn = createMockConn();
+    const pubKey = makePubKey(0xab);
+    const wrongPrefix = makePubKey(0xcd).subarray(0, 6);
+
+    const loginPromise = runMeshcoreRepeaterLogin(conn, pubKey, 'secret');
+    await Promise.resolve();
+
+    conn.emit(MC_PUSH_LOGIN_SUCCESS, { pubKeyPrefix: wrongPrefix });
+    conn.emit(MC_RESP_SENT, { estTimeout: 500 });
+    conn.emit(MC_PUSH_LOGIN_SUCCESS, { pubKeyPrefix: pubKey.subarray(0, 6), permissions: 1 });
+
+    await expect(loginPromise).resolves.toMatchObject({
+      pubKeyPrefix: pubKey.subarray(0, 6),
+      permissions: 1,
+    });
+  });
+});
+
+describe('runMeshcoreRepeaterStatusRequest', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('succeeds when wrong-prefix StatusResponse arrives before the matching one', async () => {
+    const conn = createMockConn();
+    const pubKey = makePubKey(0x11);
+    const wrongPrefix = makePubKey(0x22).subarray(0, 6);
+    const statusData = buildStatusData();
+
+    const statusPromise = runMeshcoreRepeaterStatusRequest(conn, pubKey, 1000);
+    await Promise.resolve();
+
+    conn.emit(MC_PUSH_STATUS_RESPONSE, { pubKeyPrefix: wrongPrefix, statusData });
+    conn.emit(MC_RESP_SENT, { estTimeout: 100 });
+    conn.emit(MC_PUSH_STATUS_RESPONSE, {
+      pubKeyPrefix: pubKey.subarray(0, 6),
+      statusData,
+    });
+
+    await expect(statusPromise).resolves.toMatchObject({ batt_milli_volts: 3700 });
+  });
+
+  it('rejects on Err after send', async () => {
+    const conn = createMockConn();
+    const pubKey = makePubKey(3);
+    const statusPromise = runMeshcoreRepeaterStatusRequest(conn, pubKey, 1000);
+    await Promise.resolve();
+    conn.emit(MC_RESP_ERR);
+    await expect(statusPromise).rejects.toThrow(/rejected status request/i);
+  });
+});
+
+describe('runMeshcoreRepeaterTelemetryRequest', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('succeeds when wrong-prefix TelemetryResponse arrives before the matching one', async () => {
+    const conn = createMockConn();
+    const pubKey = makePubKey(0x33);
+    const wrongPrefix = makePubKey(0x44).subarray(0, 6);
+    const lppSensorData = new Uint8Array([1, 2, 3]);
+
+    const telemetryPromise = runMeshcoreRepeaterTelemetryRequest(conn, pubKey, 1000);
+    await Promise.resolve();
+
+    conn.emit(MC_PUSH_TELEMETRY_RESPONSE, { pubKeyPrefix: wrongPrefix, lppSensorData });
+    conn.emit(MC_RESP_SENT, { estTimeout: 100 });
+    conn.emit(MC_PUSH_TELEMETRY_RESPONSE, {
+      pubKeyPrefix: pubKey.subarray(0, 6),
+      lppSensorData,
+    });
+
+    await expect(telemetryPromise).resolves.toMatchObject({ lppSensorData });
+  });
+});

--- a/src/renderer/lib/meshcoreRepeaterRpcCommon.ts
+++ b/src/renderer/lib/meshcoreRepeaterRpcCommon.ts
@@ -1,0 +1,166 @@
+/** meshcore.js ResponseCodes */
+export const MC_RESP_ERR = 1;
+export const MC_RESP_SENT = 6;
+
+/** meshcore.js PushCodes */
+export const MC_PUSH_LOGIN_SUCCESS = 0x85;
+export const MC_PUSH_LOGIN_FAIL = 0x86;
+export const MC_PUSH_STATUS_RESPONSE = 0x87;
+export const MC_PUSH_TELEMETRY_RESPONSE = 0x8b;
+
+/** meshcore.js CommandCodes */
+export const MC_CMD_SEND_LOGIN = 26;
+export const MC_CMD_SEND_STATUS_REQ = 27;
+export const MC_CMD_SEND_TELEMETRY_REQ = 39;
+
+/** Minimal connection surface for prefix-matched repeater RPCs. */
+export interface MeshcoreRepeaterRpcConnection {
+  on(event: string | number, cb: (...args: unknown[]) => void): void;
+  off(event: string | number, cb: (...args: unknown[]) => void): void;
+  sendToRadioFrame(data: Uint8Array): Promise<void>;
+}
+
+export interface MeshcoreRepeaterLoginResponse {
+  reserved?: number;
+  pubKeyPrefix?: Uint8Array;
+  permissions?: number;
+}
+
+export interface MeshcoreRepeaterStatusPush {
+  reserved?: number;
+  pubKeyPrefix?: Uint8Array;
+  statusData?: Uint8Array;
+}
+
+export interface MeshcoreRepeaterTelemetryPush {
+  reserved?: number;
+  pubKeyPrefix?: Uint8Array;
+  lppSensorData?: Uint8Array;
+}
+
+/** Parsed repeater stats (matches meshcore.js getStatus resolve shape). */
+export interface MeshcoreRepeaterStats {
+  batt_milli_volts: number;
+  curr_tx_queue_len: number;
+  noise_floor: number;
+  last_rssi: number;
+  n_packets_recv: number;
+  n_packets_sent: number;
+  total_air_time_secs: number;
+  total_up_time_secs: number;
+  n_sent_flood: number;
+  n_sent_direct: number;
+  n_recv_flood: number;
+  n_recv_direct: number;
+  err_events: number;
+  last_snr: number;
+  n_direct_dups: number;
+  n_flood_dups: number;
+}
+
+export function normalizePubKeyPrefix(prefix: unknown): Uint8Array | null {
+  if (prefix instanceof Uint8Array && prefix.length === 6) {
+    return prefix;
+  }
+  if (ArrayBuffer.isView(prefix) && prefix.byteLength === 6) {
+    return new Uint8Array(prefix.buffer, prefix.byteOffset, 6);
+  }
+  if (Array.isArray(prefix) && prefix.length === 6) {
+    return Uint8Array.from(prefix);
+  }
+  return null;
+}
+
+export function pubKeyPrefixesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== 6 || b.length !== 6) return false;
+  let diff = 0;
+  for (let i = 0; i < 6; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+export function prefixToHex(prefix: Uint8Array): string {
+  return Array.from(prefix)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function unknownToError(e: unknown, fallback: string): Error {
+  if (e instanceof Error) return e;
+  if (e === null || e === undefined) return new Error(fallback);
+  if (typeof e === 'string') return new Error(e);
+  return new Error(fallback);
+}
+
+export function buildSendLoginFrame(publicKey: Uint8Array, password: string): Uint8Array {
+  if (publicKey.length !== 32) {
+    throw new Error('Repeater login requires a 32-byte public key');
+  }
+  const passwordField =
+    password.length === 0 ? new Uint8Array(0) : new TextEncoder().encode(password);
+  const frame = new Uint8Array(1 + 32 + passwordField.length);
+  frame[0] = MC_CMD_SEND_LOGIN;
+  frame.set(publicKey, 1);
+  frame.set(passwordField, 33);
+  return frame;
+}
+
+export function buildSendStatusReqFrame(publicKey: Uint8Array): Uint8Array {
+  if (publicKey.length !== 32) {
+    throw new Error('Status request requires a 32-byte public key');
+  }
+  const frame = new Uint8Array(1 + 32);
+  frame[0] = MC_CMD_SEND_STATUS_REQ;
+  frame.set(publicKey, 1);
+  return frame;
+}
+
+export function buildSendTelemetryReqFrame(publicKey: Uint8Array): Uint8Array {
+  if (publicKey.length !== 32) {
+    throw new Error('Telemetry request requires a 32-byte public key');
+  }
+  const frame = new Uint8Array(1 + 3 + 32);
+  frame[0] = MC_CMD_SEND_TELEMETRY_REQ;
+  frame.set(publicKey, 4);
+  return frame;
+}
+
+/** Parse repeater stats from StatusResponse push payload (matches meshcore.js). */
+export function parseRepeaterStatsFromStatusData(statusData: Uint8Array): MeshcoreRepeaterStats {
+  const view = new DataView(statusData.buffer, statusData.byteOffset, statusData.byteLength);
+  let o = 0;
+  const readU16 = (): number => {
+    const v = view.getUint16(o, true);
+    o += 2;
+    return v;
+  };
+  const readI16 = (): number => {
+    const v = view.getInt16(o, true);
+    o += 2;
+    return v;
+  };
+  const readU32 = (): number => {
+    const v = view.getUint32(o, true);
+    o += 4;
+    return v;
+  };
+  return {
+    batt_milli_volts: readU16(),
+    curr_tx_queue_len: readU16(),
+    noise_floor: readI16(),
+    last_rssi: readI16(),
+    n_packets_recv: readU32(),
+    n_packets_sent: readU32(),
+    total_air_time_secs: readU32(),
+    total_up_time_secs: readU32(),
+    n_sent_flood: readU32(),
+    n_sent_direct: readU32(),
+    n_recv_flood: readU32(),
+    n_recv_direct: readU32(),
+    err_events: readU16(),
+    last_snr: readI16(),
+    n_direct_dups: readU16(),
+    n_flood_dups: readU16(),
+  };
+}

--- a/src/renderer/lib/meshcoreRepeaterSession.test.ts
+++ b/src/renderer/lib/meshcoreRepeaterSession.test.ts
@@ -1,28 +1,69 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { MeshcoreRepeaterRpcConnection } from './meshcoreRepeaterRpcCommon';
+import { MC_PUSH_LOGIN_SUCCESS, MC_RESP_SENT } from './meshcoreRepeaterRpcCommon';
 import { meshcoreRepeaterTryLogin } from './meshcoreRepeaterSession';
 import {
   meshcoreApplyRepeaterSessionAuth,
   meshcoreClearRepeaterRemoteSessionAuth,
 } from './meshcoreUtils';
 
+type MockMeshcoreRepeaterConn = MeshcoreRepeaterRpcConnection & {
+  emit: (event: string | number, payload?: unknown) => void;
+  sendToRadioFrame: ReturnType<typeof vi.fn<(data: Uint8Array) => Promise<void>>>;
+};
+
+function createMockConn(): MockMeshcoreRepeaterConn {
+  const handlers = new Map<string | number, Set<(...args: unknown[]) => void>>();
+  return {
+    on(event, cb) {
+      let set = handlers.get(event);
+      if (!set) {
+        set = new Set();
+        handlers.set(event, set);
+      }
+      set.add(cb);
+    },
+    off(event, cb) {
+      handlers.get(event)?.delete(cb);
+    },
+    sendToRadioFrame: vi.fn<(data: Uint8Array) => Promise<void>>().mockResolvedValue(undefined),
+    emit(event, payload) {
+      for (const cb of handlers.get(event) ?? []) {
+        cb(payload);
+      }
+    },
+  };
+}
+
 describe('meshcoreRepeaterTryLogin', () => {
-  it('calls login after applying session password', async () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
     meshcoreClearRepeaterRemoteSessionAuth();
+  });
+
+  it('sends login frame after applying session password', async () => {
     meshcoreApplyRepeaterSessionAuth('secret');
-    const login = vi.fn().mockResolvedValue(undefined);
-    const conn = { login };
+    const conn = createMockConn();
     const pubKey = new Uint8Array(32);
-    await meshcoreRepeaterTryLogin(conn, pubKey);
-    expect(login).toHaveBeenCalledTimes(1);
-    expect(login).toHaveBeenCalledWith(pubKey, 'secret', 10000);
-    meshcoreClearRepeaterRemoteSessionAuth();
+    pubKey[0] = 0xab;
+
+    const loginPromise = meshcoreRepeaterTryLogin(conn, pubKey);
+    await Promise.resolve();
+    expect(conn.sendToRadioFrame).toHaveBeenCalledTimes(1);
+
+    conn.emit(MC_RESP_SENT, { estTimeout: 100 });
+    conn.emit(MC_PUSH_LOGIN_SUCCESS, { pubKeyPrefix: pubKey.subarray(0, 6) });
+    await loginPromise;
   });
 
   it('skips login when session password is empty', async () => {
     meshcoreClearRepeaterRemoteSessionAuth();
-    const login = vi.fn().mockResolvedValue(undefined);
-    await meshcoreRepeaterTryLogin({ login }, new Uint8Array(32));
-    expect(login).not.toHaveBeenCalled();
+    const conn = createMockConn();
+    await meshcoreRepeaterTryLogin(conn, new Uint8Array(32));
+    expect(conn.sendToRadioFrame).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/lib/meshcoreRepeaterSession.ts
+++ b/src/renderer/lib/meshcoreRepeaterSession.ts
@@ -1,15 +1,11 @@
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 
+import { runMeshcoreRepeaterLogin } from './meshcoreRepeaterLoginRpc';
+import type { MeshcoreRepeaterRpcConnection } from './meshcoreRepeaterRpcCommon';
 import { meshcoreGetRepeaterSessionPassword } from './meshcoreUtils';
 
-/** Minimal connection surface for repeater admin `login`. */
-export interface MeshcoreRepeaterLoginConn {
-  login(
-    contactPublicKey: Uint8Array,
-    password: string,
-    extraTimeoutMillis?: number,
-  ): Promise<unknown>;
-}
+/** Minimal connection surface for repeater admin login RPC. */
+export type MeshcoreRepeaterLoginConn = MeshcoreRepeaterRpcConnection;
 
 /**
  * Best-effort repeater admin login when a session password is set.
@@ -22,7 +18,7 @@ export async function meshcoreRepeaterTryLogin(
   const password = meshcoreGetRepeaterSessionPassword().trim();
   if (!password) return;
   try {
-    await conn.login(pubKey, password, 10000);
+    await runMeshcoreRepeaterLogin(conn, pubKey, password);
   } catch (e) {
     console.warn(
       '[meshcoreRepeaterSession] repeater login failed (continuing) ' + errLikeToLogString(e),

--- a/src/renderer/lib/meshcoreRepeaterStatusRpc.ts
+++ b/src/renderer/lib/meshcoreRepeaterStatusRpc.ts
@@ -1,0 +1,99 @@
+import {
+  buildSendStatusReqFrame,
+  MC_PUSH_STATUS_RESPONSE,
+  MC_RESP_ERR,
+  MC_RESP_SENT,
+  type MeshcoreRepeaterRpcConnection,
+  type MeshcoreRepeaterStats,
+  type MeshcoreRepeaterStatusPush,
+  normalizePubKeyPrefix,
+  parseRepeaterStatsFromStatusData,
+  prefixToHex,
+  pubKeyPrefixesEqual,
+  unknownToError,
+} from './meshcoreRepeaterRpcCommon';
+
+/**
+ * Resilient repeater status request: keeps listening for StatusResponse until prefix matches or timeout.
+ * Replaces meshcore.js `getStatus()` which uses `once(StatusResponse)` and drops mismatched pushes.
+ */
+export function runMeshcoreRepeaterStatusRequest(
+  conn: MeshcoreRepeaterRpcConnection,
+  contactPublicKey: Uint8Array,
+  extraTimeoutMs: number,
+): Promise<MeshcoreRepeaterStats> {
+  const expectedPrefix = contactPublicKey.subarray(0, 6);
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let responseTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = (): void => {
+      if (responseTimeoutId !== undefined) {
+        clearTimeout(responseTimeoutId);
+        responseTimeoutId = undefined;
+      }
+      conn.off(MC_RESP_SENT, onSent);
+      conn.off(MC_RESP_ERR, onErr);
+      conn.off(MC_PUSH_STATUS_RESPONSE, onStatusResponsePush);
+    };
+
+    const fail = (e: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (e === 'timeout') {
+        reject(new Error('timeout'));
+        return;
+      }
+      reject(unknownToError(e, 'repeater status request failed'));
+    };
+
+    const succeed = (stats: MeshcoreRepeaterStats): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(stats);
+    };
+
+    const onStatusResponsePush = (response: unknown): void => {
+      const r = response as MeshcoreRepeaterStatusPush;
+      const prefix = normalizePubKeyPrefix(r.pubKeyPrefix);
+      if (!prefix) return;
+      if (!pubKeyPrefixesEqual(expectedPrefix, prefix)) {
+        console.debug(
+          `[meshcoreRepeaterStatusRpc] StatusResponse prefix mismatch expected=${prefixToHex(expectedPrefix)} got=${prefixToHex(prefix)}`,
+        );
+        return;
+      }
+      const statusData = r.statusData;
+      if (!(statusData instanceof Uint8Array) || statusData.length < 48) {
+        fail(new Error('invalid status response payload'));
+        return;
+      }
+      succeed(parseRepeaterStatsFromStatusData(statusData));
+    };
+
+    const onSent = (response: unknown): void => {
+      conn.off(MC_RESP_SENT, onSent);
+      conn.off(MC_RESP_ERR, onErr);
+      const r = response as { estTimeout?: number };
+      const estTimeout = (r.estTimeout ?? 0) + extraTimeoutMs;
+      responseTimeoutId = setTimeout(() => {
+        fail('timeout');
+      }, estTimeout);
+    };
+
+    const onErr = (): void => {
+      fail(new Error('radio rejected status request'));
+    };
+
+    conn.on(MC_PUSH_STATUS_RESPONSE, onStatusResponsePush);
+    conn.on(MC_RESP_SENT, onSent);
+    conn.on(MC_RESP_ERR, onErr);
+
+    void conn.sendToRadioFrame(buildSendStatusReqFrame(contactPublicKey)).catch((err: unknown) => {
+      fail(err);
+    });
+  });
+}

--- a/src/renderer/lib/meshcoreRepeaterTelemetryRpc.ts
+++ b/src/renderer/lib/meshcoreRepeaterTelemetryRpc.ts
@@ -1,0 +1,94 @@
+import {
+  buildSendTelemetryReqFrame,
+  MC_PUSH_TELEMETRY_RESPONSE,
+  MC_RESP_ERR,
+  MC_RESP_SENT,
+  type MeshcoreRepeaterRpcConnection,
+  type MeshcoreRepeaterTelemetryPush,
+  normalizePubKeyPrefix,
+  prefixToHex,
+  pubKeyPrefixesEqual,
+  unknownToError,
+} from './meshcoreRepeaterRpcCommon';
+
+/**
+ * Resilient telemetry request: keeps listening for TelemetryResponse until prefix matches or timeout.
+ * Replaces meshcore.js `getTelemetry()` which uses `once(TelemetryResponse)` and drops mismatched pushes.
+ */
+export function runMeshcoreRepeaterTelemetryRequest(
+  conn: MeshcoreRepeaterRpcConnection,
+  contactPublicKey: Uint8Array,
+  extraTimeoutMs: number,
+): Promise<MeshcoreRepeaterTelemetryPush> {
+  const expectedPrefix = contactPublicKey.subarray(0, 6);
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let responseTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = (): void => {
+      if (responseTimeoutId !== undefined) {
+        clearTimeout(responseTimeoutId);
+        responseTimeoutId = undefined;
+      }
+      conn.off(MC_RESP_SENT, onSent);
+      conn.off(MC_RESP_ERR, onErr);
+      conn.off(MC_PUSH_TELEMETRY_RESPONSE, onTelemetryResponsePush);
+    };
+
+    const fail = (e: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (e === 'timeout') {
+        reject(new Error('timeout'));
+        return;
+      }
+      reject(unknownToError(e, 'telemetry request failed'));
+    };
+
+    const succeed = (response: MeshcoreRepeaterTelemetryPush): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(response);
+    };
+
+    const onTelemetryResponsePush = (response: unknown): void => {
+      const r = response as MeshcoreRepeaterTelemetryPush;
+      const prefix = normalizePubKeyPrefix(r.pubKeyPrefix);
+      if (!prefix) return;
+      if (!pubKeyPrefixesEqual(expectedPrefix, prefix)) {
+        console.debug(
+          `[meshcoreRepeaterTelemetryRpc] TelemetryResponse prefix mismatch expected=${prefixToHex(expectedPrefix)} got=${prefixToHex(prefix)}`,
+        );
+        return;
+      }
+      succeed(r);
+    };
+
+    const onSent = (response: unknown): void => {
+      conn.off(MC_RESP_SENT, onSent);
+      conn.off(MC_RESP_ERR, onErr);
+      const r = response as { estTimeout?: number };
+      const estTimeout = (r.estTimeout ?? 0) + extraTimeoutMs;
+      responseTimeoutId = setTimeout(() => {
+        fail('timeout');
+      }, estTimeout);
+    };
+
+    const onErr = (): void => {
+      fail(new Error('radio rejected telemetry request'));
+    };
+
+    conn.on(MC_PUSH_TELEMETRY_RESPONSE, onTelemetryResponsePush);
+    conn.on(MC_RESP_SENT, onSent);
+    conn.on(MC_RESP_ERR, onErr);
+
+    void conn
+      .sendToRadioFrame(buildSendTelemetryReqFrame(contactPublicKey))
+      .catch((err: unknown) => {
+        fail(err);
+      });
+  });
+}

--- a/src/renderer/lib/meshcoreUtils.test.ts
+++ b/src/renderer/lib/meshcoreUtils.test.ts
@@ -29,6 +29,7 @@ import {
   meshcoreMergeContactHopsAwayFromPrevious,
   meshcoreMilliVoltsToApproximateBatteryPercent,
   meshcoreMinimalNodeFromAdvertEvent,
+  meshcoreRemoveContactErrorMessage,
   meshcoreResolvedTxPowerMax,
   meshcoreScaledAdvLatLonToDeg,
   meshcoreSelfInfoBwToDisplayKhz,
@@ -699,5 +700,15 @@ describe('coerceMeshcoreExportPrivateKeyResult', () => {
     expect(coerceMeshcoreExportPrivateKeyResult(new Uint8Array(0))).toBeNull();
     expect(coerceMeshcoreExportPrivateKeyResult({ privateKey: new Uint8Array(0) })).toBeNull();
     expect(coerceMeshcoreExportPrivateKeyResult({})).toBeNull();
+  });
+});
+
+describe('meshcoreRemoveContactErrorMessage', () => {
+  it('maps bare reject to a friendly message', () => {
+    expect(meshcoreRemoveContactErrorMessage(undefined)).toContain('no detail from radio');
+  });
+
+  it('passes through Error messages', () => {
+    expect(meshcoreRemoveContactErrorMessage(new Error('table full'))).toBe('table full');
   });
 });

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -6,6 +6,7 @@ import {
   meshcoreUnpackPathLenByte,
 } from '../../shared/meshcorePathHash';
 import { isPlaceholderLongName } from '../../shared/nodeNameUtils';
+import { errLikeToLogString } from './errLikeToLogString';
 import { mergeMeshcoreLastHeardFromAdvert } from './nodeStatus';
 import type { ConnectionType, MeshNode } from './types';
 
@@ -745,4 +746,13 @@ export function coerceMeshcoreExportPrivateKeyResult(result: unknown): Uint8Arra
     return pk.byteLength > 0 ? pk : null;
   }
   return null;
+}
+
+/** Map meshcore.js bare `reject()` from removeContact to a user-visible message. */
+export function meshcoreRemoveContactErrorMessage(e: unknown): string {
+  const msg = errLikeToLogString(e);
+  if (!msg || msg === 'undefined') {
+    return 'radio rejected removeContact (no detail from radio)';
+  }
+  return msg;
 }

--- a/src/renderer/lib/meshtasticTraceRouteLookupKeys.ts
+++ b/src/renderer/lib/meshtasticTraceRouteLookupKeys.ts
@@ -1,3 +1,5 @@
+import { MAX_MESHTASTIC_TRACE_ROUTE_RESULTS, trimMapToMaxSize } from './sessionMemoryCaps';
+
 /** Stored traceroute row for the node detail modal / diagnostics */
 export interface MeshtasticTraceRouteEntry {
   route: number[];
@@ -31,10 +33,16 @@ export function mergeMeshtasticTraceRouteIntoResultsMap(
   const lookupKeys = [
     ...new Set([...baseKeys, ...(additionalLookupKeys ?? []).map((k) => k >>> 0)]),
   ];
-  const next = new Map(prev);
-  for (const k of lookupKeys) {
-    next.set(k, entry);
-  }
+  const next = trimMapToMaxSize(
+    (() => {
+      const map = new Map(prev);
+      for (const k of lookupKeys) {
+        map.set(k, entry);
+      }
+      return map;
+    })(),
+    MAX_MESHTASTIC_TRACE_ROUTE_RESULTS,
+  );
   return next;
 }
 

--- a/src/renderer/lib/sessionMemoryCaps.test.ts
+++ b/src/renderer/lib/sessionMemoryCaps.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { trimArrayTail, trimMapToMaxSize, trimMapToMaxSizeKeeping } from './sessionMemoryCaps';
+
+describe('sessionMemoryCaps', () => {
+  it('trimArrayTail keeps newest entries', () => {
+    expect(trimArrayTail([1, 2, 3, 4, 5], 3)).toEqual([3, 4, 5]);
+  });
+
+  it('trimMapToMaxSize evicts oldest keys', () => {
+    const map = new Map<number, string>([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ]);
+    expect([...trimMapToMaxSize(map, 2).keys()]).toEqual([2, 3]);
+  });
+
+  it('trimMapToMaxSizeKeeping prefers retaining keepIds', () => {
+    const map = new Map<number, string>([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+      [4, 'd'],
+    ]);
+    const trimmed = trimMapToMaxSizeKeeping(map, 2, [1, 4]);
+    expect([...trimmed.keys()].sort()).toEqual([1, 4]);
+  });
+});

--- a/src/renderer/lib/sessionMemoryCaps.ts
+++ b/src/renderer/lib/sessionMemoryCaps.ts
@@ -1,0 +1,50 @@
+/** Shared in-memory retention limits for long-running sessions. */
+
+export const MAX_TRACE_ROUTES_PER_IDENTITY = 100;
+export const MAX_MESHCORE_CLI_HISTORY_ENTRIES = 50;
+export const MAX_MESHTASTIC_TRACE_ROUTE_RESULTS = 100;
+export const MAX_DIAGNOSTICS_TRACKED_NODES = 2000;
+export const MAX_RETICULUM_IDENTITY_DESTINATIONS = 2000;
+export const LARGE_MESH_NODE_THRESHOLD = 400;
+export const LARGE_MESH_DIAGNOSTICS_REANALYSIS_DELAY_MS = 10_000;
+export const SESSION_DB_PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000;
+export const RETICULUM_MESSAGE_RETENTION_DEFAULT_COUNT = 4000;
+
+/** Keep the newest `max` entries (tail of array). */
+export function trimArrayTail<T>(items: readonly T[], max: number): T[] {
+  if (items.length <= max) return [...items];
+  return items.slice(items.length - max);
+}
+
+/** Evict oldest Map keys when size exceeds max ( insertion order ). */
+export function trimMapToMaxSize<K, V>(map: Map<K, V>, max: number): Map<K, V> {
+  if (map.size <= max) return map;
+  const next = new Map(map);
+  const removeCount = next.size - max;
+  const keys = next.keys();
+  for (let i = 0; i < removeCount; i++) {
+    const k = keys.next();
+    if (k.done) break;
+    next.delete(k.value);
+  }
+  return next;
+}
+
+/** Evict oldest Map keys not present in `keepIds`. */
+export function trimMapToMaxSizeKeeping<K, V>(
+  map: Map<K, V>,
+  max: number,
+  keepIds: Iterable<K>,
+): Map<K, V> {
+  if (map.size <= max) return map;
+  const keep = new Set(keepIds);
+  const next = new Map(map);
+  for (const key of [...next.keys()]) {
+    if (next.size <= max) break;
+    if (!keep.has(key)) next.delete(key);
+  }
+  if (next.size > max) {
+    return trimMapToMaxSize(next, max);
+  }
+  return next;
+}

--- a/src/renderer/lib/startupDbPrune.test.ts
+++ b/src/renderer/lib/startupDbPrune.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resetStartupDbPruneForTests, runStartupDbPrune } from './startupDbPrune';
+import {
+  resetStartupDbPruneForTests,
+  runSessionDbPrune,
+  runStartupDbPrune,
+} from './startupDbPrune';
 import { MESH_PROTOCOL_STORAGE_KEY } from './storedMeshProtocol';
 
 describe('runStartupDbPrune', () => {
@@ -24,6 +28,9 @@ describe('runStartupDbPrune', () => {
     vi.mocked(window.electronAPI.db.deleteNodesWithoutLongname).mockResolvedValue(0);
     vi.mocked(window.electronAPI.db.pruneMessagesByCount).mockResolvedValue({ changes: 0 });
     vi.mocked(window.electronAPI.db.pruneMeshcoreMessagesByCount).mockResolvedValue({ changes: 0 });
+    vi.mocked(window.electronAPI.db.pruneReticulumMessagesByCount).mockResolvedValue({
+      changes: 0,
+    });
     vi.mocked(window.electronAPI.appSettings.getAll).mockResolvedValue({});
   });
 
@@ -35,6 +42,7 @@ describe('runStartupDbPrune', () => {
     vi.mocked(window.electronAPI.db.deleteNodesWithoutLongname).mockClear();
     vi.mocked(window.electronAPI.db.pruneMessagesByCount).mockClear();
     vi.mocked(window.electronAPI.db.pruneMeshcoreMessagesByCount).mockClear();
+    vi.mocked(window.electronAPI.db.pruneReticulumMessagesByCount).mockClear();
   });
 
   it('runs meshtastic startup prune IPC once per session', async () => {
@@ -47,6 +55,14 @@ describe('runStartupDbPrune', () => {
     expect(window.electronAPI.db.deleteNodesWithoutLongname).toHaveBeenCalledTimes(1);
     expect(window.electronAPI.db.pruneMessagesByCount).toHaveBeenCalledTimes(1);
     expect(window.electronAPI.db.pruneMeshcoreMessagesByCount).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.db.pruneReticulumMessagesByCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('runSessionDbPrune repeats maintenance without single-flight guard', async () => {
+    await runStartupDbPrune();
+    await runSessionDbPrune();
+
+    expect(window.electronAPI.db.pruneReticulumMessagesByCount).toHaveBeenCalledTimes(2);
   });
 
   it('does not re-run when invoked again after concurrent callers', async () => {

--- a/src/renderer/lib/startupDbPrune.ts
+++ b/src/renderer/lib/startupDbPrune.ts
@@ -3,9 +3,15 @@ import { DEFAULT_APP_SETTINGS_SHARED } from './defaultAppSettings';
 import { errLikeToLogString } from './errLikeToLogString';
 import { fetchMessageRetention } from './messageRetention';
 import { parseStoredJson } from './parseStoredJson';
+import {
+  RETICULUM_MESSAGE_RETENTION_DEFAULT_COUNT,
+  SESSION_DB_PRUNE_INTERVAL_MS,
+} from './sessionMemoryCaps';
 import { getStoredMeshProtocol } from './storedMeshProtocol';
 
 let startupDbPrunePromise: Promise<void> | null = null;
+
+export { SESSION_DB_PRUNE_INTERVAL_MS };
 
 /**
  * One-shot startup DB maintenance (node/message retention, migrations).
@@ -13,8 +19,13 @@ let startupDbPrunePromise: Promise<void> | null = null;
  */
 export function runStartupDbPrune(): Promise<void> {
   if (startupDbPrunePromise) return startupDbPrunePromise;
-  startupDbPrunePromise = executeStartupDbPrune();
+  startupDbPrunePromise = executeDbPrune('startup');
   return startupDbPrunePromise;
+}
+
+/** Periodic maintenance while the app stays connected (same ops as startup prune). */
+export function runSessionDbPrune(): Promise<void> {
+  return executeDbPrune('session');
 }
 
 /** @internal Vitest only — resets single-flight guard between tests. */
@@ -22,7 +33,7 @@ export function resetStartupDbPruneForTests(): void {
   startupDbPrunePromise = null;
 }
 
-async function executeStartupDbPrune(): Promise<void> {
+async function executeDbPrune(label: 'startup' | 'session'): Promise<void> {
   const startupProtocol = getStoredMeshProtocol();
   const raw =
     parseStoredJson<Record<string, unknown>>(getAppSettingsRaw(), 'App startup node pruning') ?? {};
@@ -110,6 +121,16 @@ async function executeStartupDbPrune(): Promise<void> {
         }),
       );
     }
+  } else if (startupProtocol === 'reticulum') {
+    ops.push(
+      window.electronAPI.db
+        .pruneReticulumMessagesByCount(RETICULUM_MESSAGE_RETENTION_DEFAULT_COUNT)
+        .catch((e: unknown) => {
+          console.warn(
+            `[App] ${label} pruneReticulumMessagesByCount failed ` + errLikeToLogString(e),
+          );
+        }),
+    );
   }
 
   ops.push(
@@ -135,11 +156,20 @@ async function executeStartupDbPrune(): Promise<void> {
               .pruneMeshcoreMessagesByCount(r.meshcoreCount)
               .catch((e: unknown) => {
                 console.warn(
-                  '[App] startup pruneMeshcoreMessagesByCount failed ' + errLikeToLogString(e),
+                  `[App] ${label} pruneMeshcoreMessagesByCount failed ` + errLikeToLogString(e),
                 );
               }),
           );
         }
+        innerOps.push(
+          window.electronAPI.db
+            .pruneReticulumMessagesByCount(RETICULUM_MESSAGE_RETENTION_DEFAULT_COUNT)
+            .catch((e: unknown) => {
+              console.warn(
+                `[App] ${label} pruneReticulumMessagesByCount failed ` + errLikeToLogString(e),
+              );
+            }),
+        );
         return Promise.all(innerOps);
       })
       .catch((e: unknown) => {

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -180,6 +180,8 @@ import {
   setMeshcorePathHashModeOnRadio,
 } from '../lib/meshcorePathHashMode';
 import { meshcoreRepeaterTryLogin } from '../lib/meshcoreRepeaterSession';
+import { runMeshcoreRepeaterStatusRequest } from '../lib/meshcoreRepeaterStatusRpc';
+import { runMeshcoreRepeaterTelemetryRequest } from '../lib/meshcoreRepeaterTelemetryRpc';
 import {
   clearMeshcoreRoomAutoLoginFailure,
   getMeshcoreRoomAutoLoginFailure,
@@ -262,6 +264,7 @@ import {
   meshcoreMergeContactHopsAwayFromPrevious,
   meshcoreMilliVoltsToApproximateBatteryPercent,
   meshcoreMinimalNodeFromAdvertEvent,
+  meshcoreRemoveContactErrorMessage,
   meshcoreScaledAdvLatLonToDeg,
   meshcoreSliceContactOutPathForTrace,
   meshcoreSyntheticPlaceholderPubKeyHex,
@@ -3159,7 +3162,9 @@ export function useMeshcoreRuntime() {
       try {
         await connRef.current.removeContact(pubKey);
       } catch (e) {
-        console.warn('[useMeshcoreRuntime] removeContact error ' + errLikeToLogString(e));
+        console.warn(
+          '[useMeshcoreRuntime] removeContact error ' + meshcoreRemoveContactErrorMessage(e),
+        );
       }
     } else if (meshcoreIsChatStubNodeId(nodeId)) {
       // stub node: skip radio removal
@@ -3213,7 +3218,7 @@ export function useMeshcoreRuntime() {
           await conn.removeContact(c.publicKey).catch((e: unknown) => {
             console.warn(
               '[useMeshcoreRuntime] clearAllMeshcoreContacts removeContact error ' +
-                errLikeToLogString(e),
+                meshcoreRemoveContactErrorMessage(e),
             );
           });
         }
@@ -3303,7 +3308,7 @@ export function useMeshcoreRuntime() {
           }
           console.warn(
             '[useMeshcoreRuntime] offloadContactsFromRadio removeContact error ' +
-              errLikeToLogString(e),
+              meshcoreRemoveContactErrorMessage(e),
           );
         }
       }
@@ -3815,7 +3820,11 @@ export function useMeshcoreRuntime() {
             pubKey,
             nodesRef.current.get(nodeId)?.hw_model,
           );
-          const raw = await conn.getStatus(pubKey, MESHCORE_STATUS_TIMEOUT_MS);
+          const raw = await runMeshcoreRepeaterStatusRequest(
+            conn,
+            pubKey,
+            MESHCORE_STATUS_TIMEOUT_MS,
+          );
           const lastSnrDb = raw.last_snr * MESHCORE_RPC_SNR_RAW_TO_DB;
           const status: MeshCoreRepeaterStatus = {
             battMilliVolts: raw.batt_milli_volts,
@@ -3913,15 +3922,22 @@ export function useMeshcoreRuntime() {
             pubKey,
             nodesRef.current.get(nodeId)?.hw_model,
           );
-          const raw = await conn.getTelemetry(pubKey, MESHCORE_TELEMETRY_TIMEOUT_MS);
+          const raw = await runMeshcoreRepeaterTelemetryRequest(
+            conn,
+            pubKey,
+            MESHCORE_TELEMETRY_TIMEOUT_MS,
+          );
           let entries: CayenneLppEntry[] = [];
-          try {
-            entries = CayenneLpp.parse(raw.lppSensorData) as CayenneLppEntry[];
-          } catch (parseErr: unknown) {
-            console.warn(
-              '[useMeshcoreRuntime] requestTelemetry CayenneLpp.parse error ' +
-                errLikeToLogString(parseErr),
-            );
+          const lppSensorData = raw.lppSensorData;
+          if (lppSensorData) {
+            try {
+              entries = CayenneLpp.parse(lppSensorData) as CayenneLppEntry[];
+            } catch (parseErr: unknown) {
+              console.warn(
+                '[useMeshcoreRuntime] requestTelemetry CayenneLpp.parse error ' +
+                  errLikeToLogString(parseErr),
+              );
+            }
           }
           const result: MeshCoreNodeTelemetry = { fetchedAt: Date.now(), entries };
           for (const entry of entries) {

--- a/src/renderer/stores/diagnosticsStore.ts
+++ b/src/renderer/stores/diagnosticsStore.ts
@@ -29,6 +29,12 @@ import type { GpsSource } from '../lib/gpsSource';
 import { isLowAccuracyPosition } from '../lib/gpsSource';
 import { parseStoredJson } from '../lib/parseStoredJson';
 import type { ProtocolCapabilities } from '../lib/radio/BaseRadioProvider';
+import {
+  LARGE_MESH_DIAGNOSTICS_REANALYSIS_DELAY_MS,
+  LARGE_MESH_NODE_THRESHOLD,
+  MAX_DIAGNOSTICS_TRACKED_NODES,
+  trimMapToMaxSizeKeeping,
+} from '../lib/sessionMemoryCaps';
 import type {
   DiagnosticRow,
   HopHistoryPoint,
@@ -539,6 +545,35 @@ const diagnosticsDebounce = {
   pendingAnalyses: new Map<number, { node: MeshNode; homeNode: MeshNode | null }>(),
 };
 
+function capDiagnosticsNodeMaps<
+  T extends {
+    hopHistory: Map<number, HopHistoryPoint[]>;
+    cuHistory: Map<number, CuSample[]>;
+    packetStats: Map<number, { total: number; duplicates: number }>;
+    pathUpdatedTimestamps: Map<number, number[]>;
+  },
+>(maps: T, keepNodeIds: Iterable<number>): T {
+  return {
+    ...maps,
+    hopHistory: trimMapToMaxSizeKeeping(
+      maps.hopHistory,
+      MAX_DIAGNOSTICS_TRACKED_NODES,
+      keepNodeIds,
+    ),
+    cuHistory: trimMapToMaxSizeKeeping(maps.cuHistory, MAX_DIAGNOSTICS_TRACKED_NODES, keepNodeIds),
+    packetStats: trimMapToMaxSizeKeeping(
+      maps.packetStats,
+      MAX_DIAGNOSTICS_TRACKED_NODES,
+      keepNodeIds,
+    ),
+    pathUpdatedTimestamps: trimMapToMaxSizeKeeping(
+      maps.pathUpdatedTimestamps,
+      MAX_DIAGNOSTICS_TRACKED_NODES,
+      keepNodeIds,
+    ),
+  };
+}
+
 /** Test-only: clear debounce state to prevent timer leakage across vitest cases. */
 export function resetDiagnosticsDebounceStateForTests(): void {
   if (diagnosticsDebounce.incrementalAnalysisTimer) {
@@ -852,7 +887,15 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
       const newPacketStats = new Map(state.packetStats);
       newPacketStats.set(node.node_id, { ...stats, total: stats.total + 1 });
 
-      return { hopHistory: newHopHistory, cuHistory: newCuHistory, packetStats: newPacketStats };
+      return capDiagnosticsNodeMaps(
+        {
+          hopHistory: newHopHistory,
+          cuHistory: newCuHistory,
+          packetStats: newPacketStats,
+          pathUpdatedTimestamps: state.pathUpdatedTimestamps,
+        },
+        [node.node_id],
+      );
     });
 
     // Buffer this node for debounced analysis
@@ -1226,6 +1269,9 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
     diagnosticsDebounce.pendingAnalyses.clear();
     if (diagnosticsDebounce.fullReanalysisTimer)
       clearTimeout(diagnosticsDebounce.fullReanalysisTimer);
+    const nodes = getNodes();
+    const reanalysisDelayMs =
+      nodes.size > LARGE_MESH_NODE_THRESHOLD ? LARGE_MESH_DIAGNOSTICS_REANALYSIS_DELAY_MS : 2000;
     diagnosticsDebounce.fullReanalysisTimer = setTimeout(() => {
       diagnosticsDebounce.fullReanalysisTimer = null;
       if (capabilities?.hasHopCount === false) {
@@ -1342,7 +1388,7 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
       );
       set({ diagnosticRows, diagnosticRowsRestoredAt: null });
       schedulePersistDiagnosticRows(() => get().diagnosticRows);
-    }, 2000);
+    }, reanalysisDelayMs);
   },
 
   setCongestionHalosEnabled(enabled: boolean) {

--- a/src/renderer/stores/nodeStore.ts
+++ b/src/renderer/stores/nodeStore.ts
@@ -20,6 +20,11 @@ import type {
   TraceRouteEvent,
   WaypointEvent,
 } from '../lib/protocols/Protocol';
+import {
+  MAX_MESHCORE_CLI_HISTORY_ENTRIES,
+  MAX_TRACE_ROUTES_PER_IDENTITY,
+  trimArrayTail,
+} from '../lib/sessionMemoryCaps';
 import type { IdentityId, MeshCoreLocalStats, MeshNeighbor } from '../lib/types';
 import { getConnection } from './connectionStore';
 import { getIdentity } from './identityStore';
@@ -420,7 +425,10 @@ export function addTraceRoute(identityId: IdentityId, event: TraceRouteEvent): v
   useNodeStore.setState((s) => ({
     traceRoutes: {
       ...s.traceRoutes,
-      [identityId]: [...(s.traceRoutes[identityId] ?? []), event],
+      [identityId]: trimArrayTail(
+        [...(s.traceRoutes[identityId] ?? []), event],
+        MAX_TRACE_ROUTES_PER_IDENTITY,
+      ),
     },
   }));
 }
@@ -473,7 +481,10 @@ export function appendMeshcoreCliEntry(
   useNodeStore.setState((s) => {
     const byId = s.nodes[identityId] ?? {};
     const existing = byId[nodeId];
-    const next = [...(existing?.meshcoreCliHistory ?? []), entry];
+    const next = trimArrayTail(
+      [...(existing?.meshcoreCliHistory ?? []), entry],
+      MAX_MESHCORE_CLI_HISTORY_ENTRIES,
+    );
     return {
       nodes: {
         ...s.nodes,

--- a/src/renderer/stores/reticulumIdentityActivityStore.ts
+++ b/src/renderer/stores/reticulumIdentityActivityStore.ts
@@ -1,6 +1,10 @@
 import { create } from 'zustand';
 
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
+import {
+  MAX_RETICULUM_IDENTITY_DESTINATIONS,
+  trimMapToMaxSize,
+} from '@/renderer/lib/sessionMemoryCaps';
 
 export interface ReticulumIdentityActivityRow {
   destination_hash: string;
@@ -34,7 +38,7 @@ export const useReticulumIdentityActivityStore = create<ReticulumIdentityActivit
         set((s) => {
           const next = new Map(s.byDestination);
           next.set(key, rows);
-          return { byDestination: next };
+          return { byDestination: trimMapToMaxSize(next, MAX_RETICULUM_IDENTITY_DESTINATIONS) };
         });
         return rows;
       } catch (e) {
@@ -60,7 +64,7 @@ export const useReticulumIdentityActivityStore = create<ReticulumIdentityActivit
         const prev = next.get(key) ?? [];
         const filtered = prev.filter((r) => r.aspect !== normalized.aspect);
         next.set(key, [normalized, ...filtered]);
-        return { byDestination: next };
+        return { byDestination: trimMapToMaxSize(next, MAX_RETICULUM_IDENTITY_DESTINATIONS) };
       });
     },
 

--- a/src/renderer/vitest.electronApiMock.ts
+++ b/src/renderer/vitest.electronApiMock.ts
@@ -42,6 +42,7 @@ export function createElectronAPIMock(): ElectronAPI {
       pruneNodesByCount: vi.fn().mockResolvedValue({ changes: 0 }),
       pruneMessagesByCount: vi.fn().mockResolvedValue({ changes: 0 }),
       pruneMeshcoreMessagesByCount: vi.fn().mockResolvedValue({ changes: 0 }),
+      pruneReticulumMessagesByCount: vi.fn().mockResolvedValue({ changes: 0 }),
       deleteNodesBatch: vi.fn().mockResolvedValue(0),
       clearMessagesByChannel: vi.fn().mockResolvedValue(undefined),
       getMessageChannels: vi.fn().mockResolvedValue([]),

--- a/src/shared/electron-api.types.ts
+++ b/src/shared/electron-api.types.ts
@@ -214,6 +214,7 @@ export interface ElectronAPI {
     pruneNodesByCount: (maxCount: number) => Promise<DbPruneResult>;
     pruneMessagesByCount: (maxCount: number) => Promise<DbPruneResult>;
     pruneMeshcoreMessagesByCount: (maxCount: number) => Promise<DbPruneResult>;
+    pruneReticulumMessagesByCount: (maxCount: number) => Promise<DbPruneResult>;
     deleteNodesNeverHeard: () => Promise<number>;
     deleteNodesBatch: (nodeIds: number[]) => Promise<number>;
     clearMessagesByChannel: (channel: number) => Promise<void>;


### PR DESCRIPTION
## Summary
- Replace meshcore.js `once()`-based repeater login/status/telemetry RPCs with prefix-matched listeners to avoid dropped responses on busy 354-repeater meshes.
- Cap unbounded in-memory stores across MeshCore, Meshtastic, and Reticulum; add 6-hour session DB prune and Reticulum message count pruning IPC.
- Patch meshcore.js to silently ignore push `0x8F` (143) and response 25, downgrade other unhandled frames to `console.debug`, and log main-process BLE health after 24h uptime to help diagnose multi-day `EXC_BREAKPOINT` crashes.

## Test plan
- [x] `pnpm run test:run` (pre-commit, 4050 tests)
- [ ] Connect MeshCore BLE-only to a busy repeater mesh; verify login/status/telemetry still succeed under concurrent traffic
- [ ] Leave app open >24h (or lower threshold locally) and confirm `[main] long-session health` log lines appear
- [ ] Confirm startup + 6h DB prune runs without errors (`runSessionDbPrune` / Reticulum prune IPC)
- [ ] Verify no `unhandled frame: code=143` spam in logs after meshcore.js patch