### PR TITLE
fix: gate release publish on single draft GitHub release

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -139,6 +139,8 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/download-artifact@v8
         with:
           pattern: 'org.coloradomesh.MeshClient-*'
@@ -160,6 +162,11 @@ jobs:
             rm -rf "$dir"
             mv "$staging" "flatpak-dist/${name}"
           done
+
+      - name: Ensure draft GitHub release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/ci-ensure-github-draft-release.mjs
 
       - name: Attach Flatpak to release
         # softprops/action-gh-release v3 (Node 24)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,28 @@ on:
       - 'v*'
   workflow_dispatch:
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  prepare-github-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Ensure draft GitHub release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/ci-ensure-github-draft-release.mjs
+
   release:
+    needs: prepare-github-release
+    if: ${{ !cancelled() && needs.prepare-github-release.result != 'failure' }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -54,13 +54,14 @@ Test results are available as a downloadable artifact from the workflow run.
 
 Triggered by pushing a version tag (e.g., `v1.2.3`):
 
-1. Builds for all three platforms in parallel:
+1. **`prepare-github-release`** — creates a single draft GitHub release for the tag (prevents parallel electron-builder jobs from creating duplicate drafts and 404 asset uploads)
+2. Builds for all three platforms in parallel:
    - `macos-latest` → `pnpm run dist:mac:publish`
    - `ubuntu-latest` → `pnpm run dist:linux:publish`
    - `windows-latest` → `pnpm run dist:win:publish`
-2. Rebuilds native dependencies (`pnpm run rebuild`)
-3. Installs Linux build dependencies (`libudev-dev`, `rpm`)
-4. Publishes artifacts to GitHub Releases
+3. Rebuilds native dependencies (`pnpm run rebuild`)
+4. Installs Linux build dependencies (`libudev-dev`, `rpm`)
+5. Publishes artifacts to GitHub Releases
 
 Linux packaging smoke (`verify-linux-packaging.mjs`) asserts `.deb` **Description** metadata is ASCII-only. See [Release Process](release-process.md).
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -197,6 +197,12 @@ Follow [Semantic Versioning](https://semver.org/):
 
 - Confirm the workflow job has `contents: write`
 - Publishing uses `GITHUB_TOKEN` as `GH_TOKEN`; forked or restricted workflows may lack upload permission
+- **404 uploading to `/releases/{id}/assets`:** parallel `dist:*:publish` jobs raced and created duplicate draft releases. Re-run the failed release workflow after merging the `prepare-github-release` gate (or delete orphan drafts and re-run). Do not PATCH release `tag_name` via API while CI is uploading — that orphans in-flight upload targets.
+
+### Duplicate draft releases for one tag
+
+- Caused by concurrent electron-builder publish before the shared draft exists. `release.yaml` now runs `scripts/ci-ensure-github-draft-release.mjs` once before the macOS/Linux/Windows matrix.
+- To recover on a broken tag: delete orphan draft releases in GitHub → Releases, keep the draft that has the most assets (or none), re-run **Build/Release Electron App** on the tag.
 
 ### Tag already exists
 

--- a/scripts/ci-ensure-github-draft-release.mjs
+++ b/scripts/ci-ensure-github-draft-release.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Ensure a draft GitHub release exists for the current tag before parallel
+ * electron-builder --publish always jobs run.
+ *
+ * Failure point: concurrent publish jobs each create their own draft release;
+ * uploads to the loser release id 404 when GitHub consolidates/deletes it.
+ * Fallback: create once here; matrix jobs attach assets to the same release.
+ */
+
+const OWNER = 'Colorado-Mesh';
+const REPO = 'mesh-client';
+const API_ROOT = `https://api.github.com/repos/${OWNER}/${REPO}`;
+
+function fail(message) {
+  console.error(`[ci-ensure-github-draft-release] ${message}`);
+  process.exit(1);
+}
+
+function resolveTag(argv, env) {
+  const flagIndex = argv.indexOf('--tag');
+  if (flagIndex >= 0 && argv[flagIndex + 1]) {
+    return argv[flagIndex + 1];
+  }
+  const ref = env.GITHUB_REF ?? '';
+  if (ref.startsWith('refs/tags/')) {
+    return ref.slice('refs/tags/'.length);
+  }
+  fail('Missing tag: pass --tag vX.Y.Z or run on a refs/tags/v* workflow ref');
+}
+
+function authToken(env) {
+  const token = env.GH_TOKEN ?? env.GITHUB_TOKEN;
+  if (!token) {
+    fail('GH_TOKEN or GITHUB_TOKEN is required');
+  }
+  return token;
+}
+
+async function githubRequest(path, { token, method = 'GET', body } = {}) {
+  const response = await fetch(`${API_ROOT}${path}`, {
+    method,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await response.text();
+  let json = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = { message: text };
+    }
+  }
+
+  return { response, json };
+}
+
+async function getReleaseByTag(tag, token) {
+  const { response, json } = await githubRequest(`/releases/tags/${encodeURIComponent(tag)}`, {
+    token,
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    fail(
+      `GET release for ${tag} failed (${response.status}): ${json?.message ?? response.statusText}`,
+    );
+  }
+  return json;
+}
+
+async function createDraftRelease(tag, token) {
+  const version = tag.startsWith('v') ? tag.slice(1) : tag;
+  const { response, json } = await githubRequest('/releases', {
+    token,
+    method: 'POST',
+    body: {
+      tag_name: tag,
+      name: version,
+      draft: true,
+      generate_release_notes: false,
+      body: `Draft release for ${tag}. CI is uploading platform artifacts.`,
+    },
+  });
+
+  if (response.status === 422) {
+    // Another job won the race — re-fetch by tag.
+    const existing = await getReleaseByTag(tag, token);
+    if (existing) {
+      return existing;
+    }
+  }
+
+  if (!response.ok) {
+    fail(
+      `POST draft release for ${tag} failed (${response.status}): ${json?.message ?? response.statusText}`,
+    );
+  }
+
+  return json;
+}
+
+export async function ensureGithubDraftRelease({ tag, token, log = console.debug }) {
+  const existing = await getReleaseByTag(tag, token);
+  if (existing) {
+    log(`[ci-ensure-github-draft-release] Using existing release ${existing.id} for ${tag}`);
+    return existing;
+  }
+
+  const created = await createDraftRelease(tag, token);
+  log(`[ci-ensure-github-draft-release] Created draft release ${created.id} for ${tag}`);
+  return created;
+}
+
+import { pathToFileURL } from 'node:url';
+
+async function main() {
+  const tag = resolveTag(process.argv.slice(2), process.env);
+  const token = authToken(process.env);
+  await ensureGithubDraftRelease({ tag, token });
+}
+
+const entry = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (entry && import.meta.url === entry) {
+  main().catch((error) => {
+    const detail = error instanceof Error ? error.message : String(error);
+    fail(`Unexpected error: ${detail}`);
+  });
+}

--- a/scripts/ci-ensure-github-draft-release.test.mjs
+++ b/scripts/ci-ensure-github-draft-release.test.mjs
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ensureGithubDraftRelease } from './ci-ensure-github-draft-release.mjs';
+
+const TAG = 'v5.21.0';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('ensureGithubDraftRelease', () => {
+  it('returns existing release when tag is already published as draft', async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      expect(init?.method ?? 'GET').toBe('GET');
+      expect(String(url)).toContain(`/releases/tags/${TAG}`);
+      return new Response(JSON.stringify({ id: 42, tag_name: TAG, draft: true }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const release = await ensureGithubDraftRelease({
+      tag: TAG,
+      token: 'test-token',
+      log: () => {},
+    });
+
+    expect(release.id).toBe(42);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a draft release when tag has no release yet', async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const method = init?.method ?? 'GET';
+      const href = String(url);
+      if (method === 'GET' && href.includes(`/releases/tags/${TAG}`)) {
+        return new Response(JSON.stringify({ message: 'Not Found' }), { status: 404 });
+      }
+      if (method === 'POST' && href.endsWith('/releases')) {
+        return new Response(JSON.stringify({ id: 99, tag_name: TAG, draft: true }), {
+          status: 201,
+        });
+      }
+      throw new Error(`Unexpected fetch ${method} ${href}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const release = await ensureGithubDraftRelease({
+      tag: TAG,
+      token: 'test-token',
+      log: () => {},
+    });
+
+    expect(release.id).toBe(99);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const createCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST');
+    expect(JSON.parse(createCall[1].body)).toMatchObject({
+      tag_name: TAG,
+      name: '5.21.0',
+      draft: true,
+    });
+  });
+
+  it('re-fetches when create hits a 422 race', async () => {
+    let getCount = 0;
+    const fetchMock = vi.fn(async (url, init) => {
+      const method = init?.method ?? 'GET';
+      const href = String(url);
+      if (method === 'GET' && href.includes(`/releases/tags/${TAG}`)) {
+        getCount += 1;
+        if (getCount === 1) {
+          return new Response(JSON.stringify({ message: 'Not Found' }), { status: 404 });
+        }
+        return new Response(JSON.stringify({ id: 7, tag_name: TAG, draft: true }), {
+          status: 200,
+        });
+      }
+      if (method === 'POST' && href.endsWith('/releases')) {
+        return new Response(JSON.stringify({ message: 'Already exists' }), { status: 422 });
+      }
+      throw new Error(`Unexpected fetch ${method} ${href}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const release = await ensureGithubDraftRelease({
+      tag: TAG,
+      token: 'test-token',
+      log: () => {},
+    });
+
+    expect(release.id).toBe(7);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `scripts/ci-ensure-github-draft-release.mjs` to create exactly one draft GitHub release per tag before any CI upload step runs.
- Wire a `prepare-github-release` job into `release.yaml` (with per-tag workflow concurrency) so macOS/Linux/Windows `dist:*:publish` jobs attach to the same release instead of racing duplicate drafts.
- Call the same ensure step from `flatpak.yaml` before attaching Flatpak bundles.
- Document recovery steps for 404 asset uploads and duplicate draft releases.

## Problem

[v5.21.0 release run 28905923567](https://github.com/Colorado-Mesh/mesh-client/actions/runs/28905923567) failed on Linux publish with **404** uploading to `/releases/350624950/assets`. Parallel electron-builder jobs each created their own draft release; Linux targeted the orphan draft that was removed when the other draft won.

## Test plan

- [x] `pnpm exec vitest run scripts/ci-ensure-github-draft-release.test.mjs`
- [x] `actionlint` on updated workflows
- [ ] After merge: convert `v5.21.0` back to draft (if needed), re-run **Build/Release Electron App** on the tag and confirm Linux/Windows assets land on the same release as macOS