### PR TITLE
fix: address CodeQL findings in dedup, peer store, and display names

### DIFF
--- a/src/renderer/lib/meshcoreStoreDedup.test.ts
+++ b/src/renderer/lib/meshcoreStoreDedup.test.ts
@@ -146,6 +146,20 @@ describe('meshcoreStoreDedup', () => {
     expect(meshcoreMessageStoreId(msg)).toBe(`room:${roomId >>> 0}:17:1700000000`);
   });
 
+  it('assigns room store ids when only legacy room channel and to are set', () => {
+    const roomId = 0xac200e59;
+    const msg = {
+      sender_id: 0x11,
+      sender_name: 'Author',
+      payload: 'Welcome',
+      channel: MESHCORE_ROOM_MESSAGE_CHANNEL,
+      timestamp: 1_700_000_000_000,
+      to: roomId,
+      receivedVia: 'rf' as const,
+    };
+    expect(meshcoreMessageStoreId(msg)).toBe(`room:${roomId >>> 0}:17:1700000000`);
+  });
+
   it('keeps two room posts in the same UTC second from different authors', () => {
     const roomId = 0xac200e59;
     const tsMs = 1_700_000_005_000;
@@ -215,6 +229,7 @@ describe('meshcoreStoreDedup', () => {
     expect(result.inserted).toBe(false);
     expect(result.message.timestamp).toBe(firmwareTsMs);
     expect(result.message.status).toBe('acked');
+    expect(result.message.payload).toBe('Testing from the mesh-client');
     expect(Object.values(useMessageStore.getState().messages[ID] ?? {})).toHaveLength(1);
   });
 

--- a/src/renderer/lib/meshcoreStoreDedup.ts
+++ b/src/renderer/lib/meshcoreStoreDedup.ts
@@ -61,15 +61,15 @@ export function meshcoreMessageStoreId(msg: ChatMessage): string {
       msg.sender_id > 0 ? msg.sender_id : undefined,
     );
   }
-  if (msg.channel != null && msg.channel >= 0) {
-    return meshcoreChannelMessageStoreId(msg.channel, meshcoreTimestampSec(msg.timestamp));
-  }
   if (msg.channel === MESHCORE_ROOM_MESSAGE_CHANNEL && msg.to != null) {
     return meshcoreRoomMessageStoreId(
       msg.to,
       meshcoreTimestampSec(msg.timestamp),
       msg.sender_id > 0 ? msg.sender_id : undefined,
     );
+  }
+  if (msg.channel != null && msg.channel >= 0) {
+    return meshcoreChannelMessageStoreId(msg.channel, meshcoreTimestampSec(msg.timestamp));
   }
   return `${msg.sender_id}-${msg.timestamp}-${msg.channel ?? -1}`;
 }
@@ -248,7 +248,7 @@ function mergeRoomPostDuplicate(existing: ChatMessage, incoming: ChatMessage): C
     ...incoming,
     timestamp,
     status,
-    payload: incoming.meshcoreDedupeKey ?? incoming.payload ?? existing.payload,
+    payload: incoming.payload ?? existing.payload,
     meshcoreDedupeKey: incoming.meshcoreDedupeKey ?? existing.meshcoreDedupeKey,
     sender_name: incoming.sender_name || existing.sender_name,
     receivedVia: mergeMeshcoreReceivedVia(existing.receivedVia, incoming.receivedVia),

