### PR TITLE
fix: pre-release BLE reconnect hardening and log noise cleanup

### DIFF
--- a/src/main/index.contract.test.ts
+++ b/src/main/index.contract.test.ts
@@ -26,6 +26,13 @@ describe('Noble BLE disconnect handling (source contract)', () => {
       /noble-ble-to-radio: disconnected during write, ignoring session=/,
     );
   });
+
+  it('returns scan_busy result instead of throwing when Reticulum holds the scan mutex', () => {
+    expect(INDEX_SOURCE).toContain('BleScanBusyError');
+    expect(INDEX_SOURCE).toMatch(
+      /noble-ble-start-scan[\s\S]{0,1200}err instanceof BleScanBusyError[\s\S]{0,400}code: 'scan_busy'/,
+    );
+  });
 });
 
 describe('MeshCore packet log IPC (source contract)', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,7 @@ import type { TAKServerStatus, TAKSettings } from '../shared/tak-types';
 import {
   bleCoexistenceCoordinator,
   type BlePeripheralOwner,
+  BleScanBusyError,
   type BleScanOwner,
 } from './ble-coexistence-coordinator';
 import { formatChatExportLines } from './chatExportFormat';
@@ -2642,9 +2643,20 @@ ipcMain.handle('noble-ble-start-scan', async (event, sessionId: unknown) => {
   }
   if (isQuitting) {
     console.debug('[main] noble-ble-start-scan: ignoring (app is quitting)');
-    return;
+    return { ok: true as const };
   }
-  await nobleBleManager.startScanning(sessionId);
+  try {
+    await nobleBleManager.startScanning(sessionId);
+    return { ok: true as const };
+  } catch (err) {
+    if (err instanceof BleScanBusyError) {
+      console.debug(
+        `[main] noble-ble-start-scan: scan busy (owner=${err.scanOwner}) session=${sessionId}`,
+      );
+      return { ok: false as const, code: 'scan_busy' as const, owner: err.scanOwner };
+    }
+    throw err;
+  }
 });
 ipcMain.handle('noble-ble-stop-scan', async (event, sessionId: unknown) => {
   assertIpcSender(event, 'noble-ble-stop-scan');

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -611,7 +611,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('noble-ble-from-radio', handler);
     return () => ipcRenderer.off('noble-ble-from-radio', handler);
   },
-  startNobleBleScanning: (sessionId: NobleBleSessionId): Promise<void> =>
+  startNobleBleScanning: (sessionId: NobleBleSessionId) =>
     ipcRenderer.invoke('noble-ble-start-scan', sessionId),
   stopNobleBleScanning: (sessionId: NobleBleSessionId): Promise<void> =>
     ipcRenderer.invoke('noble-ble-stop-scan', sessionId),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4011,7 +4011,11 @@ function ConnectionBanner({
     connectionType === 'serial'
   ) {
     return (
-      <div className="flex items-center justify-between border-b border-red-700 bg-red-900/80 px-4 py-2">
+      <div
+        role="region"
+        aria-label={t('connectionBanner.statusRegion')}
+        className="flex items-center justify-between border-b border-red-700 bg-red-900/80 px-4 py-2"
+      >
         <div className="flex items-center gap-2">
           <span className="text-red-400">⚠</span>
           <span className="text-sm text-red-200">{t('connectionBanner.serialReselect')}</span>
@@ -4030,7 +4034,11 @@ function ConnectionBanner({
 
   if (status === 'disconnected' && connectionLoss) {
     return (
-      <div className="flex items-center justify-between border-b border-red-700 bg-red-900/80 px-4 py-2">
+      <div
+        role="region"
+        aria-label={t('connectionBanner.statusRegion')}
+        className="flex items-center justify-between border-b border-red-700 bg-red-900/80 px-4 py-2"
+      >
         <div className="flex items-center gap-2">
           <span className="text-red-400">⚠</span>
           <span className="text-sm text-red-200">{t('connectionBanner.disconnectedLoss')}</span>
@@ -4049,7 +4057,11 @@ function ConnectionBanner({
 
   if (status === 'stale') {
     return (
-      <div className="flex items-center justify-between border-b border-yellow-700 bg-yellow-900/80 px-4 py-2">
+      <div
+        role="region"
+        aria-label={t('connectionBanner.statusRegion')}
+        className="flex items-center justify-between border-b border-yellow-700 bg-yellow-900/80 px-4 py-2"
+      >
         <div className="flex items-center gap-2">
           <span className="text-yellow-400">⚠</span>
           <span className="text-sm text-yellow-200">{t('connectionBanner.staleLoss')}</span>
@@ -4068,9 +4080,15 @@ function ConnectionBanner({
 
   if (status === 'reconnecting') {
     return (
-      <div className="flex items-center gap-2 border-b border-orange-700 bg-orange-900/80 px-4 py-2">
-        <span className="inline-block animate-spin text-orange-400">⟳</span>
-        <span className="animate-pulse text-sm text-orange-200">
+      <div
+        role="region"
+        aria-label={t('connectionBanner.statusRegion')}
+        className="flex items-center gap-2 border-b border-orange-700 bg-orange-900/80 px-4 py-2"
+      >
+        <span aria-hidden className="inline-block animate-spin text-orange-200">
+          ⟳
+        </span>
+        <span className="text-sm text-orange-200">
           {t('connectionBanner.reconnectingAttempt', {
             attempt: reconnectAttempt ?? 1,
             max: 5,

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -1286,7 +1286,7 @@ describe('ConnectionPanel serial auto-connect BLE fallback', () => {
     const onAutoConnect = vi
       .fn()
       .mockRejectedValue(new Error('Serial auto-connect failed (radio did not respond)'));
-    vi.mocked(window.electronAPI.startNobleBleScanning).mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockResolvedValue({ ok: true });
 
     try {
       render(

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -38,7 +38,7 @@ import {
   loadProtocolMqttSettings,
   persistMqttSettingsIfChanged,
 } from '../hooks/useProtocolMqttSettings';
-import { reconnectBleWithScan } from '../lib/bleReconnectHelper';
+import { reconnectBleWithScan, startNobleBleScanningWithRetry } from '../lib/bleReconnectHelper';
 import {
   humanizeBleError,
   humanizeHttpError,
@@ -1162,7 +1162,7 @@ export default function ConnectionPanel({
       // Reconnect to the last device uses handleReconnect / startup auto-connect instead.
       setConnectionStage('connectionPanel.stageScanning');
       try {
-        await window.electronAPI.startNobleBleScanning(protocol);
+        await startNobleBleScanningWithRetry(protocol);
       } catch (err) {
         console.warn('[ConnectionPanel] startNobleBleScanning failed: ' + errLikeToLogString(err));
         const bleErrMsg = humanizeBleError(err, t);

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -2775,13 +2775,18 @@ export default function ConnectionPanel({
                 Docs ↗
               </a>
               <span
-                className={`text-xs font-medium ${
-                  state.status === 'reconnecting'
-                    ? 'animate-pulse text-orange-400'
-                    : 'text-brand-green'
+                className={`inline-flex items-center gap-1 text-xs font-medium ${
+                  state.status === 'reconnecting' ? 'text-orange-200' : 'text-brand-green'
                 }`}
               >
-                ● {state.status}
+                {state.status === 'reconnecting' ? (
+                  <span aria-hidden className="inline-block animate-pulse">
+                    ●
+                  </span>
+                ) : (
+                  <>●</>
+                )}{' '}
+                {state.status}
               </span>
             </div>
           </div>

--- a/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
+++ b/src/renderer/hooks/meshcore/meshcoreLegacyConnEvents.ts
@@ -67,7 +67,9 @@ import {
 } from '../../lib/meshcoreWaitingMessageItem';
 import {
   isMeshcoreCompanionDrainDeferred,
+  isMeshcoreSyncNextMessageTimeoutError,
   logMeshcoreWaitingMessagesDrainError,
+  markMeshcoreMsgWaitingEvent,
   resetMeshcoreWaitingMessagesDrainSchedule,
   scheduleMeshcoreWaitingMessagesDrain,
   shouldActivateWaitingMessagesBanner,
@@ -755,11 +757,19 @@ export function attachMeshcoreLegacyConnEvents(
           let silentDrainExhaustedCap = false;
           for (let i = 0; i < MESHCORE_SYNC_NEXT_MESSAGE_MAX_PER_DRAIN; i += 1) {
             if (!meshcoreHookMountedRef.current) break;
-            const raw = await withTimeout(
-              conn.syncNextMessage(),
-              MESHCORE_SYNC_NEXT_MESSAGE_TIMEOUT_MS,
-              'MeshCore syncNextMessage',
-            );
+            let raw: unknown;
+            try {
+              raw = await withTimeout(
+                conn.syncNextMessage(),
+                MESHCORE_SYNC_NEXT_MESSAGE_TIMEOUT_MS,
+                'MeshCore syncNextMessage',
+              );
+            } catch (e: unknown) {
+              if (isMeshcoreSyncNextMessageTimeoutError(e)) {
+                break;
+              }
+              throw e;
+            }
             const item = normalizeMeshcoreWaitingMessageItem(raw);
             if (!item) break;
             await ingestItem(item);
@@ -795,6 +805,7 @@ export function attachMeshcoreLegacyConnEvents(
   };
   processWaitingMessagesRef.current = processWaitingMessages;
   onMeshcoreConn(131, () => {
+    markMeshcoreMsgWaitingEvent();
     scheduleMeshcoreWaitingMessagesDrain(
       async () => {
         try {

--- a/src/renderer/hooks/useMeshcoreRuntime.waiting-messages-drain.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.waiting-messages-drain.test.tsx
@@ -259,4 +259,31 @@ describe('useMeshcoreRuntime waiting messages drain', () => {
     );
     expect(getWaitingMessagesMock).not.toHaveBeenCalled();
   }, 15_000);
+
+  it('event 131 silent drain treats syncNextMessage timeout as empty queue', async () => {
+    syncNextMessageMock.mockRejectedValue(
+      new Error('MeshCore syncNextMessage timed out after 12000ms'),
+    );
+
+    const result = await connectSerialConfigured();
+    const conn = lastMeshSerialMock.current;
+    expect(conn).not.toBeNull();
+
+    act(() => {
+      conn!.emit(131);
+    });
+
+    await waitFor(
+      () => {
+        expect(syncNextMessageMock).toHaveBeenCalled();
+      },
+      { timeout: 8_000 },
+    );
+    await waitFor(
+      () => {
+        expect(result.current.waitingMessagesSilentDrainActive).toBe(false);
+      },
+      { timeout: 8_000 },
+    );
+  }, 20_000);
 });

--- a/src/renderer/lib/bleReconnectHelper.test.ts
+++ b/src/renderer/lib/bleReconnectHelper.test.ts
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { verifyNobleBleRfLink } from './bleReconnectHelper';
+import { MESHCORE_SETUP_ABORT_MESSAGE } from './bleConnectErrors';
+import {
+  BLE_SCAN_BUSY_MAX_WAIT_MS,
+  BLE_SCAN_BUSY_RETRY_INTERVAL_MS,
+  reconnectBleWithScan,
+  startNobleBleScanningWithRetry,
+  verifyNobleBleRfLink,
+} from './bleReconnectHelper';
 
 describe('verifyNobleBleRfLink', () => {
   beforeEach(() => {
@@ -31,5 +38,69 @@ describe('verifyNobleBleRfLink', () => {
   it('returns false when Noble IPC throws', async () => {
     vi.mocked(window.electronAPI.isNobleBleConnected).mockRejectedValue(new Error('ipc down'));
     await expect(verifyNobleBleRfLink('ble', 'meshtastic')).resolves.toBe(false);
+  });
+});
+
+describe('startNobleBleScanningWithRetry', () => {
+  beforeEach(() => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh)' });
+    window.electronAPI = {
+      ...window.electronAPI,
+      getPlatform: vi.fn().mockReturnValue('darwin'),
+      startNobleBleScanning: vi.fn().mockResolvedValue({ ok: true }),
+    };
+  });
+
+  it('retries when scan is busy then succeeds', async () => {
+    vi.useFakeTimers();
+    vi.mocked(window.electronAPI.startNobleBleScanning)
+      .mockResolvedValueOnce({ ok: false, code: 'scan_busy', owner: 'reticulum' })
+      .mockResolvedValueOnce({ ok: true });
+
+    const pending = startNobleBleScanningWithRetry('meshcore');
+    await vi.advanceTimersByTimeAsync(BLE_SCAN_BUSY_RETRY_INTERVAL_MS);
+    await expect(pending).resolves.toBeUndefined();
+    expect(window.electronAPI.startNobleBleScanning).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('fails after max wait when scan stays busy', async () => {
+    vi.useFakeTimers();
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockResolvedValue({
+      ok: false,
+      code: 'scan_busy',
+      owner: 'reticulum',
+    });
+
+    const pending = startNobleBleScanningWithRetry('meshcore');
+    const rejection = expect(pending).rejects.toThrow(/Bluetooth scan in progress \(reticulum\)/);
+    await vi.advanceTimersByTimeAsync(BLE_SCAN_BUSY_MAX_WAIT_MS + BLE_SCAN_BUSY_RETRY_INTERVAL_MS);
+    await rejection;
+    vi.useRealTimers();
+  });
+});
+
+describe('reconnectBleWithScan', () => {
+  beforeEach(() => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh)' });
+    window.electronAPI = {
+      ...window.electronAPI,
+      getPlatform: vi.fn().mockReturnValue('darwin'),
+      startNobleBleScanning: vi.fn().mockResolvedValue({ ok: true }),
+      stopNobleBleScanning: vi.fn().mockResolvedValue(undefined),
+      onNobleBleDeviceDiscovered: vi.fn().mockReturnValue(() => {}),
+    };
+  });
+
+  it('does not scan when immediate connect fails with MeshCore setup abort', async () => {
+    const connect = vi
+      .fn()
+      .mockRejectedValue(new DOMException(MESHCORE_SETUP_ABORT_MESSAGE, 'AbortError'));
+
+    await expect(reconnectBleWithScan('meshcore', 'abc', connect)).rejects.toMatchObject({
+      name: 'AbortError',
+      message: MESHCORE_SETUP_ABORT_MESSAGE,
+    });
+    expect(window.electronAPI.startNobleBleScanning).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/lib/bleReconnectHelper.ts
+++ b/src/renderer/lib/bleReconnectHelper.ts
@@ -1,9 +1,17 @@
-import type { NobleBleSessionId } from '@/shared/electron-api.types';
+import type { NobleBleSessionId, NobleBleStartScanResult } from '@/shared/electron-api.types';
 
+import { MESHCORE_SETUP_ABORT_MESSAGE } from './bleConnectErrors';
 import { errLikeToLogString } from './errLikeToLogString';
+import { isBleScanBusyErrorMessage } from './reticulum/reticulumBleAdapterLease';
 import type { MeshProtocol } from './types';
 
 export const BLE_RECONNECT_SCAN_TIMEOUT_MS = 30_000;
+
+/** Poll interval while waiting for Reticulum/external BLE scan to release the adapter. */
+export const BLE_SCAN_BUSY_RETRY_INTERVAL_MS = 250;
+
+/** Max wait for scan mutex before failing Noble reconnect scan fallback. */
+export const BLE_SCAN_BUSY_MAX_WAIT_MS = 20_000;
 
 /** Noble wait-for-peripheral + scan fallback; ConnectionPanel must not use a shorter UI timeout. */
 export const BLE_NOBLE_AUTO_CONNECT_MAX_MS = 30_000 + BLE_RECONNECT_SCAN_TIMEOUT_MS + 15_000;
@@ -14,6 +22,59 @@ function isLinuxPlatform(): boolean {
 
 function isLinuxWebBluetoothPlatform(): boolean {
   return typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('linux');
+}
+
+function isMeshcoreSetupAbortError(err: unknown): boolean {
+  return (
+    err instanceof DOMException &&
+    err.name === 'AbortError' &&
+    err.message === MESHCORE_SETUP_ABORT_MESSAGE
+  );
+}
+
+function isNobleBleStartScanBusyResult(
+  result: NobleBleStartScanResult,
+): result is Extract<NobleBleStartScanResult, { ok: false; code: 'scan_busy' }> {
+  return !result.ok && result.code === 'scan_busy';
+}
+
+function nobleBleStartScanBusyMessage(owner: string): string {
+  return `Bluetooth scan in progress (${owner})`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** Start Noble scan; retry when Reticulum or another owner holds the scan mutex. */
+export async function startNobleBleScanningWithRetry(
+  sessionId: NobleBleSessionId,
+  opts?: { maxWaitMs?: number; retryIntervalMs?: number },
+): Promise<void> {
+  const maxWaitMs = opts?.maxWaitMs ?? BLE_SCAN_BUSY_MAX_WAIT_MS;
+  const retryIntervalMs = opts?.retryIntervalMs ?? BLE_SCAN_BUSY_RETRY_INTERVAL_MS;
+  const deadline = Date.now() + maxWaitMs;
+  let lastOwner = 'unknown';
+
+  while (Date.now() < deadline) {
+    const result = await window.electronAPI.startNobleBleScanning(sessionId);
+    if (result.ok) {
+      return;
+    }
+    if (isNobleBleStartScanBusyResult(result)) {
+      lastOwner = result.owner;
+      console.debug(
+        `[bleReconnectHelper] scan busy (owner=${result.owner}) — retrying in ${retryIntervalMs}ms`,
+      );
+      await sleep(retryIntervalMs);
+      continue;
+    }
+    throw new Error('Noble BLE scan failed');
+  }
+
+  throw new Error(nobleBleStartScanBusyMessage(lastOwner));
 }
 
 /** Verify Noble BLE GATT is still connected after configure (macOS/Windows). */
@@ -40,7 +101,7 @@ export async function reconnectBleWithScan(
   protocol: MeshProtocol,
   peripheralId: string,
   connect: () => Promise<void>,
-  opts?: { scanTimeoutMs?: number },
+  opts?: { scanTimeoutMs?: number; scanBusyMaxWaitMs?: number },
 ): Promise<void> {
   if (isLinuxPlatform()) {
     await connect();
@@ -52,6 +113,9 @@ export async function reconnectBleWithScan(
     await connect();
     return;
   } catch (err) {
+    if (isMeshcoreSetupAbortError(err)) {
+      throw err;
+    }
     console.debug(
       '[bleReconnectHelper] immediate connect failed — scanning ' + errLikeToLogString(err),
     );
@@ -59,6 +123,8 @@ export async function reconnectBleWithScan(
 
   const sessionId: NobleBleSessionId = protocol;
   const timeoutMs = opts?.scanTimeoutMs ?? BLE_RECONNECT_SCAN_TIMEOUT_MS;
+  const scanBusyMaxWaitMs = opts?.scanBusyMaxWaitMs ?? BLE_SCAN_BUSY_MAX_WAIT_MS;
+  const scanStartedAt = Date.now();
 
   return new Promise<void>((resolve, reject) => {
     const abortController = new AbortController();
@@ -93,16 +159,24 @@ export async function reconnectBleWithScan(
       });
     });
 
+    const remainingDiscoveryMs = Math.max(0, timeoutMs - (Date.now() - scanStartedAt));
     scanTimeout = setTimeout(() => {
       finish(() => {
         reject(new Error(`BLE auto-reconnect timed out after ${timeoutMs / 1000}s`));
       });
-    }, timeoutMs);
+    }, remainingDiscoveryMs);
 
-    void window.electronAPI.startNobleBleScanning(sessionId).catch((err: unknown) => {
-      finish(() => {
-        reject(err instanceof Error ? err : new Error(String(err)));
-      });
-    });
+    void startNobleBleScanningWithRetry(sessionId, { maxWaitMs: scanBusyMaxWaitMs }).catch(
+      (err: unknown) => {
+        finish(() => {
+          const message = err instanceof Error ? err.message : String(err);
+          if (isBleScanBusyErrorMessage(message)) {
+            reject(new Error(message));
+            return;
+          }
+          reject(err instanceof Error ? err : new Error(String(err)));
+        });
+      },
+    );
   });
 }

--- a/src/renderer/lib/devElectronApiStub.ts
+++ b/src/renderer/lib/devElectronApiStub.ts
@@ -147,7 +147,7 @@ export function createDevElectronApiStub(): typeof window.electronAPI {
     onNobleBleDisconnected: noopUnsub,
     onNobleBleConnectAborted: noopUnsub,
     onNobleBleFromRadio: noopUnsub,
-    startNobleBleScanning: noopAsync,
+    startNobleBleScanning: async () => ({ ok: true as const }),
     stopNobleBleScanning: noopAsync,
     connectNobleBle: async () => ({ ok: true }),
     disconnectNobleBle: noopAsync,

--- a/src/renderer/lib/meshcoreWaitingMessagesDrain.test.ts
+++ b/src/renderer/lib/meshcoreWaitingMessagesDrain.test.ts
@@ -4,18 +4,22 @@ import * as meshcoreRepeaterRpcInFlight from './meshcoreRepeaterRpcInFlight';
 import * as meshcoreTracePathMultiplex from './meshcoreTracePathMultiplex';
 import {
   isMeshcoreCompanionDrainDeferred,
+  isMeshcoreSyncNextMessageTimeoutError,
   logMeshcoreWaitingMessagesDrainError,
   markMeshcoreCompanionTx,
+  markMeshcoreMsgWaitingEvent,
   resetMeshcoreWaitingMessagesDrainSchedule,
   resetMeshcoreWaitingMessagesDrainState,
   scheduleMeshcoreWaitingMessagesDrain,
   shouldActivateWaitingMessagesBanner,
+  shouldRunMeshcoreWaitingMessagesPeriodicPoll,
   waitingMessagesDrainTimeoutMs,
 } from './meshcoreWaitingMessagesDrain';
 import {
   MESHCORE_WAITING_MESSAGES_AFTER_TX_DEFER_MS,
   MESHCORE_WAITING_MESSAGES_CONGESTED_RETRY_MS,
   MESHCORE_WAITING_MESSAGES_DRAIN_DEBOUNCE_MS,
+  MESHCORE_WAITING_MESSAGES_POLL_MS,
   MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS,
   MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS,
   MESHCORE_WAITING_MESSAGES_SYNC_TIMEOUT_MS,
@@ -199,6 +203,44 @@ describe('logMeshcoreWaitingMessagesDrainError', () => {
     logMeshcoreWaitingMessagesDrainError('manual sync', new Error('timed out after 60000ms'), true);
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+});
+
+describe('isMeshcoreSyncNextMessageTimeoutError', () => {
+  it('matches silent syncNextMessage timeout messages', () => {
+    expect(
+      isMeshcoreSyncNextMessageTimeoutError(
+        new Error('MeshCore syncNextMessage timed out after 12000ms'),
+      ),
+    ).toBe(true);
+    expect(isMeshcoreSyncNextMessageTimeoutError(new Error('getWaitingMessages timed out'))).toBe(
+      false,
+    );
+  });
+});
+
+describe('shouldRunMeshcoreWaitingMessagesPeriodicPoll', () => {
+  beforeEach(() => {
+    resetMeshcoreWaitingMessagesDrainState(0);
+  });
+
+  it('runs when waiting message count is positive', () => {
+    expect(shouldRunMeshcoreWaitingMessagesPeriodicPoll(2, MESHCORE_WAITING_MESSAGES_POLL_MS)).toBe(
+      true,
+    );
+  });
+
+  it('skips when idle and no recent event 131', () => {
+    expect(shouldRunMeshcoreWaitingMessagesPeriodicPoll(0, MESHCORE_WAITING_MESSAGES_POLL_MS)).toBe(
+      false,
+    );
+  });
+
+  it('runs after a recent event 131', () => {
+    markMeshcoreMsgWaitingEvent(0);
+    expect(
+      shouldRunMeshcoreWaitingMessagesPeriodicPoll(0, MESHCORE_WAITING_MESSAGES_POLL_MS - 1),
+    ).toBe(true);
   });
 });
 

--- a/src/renderer/lib/meshcoreWaitingMessagesDrain.ts
+++ b/src/renderer/lib/meshcoreWaitingMessagesDrain.ts
@@ -6,6 +6,7 @@ import {
   MESHCORE_WAITING_MESSAGES_AFTER_TX_DEFER_MS,
   MESHCORE_WAITING_MESSAGES_CONGESTED_RETRY_MS,
   MESHCORE_WAITING_MESSAGES_DRAIN_DEBOUNCE_MS,
+  MESHCORE_WAITING_MESSAGES_POLL_MS,
   MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS,
   MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS,
   MESHCORE_WAITING_MESSAGES_SYNC_TIMEOUT_MS,
@@ -13,6 +14,7 @@ import {
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let lastCompanionTxAt = 0;
+let lastMsgWaitingEventAt = 0;
 
 /** Record outbound companion RF TX so auto-drains can defer until the radio settles. */
 export function markMeshcoreCompanionTx(): void {
@@ -26,6 +28,27 @@ export function resetMeshcoreWaitingMessagesDrainState(now = 0): void {
     debounceTimer = null;
   }
   lastCompanionTxAt = now;
+  lastMsgWaitingEventAt = now;
+}
+
+/** Record MsgWaiting (event 131) so periodic safety-net polls can skip idle queues. */
+export function markMeshcoreMsgWaitingEvent(now = Date.now()): void {
+  lastMsgWaitingEventAt = now;
+}
+
+/** True when the 5-minute safety-net poll should run (queued count or recent event 131). */
+export function shouldRunMeshcoreWaitingMessagesPeriodicPoll(
+  waitingMessagesCount: number,
+  now = Date.now(),
+): boolean {
+  if (waitingMessagesCount > 0) return true;
+  return now - lastMsgWaitingEventAt < MESHCORE_WAITING_MESSAGES_POLL_MS;
+}
+
+/** True when silent incremental syncNextMessage hit the fail-fast timeout (empty queue). */
+export function isMeshcoreSyncNextMessageTimeoutError(error: unknown): boolean {
+  const errMsg = errLikeToLogString(error).toLowerCase();
+  return errMsg.includes('syncnextmessage') && errMsg.includes('timed out');
 }
 
 export function resetMeshcoreWaitingMessagesDrainSchedule(): void {

--- a/src/renderer/lib/rfReconnectHelper.test.ts
+++ b/src/renderer/lib/rfReconnectHelper.test.ts
@@ -18,7 +18,7 @@ describe('reconnectRfFromLastConnection', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
-    window.electronAPI.startNobleBleScanning = vi.fn().mockResolvedValue(undefined);
+    window.electronAPI.startNobleBleScanning = vi.fn().mockResolvedValue({ ok: true });
     window.electronAPI.stopNobleBleScanning = vi.fn().mockResolvedValue(undefined);
     window.electronAPI.onNobleBleDeviceDiscovered = vi.fn(() => () => {});
   });

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Znovu připojit",
     "reconnectingAttempt": "Opětovné připojení... Pokus {{attempt}}/{{max}}",
     "serialReselect": "Ztráta sériového připojení USB — vyberte zařízení znovu",
-    "serialReselectAction": "Výběr sériového portu"
+    "serialReselectAction": "Výběr sériového portu",
+    "statusRegion": "Stav připojení"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Maximální počet pokusů o opětovné připojení MQTT",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Erneut verbinden",
     "reconnectingAttempt": "Wiederverbinden… Versuch {{attempt}}/{{max}}",
     "serialReselect": "USB-Seriellverbindung unterbrochen — wählen Sie Ihr Gerät erneut aus",
-    "serialReselectAction": "Serielle Schnittstelle auswählen"
+    "serialReselectAction": "Serielle Schnittstelle auswählen",
+    "statusRegion": "Verbindungsstatus"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Max. MQTT-Wiederverbindungsversuche",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Reconnect",
     "reconnectingAttempt": "Reconnecting… attempt {{attempt}}/{{max}}",
     "serialReselect": "USB serial connection lost — select your device again",
-    "serialReselectAction": "Select serial port"
+    "serialReselectAction": "Select serial port",
+    "statusRegion": "Connection status"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Max MQTT reconnect attempts",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Reconectar",
     "reconnectingAttempt": "Volviendo a conectar… intento {{attempt}}/{{max}}",
     "serialReselect": "Conexión serie USB perdida — seleccione su dispositivo de nuevo",
-    "serialReselectAction": "Seleccionar puerto serie"
+    "serialReselectAction": "Seleccionar puerto serie",
+    "statusRegion": "Estado de conexión"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Intentos de reconexión MQTT máximos",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Reconnecter",
     "reconnectingAttempt": "Reconnexion... tentative {{attempt}}/{{max}}",
     "serialReselect": "Connexion série USB perdue — sélectionnez à nouveau votre appareil",
-    "serialReselectAction": "Sélectionner le port série"
+    "serialReselectAction": "Sélectionner le port série",
+    "statusRegion": "État des connexions"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Nombre maximal de tentatives de reconnexion MQTT",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Sambung ulang",
     "reconnectingAttempt": "Menghubungkan kembali… upaya {{attempt}}/{{max}}",
     "serialReselect": "Koneksi serial USB terputus — pilih perangkat Anda lagi",
-    "serialReselectAction": "Pilih port serial"
+    "serialReselectAction": "Pilih port serial",
+    "statusRegion": "Status Koneksi"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Upaya penyambungan kembali MQTT maks",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Connessione",
     "reconnectingAttempt": "Riconnessione in corso... tentativo {{attempt}}/{{max}}",
     "serialReselect": "Connessione seriale USB persa — seleziona di nuovo il tuo dispositivo",
-    "serialReselectAction": "Seleziona porta seriale"
+    "serialReselectAction": "Seleziona porta seriale",
+    "statusRegion": "Stato della connessione"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Numero massimo di tentativi di riconnessione MQTT",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "再接続",
     "reconnectingAttempt": "再接続中… {{attempt}}/{{max}} 回目",
     "serialReselect": "USBシリアル接続が失われました—デバイスを再度選択してください",
-    "serialReselectAction": "シリアルポートを選択"
+    "serialReselectAction": "シリアルポートを選択",
+    "statusRegion": "接続状態"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "MQTT 再接続の最大試行回数",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "재접속",
     "reconnectingAttempt": "다시 연결 중… 시도 {{attempt}}/{{max}}",
     "serialReselect": "USB 직렬 연결 끊김 — 장치를 다시 선택하십시오",
-    "serialReselectAction": "직렬 포트 선택"
+    "serialReselectAction": "직렬 포트 선택",
+    "statusRegion": "연결 상태"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "최대 MQTT 재연결 시도",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Opnieuw verbinden",
     "reconnectingAttempt": "Opnieuw verbinden… poging {{attempt}}/{{max}}",
     "serialReselect": "USB seriële verbinding verbroken — selecteer uw apparaat opnieuw",
-    "serialReselectAction": "Seriële poort selecteren"
+    "serialReselectAction": "Seriële poort selecteren",
+    "statusRegion": "Verbindingsstatus"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Max. MQTT-pogingen om opnieuw verbinding te maken",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Połącz ponownie",
     "reconnectingAttempt": "Ponowne łączenie… próba {{attempt}}/{{max}}",
     "serialReselect": "Utracono połączenie szeregowe USB — wybierz ponownie swoje urządzenie",
-    "serialReselectAction": "Wybierz port szeregowy"
+    "serialReselectAction": "Wybierz port szeregowy",
+    "statusRegion": "Status połączenia"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Maksymalna liczba prób ponownego połączenia MQTT",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Reconectar",
     "reconnectingAttempt": "Reconectando… tentativa {{attempt}}/{{max}}",
     "serialReselect": "Conexão serial USB perdida — selecione seu dispositivo novamente",
-    "serialReselectAction": "Selecionar porta serial"
+    "serialReselectAction": "Selecionar porta serial",
+    "statusRegion": "Status da conexão"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Tentativas máximas de reconexão do MQTT",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Перепідключення",
     "reconnectingAttempt": "Повторное подключение… попытка {{attempt}}/{{max}}",
     "serialReselect": "Последовательное USB-соединение потеряно — выберите устройство еще раз",
-    "serialReselectAction": "Выберите последовательный порт"
+    "serialReselectAction": "Выберите последовательный порт",
+    "statusRegion": "Статус подключения"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Максимальное количество попыток переподключения MQTT",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Yeniden bağlanınız",
     "reconnectingAttempt": "Yeniden bağlanıyor… {{attempt}}/{{max}} denemesi",
     "serialReselect": "USB seri bağlantısı kesildi — cihazınızı tekrar seçin",
-    "serialReselectAction": "Seri port seçin"
+    "serialReselectAction": "Seri port seçin",
+    "statusRegion": "Bağlantı durumu"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Maksimum MQTT yeniden bağlanma denemesi",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "Повторно під’єднати",
     "reconnectingAttempt": "Повторне підключення… спроба {{attempt}}/{{max}}",
     "serialReselect": "Серійне з'єднання USB втрачено — виберіть пристрій знову",
-    "serialReselectAction": "Виберіть послідовний порт"
+    "serialReselectAction": "Виберіть послідовний порт",
+    "statusRegion": "Стан з'єднання"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "Максимальна кількість спроб повторного підключення MQTT",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -612,7 +612,8 @@
     "reconnect": "重新连接",
     "reconnectingAttempt": "正在重新连接… 尝试 {{attempt}}/{{max}}",
     "serialReselect": "USB串行连接丢失—请重新选择您的设备",
-    "serialReselectAction": "选择串行端口"
+    "serialReselectAction": "选择串行端口",
+    "statusRegion": "连接状态"
   },
   "connectionPanel": {
     "maxReconnectAttempts": "最大MQTT重新连接尝试次数",

--- a/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
@@ -165,6 +165,20 @@ describe('useMeshcoreRuntime manual disconnect must not auto-reconnect', () => {
       /if \(meshcoreExplicitDisconnectRef\.current\) \{[\s\S]*?meshcoreIsReconnectingRef\.current = false/,
     );
   });
+
+  it('attemptMeshcoreReconnect treats setup AbortError as superseded reconnect', () => {
+    const reconnectBody = extractUseCallbackBody(RUNTIME_SOURCE, 'attemptMeshcoreReconnect');
+    expect(reconnectBody).toMatch(
+      /err\.message === MESHCORE_SETUP_ABORT_MESSAGE[\s\S]*?reconnect aborted \(setup superseded\)/,
+    );
+  });
+
+  it('periodic waiting-message poll skips idle queues', () => {
+    expect(RUNTIME_SOURCE).toContain('shouldRunMeshcoreWaitingMessagesPeriodicPoll');
+    expect(RUNTIME_SOURCE).toMatch(
+      /shouldRunMeshcoreWaitingMessagesPeriodicPoll\(waitingMessagesCountRef\.current\)/,
+    );
+  });
 });
 
 describe('meshcoreLegacyConnEvents disconnected handler (regression)', () => {
@@ -192,6 +206,11 @@ describe('meshcoreLegacyConnEvents disconnected handler (regression)', () => {
     expect(CONN_EVENTS_SOURCE).toMatch(
       /publishMeshcorePacketLog[\s\S]{0,800}MQTT packet-log publish failed/,
     );
+  });
+
+  it('marks event 131 and treats silent syncNextMessage timeout as empty queue', () => {
+    expect(CONN_EVENTS_SOURCE).toContain('markMeshcoreMsgWaitingEvent()');
+    expect(CONN_EVENTS_SOURCE).toMatch(/isMeshcoreSyncNextMessageTimeoutError\(e\)[\s\S]*?break;/);
   });
 });
 

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -316,6 +316,7 @@ import {
   logMeshcoreWaitingMessagesDrainError,
   markMeshcoreCompanionTx,
   scheduleMeshcoreWaitingMessagesDrain,
+  shouldRunMeshcoreWaitingMessagesPeriodicPoll,
 } from '../lib/meshcoreWaitingMessagesDrain';
 import {
   bindMeshcoreIngress,
@@ -471,6 +472,7 @@ export function useMeshcoreRuntime() {
   const [mqttStatus, setMqttStatus] = useState<MQTTStatus>('disconnected');
   const [mqttConnectionLoss, setMqttConnectionLoss] = useState(false);
   const [waitingMessagesCount, setWaitingMessagesCount] = useState(0);
+  const waitingMessagesCountRef = useRef(0);
   const [waitingMessagesSyncActive, setWaitingMessagesSyncActive] = useState(false);
   const [waitingMessagesSyncProgress, setWaitingMessagesSyncProgress] = useState<{
     processed: number;
@@ -803,6 +805,10 @@ export function useMeshcoreRuntime() {
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  useEffect(() => {
+    waitingMessagesCountRef.current = waitingMessagesCount;
+  }, [waitingMessagesCount]);
 
   useEffect(() => {
     rawPacketsRef.current = rawPackets;
@@ -2296,6 +2302,9 @@ export function useMeshcoreRuntime() {
         clearInterval(meshcoreWaitingMessagesPollRef.current);
       meshcoreWaitingMessagesPollRef.current = setInterval(() => {
         if (!meshcoreHookMountedRef.current) return;
+        if (!shouldRunMeshcoreWaitingMessagesPeriodicPoll(waitingMessagesCountRef.current)) {
+          return;
+        }
         scheduleMeshcoreWaitingMessagesDrain(
           async () => {
             try {
@@ -2656,6 +2665,15 @@ export function useMeshcoreRuntime() {
         connectionLoss: false,
       }));
     } catch (err) {
+      if (
+        err instanceof DOMException &&
+        err.name === 'AbortError' &&
+        err.message === MESHCORE_SETUP_ABORT_MESSAGE
+      ) {
+        console.debug('[useMeshcoreRuntime] reconnect aborted (setup superseded)');
+        meshcoreIsReconnectingRef.current = false;
+        return;
+      }
       if (opened?.driverIdentityId) {
         await connectionDriver.disconnect(opened.driverIdentityId).catch((e: unknown) => {
           console.debug(

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -76,6 +76,13 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     );
   });
 
+  it('logs at debug when Noble yield release nudges reconnect', () => {
+    expect(SOURCE).toMatch(/nobleYieldReconnectNudgeRef\.current = true/);
+    expect(SOURCE).toMatch(
+      /afterNobleYieldRelease[\s\S]*?Noble BLE yield released — initiating Meshtastic reconnect/,
+    );
+  });
+
   it('skips Noble yield nudge when Meshtastic is configured and connected', () => {
     expect(SOURCE).toMatch(
       /onNobleYieldReleased[\s\S]*?meshtasticDriverConnectedRef\.current && deviceConfiguredRef\.current[\s\S]*?return;/,

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -1836,11 +1836,25 @@ export function useMeshtasticRuntime() {
   );
 
   // ─── Connection lost handler ──────────────────────────────────
+  const nobleYieldReconnectNudgeRef = useRef(false);
+
   const handleConnectionLost = useCallback(() => {
     reconnectGenerationRef.current += 1;
+    const afterNobleYieldRelease = nobleYieldReconnectNudgeRef.current;
+    nobleYieldReconnectNudgeRef.current = false;
     if (!isReconnectingRef.current) {
-      console.warn('[useMeshtasticRuntime] Connection lost — initiating reconnect');
+      if (afterNobleYieldRelease) {
+        console.debug(
+          '[useMeshtasticRuntime] Noble BLE yield released — initiating Meshtastic reconnect',
+        );
+      } else {
+        console.warn('[useMeshtasticRuntime] Connection lost — initiating reconnect');
+      }
       isReconnectingRef.current = true;
+    } else if (afterNobleYieldRelease) {
+      console.debug(
+        '[useMeshtasticRuntime] Noble BLE yield released during reconnect — restarting reconnect cycle',
+      );
     } else {
       console.warn(
         '[useMeshtasticRuntime] Connection lost during reconnect — restarting reconnect cycle',
@@ -2106,6 +2120,7 @@ export function useMeshtasticRuntime() {
       );
       reconnectAttemptRef.current = 0;
       isReconnectingRef.current = false;
+      nobleYieldReconnectNudgeRef.current = true;
       handleConnectionLostRef.current();
     };
     window.addEventListener(NOBLE_BLE_YIELD_RELEASED_EVENT, onNobleYieldReleased);

--- a/src/renderer/stores/reticulumPeerStore.test.ts
+++ b/src/renderer/stores/reticulumPeerStore.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ReticulumContact } from '@/shared/reticulum-types';
+
 import {
   capReticulumPeerMaps,
   mergeReticulumPeerMaps,
@@ -64,6 +66,40 @@ describe('mergeReticulumPeerMaps', () => {
     expect(contacts.get('def456')?.last_heard).toBe(1000);
     expect(peers.has('def456')).toBe(true);
   });
+
+  it('reflects contact fields on the merged peer entry and applies SQLite overlay to contacts', () => {
+    const { peers, contacts } = mergeReticulumPeerMaps(
+      [],
+      [
+        {
+          destination_hash: 'def456',
+          display_name: 'Contact B',
+          last_heard: 1000,
+          hops: 1,
+        },
+      ],
+      [
+        {
+          destination_hash: 'def456',
+          display_name: 'Saved Contact',
+          favorited: 1,
+        },
+      ],
+    );
+
+    const contact = contacts.get('def456');
+    expect(contact?.last_heard).toBe(1000);
+    expect(contact?.hops).toBe(1);
+    expect(contact?.favorited).toBe(true);
+    expect(contact?.custom_display_name).toBe('Saved Contact');
+
+    const peer = peers.get('def456') as ReticulumContact | undefined;
+    expect(peer?.last_heard).toBe(1000);
+    expect(peer?.hops).toBe(1);
+    expect(peer?.favorited).toBe(true);
+    expect(peer?.custom_display_name).toBe('Saved Contact');
+    expect(peer?.display_name).toBe('Contact B');
+  });
 });
 
 describe('reticulumPeerStore', () => {
@@ -108,6 +144,22 @@ describe('reticulumPeerStore', () => {
     expect(useReticulumPeerStore.getState().isContact('peeronly')).toBe(false);
     expect(useReticulumPeerStore.getState().isContact('CONTACT1')).toBe(true);
     expect(useReticulumPeerStore.getState().isContact('NONEXISTENT')).toBe(false);
+  });
+
+  it('getPeer normalizes hash case like isContact', () => {
+    useReticulumPeerStore
+      .getState()
+      .replacePeers([{ destination_hash: 'abc123', display_name: 'Peer A', hops: 2 }]);
+    useReticulumPeerStore
+      .getState()
+      .replaceContacts([{ destination_hash: 'contact1', last_heard: 100, display_name: 'LXMF' }]);
+
+    expect(useReticulumPeerStore.getState().getPeer('ABC123')?.display_name).toBe('Peer A');
+    expect(useReticulumPeerStore.getState().getPeer('CONTACT1')?.display_name).toBe('LXMF');
+    const contactPeer = useReticulumPeerStore.getState().getPeer('contact1') as
+      ReticulumContact | undefined;
+    expect(contactPeer?.last_heard).toBe(100);
+    expect(useReticulumPeerStore.getState().getPeer('missing')).toBeUndefined();
   });
 
   it('clearPeers empties peers and contacts', () => {

--- a/src/renderer/vitest.electronApiMock.ts
+++ b/src/renderer/vitest.electronApiMock.ts
@@ -162,7 +162,7 @@ export function createElectronAPIMock(): ElectronAPI {
     onNobleBleDisconnected: vi.fn().mockReturnValue(() => {}),
     onNobleBleConnectAborted: vi.fn().mockReturnValue(() => {}),
     onNobleBleFromRadio: vi.fn().mockReturnValue(() => {}),
-    startNobleBleScanning: vi.fn().mockResolvedValue(undefined),
+    startNobleBleScanning: vi.fn().mockResolvedValue({ ok: true }),
     stopNobleBleScanning: vi.fn().mockResolvedValue(undefined),
     connectNobleBle: vi.fn().mockResolvedValue({ ok: true }),
     disconnectNobleBle: vi.fn().mockResolvedValue(undefined),

--- a/src/shared/electron-api.types.ts
+++ b/src/shared/electron-api.types.ts
@@ -170,6 +170,9 @@ export type BlePeripheralOwner =
 
 export type BleScanOwner = 'noble' | 'reticulum' | 'webbt';
 
+export type NobleBleStartScanResult =
+  { ok: true } | { ok: false; code: 'scan_busy'; owner: BleScanOwner };
+
 export interface BleRegisteredConnection {
   mac: string;
   owner: BlePeripheralOwner;
@@ -685,7 +688,7 @@ export interface ElectronAPI {
   onNobleBleFromRadio: (
     cb: (payload: { sessionId: NobleBleSessionId; bytes: Uint8Array }) => void,
   ) => () => void;
-  startNobleBleScanning: (sessionId: NobleBleSessionId) => Promise<void>;
+  startNobleBleScanning: (sessionId: NobleBleSessionId) => Promise<NobleBleStartScanResult>;
   stopNobleBleScanning: (sessionId: NobleBleSessionId) => Promise<void>;
   connectNobleBle: (
     sessionId: NobleBleSessionId,


### PR DESCRIPTION
## Summary

- Harden triple-protocol Noble BLE startup/reconnect: return structured `scan_busy` from `noble-ble-start-scan` IPC instead of throwing, retry scan start in `bleReconnectHelper`, treat MeshCore setup `AbortError` as superseded reconnect, and skip scan fallback when setup is aborted.
- Stop MeshCore waiting-message poll waste: treat silent `syncNextMessage` timeouts as an empty queue and gate the 5-minute safety poll when the queue is idle (count=0, no recent event 131).
- Reduce misleading reconnect log noise: Meshtastic reconnect after Reticulum Noble BLE yield release logs at debug instead of warn.
- Improve connection banner accessibility: add `role="region"` + `statusRegion` aria-label, move reconnect pulse to an `aria-hidden` decorative layer, and use `text-orange-200` for WCAG contrast.
- Expand test coverage for Reticulum peer merge overlay (contact fields + SQLite overlay) and case-normalized `getPeer` lookups.

## Test plan

- [x] `pnpm run test:run` (pre-commit full suite on changed files)
- [x] `pnpm run lint` and `pnpm run typecheck`
- [x] `pnpm run check:i18n`
- [ ] Manual: triple-protocol startup with Meshtastic + MeshCore BLE + Reticulum BLE RNode — no IPC scan_busy errors in log
- [ ] Manual: Reticulum Noble yield release → Meshtastic reconnect logs at debug, not warn
- [ ] Manual: idle MeshCore waiting-message queue — no 12s `syncNextMessage` timeout spam every 5 minutes
- [ ] Manual: reconnect banner passes axe contrast/landmark checks in dev