### PR TITLE
fix: extract arm64 AppImages on x64 CI with unsquashfs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -164,6 +164,10 @@ jobs:
           name: ${{ matrix.artifact }}
           path: release
 
+      - name: Install squashfs-tools (cross-arch AppImage extract)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y squashfs-tools
+
       - name: Run packaging smoke test
         run: ${{ matrix.smoke_run }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -171,6 +171,10 @@ jobs:
           name: ${{ matrix.artifact }}
           path: release
 
+      - name: Install squashfs-tools (cross-arch AppImage extract)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y squashfs-tools
+
       - name: Run packaging smoke test
         run: ${{ matrix.smoke_run }}
 

--- a/scripts/test-linux-appimage-reticulum-sidecar.mjs
+++ b/scripts/test-linux-appimage-reticulum-sidecar.mjs
@@ -5,7 +5,18 @@
  * Works when packaging-smoke artifacts include AppImages but not linux-unpacked dirs.
  */
 import { spawnSync } from 'child_process';
-import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import path, { resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -26,6 +37,102 @@ function isArm64Name(name) {
   return /arm64|aarch64/i.test(name);
 }
 
+/** ELF e_machine values for Linux AppImage runtimes we ship. */
+export const EM_X86_64 = 62;
+export const EM_AARCH64 = 183;
+
+const SQUASHFS_MAGIC = Buffer.from('hsqs');
+
+/** @param {Buffer} header At least 20 bytes from the start of an ELF file. */
+export function readElfMachineFromHeader(header) {
+  if (
+    header.length < 20 ||
+    header[0] !== 0x7f ||
+    header[1] !== 0x45 ||
+    header[2] !== 0x4c ||
+    header[3] !== 0x46
+  ) {
+    return null;
+  }
+  return header.readUInt16LE(18);
+}
+
+/** @param {string} appImagePath */
+export function readElfMachine(appImagePath) {
+  const header = readBytes(appImagePath, 0, 20);
+  return readElfMachineFromHeader(header);
+}
+
+/** @param {string} [hostArch=process.arch] */
+export function hostElfMachine(hostArch = process.arch) {
+  if (hostArch === 'arm64') return EM_AARCH64;
+  if (hostArch === 'x64') return EM_X86_64;
+  return null;
+}
+
+/**
+ * True when the AppImage runtime cannot execute on this host (e.g. arm64 image on x64 CI).
+ * @param {string} appImagePath
+ * @param {string} [hostArch=process.arch]
+ */
+export function appImageNeedsUnsquashfsExtract(appImagePath, hostArch = process.arch) {
+  const imageMachine = readElfMachine(appImagePath);
+  const machine = hostElfMachine(hostArch);
+  if (imageMachine === null || machine === null) return false;
+  return imageMachine !== machine;
+}
+
+/** @param {string} filePath @param {number} offset @param {number} length */
+function readBytes(filePath, offset, length) {
+  const buf = Buffer.alloc(length);
+  const fd = openSync(filePath, 'r');
+  try {
+    const bytesRead = readSync(fd, buf, 0, length, offset);
+    return buf.subarray(0, bytesRead);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Locate embedded squashfs in a type-2 AppImage without executing it. */
+export function findSquashfsOffset(appImagePath) {
+  const type2Header = readBytes(appImagePath, 0, 16);
+  if (type2Header.length >= 16) {
+    const offset = Number(type2Header.readBigUInt64LE(8));
+    if (offset > 0) {
+      const magic = readBytes(appImagePath, offset, SQUASHFS_MAGIC.length);
+      if (magic.equals(SQUASHFS_MAGIC)) {
+        return offset;
+      }
+    }
+  }
+
+  const CHUNK_BYTES = 4 * 1024 * 1024;
+  const overlap = SQUASHFS_MAGIC.length - 1;
+  const { size } = statSync(appImagePath);
+  const fd = openSync(appImagePath, 'r');
+  try {
+    let pos = 0;
+    /** @type {Buffer} */
+    let prevTail = Buffer.alloc(0);
+    while (pos < size) {
+      const toRead = Math.min(CHUNK_BYTES, size - pos);
+      const chunk = Buffer.alloc(toRead);
+      readSync(fd, chunk, 0, toRead, pos);
+      const searchBuf = Buffer.concat([prevTail, chunk]);
+      const idx = searchBuf.indexOf(SQUASHFS_MAGIC);
+      if (idx !== -1) {
+        return pos - prevTail.length + idx;
+      }
+      prevTail = chunk.subarray(Math.max(0, chunk.length - overlap));
+      pos += toRead;
+    }
+  } finally {
+    closeSync(fd);
+  }
+  return null;
+}
+
 /** Prepare a clean extract directory for AppImage --appimage-extract (spawnSync needs existing cwd). */
 export function prepareAppImageExtractDir(extractDir) {
   rmSync(extractDir, { recursive: true, force: true });
@@ -33,8 +140,38 @@ export function prepareAppImageExtractDir(extractDir) {
 }
 
 /** @param {string} appImagePath @param {string} extractDir */
+function extractAppImageWithUnsquashfs(appImagePath, extractDir) {
+  const offset = findSquashfsOffset(appImagePath);
+  if (offset === null) {
+    fail(`Could not find squashfs payload in AppImage: ${appImagePath}`);
+  }
+  const payloadRoot = path.join(extractDir, 'squashfs-root');
+  const result = spawnSync(
+    'unsquashfs',
+    ['-f', '-o', String(offset), '-d', payloadRoot, appImagePath],
+    {
+      stdio: 'inherit',
+      env: process.env,
+    },
+  );
+  if (result.error) {
+    fail(`Failed to run unsquashfs (install squashfs-tools): ${result.error.message}`);
+  }
+  if ((result.status ?? 1) !== 0) {
+    fail(`unsquashfs exited ${result.status ?? 'null'} for ${appImagePath}`);
+  }
+  if (!existsSync(payloadRoot)) {
+    fail(`unsquashfs did not create squashfs-root under ${extractDir}`);
+  }
+  return payloadRoot;
+}
+
+/** @param {string} appImagePath @param {string} extractDir */
 function extractAppImage(appImagePath, extractDir) {
   prepareAppImageExtractDir(extractDir);
+  if (appImageNeedsUnsquashfsExtract(appImagePath)) {
+    return extractAppImageWithUnsquashfs(appImagePath, extractDir);
+  }
   // Artifact downloads may drop +x on AppImages.
   chmodSync(appImagePath, 0o755);
   const result = spawnSync(appImagePath, ['--appimage-extract'], {

--- a/scripts/test-linux-appimage-reticulum-sidecar.mjs
+++ b/scripts/test-linux-appimage-reticulum-sidecar.mjs
@@ -9,6 +9,7 @@ import {
   chmodSync,
   closeSync,
   existsSync,
+  fstatSync,
   mkdirSync,
   openSync,
   readSync,
@@ -109,9 +110,9 @@ export function findSquashfsOffset(appImagePath) {
 
   const CHUNK_BYTES = 4 * 1024 * 1024;
   const overlap = SQUASHFS_MAGIC.length - 1;
-  const { size } = statSync(appImagePath);
   const fd = openSync(appImagePath, 'r');
   try {
+    const { size } = fstatSync(fd);
     let pos = 0;
     /** @type {Buffer} */
     let prevTail = Buffer.alloc(0);

--- a/scripts/test-linux-appimage-reticulum-sidecar.test.mjs
+++ b/scripts/test-linux-appimage-reticulum-sidecar.test.mjs
@@ -1,9 +1,31 @@
 import { spawnSync } from 'child_process';
-import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { prepareAppImageExtractDir } from './test-linux-appimage-reticulum-sidecar.mjs';
+import {
+  EM_AARCH64,
+  EM_X86_64,
+  appImageNeedsUnsquashfsExtract,
+  findSquashfsOffset,
+  hostElfMachine,
+  prepareAppImageExtractDir,
+  readElfMachine,
+  readElfMachineFromHeader,
+} from './test-linux-appimage-reticulum-sidecar.mjs';
+
+/** @param {number} machine ELF e_machine */
+function makeElfHeader(machine) {
+  const header = Buffer.alloc(20);
+  header[0] = 0x7f;
+  header[1] = 0x45;
+  header[2] = 0x4c;
+  header[3] = 0x46;
+  header[4] = 2;
+  header[5] = 1;
+  header.writeUInt16LE(machine, 18);
+  return header;
+}
 
 describe('test-linux-appimage-reticulum-sidecar', () => {
   it('prepareAppImageExtractDir creates cwd so spawnSync does not fail with ENOENT', () => {
@@ -16,6 +38,48 @@ describe('test-linux-appimage-reticulum-sidecar', () => {
       const result = spawnSync(process.execPath, ['-e', 'process.exit(0)'], { cwd: extractDir });
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(0);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('readElfMachineFromHeader reads e_machine from ELF header bytes', () => {
+    expect(readElfMachineFromHeader(makeElfHeader(EM_X86_64))).toBe(EM_X86_64);
+    expect(readElfMachineFromHeader(makeElfHeader(EM_AARCH64))).toBe(EM_AARCH64);
+    expect(readElfMachineFromHeader(Buffer.from('not-elf'))).toBeNull();
+  });
+
+  it('appImageNeedsUnsquashfsExtract is true for cross-arch AppImages', () => {
+    const parent = mkdtempSync(path.join(tmpdir(), 'mesh-appimage-elf-'));
+    const appImagePath = path.join(parent, 'fake.AppImage');
+    try {
+      writeFileSync(appImagePath, makeElfHeader(EM_AARCH64));
+      expect(hostElfMachine('x64')).toBe(EM_X86_64);
+      expect(appImageNeedsUnsquashfsExtract(appImagePath, 'x64')).toBe(true);
+      expect(appImageNeedsUnsquashfsExtract(appImagePath, 'arm64')).toBe(false);
+      expect(readElfMachine(appImagePath)).toBe(EM_AARCH64);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('findSquashfsOffset reads type-2 header offset and falls back to hsqs scan', () => {
+    const parent = mkdtempSync(path.join(tmpdir(), 'mesh-appimage-sqfs-'));
+    const headerOffsetPath = path.join(parent, 'header.AppImage');
+    const scanPath = path.join(parent, 'scan.AppImage');
+    try {
+      const offset = 128;
+      const withHeader = Buffer.alloc(256);
+      withHeader.writeBigUInt64LE(BigInt(offset), 8);
+      withHeader.write('hsqs', offset);
+      writeFileSync(headerOffsetPath, withHeader);
+      expect(findSquashfsOffset(headerOffsetPath)).toBe(offset);
+
+      const scanOffset = 64;
+      const withoutHeader = Buffer.alloc(128);
+      withoutHeader.write('hsqs', scanOffset);
+      writeFileSync(scanPath, withoutHeader);
+      expect(findSquashfsOffset(scanPath)).toBe(scanOffset);
     } finally {
       rmSync(parent, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Fix Linux `packaging-smoke` CI failing when verifying the arm64 AppImage Reticulum sidecar on `ubuntu-latest` (x64 runners).
- Detect cross-arch AppImages via ELF `e_machine` and extract the embedded squashfs with `unsquashfs` instead of running `--appimage-extract`.
- Parse type-2 AppImage payload offset from the header with `hsqs` magic fallback scan.
- Install `squashfs-tools` in Linux packaging-smoke workflow steps (`build.yaml` + `release.yaml`).
- Add unit tests for ELF detection, cross-arch gating, and squashfs offset lookup.

## Commits

- `38601d50` fix: extract arm64 AppImages on x64 CI with unsquashfs

## Context

#618 fixed ENOENT when the extract directory was missing before `spawnSync`. The x64 AppImage smoke check then passed, but arm64 still failed with:

```
Mesh-client-5.20.4-arm64.AppImage: 2: Syntax error: "(" unexpected
```

x64 runners cannot execute aarch64 AppImage runtimes, so extraction must not depend on running the outer ELF.

## Test plan

- [x] `pnpm exec vitest run scripts/test-linux-appimage-reticulum-sidecar.test.mjs`
- [ ] CI `packaging-smoke` Linux job passes (`verify-linux-packaging.mjs` + `test-linux-appimage-reticulum-sidecar.mjs`)