### PR TITLE
fix: attribute MQTT LongFast messages to configured channel slot

### DIFF
--- a/src/main/mqtt-manager.test.ts
+++ b/src/main/mqtt-manager.test.ts
@@ -1293,6 +1293,45 @@ describe('updateChannelKeys', () => {
     expect(byName.get('LongFast')?.equals(CUSTOM_PSK)).toBe(true);
   });
 
+  it('records LongFast index when radio sync pushes default public PSK', () => {
+    const manager = new MQTTManager();
+    (manager as any)._doConnect = () => {};
+    manager.connect({
+      server: 'localhost',
+      port: 1883,
+      username: '',
+      password: '',
+      topicPrefix: 'msh/',
+      autoLaunch: false,
+      channelPsks: [`LongFast=${CUSTOM_PSK.toString('base64')}`],
+    });
+
+    manager.updateChannelKeys([{ name: 'LongFast', pskBase64: 'AQ==', index: 1 }]);
+
+    const byName: Map<string, Buffer> = (manager as any).channelKeysByName;
+    expect(byName.get('LongFast')?.equals(CUSTOM_PSK)).toBe(true);
+    const nameToIndex: Map<string, number> = (manager as any).channelNameToIndex;
+    expect(nameToIndex.get('LongFast')).toBe(1);
+  });
+
+  it('stores LongFast index mapping from default public radio sync', () => {
+    const manager = new MQTTManager();
+    (manager as any)._doConnect = () => {};
+    manager.connect({
+      server: 'localhost',
+      port: 1883,
+      username: '',
+      password: '',
+      topicPrefix: 'msh/',
+      autoLaunch: false,
+    });
+
+    manager.updateChannelKeys([{ name: 'LongFast', pskBase64: 'AQ==', index: 1 }]);
+
+    const nameToIndex: Map<string, number> = (manager as any).channelNameToIndex;
+    expect(nameToIndex.get('LongFast')).toBe(1);
+  });
+
   it('preserves manual Garber PSK when radio sync pushes a different key', () => {
     const manager = new MQTTManager();
     (manager as any)._doConnect = () => {};
@@ -1545,6 +1584,39 @@ describe('onMessage — encrypted TEXT_MESSAGE channel attribution', () => {
 
     expect(messages).toHaveLength(1);
     expect((messages[0] as { channel: number }).channel).toBe(0);
+  });
+
+  it('attributes LongFast topic to configured non-zero slot', () => {
+    const manager = new MQTTManager();
+    (manager as any)._doConnect = () => {};
+    manager.connect({
+      server: 'localhost',
+      port: 1883,
+      username: '',
+      password: '',
+      topicPrefix: 'msh/',
+      autoLaunch: false,
+    });
+
+    manager.updateChannelKeys([{ name: 'LongFast', pskBase64: 'AQ==', index: 1 }]);
+
+    const nodeId = 0x11223355;
+    const packetId = 0x00000034;
+    const dataBytes = toBinary(
+      DataSchema,
+      create(DataSchema, {
+        portnum: PortNum.TEXT_MESSAGE_APP,
+        payload: new TextEncoder().encode('hello longfast slot 1'),
+      }),
+    );
+    const payload = buildEnvelope({ nodeId, packetId, dataBytes, psk: DEFAULT_PSK });
+
+    const messages: unknown[] = [];
+    manager.on('message', (m) => messages.push(m));
+    (manager as any).onMessage('msh/US/2/e/LongFast/!11223355', payload);
+
+    expect(messages).toHaveLength(1);
+    expect((messages[0] as { channel: number }).channel).toBe(1);
   });
 
   it('attributes unknown topic channel names to channel 0', () => {

--- a/src/main/mqtt-manager.ts
+++ b/src/main/mqtt-manager.ts
@@ -334,10 +334,20 @@ export class MQTTManager extends EventEmitter {
       this.channelNameToIndex.delete(name);
     }
     this.radioChannelKeyNames.clear();
+    const radioTopicIndices = new Map<string, number>();
     for (const entry of entries) {
       const name = entry.name.trim();
       const psk = parsePsk(entry.pskBase64);
       if (!name || !psk) continue;
+      if (entry.index !== undefined && Number.isInteger(entry.index)) {
+        const idx = entry.index >>> 0;
+        if (idx <= 7) {
+          radioTopicIndices.set(name, idx);
+          if (!this.manualChannelKeyNames.has(name)) {
+            this.channelNameToIndex.set(name, idx);
+          }
+        }
+      }
       if (this.manualChannelKeyNames.has(name)) continue;
       const existing = this.channelKeysByName.get(name);
       if (
@@ -349,12 +359,18 @@ export class MQTTManager extends EventEmitter {
       }
       this.channelKeysByName.set(name, psk);
       this.radioChannelKeyNames.add(name);
-      if (entry.index !== undefined && Number.isInteger(entry.index)) {
-        const idx = entry.index >>> 0;
-        if (idx <= 7) this.channelNameToIndex.set(name, idx);
-      }
     }
     this.applyManualChannelPskLines(this.manualChannelPskLines);
+    for (const [name, idx] of radioTopicIndices) {
+      if (!this.manualChannelKeyNames.has(name)) continue;
+      const manualHasExplicitIndex = this.manualChannelPskLines.some((line) => {
+        const parsed = parseChannelPskLine(line);
+        return parsed?.name === name && parsed.index !== undefined;
+      });
+      if (!manualHasExplicitIndex) {
+        this.channelNameToIndex.set(name, idx);
+      }
+    }
     this.rebuildAllDecryptKeys();
   }
 

--- a/src/renderer/lib/meshtasticMqttPublish.test.ts
+++ b/src/renderer/lib/meshtasticMqttPublish.test.ts
@@ -210,9 +210,23 @@ describe('meshtasticMqttChannelKeyEntries', () => {
     expect(entries).toEqual([expect.objectContaining({ name: 'HamNet', index: 2 })]);
   });
 
-  it('skips default public single-byte PSK (AQ==)', () => {
+  it('includes default public LongFast at configured index for mqtt topic mapping', () => {
     const entries = meshtasticMqttChannelKeyEntries([
-      { index: 0, name: 'LongFast', role: 1, psk: new Uint8Array([1]) },
+      { index: 1, name: 'LongFast', role: 2, psk: new Uint8Array([1]) },
+      { index: 0, name: 'Private', role: 1, psk: new Uint8Array(16).fill(9) },
+    ]);
+    expect(entries).toHaveLength(2);
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'LongFast', index: 1, pskBase64: 'AQ==' }),
+        expect.objectContaining({ name: 'Private', index: 0 }),
+      ]),
+    );
+  });
+
+  it('skips empty PSK channels', () => {
+    const entries = meshtasticMqttChannelKeyEntries([
+      { index: 0, name: 'Empty', role: 1, psk: new Uint8Array(0) },
       { index: 1, name: 'Private', role: 2, psk: new Uint8Array(16).fill(9) },
     ]);
     expect(entries).toHaveLength(1);

--- a/src/renderer/lib/meshtasticMqttPublish.ts
+++ b/src/renderer/lib/meshtasticMqttPublish.ts
@@ -238,7 +238,9 @@ export function meshtasticMqttChannelKeyEntries(
     if (ch.role === MESHTASTIC_CHANNEL_ROLE.DISABLED) continue;
     const name = resolveMeshtasticMqttChannelName(ch);
     if (!name) continue;
-    if (!isNonTrivialMeshtasticChannelPsk(ch.psk)) continue;
+    if (!isNonTrivialMeshtasticChannelPsk(ch.psk) && !isMeshtasticDefaultPublicPsk(ch.psk)) {
+      continue;
+    }
     entries.push({ name, pskBase64: pskToBase64(ch.psk), index: ch.index });
   }
   return entries;


### PR DESCRIPTION
## Summary

- Include default-public channels in `meshtasticMqttChannelKeyEntries` so radio slot indices reach `mqtt:updateChannelKeys` even when LongFast uses the well-known `AQ==` PSK.
- Register `channelNameToIndex` from radio sync before key-preservation skips and restore radio indices after manual PSK lines when the manual line has no explicit `@index`.
- Add regression tests for LongFast in slot 1 (renderer entries, main index map, and inbound MQTT topic attribution).

## Why

MQTT topic names always use `LongFast` regardless of local slot; without the index mapping, inbound traffic was hardcoded to channel 0 and showed up in the user's private primary channel when LongFast lived in slot 1.

## Test plan

- [ ] Configure LongFast in channel slot 1 (not slot 0)
- [ ] Connect MQTT and verify inbound LongFast messages appear under the correct channel tab, not the primary private channel
- [ ] `pnpm run test:run -- src/main/mqtt-manager.test.ts src/renderer/lib/meshtasticMqttPublish.test.ts`