### PR TITLE
fix: move Colorado Mesh MQTT preset to port 443

### DIFF
--- a/src/main/mqtt-manager.test.ts
+++ b/src/main/mqtt-manager.test.ts
@@ -938,7 +938,7 @@ describe('_doConnect — WebSocket scheme', () => {
 
   it('uses ws:// for port 1883 (plaintext MQTT port, no TLS)', () => {
     new MQTTManager().connect({
-      server: 'mqtt.meshcore.coloradomesh.org',
+      server: 'broker.example.com',
       port: 1883,
       username: '',
       password: '',
@@ -1064,10 +1064,10 @@ describe('_doConnect — WebSocket scheme', () => {
     ).toBe('mqtts');
   });
 
-  it('uses wss:// when tlsEnabled is true on port 1883', () => {
+  it('uses wss:// when tlsEnabled is true on port 443', () => {
     new MQTTManager().connect({
       server: 'mqtt.meshcore.coloradomesh.org',
-      port: 1883,
+      port: 443,
       username: '',
       password: '',
       topicPrefix: 'meshcore',
@@ -1085,7 +1085,7 @@ describe('_doConnect — WebSocket scheme', () => {
   it('uses custom wsPath when provided', () => {
     new MQTTManager().connect({
       server: 'mqtt.meshcore.coloradomesh.org',
-      port: 1883,
+      port: 443,
       username: '',
       password: '',
       topicPrefix: 'meshcore',

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -2260,7 +2260,7 @@ export default function ConnectionPanel({
                         setMeshcoreMqttSettings((prev) => ({
                           ...prev,
                           server: COLORADO_MESH_HOST,
-                          port: 1883,
+                          port: 443,
                           topicPrefix: 'meshcore/DEN',
                           useWebSocket: true,
                           tlsEnabled: true,

--- a/src/renderer/lib/connectionPanelStorageMigrations.test.ts
+++ b/src/renderer/lib/connectionPanelStorageMigrations.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  COLORADO_MESH_PORT_MIGRATION_KEY,
   LEGACY_MQTT_SETTINGS_KEY,
   MESHCORE_MQTT_SETTINGS_KEY,
   MESHCORE_TOPIC_IATA_MIGRATION_KEY,
@@ -84,6 +85,22 @@ describe('runConnectionPanelStorageMigrations', () => {
   it('sets migration marker even when meshcore settings are absent', () => {
     runConnectionPanelStorageMigrations();
     expect(localStorage.getItem(MESHCORE_TOPIC_IATA_MIGRATION_KEY)).toBe('1');
+  });
+
+  it('migrates Colorado Mesh port from 1883 to 443', () => {
+    localStorage.setItem(
+      MESHCORE_MQTT_SETTINGS_KEY,
+      JSON.stringify({ server: COLORADO_MESH_HOST, topicPrefix: 'meshcore/DEN', port: 1883 }),
+    );
+    localStorage.setItem(MESHCORE_TOPIC_IATA_MIGRATION_KEY, '1');
+
+    runConnectionPanelStorageMigrations();
+
+    const parsed = JSON.parse(localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY) ?? '{}') as {
+      port?: number;
+    };
+    expect(parsed.port).toBe(443);
+    expect(localStorage.getItem(COLORADO_MESH_PORT_MIGRATION_KEY)).toBe('1');
   });
 
   it('is idempotent on second call', () => {

--- a/src/renderer/lib/connectionPanelStorageMigrations.ts
+++ b/src/renderer/lib/connectionPanelStorageMigrations.ts
@@ -5,6 +5,7 @@ import type { MQTTSettings } from './types';
 const LEGACY_MQTT_SETTINGS_KEY = 'mesh-client:mqttSettings';
 const MESHCORE_MQTT_SETTINGS_KEY = 'mesh-client:mqttSettings:meshcore';
 const MESHCORE_TOPIC_IATA_MIGRATION_KEY = 'mesh-client:migrated:meshcore-topic-iata-v1';
+const COLORADO_MESH_PORT_MIGRATION_KEY = 'mesh-client:migrated:colorado-mesh-port-443-v1';
 
 function migrateMqttSettingsOnce(): void {
   if (localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY) !== null) return;
@@ -34,10 +35,33 @@ function migrateMeshcoreTopicIataOnce(): void {
   localStorage.setItem(MESHCORE_TOPIC_IATA_MIGRATION_KEY, '1');
 }
 
+function migrateColoradoMeshPortOnce(): void {
+  if (localStorage.getItem(COLORADO_MESH_PORT_MIGRATION_KEY) !== null) return;
+  const raw = localStorage.getItem(MESHCORE_MQTT_SETTINGS_KEY);
+  if (raw) {
+    const parsed = parseStoredJson<Partial<MQTTSettings>>(raw, 'migrateColoradoMeshPortOnce');
+    if (
+      parsed &&
+      typeof parsed.server === 'string' &&
+      parsed.server.trim() === COLORADO_MESH_HOST &&
+      parsed.port === 1883
+    ) {
+      localStorage.setItem(MESHCORE_MQTT_SETTINGS_KEY, JSON.stringify({ ...parsed, port: 443 }));
+    }
+  }
+  localStorage.setItem(COLORADO_MESH_PORT_MIGRATION_KEY, '1');
+}
+
 /** Idempotent localStorage migrations for ConnectionPanel MQTT settings. */
 export function runConnectionPanelStorageMigrations(): void {
   migrateMqttSettingsOnce();
   migrateMeshcoreTopicIataOnce();
+  migrateColoradoMeshPortOnce();
 }
 
-export { LEGACY_MQTT_SETTINGS_KEY, MESHCORE_MQTT_SETTINGS_KEY, MESHCORE_TOPIC_IATA_MIGRATION_KEY };
+export {
+  COLORADO_MESH_PORT_MIGRATION_KEY,
+  LEGACY_MQTT_SETTINGS_KEY,
+  MESHCORE_MQTT_SETTINGS_KEY,
+  MESHCORE_TOPIC_IATA_MIGRATION_KEY,
+};

--- a/src/renderer/lib/letsMeshConnectionGuards.ts
+++ b/src/renderer/lib/letsMeshConnectionGuards.ts
@@ -1,19 +1,15 @@
-import { COLORADO_MESH_HOST, isLetsMeshSettings } from './letsMeshJwt';
+import { isLetsMeshSettings } from './letsMeshJwt';
 import type { MQTTSettings } from './types';
 
-function getExpectedPort(server: string): number | null {
-  if (server.trim() === COLORADO_MESH_HOST) return 1883;
-  return 443;
-}
+const DEVICE_SIGNING_BROKER_PORT = 443;
 
 /** Hard validation before connecting with the LetsMesh preset (public US/EU brokers only). */
 export function validateLetsMeshPresetConnect(settings: MQTTSettings): string | null {
   if (!(settings.useWebSocket ?? false)) {
     return 'LetsMesh requires WebSocket transport.';
   }
-  const expectedPort = getExpectedPort(settings.server);
-  if (settings.port !== expectedPort) {
-    return `LetsMesh requires port ${expectedPort}.`;
+  if (settings.port !== DEVICE_SIGNING_BROKER_PORT) {
+    return `LetsMesh requires port ${DEVICE_SIGNING_BROKER_PORT}.`;
   }
   if (!isLetsMeshSettings(settings.server)) {
     return 'LetsMesh / MeshMapper preset only supports known device-signing brokers. Use Custom for other brokers.';
@@ -35,8 +31,7 @@ export function validateLetsMeshManualCredentials(settings: MQTTSettings): strin
 /** True if current fields diverge from what the public LetsMesh brokers need. */
 export function letsMeshPresetConfigurationDeviation(settings: MQTTSettings): boolean {
   if (!(settings.useWebSocket ?? false)) return true;
-  const expectedPort = getExpectedPort(settings.server);
-  if (settings.port !== expectedPort) return true;
+  if (settings.port !== DEVICE_SIGNING_BROKER_PORT) return true;
   if (!isLetsMeshSettings(settings.server)) return true;
   if ((settings.keepalive ?? 30) !== 30) return true;
   return false;

--- a/src/renderer/lib/letsMeshJwt.ts
+++ b/src/renderer/lib/letsMeshJwt.ts
@@ -19,7 +19,7 @@ export const LETSMESH_HOST_US = 'mqtt-us-v1.letsmesh.net';
 export const LETSMESH_HOST_EU = 'mqtt-eu-v1.letsmesh.net';
 /** MeshMapper broker (WebSocket TLS on 443). */
 export const MESHMAPPER_HOST = 'mqtt.meshmapper.cc';
-/** Colorado Mesh broker (WebSocket, TLS enabled, port 1883). */
+/** Colorado Mesh broker (WebSocket TLS on 443). */
 export const COLORADO_MESH_HOST = 'mqtt.meshcore.coloradomesh.org';
 
 /** @deprecated Use {@link LETSMESH_HOST_US} */

--- a/src/renderer/lib/mqttAutoLaunch.test.ts
+++ b/src/renderer/lib/mqttAutoLaunch.test.ts
@@ -84,7 +84,7 @@ describe('shouldAutoLaunchMeshcoreMqttAtStartup', () => {
       MESHCORE_KEY,
       JSON.stringify({
         server: 'mqtt.meshcore.coloradomesh.org',
-        port: 1883,
+        port: 443,
         autoLaunch: true,
         useWebSocket: true,
       }),

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh potřebuje WebSocket na portu 443 a server mqtt-us-v1.letsmesh.net nebo mqtt-eu-v1.letsmesh.net. Použijte Region (US/EU), nebo přepněte na Custom pro ostatní brokery.",
-      "coloradomesh": "Colorado Mesh potřebuje WebSocket na portu 1883 s povoleným TLS, server mqtt.meshcore.coloradomesh.org, cestu /ws. Resetujte předvolbu nebo přepněte na Vlastní pro ostatní brokery.",
+      "coloradomesh": "Colorado Mesh potřebuje WebSocket na portu 443 s povoleným TLS, server mqtt.meshcore.coloradomesh.org, cestu /ws. Resetujte předvolbu nebo přepněte na Vlastní pro ostatní brokery.",
       "meshmapper": "MeshMapper potřebuje WebSocket na portu 443 a server mqtt.meshmapper.cc. Resetujte předvolbu nebo přepněte na Vlastní pro ostatní brokery."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh benötigt WebSocket auf Port 443 und den Server mqtt-us-v1.letsmesh.net oder mqtt-eu-v1.letsmesh.net. Verwenden Sie die Region (USA/EU) oder wechseln Sie für andere Broker zu „Benutzerdefiniert“.",
-      "coloradomesh": "Colorado Mesh benötigt WebSocket auf Port 1883 mit aktiviertem TLS, Server mqtt.meshcore.coloradomesh.org, Pfad /ws. Setzen Sie die Voreinstellung zurück oder wechseln Sie für andere Broker zu „Benutzerdefiniert“.",
+      "coloradomesh": "Colorado Mesh benötigt WebSocket auf Port 443 mit aktiviertem TLS, Server mqtt.meshcore.coloradomesh.org, Pfad /ws. Setzen Sie die Voreinstellung zurück oder wechseln Sie für andere Broker zu „Benutzerdefiniert“.",
       "meshmapper": "MeshMapper benötigt WebSocket auf Port 443 und den Server mqtt.meshmapper.cc. Setzen Sie die Voreinstellung zurück oder wechseln Sie für andere Broker zu „Benutzerdefiniert“."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -917,7 +917,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh needs WebSocket on port 443 and server mqtt-us-v1.letsmesh.net or mqtt-eu-v1.letsmesh.net. Use Region (US/EU), or switch to Custom for other brokers.",
-      "coloradomesh": "Colorado Mesh needs WebSocket on port 1883 with TLS enabled, server mqtt.meshcore.coloradomesh.org, path /ws. Reset the preset or switch to Custom for other brokers.",
+      "coloradomesh": "Colorado Mesh needs WebSocket on port 443 with TLS enabled, server mqtt.meshcore.coloradomesh.org, path /ws. Reset the preset or switch to Custom for other brokers.",
       "meshmapper": "MeshMapper needs WebSocket on port 443 and server mqtt.meshmapper.cc. Reset the preset or switch to Custom for other brokers."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh necesita WebSocket en el puerto 443 y el servidor mqtt-us-v1.letsmesh.net o mqtt-eu-v1.letsmesh.net. Utilice Región (EE. UU./UE) o cambie a Personalizado para otros corredores.",
-      "coloradomesh": "Colorado Mesh necesita WebSocket en el puerto 1883 con TLS habilitado, servidor mqtt.meshcore.coloradomesh.org, ruta /ws. Restablezca el ajuste preestablecido o cambie a Personalizado para otros corredores.",
+      "coloradomesh": "Colorado Mesh necesita WebSocket en el puerto 443 con TLS habilitado, servidor mqtt.meshcore.coloradomesh.org, ruta /ws. Restablezca el ajuste preestablecido o cambie a Personalizado para otros corredores.",
       "meshmapper": "MeshMapper necesita WebSocket en el puerto 443 y el servidor mqtt.meshmapper.cc. Restablezca el ajuste preestablecido o cambie a Personalizado para otros corredores."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh a besoin de WebSocket sur le port 443 et du serveur mqtt-us-v1.letsmesh.net ou mqtt-eu-v1.letsmesh.net. Utilisez Région (États-Unis/UE) ou passez à Personnalisé pour les autres courtiers.",
-      "coloradomesh": "Colorado Mesh a besoin de WebSocket sur le port 1883 avec TLS activé, serveur mqtt.meshcore.coloradomesh.org, chemin /ws. Réinitialisez le préréglage ou passez à Personnalisé pour les autres courtiers.",
+      "coloradomesh": "Colorado Mesh a besoin de WebSocket sur le port 443 avec TLS activé, serveur mqtt.meshcore.coloradomesh.org, chemin /ws. Réinitialisez le préréglage ou passez à Personnalisé pour les autres courtiers.",
       "meshmapper": "MeshMapper a besoin de WebSocket sur le port 443 et du serveur mqtt.meshmapper.cc. Réinitialisez le préréglage ou passez à Personnalisé pour les autres courtiers."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh memerlukan WebSocket pada port 443 dan server mqtt-us-v1.letsmesh.net atau mqtt-eu-v1.letsmesh.net. Gunakan Wilayah (AS/UE), atau beralih ke Kustom untuk broker lain.",
-      "coloradomesh": "Colorado Mesh memerlukan WebSocket pada port 1883 dengan TLS diaktifkan, server mqtt.meshcore.coloradomesh.org, jalur /ws. Reset preset atau alihkan ke Custom untuk broker lain.",
+      "coloradomesh": "Colorado Mesh memerlukan WebSocket pada port 443 dengan TLS diaktifkan, server mqtt.meshcore.coloradomesh.org, jalur /ws. Reset preset atau alihkan ke Custom untuk broker lain.",
       "meshmapper": "MeshMapper membutuhkan WebSocket pada port 443 dan server mqtt.meshmapper.cc. Reset preset atau alihkan ke Custom untuk broker lain."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh necessita di WebSocket sulla porta 443 e del server mqtt-us-v1.letsmesh.net o mqtt-eu-v1.letsmesh.net. Utilizza la regione (USA/UE) o passa a Personalizzato per altri broker.",
-      "coloradomesh": "Colorado Mesh necessita di WebSocket sulla porta 1883 con TLS abilitato, server mqtt.meshcore.coloradomesh.org, percorso /ws. Ripristina la preimpostazione o passa a Personalizzato per altri broker.",
+      "coloradomesh": "Colorado Mesh necessita di WebSocket sulla porta 443 con TLS abilitato, server mqtt.meshcore.coloradomesh.org, percorso /ws. Ripristina la preimpostazione o passa a Personalizzato per altri broker.",
       "meshmapper": "MeshMapper necessita di WebSocket sulla porta 443 e sul server mqtt.meshmapper.cc. Ripristina la preimpostazione o passa a Personalizzato per altri broker."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh には、ポート 443 とサーバー mqtt-us-v1.letsmesh.net または mqtt-eu-v1.letsmesh.net 上の WebSocket が必要です。地域 (US/EU) を使用するか、他のブローカーの場合はカスタムに切り替えてください。",
-      "coloradomesh": "Colorado Mesh には、TLS が有効になっているポート 1883、サーバー mqtt.meshcore.coloradomesh.org、パス /ws の WebSocket が必要です。プリセットをリセットするか、他のブローカーの場合はカスタムに切り替えます。",
+      "coloradomesh": "Colorado Mesh には、TLS が有効になっているポート 443、サーバー mqtt.meshcore.coloradomesh.org、パス /ws の WebSocket が必要です。プリセットをリセットするか、他のブローカーの場合はカスタムに切り替えます。",
       "meshmapper": "MeshMapper には、ポート 443 とサーバー mqtt.meshmapper.cc 上の WebSocket が必要です。プリセットをリセットするか、他のブローカーの場合はカスタムに切り替えます。"
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh에는 포트 443 및 서버 mqtt-us-v1.letsmesh.net 또는 mqtt-eu-v1.letsmesh.net에 WebSocket이 필요합니다. 지역(US/EU)을 사용하거나 다른 브로커의 경우 사용자 정의로 전환하세요.",
-      "coloradomesh": "Colorado Mesh는 TLS가 활성화된 포트 1883, 서버 mqtt.meshcore.coloradomesh.org, 경로 /ws에 WebSocket이 필요합니다. 다른 브로커의 경우 사전 설정을 재설정하거나 사용자 정의로 전환하세요.",
+      "coloradomesh": "Colorado Mesh는 TLS가 활성화된 포트 443, 서버 mqtt.meshcore.coloradomesh.org, 경로 /ws에 WebSocket이 필요합니다. 다른 브로커의 경우 사전 설정을 재설정하거나 사용자 정의로 전환하세요.",
       "meshmapper": "MeshMapper에는 포트 443 및 서버 mqtt.meshmapper.cc에 WebSocket이 필요합니다. 다른 브로커의 경우 사전 설정을 재설정하거나 사용자 정의로 전환하세요."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh heeft WebSocket op poort 443 en server mqtt-us-v1.letsmesh.net of mqtt-eu-v1.letsmesh.net nodig. Gebruik Regio (VS/EU) of schakel over naar Aangepast voor andere makelaars.",
-      "coloradomesh": "Colorado Mesh heeft WebSocket nodig op poort 1883 met TLS ingeschakeld, server mqtt.meshcore.coloradomesh.org, pad /ws. Reset de preset of schakel over naar Aangepast voor andere makelaars.",
+      "coloradomesh": "Colorado Mesh heeft WebSocket nodig op poort 443 met TLS ingeschakeld, server mqtt.meshcore.coloradomesh.org, pad /ws. Reset de preset of schakel over naar Aangepast voor andere makelaars.",
       "meshmapper": "MeshMapper heeft WebSocket op poort 443 en server mqtt.meshmapper.cc nodig. Reset de preset of schakel over naar Aangepast voor andere makelaars."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh potrzebuje WebSocket na porcie 443 i serwerze mqtt-us-v1.letsmesh.net lub mqtt-eu-v1.letsmesh.net. Użyj regionu (USA/UE) lub przejdź na opcję Niestandardowy dla innych brokerów.",
-      "coloradomesh": "Colorado Mesh potrzebuje protokołu WebSocket na porcie 1883 z włączoną obsługą TLS, serwer mqtt.meshcore.coloradomesh.org, ścieżka /ws. Zresetuj ustawienie wstępne lub przejdź na opcję Niestandardową dla innych brokerów.",
+      "coloradomesh": "Colorado Mesh potrzebuje protokołu WebSocket na porcie 443 z włączoną obsługą TLS, serwer mqtt.meshcore.coloradomesh.org, ścieżka /ws. Zresetuj ustawienie wstępne lub przejdź na opcję Niestandardową dla innych brokerów.",
       "meshmapper": "MeshMapper potrzebuje protokołu WebSocket na porcie 443 i serwerze mqtt.meshmapper.cc. Zresetuj ustawienie wstępne lub przejdź na opcję Niestandardową dla innych brokerów."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh precisa de WebSocket na porta 443 e servidor mqtt-us-v1.letsmesh.net ou mqtt-eu-v1.letsmesh.net. Use Região (EUA/UE) ou mude para Personalizado para outros corretores.",
-      "coloradomesh": "Colorado Mesh precisa de WebSocket na porta 1883 com TLS habilitado, servidor mqtt.meshcore.coloradomesh.org, caminho /ws. Redefina a predefinição ou mude para Personalizado para outros corretores.",
+      "coloradomesh": "Colorado Mesh precisa de WebSocket na porta 443 com TLS habilitado, servidor mqtt.meshcore.coloradomesh.org, caminho /ws. Redefina a predefinição ou mude para Personalizado para outros corretores.",
       "meshmapper": "MeshMapper precisa de WebSocket na porta 443 e servidor mqtt.meshmapper.cc. Redefina a predefinição ou mude para Personalizado para outros corretores."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh нужен WebSocket на порту 443 и сервер mqtt-us-v1.letsmesh.net или mqtt-eu-v1.letsmesh.net. Используйте регион (США/ЕС) или переключитесь на Custom для других брокеров.",
-      "coloradomesh": "Colorado Mesh требуется WebSocket на порту 1883 с включенным TLS, сервер mqtt.meshcore.coloradomesh.org, путь /ws. Сбросьте предустановку или переключитесь на Custom для других брокеров.",
+      "coloradomesh": "Colorado Mesh требуется WebSocket на порту 443 с включенным TLS, сервер mqtt.meshcore.coloradomesh.org, путь /ws. Сбросьте предустановку или переключитесь на Custom для других брокеров.",
       "meshmapper": "MeshMapper нуждается в WebSocket на порту 443 и сервере mqtt.meshmapper.cc. Сбросьте предустановку или переключитесь на Custom для других брокеров."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh'in 443 numaralı bağlantı noktasında WebSocket'e ve mqtt-us-v1.letsmesh.net veya mqtt-eu-v1.letsmesh.net sunucusuna ihtiyacı vardır. Bölge'yi (ABD/AB) kullanın veya diğer aracılar için Özel'e geçin.",
-      "coloradomesh": "Colorado Mesh'in TLS etkinleştirilmiş 1883 numaralı bağlantı noktasında WebSocket'e ihtiyacı var, sunucu mqtt.meshcore.coloradomesh.org, yol /ws. Ön ayarı sıfırlayın veya diğer aracılar için Özel'e geçin.",
+      "coloradomesh": "Colorado Mesh'in TLS etkinleştirilmiş 443 numaralı bağlantı noktasında WebSocket'e ihtiyacı var, sunucu mqtt.meshcore.coloradomesh.org, yol /ws. Ön ayarı sıfırlayın veya diğer aracılar için Özel'e geçin.",
       "meshmapper": "MeshMapper'ın 443 numaralı bağlantı noktasında WebSocket'e ve mqtt.meshmapper.cc sunucusuna ihtiyacı vardır. Ön ayarı sıfırlayın veya diğer aracılar için Özel'e geçin."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh потребує WebSocket на порту 443 і сервері mqtt-us-v1.letsmesh.net або mqtt-eu-v1.letsmesh.net. Використовуйте регіон (США/ЄС) або перейдіть на спеціальний для інших брокерів.",
-      "coloradomesh": "Colorado Mesh потребує WebSocket на порту 1883 із увімкненим TLS, сервер mqtt.meshcore.coloradomesh.org, шлях /ws. Скиньте попередні налаштування або перейдіть на Custom для інших брокерів.",
+      "coloradomesh": "Colorado Mesh потребує WebSocket на порту 443 із увімкненим TLS, сервер mqtt.meshcore.coloradomesh.org, шлях /ws. Скиньте попередні налаштування або перейдіть на Custom для інших брокерів.",
       "meshmapper": "MeshMapper потребує WebSocket на порту 443 і сервері mqtt.meshmapper.cc. Скиньте попередні налаштування або перейдіть на Custom для інших брокерів."
     },
     "meshcoreMqttIdentity": {

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -992,7 +992,7 @@
     },
     "meshcorePresetDeviation": {
       "letsmesh": "LetsMesh 需要端口 443 上的 WebSocket 和服务器 mqtt-us-v1.letsmesh.net 或 mqtt-eu-v1.letsmesh.net。使用区域（美国/欧盟），或切换到其他经纪商的自定义。",
-      "coloradomesh": "Colorado Mesh 需要端口 1883 上的 WebSocket 且启用了 TLS，服务器 mqtt.meshcore.coloradomesh.org，路径 /ws。重置预设或切换到其他经纪商的自定义。",
+      "coloradomesh": "Colorado Mesh 需要端口 443 上的 WebSocket 且启用了 TLS，服务器 mqtt.meshcore.coloradomesh.org，路径 /ws。重置预设或切换到其他经纪商的自定义。",
       "meshmapper": "MeshMapper 需要端口 443 上的 WebSocket 和服务器 mqtt.meshmapper.cc。重置预设或切换到其他经纪商的自定义。"
     },
     "meshcoreMqttIdentity": {


### PR DESCRIPTION
## Summary
- Switch the MeshCore Colorado Mesh broker preset from port 1883 to 443 to match the broker's TLS WebSocket endpoint.
- Align LetsMesh connection guards so all device-signing brokers expect port 443.
- Add a one-time localStorage migration for users with saved Colorado Mesh settings still on 1883.

## Test plan
- [x] `vitest run` for `letsMeshConnectionGuards`, `connectionPanelStorageMigrations`, `mqttAutoLaunch`, and `mqtt-manager` tests
- [ ] Select **Colorado Mesh** preset in Connection panel and confirm port shows **443**
- [ ] Connect to `mqtt.meshcore.coloradomesh.org` over WebSocket/TLS on 443
- [ ] Upgrade from a build with saved Colorado settings on 1883 and confirm port migrates to 443 automatically