### PR TITLE
fix: link preview timeout dialog and release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,8 @@ jobs:
     needs: prepare-github-release
     if: ${{ !cancelled() && needs.prepare-github-release.result != 'failure' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       include: ${{ steps.matrix.outputs.include }}
     steps:

--- a/src/main/fetchLinkPreview.test.ts
+++ b/src/main/fetchLinkPreview.test.ts
@@ -474,6 +474,38 @@ describe('fetchLinkPreview', () => {
     );
   });
 
+  it('returns null without unhandled rejection when body read times out', async () => {
+    const timeoutErr = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    const stream = new ReadableStream<Uint8Array>({
+      pull() {
+        return Promise.reject(timeoutErr);
+      },
+      cancel() {
+        return Promise.reject(timeoutErr);
+      },
+    });
+    mockFetch.mockResolvedValue(
+      mockUndiciResponse({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/html' }),
+        body: stream,
+      }),
+    );
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      expect(await fetchLinkPreview('https://example.com/slow')).toBeNull();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
   it('uses port 80 for http URLs without explicit port', async () => {
     const html = `<meta property="og:title" content="HTTP Title">`;
     mockFetch.mockResolvedValue(makeStreamResponse(html));

--- a/src/main/fetchLinkPreview.ts
+++ b/src/main/fetchLinkPreview.ts
@@ -202,7 +202,11 @@ async function readResponseBodyUpTo(
       total += slice.length;
     }
   } finally {
-    void reader.cancel();
+    try {
+      await reader.cancel();
+    } catch {
+      // catch-no-log-ok: stream may already be aborted when AbortSignal.timeout fires
+    }
   }
   if (total === 0) return null;
   const merged = new Uint8Array(total);


### PR DESCRIPTION
## Summary

- Fix unhandled promise rejection when chat link preview fetches time out: `readResponseBodyUpTo` now awaits `reader.cancel()` in a try/catch instead of `void reader.cancel()`, which previously rejected a second `TimeoutError` after `AbortSignal.timeout` aborted the body read (reproduced from Windows user logs at the same millisecond as `[chat] fetchLinkPreview error`).
- Add regression test asserting no unhandled rejection when both stream `read()` and `cancel()` reject with `TimeoutError`.
- Add `permissions: contents: read` to the `resolve-release-matrix` job in `release.yaml` to resolve CodeQL alert #97 (`actions/missing-workflow-permissions`).

## Test plan

- [x] `pnpm exec vitest run src/main/fetchLinkPreview.test.ts --project main`
- [ ] Open chat with a slow/unreachable URL in a message — preview should fail silently with no error dialog
- [ ] Confirm CodeQL alert #97 closes after merge (or re-run code scanning on the branch)