### PR TITLE
fix: harden release workflow against duplicate drafts and retag races

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -165,10 +165,15 @@ jobs:
             mv "$staging" "flatpak-dist/${name}"
           done
 
+      - name: Resolve release tag from package.json
+        id: release_tag
+        run: echo "value=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Ensure draft GitHub release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
         run: node scripts/ci-ensure-github-draft-release.mjs
 
       - name: Attach Flatpak to release

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -140,6 +140,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,17 +17,18 @@ on:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   prepare-github-release:
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
 
       - name: Ensure draft GitHub release exists
         env:
@@ -44,6 +45,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
 
       - name: Resolve release matrix
         id: matrix
@@ -67,6 +70,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,10 +30,15 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Resolve release tag from package.json
+        id: release_tag
+        run: echo "value=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Ensure draft GitHub release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
         run: node scripts/ci-ensure-github-draft-release.mjs
 
   resolve-release-matrix:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -54,8 +54,8 @@ Test results are available as a downloadable artifact from the workflow run.
 
 Triggered by pushing a version tag (e.g., `v1.2.3`):
 
-1. **`prepare-github-release`** — creates a single draft GitHub release for the tag (prevents parallel electron-builder jobs from creating duplicate drafts and 404 asset uploads)
-2. Builds for all three platforms in parallel:
+1. **`prepare-github-release`** — creates a single draft GitHub release for the tag (prevents parallel electron-builder jobs from creating duplicate drafts and 404 asset uploads). Also runs for `workflow_dispatch` rebuilds (tag resolved from `package.json`).
+2. Builds for all three platforms in parallel (or a filtered subset on `workflow_dispatch`):
    - `macos-latest` → `pnpm run dist:mac:publish`
    - `ubuntu-latest` → `pnpm run dist:linux:publish`
    - `windows-latest` → `pnpm run dist:win:publish`

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -54,7 +54,7 @@ Test results are available as a downloadable artifact from the workflow run.
 
 Triggered by pushing a version tag (e.g., `v1.2.3`):
 
-1. **`prepare-github-release`** — creates a single draft GitHub release for the tag (prevents parallel electron-builder jobs from creating duplicate drafts and 404 asset uploads). Also runs for `workflow_dispatch` rebuilds (tag resolved from `package.json`).
+1. **`prepare-github-release`** — creates a single draft GitHub release for the tag (prevents parallel electron-builder jobs from creating duplicate drafts and 404 asset uploads). On `workflow_dispatch`, the tag is resolved in the workflow from `package.json` and passed as `RELEASE_TAG` (not read inside the release API script — avoids CodeQL `js/file-access-to-http`).
 2. Builds for all three platforms in parallel (or a filtered subset on `workflow_dispatch`):
    - `macos-latest` → `pnpm run dist:mac:publish`
    - `ubuntu-latest` → `pnpm run dist:linux:publish`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -204,6 +204,8 @@ Follow [Semantic Versioning](https://semver.org/):
 - Caused when GitHub’s `GET /releases/tags/{tag}` returns **404** while multiple draft releases share the same `tag_name` — parallel `dist:*:publish` jobs each create another draft. `release.yaml` runs `scripts/ci-ensure-github-draft-release.mjs` first (list + delete empty duplicates + set `target_commitish`).
 - **Assets spread across duplicates:** run `node scripts/consolidate-github-release-duplicates.mjs --tag vX.Y.Z` (requires `GH_TOKEN`), then re-run the release workflow for any missing platform artifacts.
 - To recover on a broken tag: consolidate duplicates, keep the draft with merged assets, re-run **Build/Release Electron App** on the tag.
+- **Do not force-move the `v*` tag while a release workflow is in progress.** Retagging starts another run and (with workflow concurrency) cancels the in-flight build; smoke jobs also assume a stable workflow `github.sha`.
+- **Smoke tests fail with “ref does not point to the expected commit”:** the tag was moved after the workflow started. Re-run failed jobs only after the tag matches the run’s `headSha`, or merge the checkout `ref: ${{ github.sha }}` fix and trigger a fresh tag run.
 
 ### Tag already exists
 

--- a/scripts/ci-ensure-github-draft-release.test.mjs
+++ b/scripts/ci-ensure-github-draft-release.test.mjs
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  assertSafeReleaseTag,
   dedupeEmptyDraftReleases,
   ensureGithubDraftRelease,
   listReleasesForTag,
   pickCanonicalRelease,
   resolveTag,
-  resolveTagFromPackageVersion,
 } from './github-release-api.mjs';
 
 const TAG = 'v5.21.0';
