### PR TITLE
fix(meshtastic): serialize concurrent transport writes for HTTP connect

### DIFF
--- a/src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.test.ts
@@ -59,7 +59,7 @@ describe('pushMeshtasticTransportSideEffectUnsubs', () => {
     expect(unsubs).toHaveLength(1);
   });
 
-  it('skips transport loss watch and heartbeat for HTTP', () => {
+  it('attaches serialized transport but skips heartbeat for HTTP', () => {
     const device = mockDevice();
     pushMeshtasticTransportSideEffectUnsubs(
       device,
@@ -69,8 +69,15 @@ describe('pushMeshtasticTransportSideEffectUnsubs', () => {
     );
 
     expect(window.electronAPI.onNobleBleDisconnected).not.toHaveBeenCalled();
-    expect(attachMeshtasticTransportLossWatch).not.toHaveBeenCalled();
+    // Regression: HTTP's toDevice must be serialized too, or concurrent SDK
+    // getWriter() calls (queue vs. NODEINFO/GetMetadata retries) throw
+    // "WritableStream is locked" and silently drop outbound writes/sends.
+    expect(attachMeshtasticTransportLossWatch).toHaveBeenCalledWith(
+      device,
+      'http',
+      onTransportLost,
+    );
     expect(device.setHeartbeatInterval).not.toHaveBeenCalled();
-    expect(unsubs).toHaveLength(0);
+    expect(unsubs).toHaveLength(1);
   });
 });

--- a/src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.ts
+++ b/src/renderer/lib/meshtastic/meshtasticLegacyDeviceEvents.ts
@@ -17,8 +17,11 @@ export function pushMeshtasticTransportSideEffectUnsubs(
 ): void {
   // Noble BLE disconnect is handled at runtime mount (useMeshtasticRuntime) with storage rehydrate.
 
-  if (type === 'serial' || type === 'ble') {
+  if (type === 'serial' || type === 'ble' || type === 'http') {
     push(attachMeshtasticTransportLossWatch(device, type, onTransportLost));
+  }
+
+  if (type === 'serial' || type === 'ble') {
     try {
       device.setHeartbeatInterval(60_000);
     } catch (e) {

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
@@ -1,6 +1,7 @@
 import type { MeshDevice } from '@meshtastic/core';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { ConnectionType } from '../types';
 import {
   attachMeshtasticTransportLossWatch,
   createSerializedWritableStream,
@@ -91,5 +92,43 @@ describe('meshtasticTransportLossDetection', () => {
     await expect(writer.write(new Uint8Array([1]))).rejects.toMatchObject({
       name: 'InvalidStateError',
     });
+  });
+
+  it('serializes concurrent getWriter calls for HTTP transport (regression)', async () => {
+    // Meshtastic HTTP connect: MeshDevice's own Queue.processQueue() holds a writer
+    // lock for the whole queue drain; a concurrent NODEINFO/GetMetadata retry calling
+    // getWriter() on the same raw stream throws "WritableStream is locked" and the
+    // write is silently dropped, leaving sent messages unacknowledged.
+    let innerWriteCount = 0;
+    const inner = new WritableStream<Uint8Array>({
+      async write() {
+        innerWriteCount++;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      },
+    });
+    const device = {
+      transport: { toDevice: inner },
+    } as unknown as MeshDevice;
+
+    attachMeshtasticTransportLossWatch(device, 'http', vi.fn());
+
+    const w1 = device.transport.toDevice.getWriter();
+    const w2 = device.transport.toDevice.getWriter();
+    await Promise.all([w1.write(new Uint8Array([1])), w2.write(new Uint8Array([2]))]);
+    w1.releaseLock();
+    w2.releaseLock();
+
+    expect(innerWriteCount).toBe(2);
+  });
+
+  it('does not wrap toDevice for unsupported connection types', () => {
+    const inner = new WritableStream<Uint8Array>({ write: vi.fn() });
+    const device = {
+      transport: { toDevice: inner },
+    } as unknown as MeshDevice;
+
+    attachMeshtasticTransportLossWatch(device, 'reticulum' as unknown as ConnectionType, vi.fn());
+
+    expect(device.transport.toDevice).toBe(inner);
   });
 });

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
@@ -122,14 +122,17 @@ function createLossAwareWritableStream(
 
 /**
  * Detect serial unplug (`disconnect` event) and immediate write failures such as
- * `NetworkError: The device has been lost` after a firmware reboot.
+ * `NetworkError: The device has been lost` after a firmware reboot. Also serializes
+ * concurrent SDK `getWriter()` calls (queue, NODEINFO/GetMetadata retries, heartbeat)
+ * on serial, BLE, and HTTP transports so overlapping writes do not throw
+ * `WritableStream is locked` and get silently dropped.
  */
 export function attachMeshtasticTransportLossWatch(
   device: MeshDevice,
   type: ConnectionType,
   onConnectionLost: () => void,
 ): () => void {
-  if (type !== 'serial' && type !== 'ble') {
+  if (type !== 'serial' && type !== 'ble' && type !== 'http') {
     return () => {};
   }
 


### PR DESCRIPTION
## Summary
- Depends on / follows #638 (host:port authority validation fix) — that fix made HTTP connect actually succeed, which exposed this separate, previously-invisible bug in the send path.
- The Meshtastic SDK's own `Queue.processQueue()` (`@meshtastic/core`) holds a writer lock on `transport.toDevice` for the whole queue drain. A concurrent NODEINFO/GetMetadata retry calling `getWriter()` on the same raw HTTP stream throws `Cannot create writer when WritableStream is locked`, silently dropping the write — leaving sent chat messages unacknowledged even though incoming traffic keeps flowing.
- Confirmed directly in a real session's log (`~/.config/mesh-client/mesh-client.log`): every chat send was followed ~60s later by a routing timeout and `sendText failed`, with an explicit `WritableStream is locked` error logged during that same session.
- Serial and BLE transports already get a serialized-writer wrapper (`attachMeshtasticTransportLossWatch` → `createSerializedWritableStream`) for exactly this SDK-level concurrency issue; HTTP never did. Fix: include `'http'` in that same gate. Heartbeat (`setHeartbeatInterval`) intentionally stays scoped to serial/BLE only — unrelated to this bug, since HTTP is a polling design, not a persistent link.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec eslint` on changed files
- [x] `pnpm vitest run` on both changed test files (11/11 passing), including a regression test proving HTTP's `toDevice` now gets the serialized wrapper, and an updated test that had previously locked in the buggy "skip for HTTP" behavior
- [x] Manually verified via `pnpm start` against a real device over HTTP: connect + send/receive both work as expected
- [x] Full pre-commit hook chain passed locally