### PR TITLE
fix: Linux AppImage smoke test extract directory ENOENT

### DIFF
--- a/scripts/test-linux-appimage-reticulum-sidecar.mjs
+++ b/scripts/test-linux-appimage-reticulum-sidecar.mjs
@@ -5,9 +5,9 @@
  * Works when packaging-smoke artifacts include AppImages but not linux-unpacked dirs.
  */
 import { spawnSync } from 'child_process';
-import { existsSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
 import { tmpdir } from 'os';
-import path from 'path';
+import path, { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { assertBundledReticulumSidecarInBundle } from './assert-bundled-reticulum-sidecar.mjs';
 
@@ -26,9 +26,17 @@ function isArm64Name(name) {
   return /arm64|aarch64/i.test(name);
 }
 
+/** Prepare a clean extract directory for AppImage --appimage-extract (spawnSync needs existing cwd). */
+export function prepareAppImageExtractDir(extractDir) {
+  rmSync(extractDir, { recursive: true, force: true });
+  mkdirSync(extractDir, { recursive: true });
+}
+
 /** @param {string} appImagePath @param {string} extractDir */
 function extractAppImage(appImagePath, extractDir) {
-  rmSync(extractDir, { recursive: true, force: true });
+  prepareAppImageExtractDir(extractDir);
+  // Artifact downloads may drop +x on AppImages.
+  chmodSync(appImagePath, 0o755);
   const result = spawnSync(appImagePath, ['--appimage-extract'], {
     cwd: extractDir,
     stdio: 'inherit',
@@ -109,9 +117,13 @@ function main() {
   );
 }
 
-try {
-  main();
-} catch (e) {
-  console.error('[test-linux-appimage-reticulum-sidecar] Unexpected error:', e);
-  process.exit(1);
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  try {
+    main();
+  } catch (e) {
+    console.error('[test-linux-appimage-reticulum-sidecar] Unexpected error:', e);
+    process.exit(1);
+  }
 }

--- a/scripts/test-linux-appimage-reticulum-sidecar.test.mjs
+++ b/scripts/test-linux-appimage-reticulum-sidecar.test.mjs
@@ -1,0 +1,23 @@
+import { spawnSync } from 'child_process';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { prepareAppImageExtractDir } from './test-linux-appimage-reticulum-sidecar.mjs';
+
+describe('test-linux-appimage-reticulum-sidecar', () => {
+  it('prepareAppImageExtractDir creates cwd so spawnSync does not fail with ENOENT', () => {
+    const parent = mkdtempSync(path.join(tmpdir(), 'mesh-appimage-extract-'));
+    const extractDir = path.join(parent, 'extract');
+    try {
+      prepareAppImageExtractDir(extractDir);
+      expect(existsSync(extractDir)).toBe(true);
+
+      const result = spawnSync(process.execPath, ['-e', 'process.exit(0)'], { cwd: extractDir });
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `test-linux-appimage-reticulum-sidecar.mjs` failing in Linux `packaging-smoke` CI with `spawnSync ... AppImage ENOENT` after #616.
- Create the AppImage extract directory before `spawnSync` (Node treats a missing `cwd` as ENOENT on the executable path).
- `chmod` AppImages to `0o755` after artifact download, which can strip execute bits.
- Add `prepareAppImageExtractDir` regression test and guard `main()` with `isMain` for safe imports.

## Commits

- `5ff92779` fix: Linux AppImage smoke test extract directory ENOENT

## Test plan

- [x] `pnpm exec vitest run scripts/test-linux-appimage-reticulum-sidecar.test.mjs`
- [ ] CI `packaging-smoke` Linux job passes (`verify-linux-packaging.mjs` + `test-linux-appimage-reticulum-sidecar.mjs`)