### PR TITLE
test: cover missing uppercase Reticulum contact

### DIFF
--- a/src/renderer/stores/reticulumPeerStore.test.ts
+++ b/src/renderer/stores/reticulumPeerStore.test.ts
@@ -107,6 +107,7 @@ describe('reticulumPeerStore', () => {
     expect(useReticulumPeerStore.getState().isContact('contact1')).toBe(true);
     expect(useReticulumPeerStore.getState().isContact('peeronly')).toBe(false);
     expect(useReticulumPeerStore.getState().isContact('CONTACT1')).toBe(true);
+    expect(useReticulumPeerStore.getState().isContact('NONEXISTENT')).toBe(false);
   });
 
   it('clearPeers empties peers and contacts', () => {


### PR DESCRIPTION
## Summary
- add a negative uppercase `isContact` lookup assertion
- make the case-insensitive behavior explicit and guard against an always-true implementation

## Test plan
- [x] `pnpm run test:run -- src/renderer/stores/reticulumPeerStore.test.ts`
- [x] pre-commit lint, typecheck, checks, audit, and test suite