### PR TITLE
refactor: consolidate timeConstants shared import for CodeQL

### DIFF
--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -1,4 +1,10 @@
-import { MS_PER_MINUTE, MS_PER_SECOND } from '../../shared/timeConstants';
+import {
+  CHAT_COMPACT_CONTINUATION_TIME_GAP_MS,
+  MS_PER_DAY,
+  MS_PER_HOUR,
+  MS_PER_MINUTE,
+  MS_PER_SECOND,
+} from '../../shared/timeConstants';
 
 export {
   CHAT_COMPACT_CONTINUATION_TIME_GAP_MS,
@@ -6,7 +12,7 @@ export {
   MS_PER_HOUR,
   MS_PER_MINUTE,
   MS_PER_SECOND,
-} from '../../shared/timeConstants';
+};
 
 /** MeshCore Ping (`tracePath`) end-to-end cap (queue wait + radio); see `MESHCORE_TRACE_PING_TOTAL_TIMEOUT_MS`. */
 export const MESHCORE_TRACE_PING_TOTAL_TIMEOUT_MS = 180_000;


### PR DESCRIPTION
## Summary

- Consolidates `src/renderer/lib/timeConstants.ts` imports from `../../shared/timeConstants` into a single import block.
- Re-exports shared symbols locally instead of using a second `export { … } from` on the same path.
- Resolves CodeQL finding that `MS_PER_MINUTE` and `MS_PER_SECOND` were redundantly imported while also re-exported from the same module.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] Pre-commit hooks pass on commit
- [ ] CI green on PR