### PR TITLE
fix: align electronAPI stubs with typed IPC surface

### DIFF
--- a/src/renderer/lib/devElectronApiStub.ts
+++ b/src/renderer/lib/devElectronApiStub.ts
@@ -86,7 +86,7 @@ export function createDevElectronApiStub(): typeof window.electronAPI {
       getMeshcoreContactCount: async () => 0,
       deleteMeshcoreContactsWithoutPubkey: async () => ({ deleted: 0, excludedStubCount: 0 }),
       offloadAllMeshcoreContacts: async () => 0,
-      getMeshcoreContactById: async () => undefined,
+      getMeshcoreContactById: async () => null,
       updateMeshcoreContactNickname: noopAsync,
       updateMeshcoreContactFavorited: noopAsync,
       savePositionHistory: noopAsync,
@@ -171,11 +171,6 @@ export function createDevElectronApiStub(): typeof window.electronAPI {
     cancelBluetoothPairing: noop,
     resetBlePairingRetryCount: noop,
     clearSessionData: noopAsync,
-    getLinuxBleCapabilityStatus: async () => ({
-      platform: 'other' as const,
-      hasCapNetRaw: false,
-      detail: 'browser dev stub',
-    }),
     getGpsFix: async () => ({ lat: 0, lon: 0, source: 'ip' as const }),
     update: {
       check: noopAsync,

--- a/src/renderer/vitest.electronApiMock.ts
+++ b/src/renderer/vitest.electronApiMock.ts
@@ -101,7 +101,7 @@ export function createElectronAPIMock(): ElectronAPI {
         .fn()
         .mockResolvedValue({ deleted: 0, excludedStubCount: 0 }),
       offloadAllMeshcoreContacts: vi.fn().mockResolvedValue(0),
-      getMeshcoreContactById: vi.fn().mockResolvedValue(undefined),
+      getMeshcoreContactById: vi.fn().mockResolvedValue(null),
       updateMeshcoreContactNickname: vi.fn().mockResolvedValue(undefined),
       updateMeshcoreContactFavorited: vi.fn().mockResolvedValue(undefined),
       savePositionHistory: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

- Remove undeclared `getLinuxBleCapabilityStatus` from the browser dev stub — it was not part of `ElectronAPI`, preload, or main IPC, so renderer code could not call it in a type-safe way.
- Return `null` (not `undefined`) from `getMeshcoreContactById` in the dev stub and Vitest mock, matching the declared return type and production IPC behavior for missing contacts.

## Test plan

- [x] `pnpm run typecheck`
- [x] Pre-commit hooks passed on commit (lint, typecheck, changed tests)