### PR TITLE
fix: stop MeshCore auto-reconnect after manual disconnect

### DIFF
--- a/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
+++ b/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
@@ -214,6 +214,7 @@ export function attachMeshcoreLegacyConnEvents(
     teardownMeshcoreConnEventListeners,
     meshcorePreviousNodesBaselineForBuild,
     handleConnectionLostRef,
+    meshcoreExplicitDisconnectRef,
     bumpLastDataReceived,
   } = ctx;
 
@@ -1494,7 +1495,7 @@ export function attachMeshcoreLegacyConnEvents(
           console.debug('[meshcoreLegacyConnEvents] stale conn close ' + errLikeToLogString(e));
         });
       }
-      if (shouldReconnect) {
+      if (shouldReconnect && !meshcoreExplicitDisconnectRef.current) {
         handleConnectionLostRef.current();
       }
     });

--- a/src/renderer/hooks/meshcore/meshcoreLegacyConnEventsCtx.ts
+++ b/src/renderer/hooks/meshcore/meshcoreLegacyConnEventsCtx.ts
@@ -84,5 +84,6 @@ export interface MeshcoreLegacyConnEventsCtx {
   teardownMeshcoreConnEventListeners: (opts?: { driverDisconnect?: boolean }) => void;
   meshcorePreviousNodesBaselineForBuild: () => Map<number, MeshNode>;
   handleConnectionLostRef: RefObject<() => void>;
+  meshcoreExplicitDisconnectRef: RefObject<boolean>;
   bumpLastDataReceived?: () => void;
 }

--- a/src/renderer/hooks/useProtocolConnection.test.ts
+++ b/src/renderer/hooks/useProtocolConnection.test.ts
@@ -140,7 +140,7 @@ describe('useProtocolDisconnect (driver-first)', () => {
     });
   });
 
