### PR TITLE
fix: dedupe reticulum runtime token checks in i18n quality script

### DIFF
--- a/scripts/check-i18n-quality.mjs
+++ b/scripts/check-i18n-quality.mjs
@@ -1996,12 +1996,6 @@ function checkReticulumRuntimeAndRoutingPortIssues(ctx) {
   const { flatKey, val, enVal } = ctx;
   const issues = [];
   if (flatKey.startsWith(RETICULUM_RUNTIME_PREFIX)) {
-    for (const token of RETICULUM_RUNTIME_PROTOCOL_TOKENS) {
-      if (!enVal.includes(token)) continue;
-      if (!val.includes(token)) {
-        issues.push(`reticulum runtime copy must preserve protocol token "${token}"`);
-      }
-    }
     issues.push(...protectedProtocolTokenIssues(enVal, val, RETICULUM_RUNTIME_PROTOCOL_TOKENS));
   }
   if (flatKey.startsWith('connectionPanel.reticulumInterfaces.picker')) {

--- a/scripts/check-i18n-quality.test.mjs
+++ b/scripts/check-i18n-quality.test.mjs
@@ -5,6 +5,7 @@ import {
   interpolationPlaceholderIssues,
   localeStringQualityIssues,
   nodeListPanelConnectionCrossKeyIssues,
+  placeholderNameSet,
   protectedBrandIssues,
   protectedProtocolTokenIssues,
   RETICULUM_RUNTIME_PREFIX,
@@ -729,8 +730,7 @@ describe('localeStringQualityIssues', () => {
 });
 
 describe('interpolationPlaceholderIssues', () => {
-  it('memoizes placeholderNameSet for identical strings', async () => {
-    const { placeholderNameSet } = await import('./check-i18n-quality.mjs');
+  it('memoizes placeholderNameSet for identical strings', () => {
     const text = 'Hello {{name}} and {{count}}';
     expect(placeholderNameSet(text)).toBe(placeholderNameSet(text));
   });
@@ -1829,7 +1829,7 @@ describe('checkReticulumRuntimeAndRoutingPortIssues', () => {
       enVal: 'RNS stack is not ready',
       val: 'La pila no está lista',
     });
-    expectIssue(issues, 'reticulum runtime copy must preserve protocol token "RNS"');
+    expectIssue(issues, 'Protocol token "RNS" missing');
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove the manual `RETICULUM_RUNTIME_PROTOCOL_TOKENS` loop in `checkReticulumRuntimeAndRoutingPortIssues` that duplicated `protectedProtocolTokenIssues` and emitted two issue messages for the same missing token.
- Update the reticulum runtime quality test to assert the shared `Protocol token "…" missing` message.
- Use the existing static `placeholderNameSet` import in the memoization test instead of a redundant dynamic `import()`.

Addresses CodeQL findings for duplicate issue reporting and inconsistent test imports.

## Test plan

- [x] `pnpm exec vitest run scripts/check-i18n-quality.test.mjs` (177 tests pass)