### PR TITLE
fix: harden Reticulum discovery map memory and resilience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,9 @@ Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`).
 
 - **Sidecar:** `reticulum-sidecar/` (AGPL Rust binary `mesh-client-reticulum`); dev: `pnpm run reticulum:sidecar:dev`
 - **IPC:** `reticulum:*` main handlers (`proxyGet` / `proxyPost` / `proxyPut` / `proxyDelete`, config file read/import dialog); renderer uses `electronAPI.reticulum` proxy (no direct localhost from sandbox)
-- **Panels:** `ReticulumStackPanel` (Connection — stack lifecycle, interfaces), `ReticulumNetworkPanel` (Network — identity, stack/announce settings, propagation, config import), `ReticulumAdminPanel` (Admin — RNode flasher, factory reset), `ReticulumPeerListPanel` (Peers), `NomadNetworkPanel` (Nomad Network)
+- **Panels:** `ReticulumStackPanel` (Connection — stack lifecycle, interfaces), `ReticulumNetworkPanel` (Network — identity, stack/announce settings, propagation, config import), `ReticulumMapPanel` (Map — RMAP v4 discovery), `ReticulumRmapDiscoveryControls` / `ReticulumRmapConnectionStatus` (RMAP publish), `ReticulumAdminPanel` (Admin — RNode flasher, factory reset), `ReticulumPeerListPanel` (Peers), `NomadNetworkPanel` (Nomad Network)
+- **Stores/lib:** `reticulumDiscoveryMapStore.ts`, `reticulumRmapDiscovery.ts`, `reticulumDiscoveryMapLayout.ts`; WS event `rmap.discovery` in `useReticulumRuntime`
+- **Gating:** `hasReticulumDiscoveryMap` (Map tab); `hasReticulumInterfaceConfig` / `hasReticulumNetworkPanel` / `ProtocolCapabilities`
 - **Runtime:** `useReticulumRuntime`, `reticulumSession.ts`, `reticulumIngest.ts`; connect starts sidecar, not `ConnectionDriver` RF
 - **Diagnostics:** `ReticulumDiagnosticEngine.ts` (Reticulum-native rows; no LoRa hop-goblin semantics)
 - **No Noble/MQTT** for Reticulum tab; gate UI with `hasReticulumInterfaceConfig` / `hasReticulumNetworkPanel` / `ProtocolCapabilities`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ Path alias `@/*` maps to `src/*` (see `tsconfig.json`).
 
 ## Multi-protocol (Meshtastic + MeshCore + Reticulum)
 
-All three stacks can run at once: independent sessions, header switcher for focus (green / cyan / amber), inactive protocols stay connected, per-protocol unread badges. Meshtastic and MeshCore use `ConnectionDriver` for RF/MQTT; Reticulum uses the AGPL sidecar (`useReticulumRuntime`, no Noble/MQTT on that tab). Capabilities differ (e.g. Meshtastic: full Security PKI/Modules/TAK; MeshCore: partial Security backup/restore, Repeaters, **Rooms** BBS; Reticulum: LXMF DMs, propagation, RNode flasher, Topology). Sidebar tab slots are fixed in `src/renderer/lib/tabSlotIds.ts`; visibility is computed in `src/renderer/lib/appTabMappings.ts` (`computeTabMappings()` consumed from `App.tsx`); **Rooms** requires `hasRoomServersPanel`, Reticulum panels gate on `hasReticulumNetworkPanel` / `hasReticulumInterfaceConfig`, **Security**/`TAK` require capability flags (~16 visible tabs per LoRa protocol; MeshCore hides TAK; Reticulum hides LoRa-specific tabs).
+All three stacks can run at once: independent sessions, header switcher for focus (green / cyan / amber), inactive protocols stay connected, per-protocol unread badges. Meshtastic and MeshCore use `ConnectionDriver` for RF/MQTT; Reticulum uses the AGPL sidecar (`useReticulumRuntime`, no Noble/MQTT on that tab). Capabilities differ (e.g. Meshtastic: full Security PKI/Modules/TAK; MeshCore: partial Security backup/restore, Repeaters, **Rooms** BBS; Reticulum: LXMF DMs, propagation, RNode flasher, **Map** (RMAP v4 discovery), Topology). Sidebar tab slots are fixed in `src/renderer/lib/tabSlotIds.ts`; visibility is computed in `src/renderer/lib/appTabMappings.ts` (`computeTabMappings()` consumed from `App.tsx`); **Rooms** requires `hasRoomServersPanel`, Reticulum panels gate on `hasReticulumNetworkPanel` / `hasReticulumInterfaceConfig` / `hasReticulumDiscoveryMap`, **Security**/`TAK` require capability flags (~16 visible tabs per LoRa protocol; MeshCore hides TAK; Reticulum hides LoRa-specific tabs).
 
 **Feature gating:** use `ProtocolCapabilities` via `useRadioProvider(protocol)` from `src/renderer/lib/radio/providerFactory.ts`; do not branch on raw `protocol === 'meshcore'` strings.
 
@@ -80,7 +80,7 @@ Sanitize user-controlled strings before logs and IPC per [AGENTS.md](AGENTS.md).
 
 - **Meshtastic:** `runtime/useMeshtasticRuntime.ts`, `lib/protocols/MeshtasticProtocol.ts`, `lib/connection.ts` (`createConnection`).
 - **MeshCore:** `runtime/useMeshcoreRuntime.ts`, `lib/protocols/MeshCoreProtocol.ts`, `@liamcottle/meshcore.js`.
-- **Reticulum:** `runtime/useReticulumRuntime.ts`, `lib/reticulum/reticulumSession.ts`, `reticulum-sidecar/` (AGPL `mesh-client-reticulum`); IPC `reticulum:*` in main; docs [docs/reticulum.md](docs/reticulum.md), [docs/reticulum-sidecar-ipc.md](docs/reticulum-sidecar-ipc.md).
+- **Reticulum:** `runtime/useReticulumRuntime.ts`, `lib/reticulum/reticulumSession.ts`, `components/ReticulumMapPanel.tsx`, `stores/reticulumDiscoveryMapStore.ts`, `reticulum-sidecar/` (AGPL `mesh-client-reticulum`); IPC `reticulum:*` in main; RMAP map data: sidecar `DiscoveryStore` → REST/WS → store → join `reticulumPeerStore` for reachability; docs [docs/reticulum.md](docs/reticulum.md), [docs/reticulum-sidecar-ipc.md](docs/reticulum-sidecar-ipc.md).
 
 ### Database
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Reticulum is the third protocol tab (**amber** pill). The stack runs in an **AGP
 **Peers, topology, Nomad Network**
 
 - **Peers** tab: RNS path-table peers and LXMF contacts (separate sub-tabs); path probe and peer detail modal