@@ -15,19 +15,28 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('resolveTagFromPackageVersion', () => {
-  it('returns v-prefixed tag from package.json version', () => {
-    expect(resolveTagFromPackageVersion(process.cwd())).toMatch(/^v\d+\.\d+\.\d+/);
+describe('assertSafeReleaseTag', () => {
+  it('accepts v-prefixed semver tags', () => {
+    expect(assertSafeReleaseTag('v5.21.0')).toBe('v5.21.0');
+  });
+
+  it('rejects malformed tags', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined);
+    assertSafeReleaseTag('v5.21.0-evil/../../../etc/passwd');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
   });
 });
 
 describe('resolveTag', () => {
-  it('uses package.json version on workflow_dispatch', () => {
-    const tag = resolveTag([], {
-      GITHUB_REF: 'refs/heads/main',
-      GITHUB_EVENT_NAME: 'workflow_dispatch',
-    });
-    expect(tag).toBe(resolveTagFromPackageVersion(process.cwd()));
+  it('uses RELEASE_TAG when set', () => {
+    const tag = resolveTag([], { RELEASE_TAG: 'v5.21.0' });
+    expect(tag).toBe('v5.21.0');
+  });
+
+  it('uses refs/tags ref on tag push', () => {
+    const tag = resolveTag([], { GITHUB_REF: 'refs/tags/v5.21.0' });
+    expect(tag).toBe('v5.21.0');
   });
 });
 

--- a/scripts/ci-ensure-github-draft-release.test.mjs
+++ b/scripts/ci-ensure-github-draft-release.test.mjs
@@ -4,6 +4,8 @@ import {
   ensureGithubDraftRelease,
   listReleasesForTag,
   pickCanonicalRelease,
+  resolveTag,
+  resolveTagFromPackageVersion,
 } from './github-release-api.mjs';
 
 const TAG = 'v5.21.0';
@@ -11,6 +13,22 @@ const TAG = 'v5.21.0';
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe('resolveTagFromPackageVersion', () => {
+  it('returns v-prefixed tag from package.json version', () => {
+    expect(resolveTagFromPackageVersion(process.cwd())).toMatch(/^v\d+\.\d+\.\d+/);
+  });
+});
+
+describe('resolveTag', () => {
+  it('uses package.json version on workflow_dispatch', () => {
+    const tag = resolveTag([], {
+      GITHUB_REF: 'refs/heads/main',
+      GITHUB_EVENT_NAME: 'workflow_dispatch',
+    });
+    expect(tag).toBe(resolveTagFromPackageVersion(process.cwd()));
+  });
 });
 
 describe('pickCanonicalRelease', () => {

--- a/scripts/github-release-api.mjs
+++ b/scripts/github-release-api.mjs
@@ -3,12 +3,12 @@
  * Shared GitHub release helpers for CI ensure + manual consolidation.
  */
 
-import fs from 'node:fs';
-import path from 'node:path';
-
 export const OWNER = 'Colorado-Mesh';
 export const REPO = 'mesh-client';
 export const API_ROOT = `https://api.github.com/repos/${OWNER}/${REPO}`;
+
+/** Release tags must be vX.Y.Z — validated before any GitHub API call (CodeQL file-access-to-http). */
+export const SAFE_RELEASE_TAG_RE = /^v\d+\.\d+\.\d+$/;
 
 export function versionFromTag(tag) {
   return tag.startsWith('v') ? tag.slice(1) : tag;
@@ -19,39 +19,27 @@ export function fail(message) {
   process.exit(1);
 }
 
-export function resolveTagFromPackageVersion(cwd = process.cwd()) {
-  const pkgPath = path.join(cwd, 'package.json');
-  if (!fs.existsSync(pkgPath)) {
-    fail('package.json not found for release tag resolution');
+export function assertSafeReleaseTag(tag) {
+  if (typeof tag !== 'string' || !SAFE_RELEASE_TAG_RE.test(tag)) {
+    fail(`Release tag must match vX.Y.Z (got ${JSON.stringify(tag)})`);
   }
-  let pkg;
-  try {
-    pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    fail(`Failed to parse package.json for release tag resolution: ${detail}`);
-  }
-  if (typeof pkg.version !== 'string' || !pkg.version) {
-    fail('package.json is missing a valid "version" field for release tag resolution');
-  }
-  return `v${pkg.version}`;
+  return tag;
 }
 
-export function resolveTag(argv, env, { cwd = process.cwd() } = {}) {
+export function resolveTag(argv, env) {
   const flagIndex = argv.indexOf('--tag');
   if (flagIndex >= 0 && argv[flagIndex + 1]) {
-    return argv[flagIndex + 1];
+    return assertSafeReleaseTag(argv[flagIndex + 1]);
+  }
+  const fromEnv = env.RELEASE_TAG;
+  if (typeof fromEnv === 'string' && fromEnv) {
+    return assertSafeReleaseTag(fromEnv);
   }
   const ref = env.GITHUB_REF ?? '';
   if (ref.startsWith('refs/tags/')) {
-    return ref.slice('refs/tags/'.length);
+    return assertSafeReleaseTag(ref.slice('refs/tags/'.length));
   }
-  if (env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
-    return resolveTagFromPackageVersion(cwd);
-  }
-  fail(
-    'Missing tag: pass --tag vX.Y.Z, run on a refs/tags/v* workflow ref, or use workflow_dispatch',
-  );
+  fail('Missing tag: pass --tag vX.Y.Z, set RELEASE_TAG, or run on a refs/tags/v* workflow ref');
 }
 
 export function authToken(env) {
@@ -99,6 +87,7 @@ export function releaseMatchesTag(release, tag) {
 }
 
 export async function listReleasesForTag(tag, token) {
+  assertSafeReleaseTag(tag);
   const matches = [];
   for (let page = 1; page <= 5; page += 1) {
     const { response, json } = await githubRequest(`/releases?per_page=100&page=${page}`, {

--- a/scripts/github-release-api.mjs
+++ b/scripts/github-release-api.mjs
@@ -3,6 +3,9 @@
  * Shared GitHub release helpers for CI ensure + manual consolidation.
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
+
 export const OWNER = 'Colorado-Mesh';
 export const REPO = 'mesh-client';
 export const API_ROOT = `https://api.github.com/repos/${OWNER}/${REPO}`;
@@ -16,7 +19,25 @@ export function fail(message) {
   process.exit(1);
 }
 
-export function resolveTag(argv, env) {
+export function resolveTagFromPackageVersion(cwd = process.cwd()) {
+  const pkgPath = path.join(cwd, 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    fail('package.json not found for release tag resolution');
+  }
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    fail(`Failed to parse package.json for release tag resolution: ${detail}`);
+  }
+  if (typeof pkg.version !== 'string' || !pkg.version) {
+    fail('package.json is missing a valid "version" field for release tag resolution');
+  }
+  return `v${pkg.version}`;
+}
+
+export function resolveTag(argv, env, { cwd = process.cwd() } = {}) {
   const flagIndex = argv.indexOf('--tag');
   if (flagIndex >= 0 && argv[flagIndex + 1]) {
     return argv[flagIndex + 1];
@@ -25,7 +46,12 @@ export function resolveTag(argv, env) {
   if (ref.startsWith('refs/tags/')) {
     return ref.slice('refs/tags/'.length);
   }
-  fail('Missing tag: pass --tag vX.Y.Z or run on a refs/tags/v* workflow ref');
+  if (env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
+    return resolveTagFromPackageVersion(cwd);
+  }
+  fail(
+    'Missing tag: pass --tag vX.Y.Z, run on a refs/tags/v* workflow ref, or use workflow_dispatch',
+  );
 }
 
 export function authToken(env) {


### PR DESCRIPTION
## Summary

- Run `prepare-github-release` for **workflow_dispatch** rebuilds as well as tag pushes; resolve the release tag from `package.json` when `GITHUB_REF` is a branch.
- Pin **all** release and Flatpak publish checkouts to `${{ github.sha }}` so force-moving a tag during recovery does not fail `actions/checkout@v6` integrity checks (smoke fix from #627 only covered packaging-smoke).
- Set release workflow **`cancel-in-progress: true`** so a new tag push on the same ref cancels the previous run instead of stacking parallel uploads to orphan release IDs.
- Document retag-during-CI and smoke checkout recovery in `docs/release-process.md`.
- Add tests for `resolveTag` / `resolveTagFromPackageVersion` on `workflow_dispatch`.

## Context

Follow-up hardening after the v5.21.0 release recovery:

- Duplicate draft releases caused Linux publish **404**s (assets uploaded to deleted release IDs).
- Smoke tests failed when `v5.21.0` was force-moved mid-run while packaging-smoke still checked out the tag ref.

## Test plan

- [x] `pnpm exec vitest run scripts/ci-ensure-github-draft-release.test.mjs` (8 tests)
- [x] `actionlint` on `release.yaml` and `flatpak.yaml`
- [ ] Merge and verify next tag release: single draft, all platform assets on one release, smoke jobs green