-  it('finalizes session with driver disconnect (single teardown owner)', async () => {
+  it('finalizes Meshtastic session with driver disconnect (Connection panel path)', async () => {
     const meshtastic = createMeshtasticSessionStub();
     registerMeshtasticSession(meshtastic);
     const { result } = renderHook(() => useProtocolDisconnect());
@@ -148,6 +148,16 @@ describe('useProtocolDisconnect (driver-first)', () => {
     await result.current('meshtastic');
 
     expect(meshtastic.finalizeDriverDisconnect).toHaveBeenCalledWith({ disconnectDriver: true });
+  });
+
+  it('finalizes MeshCore session with driver disconnect (Connection panel path)', async () => {
+    const meshcore = createMeshcoreSessionStub();
+    registerMeshcoreSession(meshcore);
+    const { result } = renderHook(() => useProtocolDisconnect());
+
+    await result.current('meshcore');
+
+    expect(meshcore.finalizeDriverDisconnect).toHaveBeenCalledWith({ disconnectDriver: true });
   });
 });
 
@@ -241,7 +251,7 @@ describe('useProtocolDisconnect (reticulum)', () => {
     registerReticulumSession(null);
   });
 
-  it('finalizes reticulum session on disconnect', async () => {
+  it('finalizes Reticulum session on disconnect (Connection panel path)', async () => {
     const reticulum = createReticulumSessionStub();
     registerReticulumSession(reticulum);
     const { result } = renderHook(() => useProtocolDisconnect());

--- a/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { extractUseCallbackBody } from '../lib/sourceContractTestHelpers';
+
 const RUNTIME_SOURCE = readFileSync(join(__dirname, '../runtime/useMeshcoreRuntime.ts'), 'utf-8');
 const CONN_EVENTS_SOURCE = readFileSync(
   join(__dirname, '../hooks/meshcore/meshcoreLegacyConnEvents.ts'),
@@ -72,10 +74,53 @@ describe('useMeshcoreRuntime auto-reconnect (regression)', () => {
   });
 });
 
+describe('useMeshcoreRuntime manual disconnect must not auto-reconnect', () => {
+  it('finalizeDriverDisconnect clears reconnect session before teardown', () => {
+    const finalizeBody = extractUseCallbackBody(RUNTIME_SOURCE, 'finalizeDriverDisconnect');
+    expect(finalizeBody.length).toBeGreaterThan(0);
+    expect(finalizeBody).toContain('meshcoreExplicitDisconnectRef.current = true');
+    expect(finalizeBody).toContain('meshcoreConnectionParamsRef.current = null');
+    expect(finalizeBody).toContain('meshcoreIsReconnectingRef.current = false');
+    expect(finalizeBody).toContain('meshcoreReconnectAttemptRef.current = 0');
+    expect(finalizeBody).toContain('meshcoreReconnectGenerationRef.current += 1');
+    expect(finalizeBody).toContain('meshcoreEverConfiguredRef.current = false');
+    const teardownIndex = finalizeBody.indexOf('teardownMeshcoreConnEventListeners');
+    const explicitIndex = finalizeBody.indexOf('meshcoreExplicitDisconnectRef.current = true');
+    expect(explicitIndex).toBeGreaterThanOrEqual(0);
+    expect(teardownIndex).toBeGreaterThan(explicitIndex);
+  });
+
+  it('disconnect delegates to finalizeDriverDisconnect (Connection panel path)', () => {
+    const disconnectBody = extractUseCallbackBody(RUNTIME_SOURCE, 'disconnect');
+    expect(disconnectBody).toContain('finalizeDriverDisconnect({ disconnectDriver: true })');
+    expect(disconnectBody).not.toContain('meshcoreConnectionParamsRef.current = null');
+  });
+
+  it('handleMeshcoreConnectionLost returns early on explicit user disconnect', () => {
+    const lostBody = extractUseCallbackBody(RUNTIME_SOURCE, 'handleMeshcoreConnectionLost');
+    expect(lostBody).toMatch(
+      /if \(meshcoreExplicitDisconnectRef\.current\) \{[\s\S]*?skip reconnect \(user disconnect\)/,
+    );
+  });
+
+  it('attemptMeshcoreReconnect returns when connection params are cleared', () => {
+    const reconnectBody = extractUseCallbackBody(RUNTIME_SOURCE, 'attemptMeshcoreReconnect');
+    expect(reconnectBody).toMatch(
+      /if \(!params\) \{[\s\S]*?meshcoreIsReconnectingRef\.current = false/,
+    );
+  });
+});
+
 describe('meshcoreLegacyConnEvents disconnected handler (regression)', () => {
   it('triggers handleConnectionLost when an operational session drops', () => {
     expect(CONN_EVENTS_SOURCE).toMatch(
       /onMeshcoreConn\('disconnected'[\s\S]{0,2000}handleConnectionLostRef\.current\(\)/,
+    );
+  });
+
+  it('skips handleConnectionLost on explicit user disconnect', () => {
+    expect(CONN_EVENTS_SOURCE).toMatch(
+      /if \(shouldReconnect && !meshcoreExplicitDisconnectRef\.current\)/,
     );
   });
 

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -1682,6 +1682,7 @@ export function useMeshcoreRuntime() {
       teardownMeshcoreConnEventListeners,
       meshcorePreviousNodesBaselineForBuild,
       handleConnectionLostRef: handleMeshcoreConnectionLostRef,
+      meshcoreExplicitDisconnectRef,
       bumpLastDataReceived: bumpMeshcoreLastDataReceived,
     }),
     [
@@ -2380,6 +2381,12 @@ export function useMeshcoreRuntime() {
   const finalizeDriverDisconnect = useCallback(
     async (opts?: { disconnectDriver?: boolean }) => {
       const disconnectDriver = opts?.disconnectDriver !== false;
+      meshcoreExplicitDisconnectRef.current = true;
+      meshcoreEverConfiguredRef.current = false;
+      meshcoreConnectionParamsRef.current = null;
+      meshcoreIsReconnectingRef.current = false;
+      meshcoreReconnectAttemptRef.current = 0;
+      meshcoreReconnectGenerationRef.current += 1;
       meshcoreSetupGenerationRef.current += 1;
       const ackEntries = new Set(pendingAcksRef.current.values());
       for (const e of ackEntries) {
@@ -2591,6 +2598,10 @@ export function useMeshcoreRuntime() {
   attemptMeshcoreReconnectRef.current = attemptMeshcoreReconnect;
 
   const handleMeshcoreConnectionLost = useCallback(() => {
+    if (meshcoreExplicitDisconnectRef.current) {
+      console.debug('[useMeshcoreRuntime] skip reconnect (user disconnect)');
+      return;
+    }
     if (
       !meshcoreEverConfiguredRef.current &&
       meshcoreReconnectAttemptRef.current === 0 &&
@@ -2921,12 +2932,6 @@ export function useMeshcoreRuntime() {
   );
 
   const disconnect = useCallback(async () => {
-    meshcoreExplicitDisconnectRef.current = true;
-    meshcoreEverConfiguredRef.current = false;
-    meshcoreConnectionParamsRef.current = null;
-    meshcoreIsReconnectingRef.current = false;
-    meshcoreReconnectAttemptRef.current = 0;
-    meshcoreReconnectGenerationRef.current += 1;
     await finalizeDriverDisconnect({ disconnectDriver: true });
   }, [finalizeDriverDisconnect]);
 

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -82,3 +82,39 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     );
   });
 });
+
+describe('useMeshtasticRuntime manual disconnect must not auto-reconnect', () => {
+  it('finalizeDriverDisconnect clears reconnect session before driver teardown', () => {
+    const finalizeBody = extractUseCallbackBody(SOURCE, 'finalizeDriverDisconnect');
+    expect(finalizeBody.length).toBeGreaterThan(0);
+    expect(finalizeBody).toContain('meshtasticExplicitDisconnectRef.current = true');
+    expect(finalizeBody).toContain('connectionParamsRef.current = null');
+    expect(finalizeBody).toContain('isReconnectingRef.current = false');
+    expect(finalizeBody).toContain('reconnectAttemptRef.current = 0');
+    expect(finalizeBody).toContain('reconnectGenerationRef.current++');
+    const driverIndex = finalizeBody.indexOf('connectionDriver.disconnect');
+    const explicitIndex = finalizeBody.indexOf('meshtasticExplicitDisconnectRef.current = true');
+    expect(explicitIndex).toBeGreaterThanOrEqual(0);
+    if (driverIndex >= 0) {
+      expect(driverIndex).toBeGreaterThan(explicitIndex);
+    }
+  });
+
+  it('attemptReconnect returns when connection params are cleared', () => {
+    const reconnectBody = extractUseCallbackBody(SOURCE, 'attemptReconnect');
+    expect(reconnectBody).toMatch(/if \(!params\) \{[\s\S]*?isReconnectingRef\.current = false/);
+  });
+
+  it('Noble BLE disconnect handler respects explicit user disconnect before rehydrate', () => {
+    expect(SOURCE).toMatch(
+      /onNobleBleDisconnected[\s\S]*?meshtasticExplicitDisconnectRef\.current[\s\S]*?skip reconnect \(user disconnect\)/,
+    );
+  });
+
+  it('onPowerResume skips reconnect after explicit user disconnect', () => {
+    const resumeBody = extractUseCallbackBody(SOURCE, 'onPowerResume');
+    expect(resumeBody).toMatch(
+      /meshtasticExplicitDisconnectRef\.current[\s\S]*?skip reconnect \(user disconnect\)/,
+    );
+  });
+});

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -2230,6 +2230,7 @@ export function useMeshtasticRuntime() {
       cleanupSubscriptions();
       stopWatchdog();
       stopGpsInterval();
+      meshtasticExplicitDisconnectRef.current = true;
       isReconnectingRef.current = false;
       reconnectAttemptRef.current = 0;
       reconnectGenerationRef.current++;

--- a/src/renderer/runtime/useReticulumRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useReticulumRuntime.reconnect-hardening.test.ts
@@ -24,3 +24,36 @@ describe('useReticulumRuntime reconnect hardening (regression)', () => {
     expect(SOURCE).not.toMatch(/const wasActive = stateRef\.current\.status !== 'disconnected'/);
   });
 });
+
+describe('useReticulumRuntime manual disconnect must not auto-reconnect', () => {
+  it('finalizeDriverDisconnect delegates to full disconnect', () => {
+    expect(SOURCE).toMatch(
+      /finalizeDriverDisconnect: async \(\) => \{[\s\S]*?await disconnect\(\)/,
+    );
+  });
+
+  it('disconnect sets suppressReconnect before stopping sidecar', () => {
+    const disconnectRe =
+      /const disconnect = useCallback\(async \(\) => \{[\s\S]*?\}, \[syncConnectionStore\]\);/;
+    const disconnectBody = disconnectRe.exec(SOURCE)?.[0];
+    expect(disconnectBody).toBeDefined();
+    expect(disconnectBody).toContain('suppressReconnectRef.current = true');
+    const suppressIndex = disconnectBody!.indexOf('suppressReconnectRef.current = true');
+    const stopIndex = disconnectBody!.indexOf('reticulum.stop()');
+    expect(suppressIndex).toBeGreaterThanOrEqual(0);
+    expect(stopIndex).toBeGreaterThan(suppressIndex);
+  });
+
+  it('sidecar stop autostart reconnect respects suppressReconnect', () => {
+    expect(SOURCE).toMatch(/isReticulumAutostartEnabled\(\) && !suppressReconnectRef\.current/);
+  });
+
+  it('onPowerResume skips reconnect after explicit user disconnect', () => {
+    const resumeRe = /const onPowerResume = useCallback\([\s\S]*?\}, \[connect\]\);/;
+    const resumeBody = resumeRe.exec(SOURCE)?.[0];
+    expect(resumeBody).toBeDefined();
+    expect(resumeBody).toMatch(
+      /suppressReconnectRef\.current[\s\S]*?skip reconnect \(user disconnect\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Clear MeshCore reconnect session state (`connectionParams`, explicit-disconnect flag, reconnect generation) at the start of `finalizeDriverDisconnect`, which is what the Connection panel calls via `useProtocolDisconnect`.
- Add defense-in-depth guards in `handleMeshcoreConnectionLost` and `meshcoreLegacyConnEvents` so intentional disconnect never schedules reconnect.
- Set `meshtasticExplicitDisconnectRef` in Meshtastic `finalizeDriverDisconnect` for Noble BLE parity.
- Add cross-protocol source contract tests (MeshCore, Meshtastic, Reticulum) plus `useProtocolConnection` wiring tests for the Connection panel disconnect path.

## Problem

Clicking **Disconnect radio** on the MeshCore Connection panel triggered auto-reconnect because `useProtocolDisconnect` only called `finalizeDriverDisconnect`, which did not clear reconnect params. Meshtastic already cleared `connectionParamsRef` in finalize; Reticulum already delegates finalize to full `disconnect()`.

## Test plan

- [x] `pnpm run test:run -- src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts src/renderer/runtime/useReticulumRuntime.reconnect-hardening.test.ts src/renderer/hooks/useProtocolConnection.test.ts`
- [ ] Connect MeshCore (BLE or serial), click Disconnect — status stays `disconnected`, no reconnect banner
- [ ] Unplug device while connected — auto-reconnect still works
- [ ] Repeat disconnect check on Meshtastic and Reticulum (stop stack)