### PR TITLE
fix: address CodeQL dev stub gaps and PSK length validation

### DIFF
--- a/src/renderer/hooks/useMeshtasticRuntime.mqttIdentityTransition.test.tsx
+++ b/src/renderer/hooks/useMeshtasticRuntime.mqttIdentityTransition.test.tsx
@@ -22,7 +22,8 @@ vi.mock('../lib/connection', () => ({
 
 const VIRTUAL_ID = 0x0b2f75f3;
 const REAL_ID = 0x88cb6530;
-const MQTT_PSK_LINE = 'LongFast@0=AQ==';
+/** Valid 16-byte AES-128 manual PSK line for MQTT-only publish in tests. */
+const MQTT_PSK_LINE = 'LongFast@0=AAAAAAAAAAAAAAAAAAAAAA==';
 
 type MqttStatusHandler = (args: { status: string; protocol: string }) => void;
 type MyNodeInfoHandler = (info: { myNodeNum: number }) => void;

--- a/src/renderer/lib/devElectronApiStub.ts
+++ b/src/renderer/lib/devElectronApiStub.ts
@@ -228,6 +228,15 @@ export function createDevElectronApiStub(): typeof window.electronAPI {
       disconnect: noopAsync,
       onData: noopUnsub,
     },
+    meshtastic: {
+      tcp: {
+        connect: noopAsync,
+        write: noopAsync,
+        disconnect: noopAsync,
+        onData: noopUnsub,
+        onDisconnected: noopUnsub,
+      },
+    },
     chat: {
       export: async () => ({ success: false }),
       saveReticulumAttachment: async () => ({ success: false }),
@@ -291,6 +300,12 @@ export function createDevElectronApiStub(): typeof window.electronAPI {
       showConfigImportDialog: async () => ({ path: null, content: null }),
       onEvent: noopUnsub,
       onStatus: noopUnsub,
+    },
+    vault: {
+      setPasscode: async () => ({ ok: true }),
+      unlock: async () => ({ ok: true }),
+      lock: async () => ({ ok: true }),
+      status: async () => ({ configured: false, unlocked: false }),
     },
   } as unknown as typeof window.electronAPI;
 }

--- a/src/renderer/lib/meshtasticChannelPskInput.test.ts
+++ b/src/renderer/lib/meshtasticChannelPskInput.test.ts
@@ -78,6 +78,11 @@ describe('validateChannelPskEntries', () => {
     expect(validateChannelPskEntries([twentyBytes])).toBe('invalidLength');
   });
 
+  it('rejects decoded keys shorter than 16 bytes', () => {
+    const fifteenBytes = btoa(String.fromCharCode(...new Uint8Array(15).fill(2)));
+    expect(validateChannelPskEntries([`HamNet=${fifteenBytes}`])).toBe('invalidLength');
+  });
+
   it('returns ok for empty list', () => {
     expect(validateChannelPskEntries([])).toBe('ok');
   });
@@ -111,6 +116,11 @@ describe('parseManualChannelPublishEntry', () => {
   it('returns null for invalid AES key length', () => {
     const twentyBytes = btoa(String.fromCharCode(...Array.from({ length: 20 }, () => 0xab)));
     expect(parseManualChannelPublishEntry(`HamNet=${twentyBytes}`)).toBeNull();
+  });
+
+  it('returns null for keys shorter than 16 bytes', () => {
+    const oneByte = btoa(String.fromCharCode(0x01));
+    expect(parseManualChannelPublishEntry(`HamNet=${oneByte}`)).toBeNull();
   });
 
   it('parses reporter LongFast@0 key as 32-byte AES-256', () => {

--- a/src/renderer/lib/meshtasticChannelPskInput.ts
+++ b/src/renderer/lib/meshtasticChannelPskInput.ts
@@ -37,7 +37,7 @@ export function validateChannelPskEntries(lines: string[]): ChannelPskValidation
   for (const line of lines) {
     try {
       const raw = decodeChannelPskBase64(line);
-      if (raw.length === 16 || raw.length === 32 || raw.length < 16) continue;
+      if (raw.length === 16 || raw.length === 32) continue;
       return 'invalidLength';
     } catch {
       // catch-no-log-ok invalid base64 on blur — user-facing warning only
@@ -53,7 +53,7 @@ export function parseManualChannelPublishEntry(line: string): ManualChannelPubli
   if (split?.kind !== 'named') return null;
   try {
     const psk = decodePskBase64(split.b64);
-    if (psk.length !== 16 && psk.length !== 32 && psk.length >= 16) return null;
+    if (psk.length !== 16 && psk.length !== 32) return null;
     return { name: split.name, index: split.index, psk };
   } catch {
     // catch-no-log-ok invalid base64 on a named publish line — skip entry


### PR DESCRIPTION
## Summary
- Add missing `vault` and `meshtastic.tcp` no-op stubs to `devElectronApiStub.ts` so browser dev mode exposes the same IPC surface as preload/vitest mocks (prevents `TypeError` on `window.electronAPI.vault.*` and `meshtastic.*` calls).
- Tighten Meshtastic channel PSK validation: reject decoded keys that are not exactly 16 or 32 bytes in both `validateChannelPskEntries` and `parseManualChannelPublishEntry`.
- Add unit coverage for sub-16-byte rejection and update the MQTT identity transition test fixture to use a valid 16-byte manual PSK line.

## Test plan
- [x] `pnpm exec vitest run src/renderer/lib/meshtasticChannelPskInput.test.ts`
- [x] `pnpm exec vitest run src/renderer/hooks/useMeshtasticRuntime.mqttIdentityTransition.test.tsx`
- [x] Pre-commit hook (lint, typecheck, changed tests) passed on commit