### PR TITLE
fix: omit SharedInstanceServer runtime note from Reticulum diagnostics

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -436,7 +436,7 @@ On the **Reticulum** protocol tab, the **Diagnostics** panel includes a **Reticu
 | `missing_auto_interface`                    | No enabled `AutoInterface` (LAN discovery off)                        | **Add Auto interface**                                      |
 | `missing_shared_instance`                   | `share_instance = Yes` but `SharedInstanceServer` not up              | **Restart stack**                                           |
 
-The Connection tab **Interfaces** list shows the same audit hints per row (amber/red subtext) with **Repair** / **Disable** shortcuts. **SharedInstanceServer** is runtime-only (created when **Share instance** is on) — it shows a **Runtime** badge and cannot be edited or deleted from config.
+The Connection tab **Interfaces** list shows the same audit hints per row (amber/red subtext) with **Repair** / **Disable** shortcuts. **SharedInstanceServer** is runtime-only (created when **Share instance** is on) — it shows a **Runtime** badge and cannot be edited or deleted from config. The `runtime_only_interface` audit note is intentionally omitted from the Diagnostics panel (expected state, not a fault); misconfiguration is reported via `missing_shared_instance` or `shared_instance_unexpected` instead.
 
 Sidecar APIs: `GET /api/v1/config/audit`, `POST /api/v1/config/repair` (see [`reticulum-sidecar-ipc.md`](reticulum-sidecar-ipc.md)).
 

--- a/src/renderer/lib/diagnostics/ReticulumDiagnosticEngine.test.ts
+++ b/src/renderer/lib/diagnostics/ReticulumDiagnosticEngine.test.ts
@@ -160,6 +160,29 @@ describe('ReticulumDiagnosticEngine', () => {
     ).toBe(true);
   });
 
+  it('omits runtime_only_interface audit notes from diagnostic rows', () => {
+    const rows = buildReticulumDiagnosticRows(
+      { rns_ready: true, lxmf_ready: true, interface_count: 1, peer_count: 0 },
+      {
+        auditIssues: [
+          {
+            kind: 'runtime_only_interface',
+            severity: 'info',
+            interface_id: 'shared',
+            interface_name: 'SharedInstanceServer',
+            message: 'Runtime shared-instance server (not in config)',
+          },
+        ],
+      },
+    );
+    expect(
+      rows.some(
+        (r): r is RfDiagnosticRow =>
+          r.kind === 'rf' && r.condition === 'reticulum/audit/runtime_only_interface',
+      ),
+    ).toBe(false);
+  });
+
   it('adds auto-beacon diagnostic rows from sidecar alert', () => {
     const physical = buildReticulumDiagnosticRows(
       { rns_ready: true, lxmf_ready: true, interface_count: 1, peer_count: 0 },

--- a/src/renderer/lib/reticulum/reticulumConfigAudit.test.ts
+++ b/src/renderer/lib/reticulum/reticulumConfigAudit.test.ts
@@ -70,6 +70,31 @@ describe('reticulumConfigAudit', () => {
     expect(row?.causeI18n?.key).toBe('diagnosticsPanel.reticulum.audit.tcp_unreachable');
   });
 
+  it('auditIssuesToDiagnosticRows excludes expected runtime-only interface notes', () => {
+    const rows = auditIssuesToDiagnosticRows(
+      [
+        {
+          kind: 'runtime_only_interface',
+          severity: 'info',
+          interface_id: 'shared-instance',
+          interface_name: 'SharedInstanceServer',
+          message: 'Runtime shared-instance server (not in config)',
+        },
+        {
+          kind: 'missing_shared_instance',
+          severity: 'warning',
+          interface_name: 'SharedInstanceServer',
+          message: 'share_instance is on but SharedInstanceServer is not up',
+          repair_kind: 'restart_stack',
+        },
+      ],
+      1,
+    );
+    expect(rows).toHaveLength(1);
+    const row = rows[0] as RfDiagnosticRow;
+    expect(row?.condition).toBe('reticulum/audit/missing_shared_instance');
+  });
+
   it.each([
     'rmap_missing_coordinates',
     'rmap_no_tcp_hub',

--- a/src/renderer/lib/reticulum/reticulumConfigAudit.ts
+++ b/src/renderer/lib/reticulum/reticulumConfigAudit.ts
@@ -50,32 +50,37 @@ function auditI18nKey(kind: string): string {
   return `diagnosticsPanel.reticulum.audit.${kind}`;
 }
 
+/** Expected runtime state — not actionable; Connection tab shows a Runtime badge instead. */
+export const RETICULUM_AUDIT_KINDS_EXCLUDED_FROM_DIAGNOSTICS = new Set(['runtime_only_interface']);
+
 export function auditIssuesToDiagnosticRows(
   issues: ReticulumConfigAuditIssue[],
   selfNodeId: number,
 ): DiagnosticRow[] {
   const now = Date.now();
-  return issues.map((issue) => {
-    const ifaceId = issue.interface_id ?? undefined;
-    const slug = ifaceId ? `${issue.kind}/${ifaceId}` : issue.kind;
-    const repairKind = issue.repair_kind as ReticulumConfigRepairKind | undefined;
-    return {
-      kind: 'rf' as const,
-      id: rfRowId(selfNodeId, `reticulum/audit/${slug}`),
-      nodeId: selfNodeId,
-      condition: `reticulum/audit/${issue.kind}`,
-      cause: issue.message,
-      severity: issue.severity,
-      detectedAt: now,
-      causeI18n: {
-        key: auditI18nKey(issue.kind),
-        params: {
-          name: issue.interface_name ?? '',
-          message: issue.message,
+  return issues
+    .filter((issue) => !RETICULUM_AUDIT_KINDS_EXCLUDED_FROM_DIAGNOSTICS.has(issue.kind))
+    .map((issue) => {
+      const ifaceId = issue.interface_id ?? undefined;
+      const slug = ifaceId ? `${issue.kind}/${ifaceId}` : issue.kind;
+      const repairKind = issue.repair_kind as ReticulumConfigRepairKind | undefined;
+      return {
+        kind: 'rf' as const,
+        id: rfRowId(selfNodeId, `reticulum/audit/${slug}`),
+        nodeId: selfNodeId,
+        condition: `reticulum/audit/${issue.kind}`,
+        cause: issue.message,
+        severity: issue.severity,
+        detectedAt: now,
+        causeI18n: {
+          key: auditI18nKey(issue.kind),
+          params: {
+            name: issue.interface_name ?? '',
+            message: issue.message,
+          },
         },
-      },
-      reticulumInterfaceId: ifaceId,
-      reticulumRepairKind: repairKind ?? undefined,
-    };
-  });
+        reticulumInterfaceId: ifaceId,
+        reticulumRepairKind: repairKind ?? undefined,
+      };
+    });
 }


### PR DESCRIPTION
## Summary
- Filter `runtime_only_interface` audit notes out of Reticulum diagnostic rows so `SharedInstanceServer` no longer appears as a Diagnostics offense when share instance is working normally
- Connection tab still shows the Runtime badge and any real misconfigurations (`missing_shared_instance`, `shared_instance_unexpected`) continue to surface on Diagnostics

## Test plan
- [x] Unit tests for `auditIssuesToDiagnosticRows` and `buildReticulumDiagnosticRows` confirm `runtime_only_interface` is excluded
- [ ] With Reticulum connected and share instance enabled, Diagnostics no longer lists SharedInstanceServer under Notes
- [ ] Connection tab still shows SharedInstanceServer with Runtime badge