### PR TITLE
fix: harden arm64 apt CI setup script for re-runs and release upgrades

### DIFF
--- a/scripts/ci-setup-linux-arm64-apt.sh
+++ b/scripts/ci-setup-linux-arm64-apt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Configure apt for amd64 + arm64 cross-builds on Ubuntu 24.04 GitHub runners.
+# Configure apt for amd64 + arm64 cross-builds on Ubuntu GitHub runners.
 #
 # Failure point: `dpkg --add-architecture arm64` without arch-pinned sources makes apt
 # request arm64 indexes from archive/security mirrors that only host amd64 → 404.
@@ -7,19 +7,35 @@
 # Refs: https://github.com/actions/runner-images/issues/10901
 set -euo pipefail
 
-ubuntu_sources=/etc/apt/sources.list.d/ubuntu.sources
-if [[ ! -f "${ubuntu_sources}" ]]; then
-  echo "ci-setup-linux-arm64-apt: expected ${ubuntu_sources} (Ubuntu 24.04 deb822 format)" >&2
+ubuntu_codename=""
+if [[ -r /etc/os-release ]]; then
+  # shellcheck source=/dev/null
+  . /etc/os-release
+  ubuntu_codename="${VERSION_CODENAME:-}"
+fi
+if [[ -z "${ubuntu_codename}" ]] && command -v lsb_release > /dev/null 2>&1; then
+  ubuntu_codename="$(lsb_release -cs)"
+fi
+if [[ -z "${ubuntu_codename}" ]]; then
+  echo "ci-setup-linux-arm64-apt: could not determine Ubuntu release codename" >&2
   exit 1
 fi
 
-sudo sed -i '/^Types: deb$/a Architectures: amd64' "${ubuntu_sources}"
+ubuntu_sources=/etc/apt/sources.list.d/ubuntu.sources
+if [[ ! -f "${ubuntu_sources}" ]]; then
+  echo "ci-setup-linux-arm64-apt: expected ${ubuntu_sources} (Ubuntu deb822 format)" >&2
+  exit 1
+fi
 
-sudo tee /etc/apt/sources.list.d/arm64.list > /dev/null << 'EOF'
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-backports main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main restricted universe multiverse
+if ! grep -q '^Architectures:' "${ubuntu_sources}"; then
+  sudo sed -i '/^Types: deb$/a Architectures: amd64' "${ubuntu_sources}"
+fi
+
+sudo tee /etc/apt/sources.list.d/arm64.list > /dev/null << EOF
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_codename} main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_codename}-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_codename}-backports main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${ubuntu_codename}-security main restricted universe multiverse
 EOF
 
 sudo dpkg --add-architecture arm64


### PR DESCRIPTION
## Summary

- Skip the `ubuntu.sources` `sed` step when `Architectures:` is already present, so re-running the script does not duplicate stanzas and break `apt-get update`.
- Derive the Ubuntu release codename from `/etc/os-release` (`VERSION_CODENAME`, with `lsb_release -cs` fallback) instead of hardcoding `noble` in the arm64 ports sources list.

## Test plan

- [ ] Linux CI build/release workflows pass on `ubuntu-24.04` (codename still resolves to `noble`).
- [ ] Re-running `scripts/ci-setup-linux-arm64-apt.sh` on a configured runner does not add duplicate `Architectures:` lines.