### PR TITLE
fix: configure apt for Linux arm64 cross-build on Ubuntu 24.04 CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,8 +46,7 @@ jobs:
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
+          bash scripts/ci-setup-linux-arm64-apt.sh
           sudo apt-get install -y \
             libudev-dev \
             libnss3 \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,8 +49,7 @@ jobs:
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
+          bash scripts/ci-setup-linux-arm64-apt.sh
           sudo apt-get install -y \
             libudev-dev \
             rpm \

--- a/scripts/ci-setup-linux-arm64-apt.sh
+++ b/scripts/ci-setup-linux-arm64-apt.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Configure apt for amd64 + arm64 cross-builds on Ubuntu 24.04 GitHub runners.
+#
+# Failure point: `dpkg --add-architecture arm64` without arch-pinned sources makes apt
+# request arm64 indexes from archive/security mirrors that only host amd64 → 404.
+# Fallback: pin existing deb822 stanzas to amd64 and add ports.ubuntu.com for arm64.
+# Refs: https://github.com/actions/runner-images/issues/10901
+set -euo pipefail
+
+ubuntu_sources=/etc/apt/sources.list.d/ubuntu.sources
+if [[ ! -f "${ubuntu_sources}" ]]; then
+  echo "ci-setup-linux-arm64-apt: expected ${ubuntu_sources} (Ubuntu 24.04 deb822 format)" >&2
+  exit 1
+fi
+
+sudo sed -i '/^Types: deb$/a Architectures: amd64' "${ubuntu_sources}"
+
+sudo tee /etc/apt/sources.list.d/arm64.list > /dev/null << 'EOF'
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-backports main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main restricted universe multiverse
+EOF
+
+sudo dpkg --add-architecture arm64
+sudo apt-get update


### PR DESCRIPTION
## Summary

- Add `scripts/ci-setup-linux-arm64-apt.sh` to pin Ubuntu 24.04 deb822 apt sources to `amd64` and route `arm64` packages through `ports.ubuntu.com` before enabling multiarch.
- Wire the script into the Linux dependency steps in `build.yaml` and `release.yaml`.

PR #616 added `dpkg --add-architecture arm64` for Reticulum sidecar cross-compilation (`libdbus-1-dev:arm64`, `gcc-aarch64-linux-gnu`). On `ubuntu-latest`, archive/security mirrors only publish amd64 indexes, so `apt-get update` 404'd on `binary-arm64/Packages` and blocked Linux packaging jobs ([run 28760885231](https://github.com/Colorado-Mesh/mesh-client/actions/runs/28760885231)).

## Test plan

- [ ] Re-run **Build Binaries (no release)** workflow and confirm the Ubuntu matrix job passes **Install Linux build dependencies**
- [ ] Confirm Linux artifacts (x64 + arm64 AppImage/deb/rpm) upload successfully
- [ ] Confirm packaging smoke tests pass on the downloaded Linux artifact