### PR TITLE
fix: scope MeshCore message-sync spinner to MeshCore tab

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,7 +63,7 @@ The top-level **`legend`** explains that ids like `offline-meshcore` are **inter
 - `uiStoreIdentityId` — bucket Chat and Nodes read from.
 - `identitySplit: true` while transport is connected — **suspicious** (live ingress and UI may disagree).
 - `ui.chatPanelFrozen` + `frozenMessageCount` lagging `liveResolvedMessageCount` — **legacy builds only** (Chat freeze removed in newer releases); still useful when analyzing snapshots from older versions.
-- `ui.waitingMessagesSilentDrainActive` / `ui.waitingMessagesDrainDeferred` — MeshCore incremental drain in progress or paused behind admin/trace (serial may show small batches). UI: **header status indicator** (queued backlog and active sync visible on any protocol tab; **paused** admin/trace state only on the MeshCore tab), not Chat/Rooms panel strips.
+- `ui.waitingMessagesSilentDrainActive` / `ui.waitingMessagesDrainDeferred` — MeshCore incremental drain in progress or paused behind admin/trace (serial may show small batches). UI: **header status indicator** (queued backlog visible on any protocol tab; **active sync spinner and paused/deferred** state only on the MeshCore tab), not Chat/Rooms panel strips.
 - `meshcoreContactPathDiagnostics` — redacted MeshCore contact rows with `pubKeyPrefixHex` (12 hex chars), `hopsAway`, and best known `bestPathBytes` / `bestPathHopCount` from SQLite path history (useful for ping/no-route reports).
 
 **Automatic warning codes** in `warnings[]`: `identitySplit`, `staleResolvedBucket`, `chatPanelFrozen` (legacy builds), `connectedNoPrimaryMessages`, `windowHiddenOnChat`, `sidecarNotRunning` (Reticulum stack expected but sidecar process down).

--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -795,6 +795,23 @@ describe('App accessibility', () => {
     ).toBeInTheDocument();
   });
 
+  it('hides silent drain spinner on Meshtastic tab during MeshCore message fetch', () => {
+    getStoredMeshProtocolMock.mockReturnValue('meshtastic');
+    useMeshCoreMock.mockReturnValue({
+      ...createMeshCoreMock(),
+      waitingMessagesSilentDrainActive: true,
+      syncWaitingMessages: vi.fn().mockResolvedValue(undefined),
+    });
+
+    renderApp();
+
+    expect(
+      screen.queryByRole('status', {
+        name: /Fetching messages queued on the radio/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it('hides deferred waiting-message indicator on Meshtastic tab during MeshCore admin/trace', () => {
     getStoredMeshProtocolMock.mockReturnValue('meshtastic');
     useMeshCoreMock.mockReturnValue({

--- a/src/renderer/lib/meshcoreWaitingMessagesStatusText.test.ts
+++ b/src/renderer/lib/meshcoreWaitingMessagesStatusText.test.ts
@@ -119,12 +119,20 @@ describe('meshcoreWaitingMessagesVisibleForProtocol', () => {
     expect(meshcoreWaitingMessagesVisibleForProtocol(input, 'meshcore')).toBe(true);
   });
 
-  it('keeps active sync visible cross-tab', () => {
-    const input: MeshcoreWaitingMessagesStatusInput = {
+  it('hides active sync off the MeshCore tab', () => {
+    const silentDrain: MeshcoreWaitingMessagesStatusInput = {
       ...baseInput,
       waitingMessagesSilentDrainActive: true,
     };
-    expect(meshcoreWaitingMessagesVisibleForProtocol(input, 'meshtastic')).toBe(true);
-    expect(meshcoreWaitingMessagesVisibleForProtocol(input, 'meshcore')).toBe(true);
+    expect(meshcoreWaitingMessagesVisibleForProtocol(silentDrain, 'meshcore')).toBe(true);
+    expect(meshcoreWaitingMessagesVisibleForProtocol(silentDrain, 'meshtastic')).toBe(false);
+    expect(meshcoreWaitingMessagesVisibleForProtocol(silentDrain, 'reticulum')).toBe(false);
+
+    const manualSync: MeshcoreWaitingMessagesStatusInput = {
+      ...baseInput,
+      waitingMessagesSyncActive: true,
+    };
+    expect(meshcoreWaitingMessagesVisibleForProtocol(manualSync, 'meshcore')).toBe(true);
+    expect(meshcoreWaitingMessagesVisibleForProtocol(manualSync, 'meshtastic')).toBe(false);
   });
 });

--- a/src/renderer/lib/meshcoreWaitingMessagesStatusText.ts
+++ b/src/renderer/lib/meshcoreWaitingMessagesStatusText.ts
@@ -81,12 +81,13 @@ export function meshcoreWaitingMessagesVisibleForProtocol(
   activeProtocol: 'meshtastic' | 'meshcore' | 'reticulum',
 ): boolean {
   if (!meshcoreWaitingMessagesVisible(input)) return false;
-  if (
-    activeProtocol !== 'meshcore' &&
-    input.waitingMessagesDrainDeferred &&
-    !meshcoreWaitingMessagesSyncBusy(input)
-  ) {
-    return false;
+  if (activeProtocol !== 'meshcore') {
+    if (meshcoreWaitingMessagesSyncBusy(input)) {
+      return false;
+    }
+    if (input.waitingMessagesDrainDeferred) {
+      return false;
+    }
   }
   return true;
 }


### PR DESCRIPTION
## Summary
- Scope MeshCore header sync spinner (silent drain and manual sync) to the MeshCore tab only via `meshcoreWaitingMessagesVisibleForProtocol`.
- Keep queued backlog pill + **Sync now** visible cross-tab so users still see pending radio messages on Meshtastic/Reticulum.
- Add App/unit coverage and update troubleshooting snapshot field note.

The prior deferred-only scoping fix left background MeshCore drain spinners visible on other protocol tabs, which looked like Meshtastic was syncing.

## Test plan
- [x] `vitest` — `meshcoreWaitingMessagesStatusText.test.ts`, App waiting-message indicator tests
- [ ] Dual-protocol setup: switch to Meshtastic while MeshCore silently drains — no header spinner on Meshtastic
- [ ] MeshCore tab during drain — spinner still appears
- [ ] Queued backlog count pill still visible on Meshtastic when messages are waiting