### PR TITLE
fix(main): validate host:port authority in http:preflight/http:connect

### DIFF
--- a/src/main/index.ipc-security.test.ts
+++ b/src/main/index.ipc-security.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { describe, expect, it } from 'vitest';
 
+import { formatHostForUrl, parseConnectHostPort } from '../shared/connectHost';
 import { isValidHttpHostname } from './httpHostValidation';
 
 const INDEX_SOURCE = readFileSync(join(__dirname, 'index.ts'), 'utf-8');
@@ -15,7 +16,7 @@ const GPS_IPC_SOURCE = readFileSync(join(__dirname, 'ipc/gps-handlers.ts'), 'utf
 describe('validateHttpHost (source contract)', () => {
   it('uses isValidHttpHostname from httpHostValidation', () => {
     expect(INDEX_SOURCE).toContain("import { isValidHttpHostname } from './httpHostValidation'");
-    expect(INDEX_SOURCE).toContain('isValidHttpHostname(host)');
+    expect(INDEX_SOURCE).toContain('isValidHttpHostname(bareHost)');
   });
 
   it('calls validateHttpHost in http:preflight handler', () => {
@@ -50,6 +51,41 @@ describe('validateHttpHost (source contract)', () => {
     expect(isValidHttpHostname('::1')).toBe(true);
     expect(isValidHttpHostname('[::1]')).toBe(true);
     expect(isValidHttpHostname('fd00::1')).toBe(true);
+  });
+
+  it('strips a trailing port via parseConnectHostPort before calling isValidHttpHostname', () => {
+    // http:preflight/http:connect are called with an authority string that always
+    // has a port appended (connection.ts: formatHostForUrl(host, port)), even for
+    // a bare IP with no port typed. isValidHttpHostname alone rejects that string
+    // because it looks like an unbracketed (and invalid) IPv6 literal.
+    const bodyIdx = INDEX_SOURCE.indexOf('function validateHttpHost(');
+    expect(bodyIdx).toBeGreaterThan(-1);
+    const body = INDEX_SOURCE.slice(bodyIdx, bodyIdx + 500);
+    expect(body).toContain('parseConnectHostPort(host, 0).host');
+  });
+
+  it('regression: recovers a validatable host from formatHostForUrl output (connection.ts http case)', () => {
+    const urlHost = formatHostForUrl('192.168.1.50', 80);
+    expect(urlHost).toBe('192.168.1.50:80');
+
+    // Without the fix, validateHttpHost would call isValidHttpHostname directly
+    // on this authority string, which fails.
+    expect(isValidHttpHostname(urlHost)).toBe(false);
+
+    // The fix strips the port first, recovering a validatable bare host.
+    expect(isValidHttpHostname(parseConnectHostPort(urlHost, 0).host)).toBe(true);
+  });
+
+  it('regression: IPv6 authority from formatHostForUrl also validates after stripping the port', () => {
+    const urlHost = formatHostForUrl('fd00::1', 4403);
+    expect(urlHost).toBe('[fd00::1]:4403');
+    expect(isValidHttpHostname(urlHost)).toBe(false);
+    expect(isValidHttpHostname(parseConnectHostPort(urlHost, 0).host)).toBe(true);
+  });
+
+  it('still validates a bare host with no port, as used by meshcore:tcp-connect', () => {
+    expect(parseConnectHostPort('fd00::1', 0).host).toBe('fd00::1');
+    expect(isValidHttpHostname(parseConnectHostPort('fd00::1', 0).host)).toBe(true);
   });
 });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,7 +27,7 @@ import zlib from 'zlib';
 
 import type { MQTTSettings } from '../renderer/lib/types';
 import { APP_ABOUT_TAGLINE } from '../shared/appTagline';
-import { formatHostForSocket } from '../shared/connectHost';
+import { formatHostForSocket, parseConnectHostPort } from '../shared/connectHost';
 import { NODES_LAST_HEARD_SEC_SQL, normalizeLastHeardToUnixSec } from '../shared/lastHeardUnits';
 import {
   sanitizeMeshcoreAdvLatLonForDb,
@@ -5695,7 +5695,11 @@ function validateHttpHost(host: unknown): asserts host is string {
   if (typeof host !== 'string' || host.length === 0 || host.length > MAX_HOST_LENGTH) {
     throw new Error('Invalid host');
   }
-  if (!isValidHttpHostname(host)) {
+  // http:preflight/http:connect pass an authority string with a port already
+  // appended (formatHostForUrl); meshcore:tcp-connect passes a bare host.
+  // Strip a trailing port before validating so both call sites work.
+  const bareHost = parseConnectHostPort(host, 0).host;
+  if (!isValidHttpHostname(bareHost)) {
     throw new Error('Invalid host format');
   }
 }


### PR DESCRIPTION
## Summary
- `connection.ts` always appends a port via `formatHostForUrl(host, port)` before calling `http:preflight`/`http:connect`, even for a bare IP with no port typed. `validateHttpHost`'s `isValidHttpHostname` check expects a bare host (no port), so it rejected the resulting `host:port` authority string as an invalid IPv6 literal — breaking every Meshtastic HTTP connect attempt (by IP or hostname) with `Invalid host format`.
- Regression introduced in #610 when the HTTP connect path switched from a bare host to `parseConnectHostPort` + `formatHostForUrl`.
- Fix: `validateHttpHost` now strips a trailing port via `parseConnectHostPort` before validating, leaving `meshcore:tcp-connect` (which already passes a bare host) unaffected.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec eslint src/main/index.ts src/main/index.ipc-security.test.ts`
- [x] `pnpm vitest run src/main/index.ipc-security.test.ts` (70 tests, incl. new regression tests reproducing the reported bug for both IPv4 and bracketed IPv6 authorities)
- [x] Full pre-commit hook chain passed locally