--- a/src/renderer/stores/reticulumPeerStore.ts
+++ b/src/renderer/stores/reticulumPeerStore.ts
@@ -11,11 +11,12 @@ import {
 import { MAX_MESH_ENTITY_CAP } from '@/renderer/lib/sessionMemoryCaps';
 import { useNodeStore } from '@/renderer/stores/nodeStore';
 import { omitRecordKey } from '@/renderer/stores/storeUtils';
-import type {
-  ReticulumContact,
-  ReticulumContactWireRow,
-  ReticulumPeer,
-  ReticulumPeerWireRow,
+import {
+  isReticulumContact,
+  type ReticulumContact,
+  type ReticulumContactWireRow,
+  type ReticulumPeer,
+  type ReticulumPeerWireRow,
 } from '@/shared/reticulum-types';
 import { sanitizeReticulumDisplayName } from '@/shared/reticulumDisplayName';
 
@@ -209,8 +210,8 @@ export function capReticulumPeerMaps(
     return { peers, contacts };
   }
   const sorted = [...peers.entries()].sort(([, a], [, b]) => {
-    const aSeen = a.last_seen ?? ('last_heard' in a ? (a as ReticulumContact).last_heard : 0) ?? 0;
-    const bSeen = b.last_seen ?? ('last_heard' in b ? (b as ReticulumContact).last_heard : 0) ?? 0;
+    const aSeen = a.last_seen ?? (isReticulumContact(a) ? a.last_heard : 0) ?? 0;
+    const bSeen = b.last_seen ?? (isReticulumContact(b) ? b.last_heard : 0) ?? 0;
     return bSeen - aSeen;
   });
   const cappedPeers = new Map(sorted.slice(0, max));
@@ -354,8 +355,7 @@ export const useReticulumPeerStore = create<ReticulumPeerStoreState>((set, get) 
         destination_hash: key,
         display_name: trimmed,
         favorited: peer?.favorited ?? false,
-        last_heard:
-          'last_heard' in (peer ?? {}) ? (peer as ReticulumContact).last_heard : undefined,
+        last_heard: isReticulumContact(peer) ? peer.last_heard : undefined,
       });
     } catch (e) {
       console.warn('[reticulumPeerStore] setCustomDisplayName ' + errLikeToLogString(e));

--- a/src/shared/reticulum-types.ts
+++ b/src/shared/reticulum-types.ts
@@ -70,6 +70,10 @@ export interface ReticulumContact extends ReticulumPeer {
   last_heard: number;
 }
 
+export function isReticulumContact(peer: ReticulumPeer | undefined): peer is ReticulumContact {
+  return peer != null && 'last_heard' in peer;
+}
+
 /** Sidecar wire row for GET /api/v1/peers */
 export interface ReticulumPeerWireRow {
   destination_hash: string;

--- a/src/shared/reticulumDisplayName.test.ts
+++ b/src/shared/reticulumDisplayName.test.ts
@@ -32,9 +32,17 @@ describe('sanitizeReticulumDisplayName', () => {
     expect(sanitizeReticulumDisplayName('')).toBeUndefined();
     expect(sanitizeReticulumDisplayName(null)).toBeUndefined();
   });
+});
 
-  it('sanitizeReticulumDisplayNameForDb maps missing to null', () => {
+describe('sanitizeReticulumDisplayNameForDb', () => {
+  it('maps missing or invalid names to null', () => {
+    expect(sanitizeReticulumDisplayNameForDb(null)).toBeNull();
+    expect(sanitizeReticulumDisplayNameForDb(undefined)).toBeNull();
+    expect(sanitizeReticulumDisplayNameForDb('')).toBeNull();
     expect(sanitizeReticulumDisplayNameForDb('{"h":"abc"}')).toBeNull();
+  });
+
+  it('returns sanitized plain names for SQLite upsert', () => {
     expect(sanitizeReticulumDisplayNameForDb('Runr02')).toBe('Runr02');
   });
 });


### PR DESCRIPTION
## Summary

- **MeshCore store dedup:** Reorder `meshcoreMessageStoreId` so `MESHCORE_ROOM_MESSAGE_CHANNEL` (`-2`) is resolved before the `channel >= 0` branch, making room-post ID assignment explicit. Fix `mergeRoomPostDuplicate` to keep `incoming.payload ?? existing.payload` instead of preferring `meshcoreDedupeKey` as display text.
- **Reticulum peer store:** Add shared `isReticulumContact` type guard and use it in `capReticulumPeerMaps` and `setCustomDisplayName` instead of fragile `'last_heard' in (peer ?? {})` checks.
- **Display name tests:** Move `sanitizeReticulumDisplayNameForDb` into its own `describe` block and add coverage for `null`, `undefined`, and empty string inputs.

## Test plan

- [x] `pnpm exec vitest run src/renderer/lib/meshcoreStoreDedup.test.ts src/shared/reticulumDisplayName.test.ts src/renderer/stores/reticulumPeerStore.test.ts`
- [x] Pre-commit hook passed on commit