### PR TITLE
fix: DMG verify detaches before validateAppBundle runs

### DIFF
--- a/scripts/verify-mac-packaging.mjs
+++ b/scripts/verify-mac-packaging.mjs
@@ -199,8 +199,8 @@ function extractZipToTemp(zipPath) {
   return bundle;
 }
 
-/** @param {string} dmgPath @returns {string} */
-function mountDmgAndFindApp(dmgPath) {
+/** @param {string} dmgPath @param {(bundle: string) => void} validate */
+function mountDmgAndValidate(dmgPath, validate) {
   rmSync(VERIFY_DMG_MOUNT_DIR, { recursive: true, force: true });
   mkdirSync(VERIFY_DMG_MOUNT_DIR, { recursive: true });
 
@@ -216,7 +216,7 @@ function mountDmgAndFindApp(dmgPath) {
     if (!bundle) {
       fail(`No complete ${APP_NAME}.app found inside dmg: ${dmgPath}`);
     }
-    return bundle;
+    validate(bundle);
   } finally {
     detachDmgMount();
   }
@@ -293,8 +293,9 @@ function main() {
   if (!primaryDmg) {
     fail(`No .dmg artifact to mount under ${releaseDir}`);
   }
-  const dmgBundle = mountDmgAndFindApp(primaryDmg);
-  validateAppBundle(dmgBundle, 'dmg');
+  mountDmgAndValidate(primaryDmg, (dmgBundle) => {
+    validateAppBundle(dmgBundle, 'dmg');
+  });
   validatedSources.push('dmg');
 
   const version = JSON.parse(readFileSync(path.join(projectRoot, 'package.json'), 'utf-8')).version;


### PR DESCRIPTION
## Problem

`mountDmgAndFindApp()` (introduced in #661) has a `finally { detachDmgMount() }` block that unmounts the DMG **before** returning the bundle path. When `main()` then calls `validateAppBundle(dmgBundle, "dmg")`, the files no longer exist because the DMG is already detached.

This causes:
```
[verify-mac-packaging] No Contents/MacOS/Mesh-client + Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework in dmg Mesh-client.app at .../release/.verify-mac-dmg-mount/Mesh-client.app
```

See: https://github.com/Colorado-Mesh/mesh-client/actions/runs/29204217426/job/86680736196

## Fix

Rename `mountDmgAndFindApp` to `mountDmgAndValidate` with a callback parameter. The validation runs **inside** the try block while the DMG is still mounted, before `finally` detaches it.

## What passed before

The signing + notarization succeeded — this is purely a verification script race condition.