-- **Map** tab: local RMAP v4 discovery map (Leaflet + OSM basemaps; heard opt-in interfaces with GPS); **Global map** link to [rmap.world](https://rmap.world/)
+- **Map** tab: local RMAP v4 discovery map (Leaflet + OSM basemaps; heard opt-in interfaces with GPS; interface-type filters; reachable vs heard-only sidebar list; publish via Network + Connection); **Global map** link to [rmap.world](https://rmap.world/) — no position trails or waypoints (contrast with Meshtastic/MeshCore Map)
 - **Topology** tab: best-effort graph from the RNS path table (next-hop edges, BFS layout)
 - **Nomad Network** tab: collapsible favourites/announces list (default **Favourites** sub-tab); panel lazy-mounts after first visit and keeps browse state across tab switches (`mesh-client:nomadNodeListCollapsed` for sidebar width)
 

--- a/docs/reticulum-sidecar-ipc.md
+++ b/docs/reticulum-sidecar-ipc.md
@@ -72,23 +72,27 @@ The Connection tab UI edits a subset: **name** for all types; **host** / **port*
 
 ### Peers, topology, and propagation
 
-| Method | Path                                 | Body / notes                  | Response                                                                                                                       |
-| ------ | ------------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| GET    | `/api/v1/peers`                      |                               | `{ peers: [] }` — live path table when `rns-stack` enabled                                                                     |
-| POST   | `/api/v1/peers/{hash}/path`          |                               | `{ ok }` — emits `peers_updated` WS on success                                                                                 |
-| POST   | `/api/v1/peers/{hash}/probe`         |                               | `{ ok, hops? }` live; `{ ok, mode, hash }` stub — emits `peers_updated` on success                                             |
-| POST   | `/api/v1/ping`                       | `{ destination_hash }`        | `{ ok, rtt_ms? }`                                                                                                              |
-| GET    | `/api/v1/topology`                   |                               | `{ nodes, edges }` — `via_hash` is the immediate RNS next hop (transport id); sidecar infers `self → relay` when needed        |
-| GET    | `/api/v1/rmap/discovered`            |                               | `{ discovered: RmapDiscoveredWireRow[] }` — local RMAP v4 heard interfaces (7-day TTL eviction in rsReticulum DiscoveryStore)  |
-| GET    | `/api/v1/packets`                    | `?limit=500` (1–2500)         | `{ packets: [] }` — recent wire tap ring buffer                                                                                |
-| DELETE | `/api/v1/packets`                    |                               | `{ ok }` — clear wire tap buffer                                                                                               |
-| GET    | `/api/v1/propagation`                |                               | `{ propagation, preferred_id, auto_sync_interval_sec }` — `local-prop` rows include `message_count`, `storage_bytes` when live |
-| POST   | `/api/v1/propagation/add`            | `{ destination_hash, name? }` | `{ ok, node }` — add a remote propagation node by hash                                                                         |
-| POST   | `/api/v1/propagation/{id}/enable`    |                               | `{ ok }`                                                                                                                       |
-| POST   | `/api/v1/propagation/{id}/disable`   |                               | `{ ok }`                                                                                                                       |
-| POST   | `/api/v1/propagation/{id}/preferred` |                               | `{ ok }`                                                                                                                       |
-| POST   | `/api/v1/propagation/sync`           |                               | `{ ok }`                                                                                                                       |
-| POST   | `/api/v1/propagation/sync/cancel`    |                               | `{ ok }`                                                                                                                       |
+| Method | Path                         | Body / notes           | Response                                                                                                                      |
+| ------ | ---------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/api/v1/peers`              |                        | `{ peers: [] }` — live path table when `rns-stack` enabled                                                                    |
+| POST   | `/api/v1/peers/{hash}/path`  |                        | `{ ok }` — emits `peers_updated` WS on success                                                                                |
+| POST   | `/api/v1/peers/{hash}/probe` |                        | `{ ok, hops? }` live; `{ ok, mode, hash }` stub — emits `peers_updated` on success                                            |
+| POST   | `/api/v1/ping`               | `{ destination_hash }` | `{ ok, rtt_ms? }`                                                                                                             |
+| GET    | `/api/v1/topology`           |                        | `{ nodes, edges }` — `via_hash` is the immediate RNS next hop (transport id); sidecar infers `self → relay` when needed       |
+| GET    | `/api/v1/rmap/discovered`    |                        | `{ discovered: RmapDiscoveredWireRow[] }` — local RMAP v4 heard interfaces (7-day TTL eviction in rsReticulum DiscoveryStore) |
+
+**`RmapDiscoveredWireRow` fields** (see `src/shared/reticulum-types.ts`): `discovery_hash`, `transport_id`, `discovery_name`, `interface_type`, `latitude`, `longitude`, `height`, `transport_enabled`, `reachable_on`, LoRa RF fields (`frequency`, `bandwidth`, `spreading_factor`, …), `hops`, `stamp_value`, `discovered`, `last_heard`, `heard_count`, `status` (`available`/`stale`/`unknown`), `has_coordinates`. Renderer caps at 2,000 newest rows with client-side TTL eviction.
+
+**WS `rmap.discovery`:** sidecar polls DiscoveryStore every **10s**; emits full `{ discovered: [...] }` snapshot when JSON fingerprint changes. Stub builds return `{ discovered: [] }`.
+| GET | `/api/v1/packets` | `?limit=500` (1–2500) | `{ packets: [] }` — recent wire tap ring buffer |
+| DELETE | `/api/v1/packets` | | `{ ok }` — clear wire tap buffer |
+| GET | `/api/v1/propagation` | | `{ propagation, preferred_id, auto_sync_interval_sec }` — `local-prop` rows include `message_count`, `storage_bytes` when live |
+| POST | `/api/v1/propagation/add` | `{ destination_hash, name? }` | `{ ok, node }` — add a remote propagation node by hash |
+| POST | `/api/v1/propagation/{id}/enable` | | `{ ok }` |
+| POST | `/api/v1/propagation/{id}/disable` | | `{ ok }` |
+| POST | `/api/v1/propagation/{id}/preferred` | | `{ ok }` |
+| POST | `/api/v1/propagation/sync` | | `{ ok }` |
+| POST | `/api/v1/propagation/sync/cancel` | | `{ ok }` |
 
 ### Nomad Network
 

--- a/docs/reticulum.md
+++ b/docs/reticulum.md
@@ -91,7 +91,19 @@ The **Map** tab shows **local** RMAP v4 discovery data — interfaces your stack
 
 **Publish (appear on maps):** Network → **RMAP v4 discovery** or per-interface RMAP toggles on Connection. Requires App → GPS coordinates for map markers. LoRa-only stacks need an enabled TCP hub (for example `rmap.world:4242`) so discovery announces reach the wider network — see config audit `rmap_no_tcp_hub`.
 
-**Consume (Map tab):** Sidecar sets `discover_interfaces = Yes` in rnsd config on bootstrap so the stack listens for discovery announces. Markers show GPS when coordinates were included in the announce; interfaces without coords appear in the sidebar list only. **Reachable** badges join discovery rows with the RNS path table (Peers tab).
+**Consume (Map tab):** Sidecar sets `discover_interfaces = Yes` in rnsd config on bootstrap so the stack listens for discovery announces. Markers show GPS when coordinates were included in the announce; interfaces without coords appear in the sidebar list only. **Reachable** badges join discovery rows with the RNS path table (Peers tab) by matching `transport_id` against peer `destination_hash` or `via_hash`.
+
+**UI:** Leaflet map with 280px sidebar list; filter pills (All, LoRa, Backbone, I2P, TCP, Other); basemap switcher and Locate Me (App GPS); manual Refresh; marker click opens peer detail when the node is in the path table. List row click flies to coordinates at zoom 14.
+
+**Refresh model:** Map tab polls `GET /api/v1/rmap/discovered` every **30s** while mounted; sidecar also pushes WebSocket `rmap.discovery` every **10s** when the discovery fingerprint changes (runtime updates store even when Map tab is hidden).
+
+**Publish settings (Network → RMAP v4 discovery):** announce interval **60–1440 min** (default **360**); optional height (meters) and `reachable_on` (max 256 chars). LoRa/BLE publish auto-enables `enable_transport` and the **`rmap.world:4242`** hub. Stack restart confirm after enabling publish.
+
+**Performance / memory:** Renderer mirrors discovery rows in `reticulumDiscoveryMapStore` (in-memory only; capped at **2,000** newest rows with client-side 7-day `last_heard` eviction). Peer store capped at **10,000** entries on refresh. Leaflet uses `preferCanvas`; tile layer `keepBuffer={1}`. No marker clustering — typical scale is bounded by sidecar TTL. Stores clear on disconnect and unexpected sidecar stop.
+
+**Config audit kinds:** `rmap_missing_coordinates`, `rmap_no_tcp_hub`, `rmap_transport_disabled`, `rmap_i2p_not_connectable`.
+
+**Implementation:** `ReticulumMapPanel.tsx`, `reticulumDiscoveryMapStore.ts`, `reticulumDiscoveryMapLayout.ts`, `reticulumRmapDiscovery.ts`, `useReticulumRuntime.ts` (WS `rmap.discovery`).
 
 **Related panels:** **Topology** = logical hops (no geography); **Peers** = path table; **Map** = geographic discovery + reachability.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -956,6 +956,10 @@ In dev, **Start stack** now rebuilds when `reticulum-sidecar/src/**/*.rs` or `Ca
 4. **Missing GPS in announce** — nodes without latitude/longitude appear in the list panel only (no map marker).
 5. **Global coverage** — the in-app map shows **heard** opt-in nodes only; use **Global map** (rmap.world) for worldwide view.
 6. **`discover_interfaces`** — sidecar enables `discover_interfaces = Yes` on bootstrap; restart the stack after upgrading if the Map tab stays empty on an old config.
+7. **Stub sidecar** — dev builds without `rns-stack` return an empty discovered list.
+8. **Filter empty** — interface-type filter pills may exclude all rows; try **All**.
+9. **Refresh errors** — transient sidecar errors show inline `refreshFailed` without clearing last-good markers.
+10. **No publish-capable interface** — Auto and outbound TCP client types cannot publish RMAP discovery.
 
 ### Reticulum interface add/edit/delete fails
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2625,8 +2625,8 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
   immediate@3.0.6:
@@ -5664,7 +5664,7 @@ snapshots:
       '@typescript-eslint/utils': 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.63.0
       eslint: 10.6.0(jiti@2.7.0)
-      ignore: 7.0.5
+      ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -7112,7 +7112,7 @@ snapshots:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
       fast-glob: 3.3.3
-      ignore: 7.0.5
+      ignore: 7.0.6
       is-path-inside: 4.0.0
       slash: 5.1.0
       unicorn-magic: 0.4.0
@@ -7214,7 +7214,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  ignore@7.0.5: {}
+  ignore@7.0.6: {}
 
   immediate@3.0.6: {}
 

--- a/scripts/check-i18n-quality.mjs
+++ b/scripts/check-i18n-quality.mjs
@@ -3191,6 +3191,91 @@ function checkRepeatersCliIssues(ctx) {
   return issues;
 }
 
+const RETICULUM_MAP_REACHABLE_KEY = 'reticulumMap.reachable';
+const RETICULUM_MAP_HEARD_ONLY_KEY = 'reticulumMap.heardOnly';
+const RETICULUM_MAP_OPEN_GLOBAL_KEY = 'reticulumMap.openGlobalMap';
+const RETICULUM_MAP_OPEN_NODE_ARIA_KEY = 'reticulumMap.openNodeAria';
+const RETICULUM_MAP_FILTER_BACKBONE_KEY = 'reticulumMap.filter.backbone';
+
+const RETICULUM_MAP_REACHABLE_FALSE_FRIENDS = [
+  {
+    re: /lexique de la théorie des graphes/i,
+    hint: 'use network-reachable wording, not graph theory',
+  },
+  { re: /^greifbar\.?$/i, hint: 'use "Erreichbar", not affordable Greifbar' },
+  { re: /^reachable$/i, hint: 'translate reachable for network path table' },
+];
+
+const RETICULUM_MAP_BACKBONE_FALSE_FRIENDS = [
+  { re: /colonne vertébrale/i, hint: 'use network backbone, not spine/anatomy' },
+  { re: /^椎骨$/i, hint: 'use Backbone or network backbone, not vertebra' },
+];
+
+/**
+ * @param {LocaleQualityCtx} ctx
+ * @returns {string[]}
+ */
+function checkReticulumMapIssues(ctx) {
+  const { locale, flatKey, val, enVal } = ctx;
+  const issues = [];
+  if (!flatKey.startsWith('reticulumMap.') && !flatKey.startsWith('reticulumRmapDiscovery.')) {
+    return issues;
+  }
+
+  if (flatKey === RETICULUM_MAP_OPEN_GLOBAL_KEY && /^\[.*\?]$/.test(val)) {
+    issues.push('reticulumMap.openGlobalMap must not use CAT […?] placeholder');
+  }
+
+  if (flatKey === RETICULUM_MAP_REACHABLE_KEY && locale !== 'en') {
+    if (val === enVal) {
+      issues.push('reticulumMap.reachable must be translated');
+    }
+    for (const { re, hint } of RETICULUM_MAP_REACHABLE_FALSE_FRIENDS) {
+      if (re.test(val)) {
+        issues.push(`reticulumMap.reachable false friend: ${hint}`);
+      }
+    }
+  }
+
+  if (flatKey === RETICULUM_MAP_HEARD_ONLY_KEY && locale !== 'en' && val === enVal) {
+    issues.push('reticulumMap.heardOnly must be translated');
+  }
+
+  if (
+    flatKey === RETICULUM_MAP_OPEN_NODE_ARIA_KEY &&
+    enVal.includes('{{name}}') &&
+    locale !== 'en'
+  ) {
+    for (const { re, hint } of [
+      { re: /détails de \{\{name\}\}/i, hint: 'use show-on-map wording, not open details' },
+      { re: /details für \{\{name\}\}/i, hint: 'use show-on-map wording, not open details' },
+      { re: /\{\{name\}\}の詳細/i, hint: 'use show-on-map wording, not open details' },
+    ]) {
+      if (re.test(val)) {
+        issues.push(`reticulumMap.openNodeAria false friend: ${hint}`);
+      }
+    }
+  }
+
+  if (flatKey === RETICULUM_MAP_FILTER_BACKBONE_KEY) {
+    for (const { re, hint } of RETICULUM_MAP_BACKBONE_FALSE_FRIENDS) {
+      if (re.test(val)) {
+        issues.push(`reticulumMap.filter.backbone false friend: ${hint}`);
+      }
+    }
+  }
+
+  if (
+    flatKey === 'reticulumRmapDiscovery.gpsRequiredTitle' &&
+    locale === 'ru' &&
+    /sono necessarie/i.test(val)
+  ) {
+    issues.push('reticulumRmapDiscovery.gpsRequiredTitle must be Russian, not Italian');
+  }
+
+  return issues;
+}
+
 const LOCALE_STRING_QUALITY_CHECKS = [
   checkCatEncodingAndMeshtasticIssues,
   checkMustTranslateAndFormFieldIssues,
@@ -3214,6 +3299,7 @@ const LOCALE_STRING_QUALITY_CHECKS = [
   checkBootSequenceTransportIssues,
   checkReticulumDefaultHubKeyIssues,
   checkRepeatersCliIssues,
+  checkReticulumMapIssues,
 ];
 
 /**

--- a/src/renderer/components/MapPanel.tsx
+++ b/src/renderer/components/MapPanel.tsx
@@ -45,7 +45,11 @@ import { useMapLayerStore } from '../stores/mapLayerStore';
 import { useMapViewportStore } from '../stores/mapViewportStore';
 import { getWeightedPaths, usePathHistoryStore } from '../stores/pathHistoryStore';
 import { usePositionHistoryStore } from '../stores/positionHistoryStore';
-import { LocateMeControl } from './map/leafletMapControls';
+import {
+  ensureLoRaMapPanelStyles,
+  LocateMeControl,
+  MapViewportSaver,
+} from './map/leafletMapControls';
 
 const WAYPOINT_MARKER_ICON = L.divIcon({
   className: '',
@@ -54,81 +58,7 @@ const WAYPOINT_MARKER_ICON = L.divIcon({
   iconAnchor: [9, 9],
 });
 
-// ─── Map styles (anomaly halos + dark popup) ──────────────────────────────────
-
-const MAP_STYLE_ID = 'map-styles';
-function ensureMapStyles() {
-  if (document.getElementById(MAP_STYLE_ID)) return;
-  const style = document.createElement('style');
-  style.id = MAP_STYLE_ID;
-  style.textContent = `
-    @keyframes anomaly-pulse {
-      0%, 100% { opacity: 0.75; }
-      50%       { opacity: 0.15; }
-    }
-    .anomaly-halo-warning {
-      animation: anomaly-pulse 2s ease-in-out infinite;
-      pointer-events: none !important;
-    }
-    .anomaly-halo-error {
-      animation: anomaly-pulse 1.4s ease-in-out infinite;
-      pointer-events: none !important;
-    }
-    html[data-reduce-motion='true'] .anomaly-halo-warning,
-    html[data-reduce-motion='true'] .anomaly-halo-error {
-      animation: none !important;
-      opacity: 0.75 !important;
-    }
-    .leaflet-popup.map-node-popup .leaflet-popup-content-wrapper {
-      background: #0f172a;
-      border: 1px solid #334155;
-      color: #e5e7eb;
-      border-radius: 0.75rem;
-      padding: 0;
-      box-shadow: 0 25px 50px -12px rgba(0,0,0,0.5);
-    }
-    .leaflet-popup.map-node-popup .leaflet-popup-content {
-      margin: 0;
-      min-width: 280px;
-      max-width: 340px;
-      max-height: 70vh;
-      overflow: hidden;
-    }
-    .leaflet-popup.map-node-popup .leaflet-popup-content > div {
-      max-height: 70vh;
-      overflow-y: auto;
-    }
-    .leaflet-popup.map-node-popup .leaflet-popup-tip {
-      background: #0f172a;
-    }
-    .leaflet-popup.map-node-popup .leaflet-popup-close-button {
-      color: #9ca3af !important;
-    }
-    .leaflet-popup.map-node-popup .leaflet-popup-close-button:hover {
-      color: #e5e7eb !important;
-    }
-    .leaflet-locate-control a {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 30px;
-      height: 30px;
-      background: #ffffff;
-      color: #52525b;
-      cursor: pointer;
-      border: none;
-      outline: none;
-    }
-    .leaflet-locate-control a:hover {
-      background: #f4f4f5;
-      color: #000000;
-    }
-    .leaflet-locate-control a.locating {
-      color: #3b82f6;
-    }
-  `;
-  document.head.appendChild(style);
-}
+// ─── Map styles (anomaly halos + dark popup) — see ensureLoRaMapPanelStyles in leafletMapControls ─
 
 // ─── Marker icon helpers ──────────────────────────────────────────────────────
 
@@ -451,39 +381,6 @@ function MapFitter({
       map.setView(center, DEFAULT_ZOOM);
     }
   }, [positions, ourPosition, map, shouldFitOnMount]);
-  return null;
-}
-
-// ─── ViewportSaver ────────────────────────────────────────────────────────────
-// Only save viewport when we have position data, so that when data arrives
-// later we still perform the initial fit once instead of staying at default.
-
-const VIEWPORT_EPS = 1e-6;
-
-function ViewportSaver({ hasAnyPositions }: { hasAnyPositions: boolean }) {
-  const map = useMap();
-  const setViewport = useMapViewportStore((s) => s.setViewport);
-  useEffect(() => {
-    if (!hasAnyPositions) return;
-    const onMoveEnd = () => {
-      const center = map.getCenter();
-      const zoom = map.getZoom();
-      const next = { center: [center.lat, center.lng] as [number, number], zoom };
-      const current = useMapViewportStore.getState().viewport;
-      if (
-        current?.zoom === next.zoom &&
-        Math.abs(current.center[0] - next.center[0]) < VIEWPORT_EPS &&
-        Math.abs(current.center[1] - next.center[1]) < VIEWPORT_EPS
-      ) {
-        return;
-      }
-      setViewport(next);
-    };
-    map.on('moveend', onMoveEnd);
-    return () => {
-      map.off('moveend', onMoveEnd);
-    };
-  }, [map, setViewport, hasAnyPositions]);
   return null;
 }
 
@@ -836,7 +733,7 @@ export default function MapPanel({
   ]);
 
   useEffect(() => {
-    ensureMapStyles();
+    ensureLoRaMapPanelStyles();
     void loadHistoryFromDb().catch((e: unknown) => {
       console.warn('[MapPanel] loadHistoryFromDb failed:', String(e));
     });
@@ -1126,7 +1023,7 @@ export default function MapPanel({
         preferCanvas
       >
         <DiagnosticPanes />
-        <ViewportSaver hasAnyPositions={positions.length > 0 || !!ourPosition} />
+        <MapViewportSaver hasAnyPositions={positions.length > 0 || !!ourPosition} />
         <MapFocusController />
         <MapFitter
           positions={positions}

--- a/src/renderer/components/ReticulumMapPanel.test.tsx
+++ b/src/renderer/components/ReticulumMapPanel.test.tsx
@@ -16,12 +16,29 @@ import { useReticulumDiscoveryMapStore } from '@/renderer/stores/reticulumDiscov
 
 const flyToMock = vi.fn();
 
-const { mapContainerMock, markerMock } = vi.hoisted(() => ({
-  mapContainerMock: vi.fn(({ children }: { children: React.ReactNode }) => (
-    <div data-testid="map-container">{children}</div>
-  )),
-  markerMock: vi.fn(() => null),
-}));
+const {
+  mapContainerMock,
+  markerMock,
+  fetchReticulumRmapDiscoveredMock,
+  peerStoreState,
+  markerLastPropsRef,
+} = vi.hoisted(() => {
+  const markerLastPropsRef = {
+    current: undefined as { eventHandlers?: { click?: () => void } } | undefined,
+  };
+  return {
+    mapContainerMock: vi.fn(({ children }: { children: React.ReactNode }) => (
+      <div data-testid="map-container">{children}</div>
+    )),
+    markerMock: vi.fn((props: { eventHandlers?: { click?: () => void } }) => {
+      markerLastPropsRef.current = props;
+      return null;
+    }),
+    fetchReticulumRmapDiscoveredMock: vi.fn().mockResolvedValue([]),
+    peerStoreState: { peers: new Map<string, unknown>() },
+    markerLastPropsRef,
+  };
+});
 
 vi.mock('react-leaflet', () => ({
   MapContainer: mapContainerMock,
@@ -36,7 +53,7 @@ vi.mock('react-leaflet', () => ({
 }));
 
 vi.mock('@/renderer/lib/reticulum/reticulumSidecarReads', () => ({
-  fetchReticulumRmapDiscovered: vi.fn().mockResolvedValue([]),
+  fetchReticulumRmapDiscovered: fetchReticulumRmapDiscoveredMock,
   isReticulumSidecarRunning: vi.fn().mockResolvedValue(true),
 }));
 
@@ -51,13 +68,18 @@ vi.mock('@/renderer/components/map/leafletMapControls', () => ({
 
 vi.mock('@/renderer/stores/reticulumPeerStore', () => ({
   useReticulumPeerStore: (selector: (s: { peers: Map<string, unknown> }) => unknown) =>
-    selector({ peers: new Map() }),
+    selector(peerStoreState),
 }));
 
 describe('ReticulumMapPanel', () => {
   beforeEach(() => {
     useReticulumDiscoveryMapStore.getState().clear();
+    peerStoreState.peers = new Map();
     flyToMock.mockClear();
+    markerMock.mockClear();
+    markerLastPropsRef.current = undefined;
+    fetchReticulumRmapDiscoveredMock.mockReset();
+    fetchReticulumRmapDiscoveredMock.mockResolvedValue([]);
   });
 
   it('shows empty state when stack is off', () => {
@@ -91,7 +113,7 @@ describe('ReticulumMapPanel', () => {
         hops: 1,
         stamp_value: 14,
         discovered: 1,
-        last_heard: 2,
+        last_heard: Math.floor(Date.now() / 1000),
         heard_count: 1,
         status: 'available',
         has_coordinates: true,
@@ -116,7 +138,7 @@ describe('ReticulumMapPanel', () => {
         hops: 1,
         stamp_value: 14,
         discovered: 1,
-        last_heard: 2,
+        last_heard: Math.floor(Date.now() / 1000),
         heard_count: 1,
         status: 'available',
         has_coordinates: true,
@@ -145,7 +167,7 @@ describe('ReticulumMapPanel', () => {
         hops: 1,
         stamp_value: 14,
         discovered: 1,
-        last_heard: 2,
+        last_heard: Math.floor(Date.now() / 1000),
         heard_count: 1,
         status: 'available',
         has_coordinates: true,
@@ -156,6 +178,62 @@ describe('ReticulumMapPanel', () => {
     Object.defineProperty(list, 'scrollTop', { value: 400, configurable: true });
     fireEvent.scroll(list);
     expect(screen.getByRole('button', { name: 'aria.backToTop' })).toBeInTheDocument();
+  });
+
+  it('shows refresh error without clearing existing discoveries', async () => {
+    useReticulumDiscoveryMapStore.getState().setDiscovered([
+      {
+        discovery_hash: 'abc',
+        transport_id: 'aa'.repeat(16),
+        discovery_name: 'LoRa Node',
+        interface_type: 'RNodeInterface',
+        latitude: 40,
+        longitude: -105,
+        height: 0,
+        transport_enabled: true,
+        hops: 1,
+        stamp_value: 14,
+        discovered: 1,
+        last_heard: Math.floor(Date.now() / 1000),
+        heard_count: 1,
+        status: 'available',
+        has_coordinates: true,
+      },
+    ]);
+    fetchReticulumRmapDiscoveredMock.mockRejectedValue(new Error('sidecar timeout'));
+    render(<ReticulumMapPanel stackConfigured={true} />);
+    expect(await screen.findByText(/reticulumMap\.refreshFailed/)).toBeInTheDocument();
+    expect(screen.getByText('LoRa Node')).toBeInTheDocument();
+  });
+
+  it('calls onPeerClick with peerDetailHash when marker is clicked', () => {
+    const onPeerClick = vi.fn();
+    const transportId = 'deadbeef'.repeat(4);
+    peerStoreState.peers = new Map([
+      [transportId, { destination_hash: transportId, hops: 1, last_seen: 1 }],
+    ]);
+    useReticulumDiscoveryMapStore.getState().setDiscovered([
+      {
+        discovery_hash: 'abc',
+        transport_id: transportId,
+        discovery_name: 'LoRa Node',
+        interface_type: 'RNodeInterface',
+        latitude: 40,
+        longitude: -105,
+        height: 0,
+        transport_enabled: true,
+        hops: 1,
+        stamp_value: 14,
+        discovered: 1,
+        last_heard: Math.floor(Date.now() / 1000),
+        heard_count: 1,
+        status: 'available',
+        has_coordinates: true,
+      },
+    ]);
+    render(<ReticulumMapPanel stackConfigured={true} onPeerClick={onPeerClick} />);
+    markerLastPropsRef.current?.eventHandlers?.click?.();
+    expect(onPeerClick).toHaveBeenCalledWith(transportId);
   });
 
   it('has no serious axe violations on filter pills', async () => {
@@ -172,7 +250,7 @@ describe('ReticulumMapPanel', () => {
         hops: 1,
         stamp_value: 14,
         discovered: 1,
-        last_heard: 2,
+        last_heard: Math.floor(Date.now() / 1000),
         heard_count: 1,
         status: 'available',
         has_coordinates: true,

--- a/src/renderer/components/ReticulumMapPanel.tsx
+++ b/src/renderer/components/ReticulumMapPanel.tsx
@@ -104,7 +104,7 @@ function buildMarkerIcon(color: string): L.DivIcon {
 
 export interface ReticulumMapPanelProps {
   stackConfigured: boolean;
-  onPeerClick?: (transportId: string) => void;
+  onPeerClick?: (peerHash: string) => void;
   onOpenRmapSettings?: () => void;
   onOpenAppGpsSettings?: () => void;
 }
@@ -134,6 +134,7 @@ export default function ReticulumMapPanel({
   const [selectedHash, setSelectedHash] = useState<string | null>(null);
   const [showScrollTopButton, setShowScrollTopButton] = useState(false);
   const listScrollRef = useRef<HTMLUListElement>(null);
+  const refreshGenerationRef = useRef(0);
 
   const selfCoords = readStoredStaticGps();
 
@@ -166,21 +167,27 @@ export default function ReticulumMapPanel({
       clearDiscovered();
       return;
     }
+    const generation = ++refreshGenerationRef.current;
     setLoading(true);
     setRefreshError(null);
     try {
       const running = await isReticulumSidecarRunning();
+      if (generation !== refreshGenerationRef.current) return;
       if (!running) {
         clearDiscovered();
         return;
       }
       const rows = await fetchReticulumRmapDiscovered();
+      if (generation !== refreshGenerationRef.current) return;
       setDiscovered(rows);
     } catch (e) {
+      if (generation !== refreshGenerationRef.current) return;
       setRefreshError(errLikeToLogString(e));
       console.debug('[ReticulumMapPanel] refresh ' + errLikeToLogString(e));
     } finally {
-      setLoading(false);
+      if (generation === refreshGenerationRef.current) {
+        setLoading(false);
+      }
     }
   }, [clearDiscovered, setDiscovered, setLoading, stackConfigured]);
 
@@ -399,7 +406,11 @@ export default function ReticulumMapPanel({
                 position={[row.latitude, row.longitude]}
                 icon={buildMarkerIcon(markerColor(row.reachable, basemap.isDark))}
                 eventHandlers={{
-                  click: () => onPeerClick?.(row.transport_id),
+                  click: () => {
+                    if (row.peerDetailHash) {
+                      onPeerClick?.(row.peerDetailHash);
+                    }
+                  },
                 }}
               >
                 <Popup>

--- a/src/renderer/components/ReticulumRmapDiscoveryControls.tsx
+++ b/src/renderer/components/ReticulumRmapDiscoveryControls.tsx
@@ -141,7 +141,7 @@ export function ReticulumRmapDiscoveryControls({
           '/api/v1/stack/settings',
         )) as Record<string, unknown>;
         const heightParsed = heightMeters.trim() ? Number(heightMeters) : null;
-        await applyReticulumRmapDiscovery({
+        const result = await applyReticulumRmapDiscovery({
           interfaces,
           discoveryName: identityDisplayName,
           announceIntervalMin,
@@ -152,12 +152,40 @@ export function ReticulumRmapDiscoveryControls({
           reachableOn: reachableOn.trim() || null,
           stackSettings: parseStackSettings(stackRaw),
         });
-        addToast(t('reticulumRmapDiscovery.applySuccess'), 'success');
+        if (result.errors.length > 0) {
+          if (result.applied === 0) {
+            addToast(t('reticulumRmapDiscovery.applyFailed', { error: result.errors[0] }), 'error');
+            return;
+          }
+          addToast(
+            t('reticulumRmapDiscovery.applyPartialSuccess', {
+              applied: result.applied,
+              total: result.total,
+            }),
+            'warning',
+          );
+        } else {
+          addToast(t('reticulumRmapDiscovery.applySuccess'), 'success');
+        }
         setPublishOn(true);
         setShowRestartConfirm(true);
       } else {
-        await disableReticulumRmapDiscovery(interfaces);
-        addToast(t('reticulumRmapDiscovery.disableSuccess'), 'success');
+        const result = await disableReticulumRmapDiscovery(interfaces);
+        if (result.errors.length > 0) {
+          if (result.applied === 0) {
+            addToast(t('reticulumRmapDiscovery.applyFailed', { error: result.errors[0] }), 'error');
+            return;
+          }
+          addToast(
+            t('reticulumRmapDiscovery.disablePartialSuccess', {
+              applied: result.applied,
+              total: result.total,
+            }),
+            'warning',
+          );
+        } else {
+          addToast(t('reticulumRmapDiscovery.disableSuccess'), 'success');
+        }
         setPublishOn(false);
         setShowRestartConfirm(true);
       }

--- a/src/renderer/components/map/leafletMapControls.tsx
+++ b/src/renderer/components/map/leafletMapControls.tsx
@@ -12,6 +12,7 @@ import { useMapViewportStore } from '@/renderer/stores/mapViewportStore';
 import { useToast } from '../Toast';
 
 const MAP_STYLE_ID = 'map-styles';
+const LORA_MAP_STYLE_ID = 'map-lora-panel-styles';
 
 /** Shared Leaflet control styles (locate button) for Meshtastic/MeshCore/Reticulum maps. */
 export function ensureMapStyles(): void {
@@ -37,6 +38,62 @@ export function ensureMapStyles(): void {
     }
     .leaflet-locate-control a.locating {
       color: #3b82f6;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+/** LoRa map panel styles (anomaly halos, dark node popups) — Meshtastic/MeshCore MapPanel only. */
+export function ensureLoRaMapPanelStyles(): void {
+  ensureMapStyles();
+  if (document.getElementById(LORA_MAP_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = LORA_MAP_STYLE_ID;
+  style.textContent = `
+    @keyframes anomaly-pulse {
+      0%, 100% { opacity: 0.75; }
+      50%       { opacity: 0.15; }
+    }
+    .anomaly-halo-warning {
+      animation: anomaly-pulse 2s ease-in-out infinite;
+      pointer-events: none !important;
+    }
+    .anomaly-halo-error {
+      animation: anomaly-pulse 1.4s ease-in-out infinite;
+      pointer-events: none !important;
+    }
+    html[data-reduce-motion='true'] .anomaly-halo-warning,
+    html[data-reduce-motion='true'] .anomaly-halo-error {
+      animation: none !important;
+      opacity: 0.75 !important;
+    }
+    .leaflet-popup.map-node-popup .leaflet-popup-content-wrapper {
+      background: #0f172a;
+      border: 1px solid #334155;
+      color: #e5e7eb;
+      border-radius: 0.75rem;
+      padding: 0;
+      box-shadow: 0 25px 50px -12px rgba(0,0,0,0.5);
+    }
+    .leaflet-popup.map-node-popup .leaflet-popup-content {
+      margin: 0;
+      min-width: 280px;
+      max-width: 340px;
+      max-height: 70vh;
+      overflow: hidden;
+    }
+    .leaflet-popup.map-node-popup .leaflet-popup-content > div {
+      max-height: 70vh;
+      overflow-y: auto;
+    }
+    .leaflet-popup.map-node-popup .leaflet-popup-tip {
+      background: #0f172a;
+    }
+    .leaflet-popup.map-node-popup .leaflet-popup-close-button {
+      color: #9ca3af !important;
+    }
+    .leaflet-popup.map-node-popup .leaflet-popup-close-button:hover {
+      color: #e5e7eb !important;
     }
   `;
   document.head.appendChild(style);

--- a/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
+++ b/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
@@ -665,6 +665,7 @@ export function ReticulumInterfacesPanel({
           await onRefresh();
         }
       } catch (e) {
+        addToast(t('connectionPanel.reticulumRmap.syncFailed'), 'error');
         console.debug('[ReticulumInterfacesPanel] rmap sync ' + errLikeToLogString(e));
       }
     },

--- a/src/renderer/lib/reticulum/reticulumDiscoveryMapLayout.test.ts
+++ b/src/renderer/lib/reticulum/reticulumDiscoveryMapLayout.test.ts
@@ -4,12 +4,15 @@ import {
   haversineDistanceMeters,
   joinRmapDiscoveryWithPeers,
   matchesRmapInterfaceFilter,
+  resolveRmapPeerDetailHash,
   rmapLoRaParamsMatch,
 } from '@/renderer/lib/reticulum/reticulumDiscoveryMapLayout';
 import type {
   ReticulumPeerWireRow,
   ReticulumRmapDiscoveredWireRow,
 } from '@/shared/reticulum-types';
+
+const nowHeard = () => Math.floor(Date.now() / 1000);
 
 function sampleRow(
   partial: Partial<ReticulumRmapDiscoveredWireRow> = {},
@@ -26,7 +29,7 @@ function sampleRow(
     hops: 1,
     stamp_value: 14,
     discovered: 1,
-    last_heard: 2,
+    last_heard: nowHeard(),
     heard_count: 1,
     status: 'available',
     has_coordinates: true,
@@ -41,6 +44,21 @@ describe('reticulumDiscoveryMapLayout', () => {
     const layout = joinRmapDiscoveryWithPeers(discovered, peers);
     expect(layout.markers).toHaveLength(1);
     expect(layout.markers[0]?.reachable).toBe(true);
+    expect(layout.markers[0]?.peerDetailHash).toBe('deadbeef'.repeat(4));
+  });
+
+  it('resolveRmapPeerDetailHash matches via_hash when destination differs', () => {
+    const transportId = 'cafebabe'.repeat(4);
+    const peers: ReticulumPeerWireRow[] = [
+      { destination_hash: 'deadbeef'.repeat(4), via_hash: transportId, hops: 2 },
+    ];
+    expect(resolveRmapPeerDetailHash(transportId, peers)).toBe(transportId);
+  });
+
+  it('joinRmapDiscoveryWithPeers leaves peerDetailHash null for heard-only rows', () => {
+    const discovered = [sampleRow({ transport_id: 'unknown'.repeat(4) })];
+    const layout = joinRmapDiscoveryWithPeers(discovered, []);
+    expect(layout.markers[0]?.peerDetailHash).toBeNull();
   });
 
   it('joinRmapDiscoveryWithPeers splits list-only rows without coords', () => {

--- a/src/renderer/lib/reticulum/reticulumDiscoveryMapLayout.ts
+++ b/src/renderer/lib/reticulum/reticulumDiscoveryMapLayout.ts
@@ -8,6 +8,8 @@ export type RmapInterfaceFilter = 'all' | 'rnode' | 'i2p' | 'tcp' | 'backbone' |
 
 export interface ReticulumMapMarkerRow extends ReticulumRmapDiscoveredWireRow {
   reachable: boolean;
+  /** Resolved destination_hash for peer detail modal; null when heard-only. */
+  peerDetailHash: string | null;
 }
 
 export interface ReticulumMapLayout {
@@ -57,6 +59,28 @@ function peerTransportIds(peers: ReticulumPeerWireRow[]): Set<string> {
   return out;
 }
 
+/** Resolve transport_id to a path-table destination_hash for peer detail modal. */
+export function resolveRmapPeerDetailHash(
+  transportId: string,
+  peers: ReticulumPeerWireRow[],
+): string | null {
+  const tid = transportId.trim().toLowerCase();
+  if (!tid) return null;
+  for (const peer of peers) {
+    const dest = peer.destination_hash?.trim().toLowerCase();
+    if (dest && dest === tid) {
+      return dest;
+    }
+  }
+  for (const peer of peers) {
+    const via = peer.via_hash?.trim().toLowerCase();
+    if (via && via === tid) {
+      return via;
+    }
+  }
+  return null;
+}
+
 export function joinRmapDiscoveryWithPeers(
   discovered: ReticulumRmapDiscoveredWireRow[],
   peers: ReticulumPeerWireRow[],
@@ -65,6 +89,7 @@ export function joinRmapDiscoveryWithPeers(
   const enriched: ReticulumMapMarkerRow[] = discovered.map((row) => ({
     ...row,
     reachable: reachableIds.has(row.transport_id.trim().toLowerCase()),
+    peerDetailHash: resolveRmapPeerDetailHash(row.transport_id, peers),
   }));
 
   const markers: ReticulumMapMarkerRow[] = [];

--- a/src/renderer/lib/reticulum/reticulumRmapDiscovery.test.ts
+++ b/src/renderer/lib/reticulum/reticulumRmapDiscovery.test.ts
@@ -161,12 +161,15 @@ describe('reticulumRmapDiscovery', () => {
       loglevel: 4,
     });
 
-    await applyReticulumRmapDiscovery({
+    const result = await applyReticulumRmapDiscovery({
       interfaces: [row({ id: 'r', type: 'rnode', serial_port: '/dev/ttyUSB0' })],
       announceIntervalMin: 60,
       discoveryName: 'Test',
       stackSettings: { enable_transport: false, share_instance: true, loglevel: 4 },
     });
+
+    expect(result.applied).toBe(1);
+    expect(result.errors).toEqual([]);
 
     expect(window.electronAPI.reticulum.proxyPut).toHaveBeenCalledWith('/api/v1/stack/settings', {
       enable_transport: true,

--- a/src/renderer/lib/reticulum/reticulumRmapDiscovery.ts
+++ b/src/renderer/lib/reticulum/reticulumRmapDiscovery.ts
@@ -1,4 +1,5 @@
 import { getAppSettingsRaw, mergeAppSetting } from '@/renderer/lib/appSettingsStorage';
+import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import { readStoredStaticGps } from '@/renderer/lib/gpsSource';
 import { parseStoredJson } from '@/renderer/lib/parseStoredJson';
 import {
@@ -377,9 +378,15 @@ export interface ApplyReticulumRmapDiscoveryArgs {
   stackSettings: { enable_transport: boolean; share_instance: boolean; loglevel: number };
 }
 
+export interface RmapBatchApplyResult {
+  applied: number;
+  total: number;
+  errors: string[];
+}
+
 export async function applyReticulumRmapDiscovery(
   args: ApplyReticulumRmapDiscoveryArgs,
-): Promise<void> {
+): Promise<RmapBatchApplyResult> {
   const coords = resolveRmapCoordinates();
   if (!coords) {
     throw new ReticulumRmapGpsRequiredError();
@@ -398,29 +405,50 @@ export async function applyReticulumRmapDiscovery(
     throw new ReticulumRmapValidationError('no_publish_targets');
   }
 
+  const errors: string[] = [];
+  let applied = 0;
+
   const needsTransportBridge = targets.some(isReticulumRmapLoRaDiscoveryRow);
   if (needsTransportBridge && !args.stackSettings.enable_transport) {
-    await window.electronAPI.reticulum.proxyPut('/api/v1/stack/settings', {
-      ...args.stackSettings,
-      enable_transport: true,
-    });
+    try {
+      await window.electronAPI.reticulum.proxyPut('/api/v1/stack/settings', {
+        ...args.stackSettings,
+        enable_transport: true,
+      });
+    } catch (e) {
+      // catch-no-log-ok partial apply — surfaced via RmapBatchApplyResult.errors
+      errors.push(errLikeToLogString(e));
+    }
   }
 
   for (const row of targets) {
-    const patch = buildRmapDiscoveryPatch(row, {
-      coords,
-      discoveryName: args.discoveryName,
-      announceIntervalMin,
-      heightMeters: args.heightMeters,
-      reachableOn: reachable || null,
-      discoverable: true,
-    });
-    await window.electronAPI.reticulum.proxyPut(`/api/v1/interfaces/${row.id}`, patch);
+    try {
+      const patch = buildRmapDiscoveryPatch(row, {
+        coords,
+        discoveryName: args.discoveryName,
+        announceIntervalMin,
+        heightMeters: args.heightMeters,
+        reachableOn: reachable || null,
+        discoverable: true,
+      });
+      await window.electronAPI.reticulum.proxyPut(`/api/v1/interfaces/${row.id}`, patch);
+      applied++;
+    } catch (e) {
+      // catch-no-log-ok partial apply — surfaced via RmapBatchApplyResult.errors
+      errors.push(errLikeToLogString(e));
+    }
   }
 
   if (needsTransportBridge) {
-    await ensureRmapWorldHubEnabled(args.interfaces);
+    try {
+      await ensureRmapWorldHubEnabled(args.interfaces);
+    } catch (e) {
+      // catch-no-log-ok partial apply — surfaced via RmapBatchApplyResult.errors
+      errors.push(errLikeToLogString(e));
+    }
   }
+
+  return { applied, total: targets.length, errors };
 }
 
 export interface SetReticulumRmapDiscoverableArgs {
@@ -490,11 +518,19 @@ export async function setReticulumRmapDiscoverableForInterface(
 
 export async function disableReticulumRmapDiscovery(
   interfaces: readonly ReticulumInterfaceRow[],
-): Promise<void> {
+): Promise<RmapBatchApplyResult> {
   const patch = buildRmapDisablePatch();
-  for (const row of listReticulumRmapDiscoveryCapable(interfaces)) {
-    if (row.discoverable) {
+  const targets = listReticulumRmapDiscoveryCapable(interfaces).filter((row) => row.discoverable);
+  const errors: string[] = [];
+  let applied = 0;
+  for (const row of targets) {
+    try {
       await window.electronAPI.reticulum.proxyPut(`/api/v1/interfaces/${row.id}`, patch);
+      applied++;
+    } catch (e) {
+      // catch-no-log-ok partial disable — surfaced via RmapBatchApplyResult.errors
+      errors.push(errLikeToLogString(e));
     }
   }
+  return { applied, total: targets.length, errors };
 }

--- a/src/renderer/lib/reticulum/reticulumSidecarReads.test.ts
+++ b/src/renderer/lib/reticulum/reticulumSidecarReads.test.ts
@@ -18,6 +18,7 @@ vi.stubGlobal('window', {
 import {
   fetchReticulumIdentityStatus,
   fetchReticulumInterfaces,
+  fetchReticulumRmapDiscovered,
   formatReticulumPeerProbeToast,
   isReticulumSidecar404Error,
   isReticulumSidecarNotRunningError,
@@ -85,6 +86,33 @@ describe('reticulumSidecarReads', () => {
     await expect(fetchReticulumInterfaces()).resolves.toHaveLength(1);
     await expect(fetchReticulumInterfaces()).resolves.toHaveLength(1);
     expect(proxyGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchReticulumRmapDiscovered returns empty when sidecar is down', async () => {
+    getStatus.mockResolvedValue({ running: false, port: 0, pid: null });
+    await expect(fetchReticulumRmapDiscovered()).resolves.toEqual([]);
+    expect(proxyGet).not.toHaveBeenCalled();
+  });
+
+  it('fetchReticulumRmapDiscovered returns discovered rows on success', async () => {
+    getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
+    proxyGet.mockResolvedValue({
+      discovered: [{ discovery_hash: 'abc', transport_id: 'aa'.repeat(16), last_heard: 1 }],
+    });
+    await expect(fetchReticulumRmapDiscovered()).resolves.toHaveLength(1);
+    expect(proxyGet).toHaveBeenCalledWith('/api/v1/rmap/discovered');
+  });
+
+  it('fetchReticulumRmapDiscovered throws on unexpected proxy errors', async () => {
+    getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
+    proxyGet.mockRejectedValue(new Error('sidecar timeout'));
+    await expect(fetchReticulumRmapDiscovered()).rejects.toThrow('sidecar timeout');
+  });
+
+  it('fetchReticulumRmapDiscovered returns empty on expected proxy errors', async () => {
+    getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
+    proxyGet.mockRejectedValue(new Error('Reticulum sidecar is not running'));
+    await expect(fetchReticulumRmapDiscovered()).resolves.toEqual([]);
   });
 
   it('requestReticulumPeerPath parses ok response', async () => {

--- a/src/renderer/lib/reticulum/reticulumSidecarReads.ts
+++ b/src/renderer/lib/reticulum/reticulumSidecarReads.ts
@@ -149,10 +149,11 @@ export async function fetchReticulumRmapDiscovered(): Promise<ReticulumRmapDisco
     };
     return Array.isArray(body.discovered) ? body.discovered : [];
   } catch (e) {
-    if (!isReticulumSidecarExpectedProxyError(e)) {
-      console.debug('[reticulumSidecarReads] rmap discovered ' + errLikeToLogString(e));
+    if (isReticulumSidecarExpectedProxyError(e)) {
+      return [];
     }
-    return [];
+    console.debug('[reticulumSidecarReads] rmap discovered ' + errLikeToLogString(e));
+    throw e instanceof Error ? e : new Error(String(e));
   }
 }
 

--- a/src/renderer/lib/sessionMemoryCaps.test.ts
+++ b/src/renderer/lib/sessionMemoryCaps.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_DIAGNOSTICS_TRACKED_NODES,
   MAX_MESH_ENTITY_CAP,
   MAX_RETICULUM_IDENTITY_DESTINATIONS,
+  MAX_RMAP_DISCOVERED_ROWS,
   trimArrayTail,
   trimMapToMaxSize,
   trimMapToMaxSizeKeeping,
@@ -15,6 +16,7 @@ describe('sessionMemoryCaps', () => {
     expect(MAX_MESH_ENTITY_CAP).toBe(10_000);
     expect(MAX_DIAGNOSTICS_TRACKED_NODES).toBe(MAX_MESH_ENTITY_CAP);
     expect(MAX_RETICULUM_IDENTITY_DESTINATIONS).toBe(MAX_MESH_ENTITY_CAP);
+    expect(MAX_RMAP_DISCOVERED_ROWS).toBe(2_000);
     expect(LARGE_MESH_NODE_THRESHOLD).toBe(2000);
   });
 

--- a/src/renderer/lib/sessionMemoryCaps.ts
+++ b/src/renderer/lib/sessionMemoryCaps.ts
@@ -8,6 +8,8 @@ export const MAX_MESHCORE_CLI_HISTORY_ENTRIES = 50;
 export const MAX_MESHTASTIC_TRACE_ROUTE_RESULTS = 100;
 export const MAX_DIAGNOSTICS_TRACKED_NODES = MAX_MESH_ENTITY_CAP;
 export const MAX_RETICULUM_IDENTITY_DESTINATIONS = MAX_MESH_ENTITY_CAP;
+/** In-memory cap for RMAP discovery rows mirrored from the sidecar DiscoveryStore. */
+export const MAX_RMAP_DISCOVERED_ROWS = 2_000;
 export const LARGE_MESH_NODE_THRESHOLD = 2000;
 export const LARGE_MESH_DIAGNOSTICS_REANALYSIS_DELAY_MS = 10_000;
 export const SESSION_DB_PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000;

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Žádná povolená místní rozhraní pro publikování v RMAP.",
       "syncSuccess": "Zjištění RMAP synchronizováno s rozhraním.",
       "openGlobalMap": "Globální mapa",
-      "openGlobalMapAria": "Otevřete globální mapu RMAP v4 na rmap.world"
+      "openGlobalMapAria": "Otevřete globální mapu RMAP v4 na rmap.world",
+      "syncFailed": "Synchronizace zjišťování RMAP se nezdařila."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Aplikuje zjistitelné=ano a GPS souřadnice aplikace na všechna povolená rozhraní podporující RMAP (RNode, KISS, ble peer, I2P, UDP, Pipe). Použijte přepínače RMAP na připojení pro jemné ovládání. Cesty LoRa také umožňují dopravu a rozbočovač rmap.world.",
     "openGlobalMap": "Otevřít globální mapu",
-    "openGlobalMapAria": "Otevřete globální mapu RMAP v4 na rmap.world"
+    "openGlobalMapAria": "Otevřete globální mapu RMAP v4 na rmap.world",
+    "applyPartialSuccess": "Nastavení RMAP použito pro {{applied}} z {{total}} rozhraní.",
+    "disablePartialSuccess": "Publikování RMAP je zakázáno na {{applied}} z {{total}} rozhraní."
   },
   "reticulumTopology": {
     "title": "topologie sítě",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Keine aktivierten lokalen Schnittstellen zum Veröffentlichen auf RMAP.",
       "syncSuccess": "RMAP-Erkennung mit Schnittstelle synchronisiert.",
       "openGlobalMap": "[Globale Karte?]",
-      "openGlobalMapAria": "RMAP v4 Global Map auf rmap.world öffnen"
+      "openGlobalMapAria": "RMAP v4 Global Map auf rmap.world öffnen",
+      "syncFailed": "RMAP-Erkennungssynchronisierung fehlgeschlagen."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Wendet discoverable=yes und App GPS-Koordinaten auf alle aktivierten RMAP-fähigen Schnittstellen (RNode, KISS, BLE Peer, I2P, UDP, Pipe) an. Verwenden Sie RMAP-Schalter pro Schnittstelle für die Verbindung zur Feinsteuerung. LoRa-Pfade ermöglichen auch den Transport und den Hub rmap.world.",
     "openGlobalMap": "Globale Karte öffnen",
-    "openGlobalMapAria": "RMAP v4 Global Map auf rmap.world öffnen"
+    "openGlobalMapAria": "RMAP v4 Global Map auf rmap.world öffnen",
+    "applyPartialSuccess": "RMAP-Einstellungen wurden auf {{applied}} von {{total}} Schnittstellen angewendet.",
+    "disablePartialSuccess": "Die RMAP-Veröffentlichung ist auf {{applied}} von {{total}} Schnittstellen deaktiviert."
   },
   "reticulumTopology": {
     "title": "Netzwerk-Topologie",
@@ -4003,7 +4006,7 @@
   "reticulumMap": {
     "title": "Entdeckungskarte",
     "subtitle": "Opt-in RMAP v4-Schnittstellen, die von Ihrem Stack gehört werden (lokale Ansicht)",
-    "openGlobalMap": "[Globale Karte?]",
+    "openGlobalMap": "Globale Karte",
     "openGlobalMapAria": "RMAP v4 Global Map auf rmap.world öffnen",
     "openPublishSettings": "Veröffentlichungs-Einstellungen",
     "openPublishSettingsAria": "RMAP-Veröffentlichungseinstellungen des Reticulum-Netzwerks öffnen",
@@ -4013,11 +4016,11 @@
     "countSummary": "{{markers}} auf der Karte · Nur {{list}} Liste",
     "listTitle": "Entdeckte Schnittstellen",
     "selfMarker": "Ihre App-GPS-Position",
-    "reachable": "Greifbar.",
+    "reachable": "Erreichbar",
     "heardOnly": "Nur gehört (nicht in der Pfad-Tabelle)",
     "noCoords": "Kein GPS",
     "lastHeard": "Zuletzt gehört {{time}}",
-    "openNodeAria": "Offene Details für {{name}}",
+    "openNodeAria": "{{name}} auf der Karte anzeigen",
     "filter": {
       "all": "Alle",
       "rnode": "LoRa",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -879,7 +879,8 @@
       "openGlobalMapAria": "Open RMAP v4 global map on rmap.world",
       "needsSync": "{{count}} enabled local interface(s) need RMAP discovery sync",
       "noPublishTargets": "No enabled RMAP-capable interfaces to publish on RMAP.",
-      "syncSuccess": "RMAP discovery synced to interface."
+      "syncSuccess": "RMAP discovery synced to interface.",
+      "syncFailed": "RMAP discovery sync failed."
     },
     "reticulumPeers": {
       "hops": "Hops",
@@ -3582,7 +3583,9 @@
     "gpsRequiredBody": "RMAP map markers need latitude and longitude. Set static coordinates under App → GPS / Location, then try again.",
     "openAppGps": "Open App GPS settings",
     "applySuccess": "RMAP discovery settings applied.",
+    "applyPartialSuccess": "RMAP settings applied to {{applied}} of {{total}} interfaces.",
     "disableSuccess": "RMAP publishing disabled on local interfaces.",
+    "disablePartialSuccess": "RMAP publishing disabled on {{applied}} of {{total}} interfaces.",
     "applyFailed": "Failed to apply RMAP settings: {{error}}",
     "noPublishTargets": "No enabled RMAP-capable interfaces. Enable an RNode, KISS, BLE peer, I2P, UDP, or pipe interface first.",
     "restartTitle": "Restart Reticulum stack?",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "No hay interfaces locales habilitadas para publicar en RMAP.",
       "syncSuccess": "Descubrimiento de RMAP sincronizado con la interfaz.",
       "openGlobalMap": "Mapa mundial",
-      "openGlobalMapAria": "Abra el mapa global de RMAP v4 en rmap.world"
+      "openGlobalMapAria": "Abra el mapa global de RMAP v4 en rmap.world",
+      "syncFailed": "Error de sincronización de descubrimiento de RMAP."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Aplica discoverable=yes y las coordenadas GPS de App a todas las interfaces habilitadas para RMAP (RNode, KISS, BLE peer, I2P, UDP, pipe). Use los conmutadores RMAP por interfaz en Conexión para un control fino. Las rutas LoRa también habilitan transporte y el hub rmap.world.",
     "openGlobalMap": "Mapa mundial",
-    "openGlobalMapAria": "Abra el mapa global de RMAP v4 en rmap.world"
+    "openGlobalMapAria": "Abra el mapa global de RMAP v4 en rmap.world",
+    "applyPartialSuccess": "Configuración de RMAP aplicada a las interfaces {{applied}} de {{total}}.",
+    "disablePartialSuccess": "Publicación RMAP deshabilitada en las interfaces {{applied}} de {{total}}."
   },
   "reticulumTopology": {
     "title": "Topología de red",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Aucune interface locale activée pour publier sur RMAP.",
       "syncSuccess": "Découverte RMAP synchronisée à l'interface.",
       "openGlobalMap": "Carte mondiale",
-      "openGlobalMapAria": "Ouvrez la carte globale RMAP v4 sur rmap.world"
+      "openGlobalMapAria": "Ouvrez la carte globale RMAP v4 sur rmap.world",
+      "syncFailed": "Échec de la synchronisation de la découverte RMAP."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Applique discoverable=yes et Appliquer les coordonnées GPS à toutes les interfaces compatibles RMAP activées (RNode, KISS, ble peer, I2P, UDP, pipe). Utilisez les bascules RMAP par interface sur la connexion pour un contrôle fin. Les chemins LoRa permettent également le transport et le hub rmap.world.",
     "openGlobalMap": "Carte mondiale",
-    "openGlobalMapAria": "Ouvrez la carte globale RMAP v4 sur rmap.world"
+    "openGlobalMapAria": "Ouvrez la carte globale RMAP v4 sur rmap.world",
+    "applyPartialSuccess": "Paramètres RMAP appliqués à {{applied}} des interfaces {{total}}.",
+    "disablePartialSuccess": "Publication RMAP désactivée sur {{applied}} des interfaces {{total}}."
   },
   "reticulumTopology": {
     "title": "Topologie de réseau",
@@ -4007,21 +4010,21 @@
     "openGlobalMapAria": "Ouvrez la carte globale RMAP v4 sur rmap.world",
     "openPublishSettings": "Paramètres de publication",
     "openPublishSettingsAria": "Ouvrir les paramètres de publication RMAP de Reticulum Network",
-    "refresh": "Renouvellement",
+    "refresh": "Actualiser",
     "refreshAria": "Actualiser la carte de découverte",
-    "refreshFailed": "Impossible d'actualiser la carte de découverte : {{error}}",
+    "refreshFailed": "Impossible d'actualiser la carte de découverte : {{error}}",
     "countSummary": "{{markers}} sur la carte · {{list}} liste uniquement",
     "listTitle": "Interfaces découvertes",
     "selfMarker": "Position GPS de votre application",
-    "reachable": "Lexique de la théorie des graphes",
+    "reachable": "Joignable",
     "heardOnly": "Entendu seulement (pas dans la table des chemins)",
     "noCoords": "Pas de GPS",
     "lastHeard": "Dernière audition {{time}}",
-    "openNodeAria": "Ouvrir les détails de {{name}}",
+    "openNodeAria": "Afficher {{name}} sur la carte",
     "filter": {
       "all": "Tous",
       "rnode": "LoRa",
-      "backbone": "Colonne vertébrale",
+      "backbone": "Backbone",
       "i2p": "-I2P",
       "tcp": "TCP",
       "other": "Autre"

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Tidak ada antarmuka lokal yang diaktifkan untuk dipublikasikan di RMAP.",
       "syncSuccess": "Penemuan RMAP disinkronkan ke antarmuka.",
       "openGlobalMap": "Peta global",
-      "openGlobalMapAria": "Buka peta global RMAP v4 di rmap.world"
+      "openGlobalMapAria": "Buka peta global RMAP v4 di rmap.world",
+      "syncFailed": "Sinkronisasi penemuan RMAP gagal."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Menerapkan koordinat GPS Discoverable=yes dan App ke semua antarmuka berkemampuan RMAP yang diaktifkan (RNode, KISS, BLE peer, I2P, UDP, pipe). Gunakan sakelar RMAP per antarmuka pada Koneksi untuk kontrol yang baik. Jalur LoRa juga memungkinkan transportasi dan hub rmap.world.",
     "openGlobalMap": "Buka peta global",
-    "openGlobalMapAria": "Buka peta global RMAP v4 di rmap.world"
+    "openGlobalMapAria": "Buka peta global RMAP v4 di rmap.world",
+    "applyPartialSuccess": "Pengaturan RMAP diterapkan ke {{applied}} dari antarmuka {{total}}.",
+    "disablePartialSuccess": "Penerbitan RMAP dinonaktifkan pada {{applied}} dari antarmuka {{total}}."
   },
   "reticulumTopology": {
     "title": "Topologi jaringan",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Nessuna interfaccia locale abilitata da pubblicare su RMAP.",
       "syncSuccess": "Individuazione RMAP sincronizzata con l'interfaccia.",
       "openGlobalMap": "È un attributo globale?",
-      "openGlobalMapAria": "Apri la mappa globale RMAP v4 su rmap.world"
+      "openGlobalMapAria": "Apri la mappa globale RMAP v4 su rmap.world",
+      "syncFailed": "Sincronizzazione rilevamento RMAP non riuscita."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Applica le coordinate rilevabili=sì e GPS dell'app a tutte le interfacce abilitate RMAP (RNode, KISS, BLE peer, I2P, UDP, pipe). Utilizzare RMAP per interfaccia per attivare la connessione per un controllo preciso. I percorsi LoRa consentono anche il trasporto e l'hub rmap.world.",
     "openGlobalMap": "Apri la mappa globale",
-    "openGlobalMapAria": "Apri la mappa globale RMAP v4 su rmap.world"
+    "openGlobalMapAria": "Apri la mappa globale RMAP v4 su rmap.world",
+    "applyPartialSuccess": "Impostazioni RMAP applicate alle interfacce {{applied}} di {{total}}.",
+    "disablePartialSuccess": "Pubblicazione RMAP disabilitata sulle interfacce {{applied}} di {{total}}."
   },
   "reticulumTopology": {
     "title": "Topologia di rete.",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "RMAPに公開する有効なローカルインターフェイスはありません。",
       "syncSuccess": "RMAP検出がインターフェイスに同期されました。",
       "openGlobalMap": "グローバル マップの種類",
-      "openGlobalMapAria": "Rmap.worldでRMAP v 4グローバルマップを開く"
+      "openGlobalMapAria": "Rmap.worldでRMAP v 4グローバルマップを開く",
+      "syncFailed": "RMAP検出の同期に失敗しました。"
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "すべての有効なRMAP対応インターフェイス（ RNode、KISS、BLEピア、I 2 P、UDP、パイプ）にdiscoverable = yesとApp GPS座標を適用します。インターフェースごとのRMAPトグルを接続で使用して、細かい制御を行います。LoRaパスは、トランスポートとrmap.worldハブも有効にします。",
     "openGlobalMap": "グローバルマップを開く",
-    "openGlobalMapAria": "Rmap.worldでRMAP v 4グローバルマップを開く"
+    "openGlobalMapAria": "Rmap.worldでRMAP v 4グローバルマップを開く",
+    "applyPartialSuccess": "RMAP設定は、{{total}}インターフェイスの{{applied}}に適用されます。",
+    "disablePartialSuccess": "RMAPの公開は、{{total}}インターフェイスの{{applied}}で無効になっています。"
   },
   "reticulumTopology": {
     "title": "ネットワーク・トポロジー",
@@ -4003,7 +4006,7 @@
   "reticulumMap": {
     "title": "ディスカバリーマップ",
     "subtitle": "スタックで聞こえるRMAP v 4インターフェイスのオプトイン（ローカルビュー）",
-    "openGlobalMap": "グローバル マップの種類",
+    "openGlobalMap": "グローバルマップ",
     "openGlobalMapAria": "Rmap.worldでRMAP v 4グローバルマップを開く",
     "openPublishSettings": "公開設定",
     "openPublishSettingsAria": "Reticulum Network RMAP公開設定を開く",
@@ -4014,14 +4017,14 @@
     "listTitle": "検出されたインターフェース",
     "selfMarker": "アプリのGPS位置",
     "reachable": "到達可能",
-    "heardOnly": "HEARD ONLY (NOT IN PATH TABLE)",
+    "heardOnly": "聴取のみ（パステーブルに未登録）",
     "noCoords": "GPSなし",
     "lastHeard": "最後に聞いたのは{{time}}",
-    "openNodeAria": "{{name}}の詳細を開く",
+    "openNodeAria": "地図で{{name}}を表示",
     "filter": {
       "all": "すべて",
       "rnode": "LoRa",
-      "backbone": "椎骨",
+      "backbone": "Backbone",
       "i2p": "I 2 P",
       "tcp": "TCP",
       "other": "その他"

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "RMAP에 게시할 수 있는 로컬 인터페이스가 없습니다.",
       "syncSuccess": "RMAP 검색이 인터페이스에 동기화되었습니다.",
       "openGlobalMap": "글로벌 맵",
-      "openGlobalMapAria": "Rmap.world에서 RMAP v4 글로벌 맵 열기"
+      "openGlobalMapAria": "Rmap.world에서 RMAP v4 글로벌 맵 열기",
+      "syncFailed": "RMAP 검색 동기화에 실패했습니다."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "검색 가능 = 예 및 앱 GPS 좌표를 활성화된 모든 RMAP 가능 인터페이스 (RNode, KISS, BLE 피어, I2P, UDP, 파이프) 에 적용합니다. 미세 제어를 위해 Connection에서 인터페이스별 RMAP 토글을 사용하십시오. LoRa 경로는 또한 전송 및 rmap.world 허브를 활성화합니다.",
     "openGlobalMap": "전역 지도 열기",
-    "openGlobalMapAria": "Rmap.world에서 RMAP v4 글로벌 맵 열기"
+    "openGlobalMapAria": "Rmap.world에서 RMAP v4 글로벌 맵 열기",
+    "applyPartialSuccess": "{{total}} 인터페이스의 {{applied}}에 RMAP 설정이 적용되었습니다.",
+    "disablePartialSuccess": "{{total}} 인터페이스 중 {{applied}}에서 RMAP 게시가 비활성화되었습니다."
   },
   "reticulumTopology": {
     "title": "네트워크 토폴로지",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Geen ingeschakelde lokale interfaces om op RMAP te publiceren.",
       "syncSuccess": "RMAP-detectie gesynchroniseerd met interface.",
       "openGlobalMap": "Wereldkaart",
-      "openGlobalMapAria": "Open RMAP v4 globale kaart op rmap.world"
+      "openGlobalMapAria": "Open RMAP v4 globale kaart op rmap.world",
+      "syncFailed": "Synchronisatie van RMAP-detectie mislukt."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Is detecteerbaar=ja en past GPS-coördinaten toe op alle ingeschakelde RMAP-compatibele interfaces (RNode, KISS, BLE-peer, I2P, UDP, pipe). Gebruik per interface RMAP-schakelaars op Verbinding voor FINE-besturing. LoRa-paden maken ook transport en de rmap.world-hub mogelijk.",
     "openGlobalMap": "Globale kaart openen",
-    "openGlobalMapAria": "Open RMAP v4 globale kaart op rmap.world"
+    "openGlobalMapAria": "Open RMAP v4 globale kaart op rmap.world",
+    "applyPartialSuccess": "RMAP-instellingen toegepast op {{applied}} van {{total}} interfaces.",
+    "disablePartialSuccess": "RMAP-publicatie uitgeschakeld op {{applied}} van {{total}} interfaces."
   },
   "reticulumTopology": {
     "title": "Netwerktopologie",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Brak włączonych interfejsów lokalnych do publikowania w RMAP.",
       "syncSuccess": "Wykrywanie RMAP zsynchronizowane z interfejsem.",
       "openGlobalMap": "Mapa globalna",
-      "openGlobalMapAria": "Otwórz globalną mapę RMAP v4 na rmap.world"
+      "openGlobalMapAria": "Otwórz globalną mapę RMAP v4 na rmap.world",
+      "syncFailed": "Synchronizacja wykrywania RMAP nie powiodła się."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Stosuje wykrywalne=tak i App współrzędne GPS do wszystkich włączonych interfejsów obsługujących RMAP (RNode, KISS, BLE peer, I2P, UDP, Pipe). Użyj przełączników RMAP dla każdego interfejsu w Połączeniu, aby uzyskać dokładną kontrolę. Ścieżki LoRa umożliwiają również transport i hub rmap.world.",
     "openGlobalMap": "Otwórz mapę globalną",
-    "openGlobalMapAria": "Otwórz globalną mapę RMAP v4 na rmap.world"
+    "openGlobalMapAria": "Otwórz globalną mapę RMAP v4 na rmap.world",
+    "applyPartialSuccess": "Ustawienia RMAP zastosowane do {{applied}} z interfejsów {{total}}.",
+    "disablePartialSuccess": "Publikowanie RMAP wyłączone na {{applied}} z interfejsów {{total}}."
   },
   "reticulumTopology": {
     "title": "Topologia sieci",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Nenhuma interface local habilitada para publicar no RMAP.",
       "syncSuccess": "Descoberta de RMAP sincronizada com a interface.",
       "openGlobalMap": "mapa global",
-      "openGlobalMapAria": "Abra o mapa global do RMAP v4 em rmap.world"
+      "openGlobalMapAria": "Abra o mapa global do RMAP v4 em rmap.world",
+      "syncFailed": "Falha na sincronização de descoberta de RMAP."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Aplica descobrível=sim e as coordenadas GPS do aplicativo a todas as interfaces habilitadas para RMAP (RNode, KISS, BLE peer, I2P, UDP, pipe). Use alternâncias RMAP por interface na Conexão para controle fino. Os caminhos LoRa também permitem o transporte e o hub rmap.world.",
     "openGlobalMap": "Abrir mapa global",
-    "openGlobalMapAria": "Abra o mapa global do RMAP v4 em rmap.world"
+    "openGlobalMapAria": "Abra o mapa global do RMAP v4 em rmap.world",
+    "applyPartialSuccess": "Configurações de RMAP aplicadas às interfaces {{applied}} de {{total}}.",
+    "disablePartialSuccess": "Publicação RMAP desativada nas interfaces {{applied}} de {{total}}."
   },
   "reticulumTopology": {
     "title": "Topologia de rede",
@@ -4013,7 +4016,7 @@
     "countSummary": "{{markers}} no mapa · {{list}} apenas na lista",
     "listTitle": "Interfaces descobertas",
     "selfMarker": "Posição GPS da sua aplicação",
-    "reachable": "Reachable",
+    "reachable": "Alcançável",
     "heardOnly": "Apenas ouvido (não na tabela de caminho)",
     "noCoords": "Sem GPS",
     "lastHeard": "Ouvido pela última vez {{time}}",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Нет включенных локальных интерфейсов для публикации на RMAP.",
       "syncSuccess": "Обнаружение RMAP синхронизировано с интерфейсом.",
       "openGlobalMap": "Глобальная карта",
-      "openGlobalMapAria": "Открыть глобальную карту RMAP v4 на rmap.world"
+      "openGlobalMapAria": "Открыть глобальную карту RMAP v4 на rmap.world",
+      "syncFailed": "Ошибка синхронизации обнаружения RMAP."
     }
   },
   "contactGroupsModal": {
@@ -3575,7 +3576,7 @@
     "heightMeters": "Высота над уровнем моря (м, опционально)",
     "reachableOn": "Доступно на (имя хоста или скрипт, необязательно)",
     "helpLink": "Руководство RMAP",
-    "gpsRequiredTitle": "Sono necessarie le coordinate GPS",
+    "gpsRequiredTitle": "Требуются GPS-координаты",
     "gpsRequiredBody": "Маркерам карты RMAP нужны широта и долгота. Установите статические координаты в разделе → GPS приложения/ Местоположение, а затем повторите попытку.",
     "openAppGps": "Открыть настройки приложения",
     "applySuccess": "Применены параметры обнаружения RMAP.",
@@ -3593,7 +3594,9 @@
     },
     "hint": "Применяет discoverable=yes и App GPS-координаты ко всем включенным интерфейсам с поддержкой RMAP (RNode, KISS, BLE peer, I2P, UDP, pipe). Используйте переключатели RMAP для каждого интерфейса на подключении для точного управления. Пути LoRa также обеспечивают транспорт и хаб rmap.world.",
     "openGlobalMap": "Глобальная карта",
-    "openGlobalMapAria": "Открыть глобальную карту RMAP v4 на rmap.world"
+    "openGlobalMapAria": "Открыть глобальную карту RMAP v4 на rmap.world",
+    "applyPartialSuccess": "Настройки RMAP применены к интерфейсам {{applied}} из {{total}}.",
+    "disablePartialSuccess": "Публикация RMAP отключена на {{applied}} из {{total}} интерфейсов."
   },
   "reticulumTopology": {
     "title": "Топология сети",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "RMAP'te yayınlanacak etkinleştirilmiş yerel arayüz yok.",
       "syncSuccess": "RMAP keşfi arayüzle senkronize edildi.",
       "openGlobalMap": "Küresel harita",
-      "openGlobalMapAria": "RMAP v4 global haritasını rmap.world'de açın"
+      "openGlobalMapAria": "RMAP v4 global haritasını rmap.world'de açın",
+      "syncFailed": "RMAP keşif senkronizasyonu başarısız oldu."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Etkinleştirilmiş tüm RMAP özellikli arayüzlere (RNode, KISS, BLE peer, I2P, UDP, pipe) bulunabilir=evet ve Uygulama GPS koordinatlarını uygular. İnce kontrol için Bağlantı üzerindeki arayüz başına RMAP geçişlerini kullanın. LoRa yolları ayrıca ulaşımı ve rmap.world hub'ını etkinleştirir.",
     "openGlobalMap": "Küresel haritayı aç",
-    "openGlobalMapAria": "RMAP v4 global haritasını rmap.world'de açın"
+    "openGlobalMapAria": "RMAP v4 global haritasını rmap.world'de açın",
+    "applyPartialSuccess": "{{total}} arabirimlerinin {{applied}} öğesine uygulanan RMAP ayarları.",
+    "disablePartialSuccess": "{{total}} arayüzlerinin {{applied}} üzerinde RMAP yayınlama devre dışı bırakıldı."
   },
   "reticulumTopology": {
     "title": "Ağ topolojisi",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "Немає увімкнених локальних інтерфейсів для публікації на RMAP.",
       "syncSuccess": "Виявлення RMAP синхронізовано з інтерфейсом.",
       "openGlobalMap": "Глобальна карта",
-      "openGlobalMapAria": "Відкрити глобальну карту RMAP v4 на rmap.world"
+      "openGlobalMapAria": "Відкрити глобальну карту RMAP v4 на rmap.world",
+      "syncFailed": "Не вдалося синхронізувати виявлення RMAP."
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "Застосовує detectable=yes та App GPS-координати до всіх увімкнених інтерфейсів з підтримкою RMAP (RNode, KISS, BLE peer, I2P, UDP, pipe). Використовуйте перемикачі RMAP для кожного інтерфейсу підключення для точного керування. Шляхи LoRa також забезпечують транспорт і хаб rmap.world.",
     "openGlobalMap": "Відкрити глобальну карту",
-    "openGlobalMapAria": "Відкрити глобальну карту RMAP v4 на rmap.world"
+    "openGlobalMapAria": "Відкрити глобальну карту RMAP v4 на rmap.world",
+    "applyPartialSuccess": "Налаштування RMAP застосовуються до інтерфейсів {{applied}} з {{total}}.",
+    "disablePartialSuccess": "Видання RMAP вимкнено на {{applied}} з {{total}} інтерфейсів."
   },
   "reticulumTopology": {
     "title": "Топологія мережі",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -1037,7 +1037,8 @@
       "noPublishTargets": "没有启用要在RMAP上发布的本地接口。",
       "syncSuccess": "RMAP发现已同步到接口。",
       "openGlobalMap": "全球测绘",
-      "openGlobalMapAria": "在rmap.world上打开RMAP v4全球地图"
+      "openGlobalMapAria": "在rmap.world上打开RMAP v4全球地图",
+      "syncFailed": "RMAP发现同步失败。"
     }
   },
   "contactGroupsModal": {
@@ -3593,7 +3594,9 @@
     },
     "hint": "将discoverable = yes和应用GPS坐标应用于所有启用的支持RMAP的接口（ RNode、KISS、BLE对等点、I2P、UDP、管道）。使用连接上的每个接口RMAP切换进行精细控制。LoRa路径还支持传输和rmap.world集线器。",
     "openGlobalMap": "全球测绘",
-    "openGlobalMapAria": "在rmap.world上打开RMAP v4全球地图"
+    "openGlobalMapAria": "在rmap.world上打开RMAP v4全球地图",
+    "applyPartialSuccess": "RMAP设置已应用于{{applied}}/{{total}}接口。",
+    "disablePartialSuccess": "在{{applied}}/{{total}}接口上禁用RMAP发布。"
   },
   "reticulumTopology": {
     "title": "网络拓扑图",

--- a/src/renderer/runtime/useReticulumRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useReticulumRuntime.reconnect-hardening.test.ts
@@ -57,3 +57,19 @@ describe('useReticulumRuntime manual disconnect must not auto-reconnect', () => 
     );
   });
 });
+
+describe('useReticulumRuntime RMAP discovery map', () => {
+  it('routes rmap.discovery WS events through setDiscovered', () => {
+    expect(SOURCE).toMatch(/evt\.type === 'rmap\.discovery'[\s\S]*?setDiscovered\(p\.discovered\)/);
+  });
+
+  it('clears discovery map and peer store on disconnect and sidecar stop', () => {
+    expect(SOURCE).toContain('useReticulumDiscoveryMapStore.getState().clear()');
+    expect(SOURCE).toContain('useReticulumPeerStore.getState().clearPeers()');
+    const tearDownRe =
+      /const tearDownFromSidecarStop = useCallback\([\s\S]*?\}, \[syncConnectionStore\]\);/;
+    const tearDownBody = tearDownRe.exec(SOURCE)?.[0];
+    expect(tearDownBody).toMatch(/useReticulumDiscoveryMapStore\.getState\(\)\.clear\(\)/);
+    expect(tearDownBody).toMatch(/useReticulumPeerStore\.getState\(\)\.clearPeers\(\)/);
+  });
+});

--- a/src/renderer/runtime/useReticulumRuntime.ts
+++ b/src/renderer/runtime/useReticulumRuntime.ts
@@ -54,11 +54,7 @@ import {
   reticulumDbRowToMessageRecord,
 } from '@/renderer/lib/storeRecordAdapters';
 import { reticulumHashForNodeId } from '@/renderer/stores/reticulumPeerStore';
-import type {
-  ReticulumRmapDiscoveredWireRow,
-  ReticulumSidecarEvent,
-  ReticulumWirePacketRow,
-} from '@/shared/reticulum-types';
+import type { ReticulumSidecarEvent, ReticulumWirePacketRow } from '@/shared/reticulum-types';
 import { MS_PER_MINUTE } from '@/shared/timeConstants';
 
 import { getIdentityIdForProtocol } from '../lib/identityByProtocol';
@@ -411,9 +407,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
       if (evt.type === 'rmap.discovery' && evt.payload && typeof evt.payload === 'object') {
         const p = evt.payload as { discovered?: unknown };
         if (Array.isArray(p.discovered)) {
-          useReticulumDiscoveryMapStore
-            .getState()
-            .setDiscovered(p.discovered as ReticulumRmapDiscoveredWireRow[]);
+          useReticulumDiscoveryMapStore.getState().setDiscovered(p.discovered);
         }
       }
       if (evt.type === 'nomadnetwork.node') {
@@ -463,6 +457,8 @@ export function useReticulumRuntime(): ProtocolRuntime {
     setSelfLxmfHash(null);
     rawPacketAppenderRef.current?.clearPending();
     setRawPackets([]);
+    useReticulumDiscoveryMapStore.getState().clear();
+    useReticulumPeerStore.getState().clearPeers();
     setState(INITIAL_STATE);
     syncConnectionStore(INITIAL_STATE);
   }, [syncConnectionStore]);
@@ -572,6 +568,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
     rawPacketAppenderRef.current?.clearPending();
     setRawPackets([]);
     useReticulumDiscoveryMapStore.getState().clear();
+    useReticulumPeerStore.getState().clearPeers();
     setState(INITIAL_STATE);
     syncConnectionStore(INITIAL_STATE);
   }, [syncConnectionStore]);

--- a/src/renderer/stores/reticulumDiscoveryMapStore.test.ts
+++ b/src/renderer/stores/reticulumDiscoveryMapStore.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import { MAX_RMAP_DISCOVERED_ROWS } from '@/renderer/lib/sessionMemoryCaps';
 import {
   mergeRmapDiscoveryRows,
+  normalizeRmapDiscoveryRows,
+  RMAP_DISCOVERY_TTL_SEC,
+  sanitizeRmapDiscoveryRow,
   useReticulumDiscoveryMapStore,
 } from '@/renderer/stores/reticulumDiscoveryMapStore';
 import type { ReticulumRmapDiscoveredWireRow } from '@/shared/reticulum-types';
 
-const row = (hash: string, lastHeard: number): ReticulumRmapDiscoveredWireRow => ({
+const nowHeard = () => Math.floor(Date.now() / 1000);
+
+const row = (hash: string, lastHeard: number = nowHeard()): ReticulumRmapDiscoveredWireRow => ({
   discovery_hash: hash,
   transport_id: hash.padEnd(32, '0'),
   discovery_name: hash,
@@ -25,15 +31,60 @@ const row = (hash: string, lastHeard: number): ReticulumRmapDiscoveredWireRow =>
 });
 
 describe('reticulumDiscoveryMapStore', () => {
+  beforeEach(() => {
+    useReticulumDiscoveryMapStore.getState().clear();
+  });
+
   it('mergeRmapDiscoveryRows dedupes by discovery_hash', () => {
-    const merged = mergeRmapDiscoveryRows([row('a', 1)], [row('a', 99), row('b', 2)]);
+    const now = nowHeard();
+    const merged = mergeRmapDiscoveryRows([row('a', now - 10)], [row('a', now), row('b', now - 5)]);
     expect(merged).toHaveLength(2);
-    expect(merged.find((r) => r.discovery_hash === 'a')?.last_heard).toBe(99);
+    expect(merged.find((r) => r.discovery_hash === 'a')?.last_heard).toBe(now);
   });
 
   it('clear resets discovered rows', () => {
-    useReticulumDiscoveryMapStore.getState().setDiscovered([row('a', 1)]);
+    useReticulumDiscoveryMapStore.getState().setDiscovered([row('a')]);
     useReticulumDiscoveryMapStore.getState().clear();
     expect(useReticulumDiscoveryMapStore.getState().discovered).toEqual([]);
+  });
+
+  it('setDiscovered caps rows to MAX_RMAP_DISCOVERED_ROWS', () => {
+    const nowSec = nowHeard();
+    const rows = Array.from({ length: MAX_RMAP_DISCOVERED_ROWS + 50 }, (_, i) =>
+      row(`h${i}`, nowSec - i),
+    );
+    useReticulumDiscoveryMapStore.getState().setDiscovered(rows);
+    expect(useReticulumDiscoveryMapStore.getState().discovered).toHaveLength(
+      MAX_RMAP_DISCOVERED_ROWS,
+    );
+    expect(useReticulumDiscoveryMapStore.getState().discovered[0]?.discovery_hash).toBe('h0');
+  });
+
+  it('normalizeRmapDiscoveryRows evicts rows older than TTL', () => {
+    const nowSec = 10_000_000;
+    const fresh = row('fresh', nowSec - 100);
+    const stale = row('stale', nowSec - RMAP_DISCOVERY_TTL_SEC - 1);
+    const normalized = normalizeRmapDiscoveryRows([fresh, stale], nowSec);
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]?.discovery_hash).toBe('fresh');
+  });
+
+  it('sanitizeRmapDiscoveryRow rejects invalid rows', () => {
+    expect(sanitizeRmapDiscoveryRow(null)).toBeNull();
+    expect(sanitizeRmapDiscoveryRow({ discovery_hash: '', transport_id: 'x' })).toBeNull();
+    expect(
+      sanitizeRmapDiscoveryRow({ discovery_hash: 'a', transport_id: 'b', last_heard: NaN }),
+    ).toBeNull();
+    const valid = sanitizeRmapDiscoveryRow({
+      discovery_hash: 'abc',
+      transport_id: 'aa'.repeat(16),
+      discovery_name: 'Node',
+      interface_type: 'RNodeInterface',
+      latitude: 40,
+      longitude: -105,
+      last_heard: 100,
+      has_coordinates: true,
+    });
+    expect(valid?.discovery_hash).toBe('abc');
   });
 });

--- a/src/renderer/stores/reticulumDiscoveryMapStore.ts
+++ b/src/renderer/stores/reticulumDiscoveryMapStore.ts
@@ -1,6 +1,14 @@
 import { create } from 'zustand';
 
+import { MAX_RMAP_DISCOVERED_ROWS } from '@/renderer/lib/sessionMemoryCaps';
+import { isValidLatLon } from '@/shared/geoCoords';
 import type { ReticulumRmapDiscoveredWireRow } from '@/shared/reticulum-types';
+import { MS_PER_DAY, MS_PER_SECOND } from '@/shared/timeConstants';
+
+/** Defense-in-depth TTL aligned with sidecar DiscoveryStore (7 days). */
+export const RMAP_DISCOVERY_TTL_SEC = 7 * (MS_PER_DAY / MS_PER_SECOND);
+
+const MAX_RMAP_STRING_FIELD_LEN = 256;
 
 interface ReticulumDiscoveryMapState {
   discovered: ReticulumRmapDiscoveredWireRow[];
@@ -11,13 +19,103 @@ interface ReticulumDiscoveryMapState {
   clear: () => void;
 }
 
+function clampString(value: unknown, maxLen: number): string {
+  if (typeof value !== 'string') return '';
+  return value.slice(0, maxLen);
+}
+
+/** Sanitize and validate a single wire row; drop invalid entries. */
+export function sanitizeRmapDiscoveryRow(raw: unknown): ReticulumRmapDiscoveredWireRow | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const row = raw as Record<string, unknown>;
+  const discoveryHash = clampString(row.discovery_hash, MAX_RMAP_STRING_FIELD_LEN).trim();
+  const transportId = clampString(row.transport_id, MAX_RMAP_STRING_FIELD_LEN).trim();
+  if (!discoveryHash || !transportId) return null;
+
+  const latitude = typeof row.latitude === 'number' ? row.latitude : Number(row.latitude);
+  const longitude = typeof row.longitude === 'number' ? row.longitude : Number(row.longitude);
+  const lastHeard = typeof row.last_heard === 'number' ? row.last_heard : Number(row.last_heard);
+  if (!Number.isFinite(lastHeard) || lastHeard <= 0) return null;
+
+  const hasCoordinates =
+    Boolean(row.has_coordinates) &&
+    isValidLatLon(latitude, longitude) &&
+    !(latitude === 0 && longitude === 0);
+
+  return {
+    discovery_hash: discoveryHash,
+    transport_id: transportId,
+    discovery_name: clampString(row.discovery_name, MAX_RMAP_STRING_FIELD_LEN),
+    interface_type: clampString(row.interface_type, MAX_RMAP_STRING_FIELD_LEN),
+    latitude: Number.isFinite(latitude) ? latitude : 0,
+    longitude: Number.isFinite(longitude) ? longitude : 0,
+    height: typeof row.height === 'number' && Number.isFinite(row.height) ? row.height : 0,
+    transport_enabled: Boolean(row.transport_enabled),
+    reachable_on:
+      row.reachable_on == null
+        ? null
+        : clampString(row.reachable_on, MAX_RMAP_STRING_FIELD_LEN) || null,
+    port: typeof row.port === 'number' && Number.isFinite(row.port) ? row.port : null,
+    frequency:
+      typeof row.frequency === 'number' && Number.isFinite(row.frequency) ? row.frequency : null,
+    bandwidth:
+      typeof row.bandwidth === 'number' && Number.isFinite(row.bandwidth) ? row.bandwidth : null,
+    spreading_factor:
+      typeof row.spreading_factor === 'number' && Number.isFinite(row.spreading_factor)
+        ? row.spreading_factor
+        : null,
+    coding_rate:
+      typeof row.coding_rate === 'number' && Number.isFinite(row.coding_rate)
+        ? row.coding_rate
+        : null,
+    modulation:
+      row.modulation == null
+        ? null
+        : clampString(row.modulation, MAX_RMAP_STRING_FIELD_LEN) || null,
+    channel: typeof row.channel === 'number' && Number.isFinite(row.channel) ? row.channel : null,
+    hops: typeof row.hops === 'number' && Number.isFinite(row.hops) ? Math.trunc(row.hops) : 0,
+    stamp_value:
+      typeof row.stamp_value === 'number' && Number.isFinite(row.stamp_value)
+        ? Math.trunc(row.stamp_value)
+        : 0,
+    discovered:
+      typeof row.discovered === 'number' && Number.isFinite(row.discovered)
+        ? Math.trunc(row.discovered)
+        : 0,
+    last_heard: Math.trunc(lastHeard),
+    heard_count:
+      typeof row.heard_count === 'number' && Number.isFinite(row.heard_count)
+        ? Math.trunc(row.heard_count)
+        : 0,
+    status: clampString(row.status, 32) || 'unknown',
+    has_coordinates: hasCoordinates,
+  };
+}
+
+/** Filter stale rows, sanitize, sort by last_heard desc, and cap count. */
+export function normalizeRmapDiscoveryRows(
+  rows: unknown[],
+  nowSec: number = Math.floor(Date.now() / MS_PER_SECOND),
+): ReticulumRmapDiscoveredWireRow[] {
+  const cutoff = nowSec - RMAP_DISCOVERY_TTL_SEC;
+  const sanitized: ReticulumRmapDiscoveredWireRow[] = [];
+  for (const raw of rows) {
+    const row = sanitizeRmapDiscoveryRow(raw);
+    if (!row || row.last_heard < cutoff) continue;
+    sanitized.push(row);
+  }
+  sanitized.sort((a, b) => b.last_heard - a.last_heard);
+  if (sanitized.length <= MAX_RMAP_DISCOVERED_ROWS) return sanitized;
+  return sanitized.slice(0, MAX_RMAP_DISCOVERED_ROWS);
+}
+
 export const useReticulumDiscoveryMapStore = create<ReticulumDiscoveryMapState>((set) => ({
   discovered: [],
   loading: false,
   lastRefreshAt: null,
   setDiscovered: (rows) => {
     set({
-      discovered: rows,
+      discovered: normalizeRmapDiscoveryRows(rows),
       loading: false,
       lastRefreshAt: Date.now(),
     });
@@ -45,5 +143,5 @@ export function mergeRmapDiscoveryRows(
   for (const row of incoming) {
     byHash.set(row.discovery_hash, row);
   }
-  return [...byHash.values()].sort((a, b) => b.last_heard - a.last_heard);
+  return normalizeRmapDiscoveryRows([...byHash.values()]);
 }

--- a/src/renderer/stores/reticulumPeerStore.ts
+++ b/src/renderer/stores/reticulumPeerStore.ts
@@ -7,6 +7,7 @@ import {
   resolveReticulumDestinationHash,
   reticulumHashToNodeId,
 } from '@/renderer/lib/reticulum/destHash';
+import { MAX_MESH_ENTITY_CAP } from '@/renderer/lib/sessionMemoryCaps';
 import { useNodeStore } from '@/renderer/stores/nodeStore';
 import { omitRecordKey } from '@/renderer/stores/storeUtils';
 import type {
@@ -52,6 +53,7 @@ interface ReticulumPeerStoreState {
   getPeer: (hash: string) => ReticulumPeer | ReticulumContact | undefined;
   getDisplayName: (peer: ReticulumPeer) => string;
   isContact: (hash: string) => boolean;
+  clearPeers: () => void;
 }
 
 function normalizeHash(hash: string): string {
@@ -193,6 +195,30 @@ export function mergeReticulumPeerMaps(
   }
 
   return { peers: peerMap, contacts: contactMap };
+}
+
+/** Keep newest peers by last_seen when the path table exceeds the product cap. */
+export function capReticulumPeerMaps(
+  peers: Map<string, ReticulumPeer>,
+  contacts: Map<string, ReticulumContact>,
+  max: number = MAX_MESH_ENTITY_CAP,
+): { peers: Map<string, ReticulumPeer>; contacts: Map<string, ReticulumContact> } {
+  if (peers.size <= max) {
+    return { peers, contacts };
+  }
+  const sorted = [...peers.entries()].sort(([, a], [, b]) => {
+    const aSeen = a.last_seen ?? ('last_heard' in a ? (a as ReticulumContact).last_heard : 0) ?? 0;
+    const bSeen = b.last_seen ?? ('last_heard' in b ? (b as ReticulumContact).last_heard : 0) ?? 0;
+    return bSeen - aSeen;
+  });
+  const cappedPeers = new Map(sorted.slice(0, max));
+  const cappedContacts = new Map<string, ReticulumContact>();
+  for (const [hash, contact] of contacts) {
+    if (cappedPeers.has(hash)) {
+      cappedContacts.set(hash, contact);
+    }
+  }
+  return { peers: cappedPeers, contacts: cappedContacts };
 }
 
 export function reticulumContactToMeshNode(contact: ReticulumContact): MeshNode {
@@ -413,6 +439,14 @@ export const useReticulumPeerStore = create<ReticulumPeerStoreState>((set, get) 
   getDisplayName: (peer) => peerDisplayName(peer),
 
   isContact: (hash) => get().contacts.has(normalizeHash(hash)),
+
+  clearPeers: () => {
+    set({
+      peers: new Map(),
+      contacts: new Map(),
+      lastRefreshAt: null,
+    });
+  },
 }));
 
 /** Resolve LXMF destination hash for a numeric node id (registry, node store, peer/contact store). */
@@ -482,12 +516,8 @@ export async function refreshReticulumPeersFromSidecar(): Promise<ReticulumConta
     );
 
     const dismissed = useReticulumPeerStore.getState().dismissedContactHashes;
-    const { peers, contacts } = mergeReticulumPeerMaps(
-      wirePeers,
-      wireContacts,
-      dbRows ?? [],
-      dismissed,
-    );
+    const merged = mergeReticulumPeerMaps(wirePeers, wireContacts, dbRows ?? [], dismissed);
+    const { peers, contacts } = capReticulumPeerMaps(merged.peers, merged.contacts);
 
     useReticulumPeerStore.setState({
       peers,


### PR DESCRIPTION
## Summary

- Add client-side memory safeguards for the Reticulum RMAP discovery map: cap discovery rows at 2,000 with 7-day TTL eviction, cap peer store on refresh, and clear map/peer stores on disconnect and unexpected sidecar stop.
- Fix resilience bugs: preserve last-good map data on fetch failure, guard against stale HTTP refresh races, and resolve marker clicks to path-table peer hashes for peer detail modal.
- Report partial RMAP apply/disable failures and RMAP auto-sync errors with user-visible toasts; dedupe LoRa `MapPanel` Leaflet controls via shared `leafletMapControls`.
- Fix bad `reticulumMap` locale strings (fr/de/ja/ru/pt-BR), add i18n quality rules, and expand docs for map memory, refresh model, and contributor references.

Also includes `chore: bump deps` from the branch base.

## Commits

- `0ec6fd8d` chore: bump deps
- `82a4e2be` fix: harden Reticulum discovery map memory and resilience

## Test plan

- [x] `reticulumDiscoveryMapStore` cap/TTL/sanitize tests
- [x] `reticulumDiscoveryMapLayout` peerDetailHash tests
- [x] `fetchReticulumRmapDiscovered` error preservation tests
- [x] `useReticulumRuntime` RMAP teardown contract tests
- [x] `ReticulumMapPanel` refresh error + marker click tests
- [x] `reticulumRmapDiscovery` apply result tests
- [x] Pre-commit: lint, typecheck, check:i18n, full test suite on changed files