### PR TITLE
fix: preserve leading zeros in Meshtastic Bluetooth PIN display

### DIFF
--- a/src/renderer/components/RadioPanel.test.tsx
+++ b/src/renderer/components/RadioPanel.test.tsx
@@ -180,6 +180,67 @@ describe('RadioPanel remote target safeguards', () => {
   });
 });
 
+describe('RadioPanel Bluetooth fixed PIN display', () => {
+  it('shows leading zeros when syncing fixedPin from device config', async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          meshtasticConfigSlices={{
+            bluetooth: { enabled: true, mode: 1, fixedPin: 12345 },
+          }}
+        />
+      </ToastProvider>,
+    );
+
+    const bluetoothDetails = [...document.querySelectorAll('details')].find((d) => {
+      const span = d.querySelector(':scope > summary > span');
+      return span?.textContent?.trim() === 'Bluetooth';
+    });
+    expect(bluetoothDetails).toBeDefined();
+    await user.click(bluetoothDetails!.querySelector('summary')!);
+
+    const pinInput = screen.getByLabelText('Pairing PIN');
+    expect(pinInput).toHaveValue('012345');
+  });
+
+  it('applies fixedPin as numeric wire value while preserving leading-zero display', async () => {
+    const user = userEvent.setup();
+    const onSetConfig = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          onSetConfig={onSetConfig}
+          meshtasticConfigSlices={{
+            bluetooth: { enabled: true, mode: 1, fixedPin: 12345 },
+          }}
+        />
+      </ToastProvider>,
+    );
+
+    const bluetoothDetails = [...document.querySelectorAll('details')].find((d) => {
+      const span = d.querySelector(':scope > summary > span');
+      return span?.textContent?.trim() === 'Bluetooth';
+    });
+    expect(bluetoothDetails).toBeDefined();
+    await user.click(bluetoothDetails!.querySelector('summary')!);
+    await user.click(screen.getByRole('button', { name: 'Apply Bluetooth' }));
+
+    await waitFor(() => {
+      expect(onSetConfig).toHaveBeenCalled();
+    });
+    const payload = onSetConfig.mock.calls[0]?.[0] as {
+      payloadVariant: { case: string; value: { fixedPin: number } };
+    };
+    expect(payload.payloadVariant.case).toBe('bluetooth');
+    expect(payload.payloadVariant.value.fixedPin).toBe(12345);
+  });
+});
+
 describe('RadioPanel HelpTooltip coverage — channel edit form', () => {
   it('Key Size and Encryption Key have help tooltips once a channel slot is selected', async () => {
     const user = userEvent.setup();

--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -15,6 +15,11 @@ import {
   meshtasticConfigSliceHydrated,
 } from '@/renderer/lib/meshtastic/meshtasticConfigApply';
 import { writeClipboardText } from '@/renderer/lib/writeClipboardText';
+import {
+  formatMeshtasticBluetoothPin,
+  parseMeshtasticBluetoothPin,
+  sanitizeMeshtasticBluetoothPinInput,
+} from '@/shared/meshtasticBluetoothPin';
 import type { ApplyChannelSetResult } from '@/shared/meshtasticChannelApply';
 import {
   generateConfigUrl,
@@ -450,6 +455,45 @@ export function ConfigNumber({
   );
 }
 
+export function ConfigBluetoothPin({
+  label,
+  value,
+  onChange,
+  disabled,
+  description,
+}: {
+  label: string;
+  value: string;
+  onChange: (val: string) => void;
+  disabled: boolean;
+  description?: string;
+}) {
+  const inputId = useId();
+  return (
+    <div className="space-y-1">
+      <label htmlFor={inputId} className="text-muted text-sm">
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          id={inputId}
+          type="text"
+          inputMode="numeric"
+          autoComplete="off"
+          maxLength={6}
+          value={value}
+          onChange={(e) => {
+            onChange(sanitizeMeshtasticBluetoothPinInput(e.target.value));
+          }}
+          disabled={disabled}
+          className="bg-secondary-dark focus:border-brand-green w-28 rounded-lg border border-gray-600 px-3 py-2 font-mono text-gray-200 focus:outline-none disabled:opacity-50"
+        />
+      </div>
+      {description && <p className="text-muted text-xs">{description}</p>}
+    </div>
+  );
+}
+
 /** Collapsible section wrapper */
 function ConfigSection({
   title,
@@ -730,7 +774,7 @@ export default function RadioPanel({
 
   // ─── Bluetooth settings ───────────────────────────────────────
   const [btEnabled, setBtEnabled] = useState(true);
-  const [btFixedPin, setBtFixedPin] = useState(123456);
+  const [btFixedPin, setBtFixedPin] = useState('123456');
   const [btPairingMode, setBtPairingMode] = useState(0);
 
   // ─── Display settings ─────────────────────────────────────────
@@ -754,7 +798,9 @@ export default function RadioPanel({
 
   useSyncFormFromConfig(meshtasticConfigSlices?.bluetooth, (cfg) => {
     if (typeof cfg.enabled === 'boolean') setBtEnabled(cfg.enabled);
-    if (typeof cfg.fixedPin === 'number') setBtFixedPin(cfg.fixedPin);
+    if (typeof cfg.fixedPin === 'number') {
+      setBtFixedPin(formatMeshtasticBluetoothPin(cfg.fixedPin));
+    }
     if (typeof cfg.mode === 'number') setBtPairingMode(cfg.mode);
   });
 
@@ -949,7 +995,11 @@ export default function RadioPanel({
   const networkConfigReady = meshtasticConfigSliceHydrated(meshtasticConfigSlices?.network);
   const deviceApplyDisabled = disabled || !deviceConfigReady;
   const displayApplyDisabled = disabled || !displayConfigReady;
-  const bluetoothApplyDisabled = disabled || !bluetoothConfigReady;
+  const btFixedPinWireValue = parseMeshtasticBluetoothPin(btFixedPin);
+  const bluetoothApplyDisabled =
+    disabled ||
+    !bluetoothConfigReady ||
+    (btEnabled && btPairingMode === 1 && btFixedPinWireValue === null);
   const powerApplyDisabled = disabled || !powerConfigReady;
   const positionApplyDisabled =
     disabled || !positionConfigReady || capabilities?.hasFullPositionConfig === false;
@@ -2445,13 +2495,15 @@ export default function RadioPanel({
       {capabilities?.hasBluetoothConfig !== false && (
         <ConfigSection
           title={t('radioPanel.sectionBluetooth')}
-          onApply={() =>
-            applyConfig(t('radioPanel.sectionBluetooth'), 'bluetooth', {
+          onApply={() => {
+            const fixedPin = parseMeshtasticBluetoothPin(btFixedPin);
+            if (fixedPin === null) return;
+            void applyConfig(t('radioPanel.sectionBluetooth'), 'bluetooth', {
               enabled: btEnabled,
               mode: btPairingMode,
-              fixedPin: btFixedPin,
-            })
-          }
+              fixedPin,
+            });
+          }}
           applying={applyingSection === 'bluetooth'}
           disabled={bluetoothApplyDisabled}
         >
@@ -2476,13 +2528,11 @@ export default function RadioPanel({
             onChange={setBtPairingMode}
             disabled={disabled || applyingSection !== null || !btEnabled}
           />
-          <ConfigNumber
+          <ConfigBluetoothPin
             label={t('radioPanel.pairingPin')}
             value={btFixedPin}
             onChange={setBtFixedPin}
             disabled={disabled || applyingSection !== null || !btEnabled || btPairingMode !== 1}
-            min={100000}
-            max={999999}
             description={t('radioPanel.pairingPinDesc')}
           />
         </ConfigSection>

--- a/src/shared/meshtasticBluetoothPin.test.ts
+++ b/src/shared/meshtasticBluetoothPin.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatMeshtasticBluetoothPin,
+  parseMeshtasticBluetoothPin,
+  sanitizeMeshtasticBluetoothPinInput,
+} from './meshtasticBluetoothPin';
+
+describe('formatMeshtasticBluetoothPin', () => {
+  it('zero-pads numeric fixedPin values for display', () => {
+    expect(formatMeshtasticBluetoothPin(12345)).toBe('012345');
+    expect(formatMeshtasticBluetoothPin(123456)).toBe('123456');
+    expect(formatMeshtasticBluetoothPin(1234)).toBe('001234');
+    expect(formatMeshtasticBluetoothPin(0)).toBe('000000');
+  });
+});
+
+describe('parseMeshtasticBluetoothPin', () => {
+  it('accepts exactly six digits including leading zeros', () => {
+    expect(parseMeshtasticBluetoothPin('012345')).toBe(12345);
+    expect(parseMeshtasticBluetoothPin('123456')).toBe(123456);
+  });
+
+  it('rejects incomplete or non-digit input', () => {
+    expect(parseMeshtasticBluetoothPin('12345')).toBeNull();
+    expect(parseMeshtasticBluetoothPin('0123456')).toBeNull();
+    expect(parseMeshtasticBluetoothPin('01234a')).toBeNull();
+    expect(parseMeshtasticBluetoothPin('')).toBeNull();
+  });
+});
+
+describe('sanitizeMeshtasticBluetoothPinInput', () => {
+  it('strips non-digits and caps length at six', () => {
+    expect(sanitizeMeshtasticBluetoothPinInput('01a2345')).toBe('012345');
+    expect(sanitizeMeshtasticBluetoothPinInput('1234567890')).toBe('123456');
+  });
+});

--- a/src/shared/meshtasticBluetoothPin.ts
+++ b/src/shared/meshtasticBluetoothPin.ts
@@ -1,0 +1,19 @@
+/** Meshtastic Config.Bluetooth.fixedPin is numeric on the wire; pad for 6-digit display. */
+export function formatMeshtasticBluetoothPin(fixedPin: number): string {
+  if (!Number.isInteger(fixedPin) || fixedPin < 0 || fixedPin > 999_999) {
+    return String(fixedPin);
+  }
+  return String(fixedPin).padStart(6, '0');
+}
+
+/** Parse a 6-digit PIN string for Config.Bluetooth.fixedPin wire value. */
+export function parseMeshtasticBluetoothPin(input: string): number | null {
+  const trimmed = input.trim();
+  if (!/^\d{6}$/.test(trimmed)) return null;
+  return Number(trimmed);
+}
+
+/** Restrict Bluetooth PIN field input to at most six decimal digits. */
+export function sanitizeMeshtasticBluetoothPinInput(input: string): string {
+  return input.replace(/\D/g, '').slice(0, 6);
+}


### PR DESCRIPTION
## Summary

- Add shared helpers to format, parse, and sanitize Meshtastic Bluetooth `fixedPin` values as 6-digit strings.
- Replace the Radio panel Bluetooth PIN number input with a digit-string field so values like `012345` display correctly after syncing from the device.
- Disable Bluetooth apply when fixed-PIN mode is enabled but the PIN is not exactly six digits.
- Add unit tests for the helpers and RadioPanel tests for display sync and apply wire value.

Fixes #658

## Test plan

- [x] `pnpm exec vitest run src/shared/meshtasticBluetoothPin.test.ts`
- [x] `pnpm exec vitest run src/renderer/components/RadioPanel.test.tsx -t "Bluetooth fixed PIN"`
- [ ] Set a Meshtastic node Bluetooth PIN to `012345`, reopen Radio → Bluetooth, confirm the field shows `012345`
- [ ] Apply unchanged PIN and confirm pairing still works with the full six-digit code