### PR TITLE
feat: Add Apple code signing and notarization support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,14 +90,14 @@ jobs:
 
       - name: Build
         env:
-          # ── macOS code signing ─────────────────────────────────────────────
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.CSC_LINK && 'true' || 'false' }}
+          # ── macOS code signing (only effective on macOS runners) ────────────
+          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK && 'true' || 'false' }}
           # ── macOS notarization ─────────────────────────────────────────────
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
         run: ${{ matrix.build_script }}
 
       - name: Upload macOS Artifact

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,6 +89,15 @@ jobs:
         run: pnpm run rebuild
 
       - name: Build
+        env:
+          # ── macOS code signing ─────────────────────────────────────────────
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.CSC_LINK && 'true' || 'false' }}
+          # ── macOS notarization ─────────────────────────────────────────────
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: ${{ matrix.build_script }}
 
       - name: Upload macOS Artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,6 +130,18 @@ jobs:
         env:
           # electron-publish reads GH_TOKEN; GITHUB_TOKEN alone is not used for uploads
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # ── macOS code signing ─────────────────────────────────────────────
+          # CSC_LINK: base64-encoded .p12 Developer ID Application certificate.
+          # CSC_KEY_PASSWORD: password protecting the .p12 file.
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # Disable identity auto-discovery when no cert is available (fork PRs)
+          # so electron-builder skips signing gracefully instead of erroring.
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.CSC_LINK && 'true' || 'false' }}
+          # ── macOS notarization ─────────────────────────────────────────────
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         # dist:*:publish scripts run electron-builder with --publish always
         run: ${{ matrix.build_script }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,18 +130,18 @@ jobs:
         env:
           # electron-publish reads GH_TOKEN; GITHUB_TOKEN alone is not used for uploads
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # ── macOS code signing ─────────────────────────────────────────────
+          # ── macOS code signing (only effective on macOS runners) ────────────
           # CSC_LINK: base64-encoded .p12 Developer ID Application certificate.
           # CSC_KEY_PASSWORD: password protecting the .p12 file.
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
           # Disable identity auto-discovery when no cert is available (fork PRs)
           # so electron-builder skips signing gracefully instead of erroring.
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.CSC_LINK && 'true' || 'false' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK && 'true' || 'false' }}
           # ── macOS notarization ─────────────────────────────────────────────
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
         # dist:*:publish scripts run electron-builder with --publish always
         run: ${{ matrix.build_script }}
 

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -11,6 +11,7 @@
 - megabear - KD5IHC created the icon
 - [Soord](https://github.com/soord)
 - [WB3IHY](https://github.com/WB3IHY)
+- [Letark](https://github.com/Letark) - Apple code signing & notarization CI
 
 ## Colorado Mesh
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -34,8 +34,6 @@ extraResources:
   - from: resources/icons/mac/macos-menubar-icon-Template/macos-menubar-icon-Template@3x.png
     to: macos-menubar-icon-Template@3x.png
 mac:
-  # Ad-hoc signing test path.
-  identity: '-'
   category: public.app-category.utilities
   # Hardened runtime improves tamper resistance; required for notarized distribution.
   hardenedRuntime: true
@@ -49,6 +47,10 @@ mac:
   icon: resources/icons/mac/icon.icns
   entitlements: resources/entitlements.mac.plist
   entitlementsInherit: resources/entitlements.mac.inherit.plist
+  # Notarize after signing via Apple notarytool. Requires APPLE_ID,
+  # APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID env vars at build time.
+  # Automatically skipped when code signing is skipped (no cert available).
+  notarize: true
 linux:
   target:
     - target: AppImage


### PR DESCRIPTION
## Summary

Adds macOS Developer ID code signing and Apple notarization to the build and release workflows. Once the required secrets are configured, macOS releases will be Gatekeeper-trusted with no quarantine warnings for users.

## Changes

- **electron-builder.yml**: Remove ad-hoc signing (`identity: '-'`), add `notarize: true`
- **release.yaml**: Pass `CSC_LINK`, `CSC_KEY_PASSWORD`, and `APPLE_*` env vars to the build step
- **build.yaml**: Same env vars for manual dispatch builds
- **docs/credits.md**: Add contributor entry

## Required Secrets

Once an Apple Developer account is available, add these 5 repo secrets:

| Secret | Description |
|--------|-------------|
| `CSC_LINK` | Base64-encoded `.p12` Developer ID Application certificate |
| `CSC_KEY_PASSWORD` | Password for the `.p12` file |
| `APPLE_ID` | Apple ID email for notarization |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password (appleid.apple.com) |
| `APPLE_TEAM_ID` | 10-character Apple Developer Team ID |

## Behavior

- **With secrets**: macOS builds are signed + notarized + stapled automatically
- **Without secrets** (current state, fork PRs): `CSC_IDENTITY_AUTO_DISCOVERY=false` causes electron-builder to skip signing gracefully — builds produce unsigned artifacts identical to current behavior
- **No disruption**: Safe to merge before the Apple Developer account exists

## Tested

- All modified files pass project yamllint config
- Reviewed from security, CI/CD, and macOS packaging perspectives