### PR TITLE
fix: harden Reticulum DM delivery under transport saturation

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -987,6 +987,41 @@ In dev, **Start stack** now rebuilds when `reticulum-sidecar/src/**/*.rs` or `Ca
 
 **Fix**: Re-select the preset on the Connection tab, or clear `mesh-client:mqttSettings:meshcore` in devtools Application → Local Storage and reconnect. Migrations run on app start via `connectionPanelStorageMigrations.ts`.
 
+### Reticulum DM stuck on Sending (MeshChatX / shared instance)
+
+**Symptoms**: Outbound Reticulum DMs stay **Sending**; Device log shows `link delivery timed out` with `link establishment timeout`, and many `failed to queue path request for LXMF delivery` lines. Connection tab may show **sidecar interface issues** (TX queue drops, transport saturated). Sniffer may show a **Link Request** that never completes.
+
+**Cause**: Usually **RNS transport overload**, not a missing mesh-client chat handshake. Common triggers:
+
+1. **Shared instance conflict** — `share_instance = Yes` with another Reticulum app still running (MeshChatX, Ratspeak, standalone `rnsd`) fighting the same IPC socket.
+2. **Dead TCP hub still enabled** — outbound queue fills; path requests fail with _no available capacity_.
+3. **No propagation node** — when direct link fails, there is no store-and-forward fallback (see next section).
+
+**Fix**:
+
+1. **Fully quit** other Reticulum apps (MeshChatX, Ratspeak, any `rnsd` tray process) — not just close the window.
+2. **Stop and restart** the mesh-client Reticulum stack (Connection → **Restart stack** or stop/start).
+3. Disable unreachable TCP interfaces on Connection → Interfaces.
+4. Retry the DM; use **Peers → Request path / Probe** if the peer is reachable but the path is stale.
+5. Configure a **propagation node** on Network → Propagation for offline delivery.
+
+Export for GitHub (`reticulum.sidecar.interfaceIssueAlert`, link-timeout counts) helps confirm transport saturation vs. a single peer outage.
+
+### Reticulum: no propagation node configured
+
+**Symptoms**: Chat shows a persistent amber **propagation** notice; send failures toast _No propagation node configured_; offline peers never receive LXMF.
+
+**Cause**: Direct LXMF links require a live path. When the peer is offline or unreachable, mesh-client needs a **remote propagation node** (lxmd store-and-forward) — not a TCP transport hub.
+
+**Fix**:
+
+1. Open **Network → Propagation** (Chat notice **Set up propagation** jumps there).
+2. Add a **32-character LXMF destination hash** from whoever runs the propagation node you trust.
+3. Set **Preferred** (manual mode) or leave **Auto** when multiple nodes are listed.
+4. **Local propagation only** queues messages on this device — it does **not** replace a remote propagation node for peers you cannot reach directly.
+
+**Not the same as transport:** Ratspeak TCP hubs (e.g. `rns.ratspeak.org:4242`) and [rathole](https://github.com/ratspeak/rathole) are **connectivity / transport** tools, not LXMF propagation. mesh-client does not ship a default community propagation hash.
+
 ### Reticulum interface add/edit/delete fails
 
 **Symptoms**: Connection tab **Add interface**, **Edit**, or **Delete** shows an inline error; interface list does not refresh.

--- a/reticulum-sidecar/src/stack/lxmf_outbound.rs
+++ b/reticulum-sidecar/src/stack/lxmf_outbound.rs
@@ -17,12 +17,73 @@ use tokio::sync::mpsc;
 
 use super::{lxmf_payload_from_message, parse_hash16};
 
+const PATH_REQUEST_BACKOFF_SECS: f64 = 20.0;
+const PATH_REQUEST_MAX_ATTEMPTS: u32 = 12;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PathRequestDecision {
+    Send,
+    Backoff,
+    MaxAttempts,
+}
+
+/// Rate-limits `RequestPath` when the transport channel is full (avoids retry storms).
+struct PathRequestGate {
+    backoff_until: HashMap<[u8; 16], f64>,
+    fail_count: HashMap<[u8; 16], u32>,
+    last_warn_at: HashMap<[u8; 16], f64>,
+}
+
+impl PathRequestGate {
+    fn new() -> Self {
+        Self {
+            backoff_until: HashMap::new(),
+            fail_count: HashMap::new(),
+            last_warn_at: HashMap::new(),
+        }
+    }
+
+    fn clear_destination(&mut self, dest: [u8; 16]) {
+        self.backoff_until.remove(&dest);
+        self.fail_count.remove(&dest);
+        self.last_warn_at.remove(&dest);
+    }
+
+    fn decide(&self, dest: [u8; 16], now: f64) -> PathRequestDecision {
+        if self.fail_count.get(&dest).copied().unwrap_or(0) >= PATH_REQUEST_MAX_ATTEMPTS {
+            return PathRequestDecision::MaxAttempts;
+        }
+        if let Some(until) = self.backoff_until.get(&dest) {
+            if now < *until {
+                return PathRequestDecision::Backoff;
+            }
+        }
+        PathRequestDecision::Send
+    }
+
+    fn record_queue_failure(&mut self, dest: [u8; 16], now: f64) {
+        *self.fail_count.entry(dest).or_insert(0) += 1;
+        self.backoff_until.insert(dest, now + PATH_REQUEST_BACKOFF_SECS);
+    }
+
+    fn should_warn(&mut self, dest: [u8; 16], now: f64) -> bool {
+        let last = self.last_warn_at.get(&dest).copied().unwrap_or(0.0);
+        if now - last >= PATH_REQUEST_BACKOFF_SECS {
+            self.last_warn_at.insert(dest, now);
+            true
+        } else {
+            false
+        }
+    }
+}
+
 pub struct LxmfOutboundDriver {
     transport_tx: mpsc::Sender<TransportMessage>,
     link_delivery: LinkDeliveryManager,
     route_hops: HashMap<[u8; 16], u8>,
     known_identities: HashMap<String, [u8; 64]>,
     path_table_hashes: HashSet<String>,
+    path_request_gate: PathRequestGate,
     self_lxmf_hash: String,
     self_display_name: String,
 }
@@ -44,6 +105,7 @@ impl LxmfOutboundDriver {
             route_hops: HashMap::new(),
             known_identities: HashMap::new(),
             path_table_hashes: HashSet::new(),
+            path_request_gate: PathRequestGate::new(),
             self_lxmf_hash: self_lxmf_hash.clone(),
             self_display_name,
         };
@@ -70,6 +132,7 @@ impl LxmfOutboundDriver {
         for (hash, hops, hex_key) in entries {
             self.route_hops.insert(*hash, (*hops).max(1));
             self.path_table_hashes.insert(hex_key.clone());
+            self.path_request_gate.clear_destination(*hash);
         }
     }
 
@@ -110,7 +173,7 @@ impl LxmfOutboundDriver {
         });
 
         if !actions.is_empty() {
-            self.execute_actions(router, actions);
+            self.execute_actions(router, event_tx, actions);
         }
 
         router.run_jobs_tick();
@@ -121,21 +184,26 @@ impl LxmfOutboundDriver {
         }
     }
 
-    fn execute_actions(&mut self, router: &mut LxmRouter, actions: Vec<OutboundAction>) {
+    fn execute_actions(
+        &mut self,
+        router: &mut LxmRouter,
+        event_tx: &broadcast::Sender<String>,
+        actions: Vec<OutboundAction>,
+    ) {
         for action in actions {
             match action {
                 OutboundAction::DeliverPropagated { message, prop_hash } => {
-                    self.deliver_propagated(router, message, prop_hash);
+                    self.deliver_propagated(router, event_tx, message, prop_hash);
                 }
                 OutboundAction::DeliverDirect { message, dest_hash } => {
-                    self.deliver_direct(router, message, dest_hash, None);
+                    self.deliver_direct(router, event_tx, message, dest_hash, None);
                 }
                 OutboundAction::PlanDirect {
                     message,
                     dest_hash,
                     plan,
                 } => {
-                    self.deliver_direct(router, message, dest_hash, Some(plan));
+                    self.deliver_direct(router, event_tx, message, dest_hash, Some(plan));
                 }
                 OutboundAction::DeliverOpportunistic { message, dest_hash } => {
                     if let Ok(packed) = message.pack_payload() {
@@ -152,6 +220,7 @@ impl LxmfOutboundDriver {
                         dest = %hex::encode(msg.destination_hash),
                         "LXMF outbound message failed or expired"
                     );
+                    self.fail_outbound_message(router, event_tx, msg);
                 }
             }
         }
@@ -160,6 +229,7 @@ impl LxmfOutboundDriver {
     fn deliver_propagated(
         &mut self,
         router: &mut LxmRouter,
+        event_tx: &broadcast::Sender<String>,
         mut message: LxMessage,
         prop_hash: [u8; 16],
     ) {
@@ -168,8 +238,7 @@ impl LxmfOutboundDriver {
             .known_identities
             .contains_key(&prop_hex.to_lowercase())
         {
-            queue_path_request(&self.transport_tx, prop_hash, false, "propagation node path");
-            router.send(message);
+            self.request_path_gated(router, event_tx, prop_hash, false, "propagation node path", message);
             return;
         }
         let Some(packed) = self.pack_for_propagation(&mut message, prop_hash) else {
@@ -193,6 +262,7 @@ impl LxmfOutboundDriver {
     fn deliver_direct(
         &mut self,
         router: &mut LxmRouter,
+        event_tx: &broadcast::Sender<String>,
         mut message: LxMessage,
         dest_hash: [u8; 16],
         planned: Option<DirectDeliveryPlan>,
@@ -213,11 +283,17 @@ impl LxmfOutboundDriver {
 
         match plan {
             DirectDeliveryPlan::RequestPath { .. } | DirectDeliveryPlan::WaitForReusableLink => {
-                queue_path_request(&self.transport_tx, dest_hash, false, "direct delivery path");
-                router.send(message);
+                self.request_path_gated(
+                    router,
+                    event_tx,
+                    dest_hash,
+                    false,
+                    "direct delivery path",
+                    message,
+                );
             }
             DirectDeliveryPlan::DeferTerminalFailure | DirectDeliveryPlan::Fail => {
-                message.mark_failed();
+                self.fail_outbound_message(router, event_tx, message);
             }
             DirectDeliveryPlan::UseReusableLink | DirectDeliveryPlan::StartNewLink { .. } => {
                 let hops = match plan {
@@ -237,6 +313,70 @@ impl LxmfOutboundDriver {
                 }
             }
         }
+    }
+
+    fn request_path_gated(
+        &mut self,
+        router: &mut LxmRouter,
+        event_tx: &broadcast::Sender<String>,
+        request_hash: [u8; 16],
+        drop_existing: bool,
+        reason: &str,
+        message: LxMessage,
+    ) {
+        let now = now_f64();
+        match self.path_request_gate.decide(request_hash, now) {
+            PathRequestDecision::Send => {
+                if try_queue_path_request(&self.transport_tx, request_hash, drop_existing, reason) {
+                    router.send(message);
+                } else {
+                    self.path_request_gate.record_queue_failure(request_hash, now);
+                    if self.path_request_gate.should_warn(request_hash, now) {
+                        tracing::warn!(
+                            dest = %hex::encode(request_hash),
+                            reason,
+                            "failed to queue path request for LXMF delivery (transport channel full)"
+                        );
+                    }
+                    router.send(message);
+                }
+            }
+            PathRequestDecision::Backoff => {
+                router.send(message);
+            }
+            PathRequestDecision::MaxAttempts => {
+                tracing::warn!(
+                    dest = %hex::encode(request_hash),
+                    reason,
+                    "LXMF path request budget exhausted; marking outbound failed"
+                );
+                self.fail_outbound_message(router, event_tx, message);
+            }
+        }
+    }
+
+    fn fail_outbound_message(
+        &mut self,
+        router: &mut LxmRouter,
+        event_tx: &broadcast::Sender<String>,
+        mut message: LxMessage,
+    ) {
+        message.mark_failed();
+        if let Some(hash) = message.hash.or(message.message_id) {
+            let _ = router.mark_outbound_failed(&hash);
+            emit_outbound_status_by_hash(event_tx, &hash, "failed");
+        }
+        let method = delivery_method_label(message.method);
+        let payload = lxmf_payload_from_message(
+            &message,
+            &self.self_lxmf_hash,
+            &self.self_display_name,
+            None,
+            Some(method),
+            "outbound",
+            None,
+        );
+        emit_outbound_status(event_tx, &payload, "failed", method);
     }
 
     fn pack_for_propagation(
@@ -380,12 +520,12 @@ fn direct_reusable_link_state(
     }
 }
 
-fn queue_path_request(
+fn try_queue_path_request(
     transport_tx: &mpsc::Sender<TransportMessage>,
     request_hash: [u8; 16],
     drop_existing: bool,
     reason: &str,
-) {
+) -> bool {
     if drop_existing {
         let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
         let _ = transport_tx.try_send(TransportMessage::Rpc {
@@ -393,16 +533,19 @@ fn queue_path_request(
             response_tx,
         });
     }
-    if let Err(e) = transport_tx.try_send(TransportMessage::RequestPath {
-        destination_hash: request_hash,
-    }) {
-        tracing::warn!(
-            dest = %hex::encode(request_hash),
-            error = %e,
-            reason,
-            "failed to queue path request for LXMF delivery"
-        );
-    }
+    transport_tx
+        .try_send(TransportMessage::RequestPath {
+            destination_hash: request_hash,
+        })
+        .map_err(|e| {
+            tracing::debug!(
+                dest = %hex::encode(request_hash),
+                error = %e,
+                reason,
+                "path request try_send rejected"
+            );
+        })
+        .is_ok()
 }
 
 pub fn parse_propagation_hash(hex_str: &str) -> Option<[u8; 16]> {
@@ -414,4 +557,52 @@ fn now_f64() -> f64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs_f64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dest(byte: u8) -> [u8; 16] {
+        [byte; 16]
+    }
+
+    #[test]
+    fn path_gate_allows_first_request() {
+        let gate = PathRequestGate::new();
+        assert_eq!(gate.decide(dest(1), 100.0), PathRequestDecision::Send);
+    }
+
+    #[test]
+    fn path_gate_backoffs_after_queue_failure() {
+        let mut gate = PathRequestGate::new();
+        gate.record_queue_failure(dest(1), 100.0);
+        assert_eq!(gate.decide(dest(1), 110.0), PathRequestDecision::Backoff);
+        assert_eq!(gate.decide(dest(1), 121.0), PathRequestDecision::Send);
+    }
+
+    #[test]
+    fn path_gate_max_attempts_fails_terminal() {
+        let mut gate = PathRequestGate::new();
+        for i in 0..PATH_REQUEST_MAX_ATTEMPTS {
+            gate.record_queue_failure(dest(2), 100.0 + f64::from(i));
+        }
+        assert_eq!(gate.decide(dest(2), 500.0), PathRequestDecision::MaxAttempts);
+    }
+
+    #[test]
+    fn path_gate_clears_on_path_resolution() {
+        let mut gate = PathRequestGate::new();
+        gate.record_queue_failure(dest(3), 100.0);
+        gate.clear_destination(dest(3));
+        assert_eq!(gate.decide(dest(3), 101.0), PathRequestDecision::Send);
+    }
+
+    #[test]
+    fn path_gate_warn_is_rate_limited() {
+        let mut gate = PathRequestGate::new();
+        assert!(gate.should_warn(dest(4), 100.0));
+        assert!(!gate.should_warn(dest(4), 110.0));
+        assert!(gate.should_warn(dest(4), 121.0));
+    }
 }

--- a/src/main/reticulumSidecarIssueTracker.test.ts
+++ b/src/main/reticulumSidecarIssueTracker.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  parseLinkDeliveryTimeoutDestForTests,
   parseTcpConnectFailedIfaceForTests,
   parseTxDropIfaceForTests,
   ReticulumSidecarInterfaceIssueTracker,
@@ -11,6 +12,15 @@ const TCP_LINE =
 
 const TX_DROP_LINE =
   '[2m2026-07-03T22:56:04.991728Z [0m [31mERROR [0m [2mrns_transport::actor [0m [2m: [0m PACKET DROPPED: interface TX channel full [3minterface_id [0m [2m= [0m3 [3minterface_name [0m [2m= [0mRNS HAM RADIO [3mqueue_remaining [0m [2m= [0m0 [3mqueue_max [0m [2m= [0m1024 [3mtx_drops [0m [2m= [0m8192';
+
+const LINK_TIMEOUT_LINE =
+  'link delivery timed out dest=5526a65d0b4d23448206fd3485b76f5b state=Establishing timeout_secs=18.0 reason="link establishment timeout"';
+
+const PATH_REQUEST_SATURATED_LINE =
+  'failed to queue path request for LXMF delivery to 5526a65d0b4d23448206fd3485b76f5b (transport channel full)';
+
+const SLOW_TRANSPORT_LINE =
+  'transport query slow or failed query=GetInterfaceStats elapsed_ms=8123';
 
 describe('ReticulumSidecarInterfaceIssueTracker', () => {
   let tracker: ReticulumSidecarInterfaceIssueTracker;
@@ -27,6 +37,12 @@ describe('ReticulumSidecarInterfaceIssueTracker', () => {
     expect(parseTxDropIfaceForTests(TX_DROP_LINE)).toBe('RNS HAM RADIO');
   });
 
+  it('parses link delivery timeout destination hash', () => {
+    expect(parseLinkDeliveryTimeoutDestForTests(LINK_TIMEOUT_LINE)).toBe(
+      '5526a65d0b4d23448206fd3485b76f5b',
+    );
+  });
+
   it('builds alert with tcp and tx drop issues', () => {
     tracker.recordLine(TCP_LINE, 1_000);
     tracker.recordLine(TX_DROP_LINE, 2_000);
@@ -34,9 +50,26 @@ describe('ReticulumSidecarInterfaceIssueTracker', () => {
     expect(alert).toEqual({
       tcpConnectFailed: ['RNS HAM RADIO'],
       txQueueDrops: [{ name: 'RNS HAM RADIO', dropCount: 8192 }],
+      linkDeliveryTimeouts: [],
+      transportSaturatedCount: 0,
+      slowTransportQueryCount: 0,
       suppressedCount: 0,
       lastAtMs: 2_000,
     });
+  });
+
+  it('tracks link timeouts, transport saturation, and slow transport queries', () => {
+    tracker.recordLine(LINK_TIMEOUT_LINE, 1_000);
+    tracker.recordLine(LINK_TIMEOUT_LINE, 1_500);
+    tracker.recordLine(PATH_REQUEST_SATURATED_LINE, 2_000);
+    tracker.recordLine(PATH_REQUEST_SATURATED_LINE, 2_100);
+    tracker.recordLine(SLOW_TRANSPORT_LINE, 2_200);
+    const alert = tracker.getAlert(2_500);
+    expect(alert?.linkDeliveryTimeouts).toEqual([
+      { destinationHash: '5526a65d0b4d23448206fd3485b76f5b', count: 2 },
+    ]);
+    expect(alert?.transportSaturatedCount).toBe(2);
+    expect(alert?.slowTransportQueryCount).toBe(1);
   });
 
   it('expires alerts after stale window', () => {

--- a/src/main/reticulumSidecarIssueTracker.ts
+++ b/src/main/reticulumSidecarIssueTracker.ts
@@ -6,11 +6,17 @@ import { MS_PER_SECOND } from '../shared/timeConstants';
 const ALERT_STALE_MS = 5 * 60 * MS_PER_SECOND;
 const TCP_CONNECT_FAILED_MARKER = 'TCP connect failed';
 const TX_QUEUE_DROP_MARKER = 'PACKET DROPPED: interface TX channel full';
+const LINK_DELIVERY_TIMEOUT_MARKER = 'link delivery timed out';
+const LXMF_PATH_REQUEST_SATURATED_MARKER = 'failed to queue path request for LXMF delivery';
+const SLOW_TRANSPORT_QUERY_MARKER = 'transport query slow or failed';
 
 const TCP_CONNECT_IFACE_RE = /TCP connect failed.*?name\s*=\s*(.+?)(?:\s+error\s*=|$)/;
 const TX_DROP_IFACE_RE =
   /PACKET DROPPED: interface TX channel full.*?interface_name\s*=\s*(.+?)(?:\s+queue|$)/;
 const TX_DROP_COUNT_RE = /tx_drops\s*=\s*(\d+)/;
+const LINK_TIMEOUT_DEST_RE =
+  /link delivery timed out.*?dest\s*=\s*([0-9a-fA-F]{32}|[0-9a-fA-F]{16})/;
+const SLOW_TRANSPORT_QUERY_RE = /transport query slow or failed.*?query\s*=\s*(\S+)/;
 
 function stripAnsi(text: string): string {
   return text.replace(/\x1b\[[0-9;]*m/g, '').replace(/\[[0-9;]*m/g, ''); // eslint-disable-line no-control-regex
@@ -37,9 +43,26 @@ function parseTxDropCount(line: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+function parseLinkDeliveryTimeoutDest(line: string): string | null {
+  const match = LINK_TIMEOUT_DEST_RE.exec(normalizeSidecarLogLine(line));
+  const raw = match?.[1]?.trim().toLowerCase();
+  if (!raw) return null;
+  if (raw.length === 32) return raw;
+  if (raw.length === 16) return raw;
+  return null;
+}
+
+function parseSlowTransportQuery(line: string): string | null {
+  const match = SLOW_TRANSPORT_QUERY_RE.exec(normalizeSidecarLogLine(line));
+  return match?.[1]?.trim() ?? null;
+}
+
 export class ReticulumSidecarInterfaceIssueTracker {
   private tcpConnectFailed = new Map<string, number>();
   private txQueueDrops = new Map<string, number>();
+  private linkDeliveryTimeouts = new Map<string, number>();
+  private transportSaturatedCount = 0;
+  private slowTransportQueryCount = 0;
   private suppressedCount = 0;
   private lastAtMs: number | null = null;
 
@@ -60,6 +83,24 @@ export class ReticulumSidecarInterfaceIssueTracker {
         this.txQueueDrops.set(iface, drops ?? this.txQueueDrops.get(iface) ?? 0);
         this.lastAtMs = nowMs;
       }
+      return;
+    }
+    if (plain.includes(LINK_DELIVERY_TIMEOUT_MARKER)) {
+      const dest = parseLinkDeliveryTimeoutDest(line);
+      if (dest) {
+        this.linkDeliveryTimeouts.set(dest, (this.linkDeliveryTimeouts.get(dest) ?? 0) + 1);
+        this.lastAtMs = nowMs;
+      }
+      return;
+    }
+    if (plain.includes(LXMF_PATH_REQUEST_SATURATED_MARKER)) {
+      this.transportSaturatedCount += 1;
+      this.lastAtMs = nowMs;
+      return;
+    }
+    if (plain.includes(SLOW_TRANSPORT_QUERY_MARKER) && parseSlowTransportQuery(line)) {
+      this.slowTransportQueryCount += 1;
+      this.lastAtMs = nowMs;
     }
   }
 
@@ -76,12 +117,24 @@ export class ReticulumSidecarInterfaceIssueTracker {
     const txQueueDrops = [...this.txQueueDrops.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([name, dropCount]) => ({ name, dropCount }));
-    if (tcpConnectFailed.length === 0 && txQueueDrops.length === 0) {
+    const linkDeliveryTimeouts = [...this.linkDeliveryTimeouts.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([destinationHash, count]) => ({ destinationHash, count }));
+    if (
+      tcpConnectFailed.length === 0 &&
+      txQueueDrops.length === 0 &&
+      linkDeliveryTimeouts.length === 0 &&
+      this.transportSaturatedCount === 0 &&
+      this.slowTransportQueryCount === 0
+    ) {
       return null;
     }
     return {
       tcpConnectFailed,
       txQueueDrops,
+      linkDeliveryTimeouts,
+      transportSaturatedCount: this.transportSaturatedCount,
+      slowTransportQueryCount: this.slowTransportQueryCount,
       suppressedCount: this.suppressedCount,
       lastAtMs: this.lastAtMs,
     };
@@ -90,6 +143,9 @@ export class ReticulumSidecarInterfaceIssueTracker {
   resetForTests(): void {
     this.tcpConnectFailed.clear();
     this.txQueueDrops.clear();
+    this.linkDeliveryTimeouts.clear();
+    this.transportSaturatedCount = 0;
+    this.slowTransportQueryCount = 0;
     this.suppressedCount = 0;
     this.lastAtMs = null;
   }
@@ -101,4 +157,8 @@ export function parseTcpConnectFailedIfaceForTests(line: string): string | null 
 
 export function parseTxDropIfaceForTests(line: string): string | null {
   return parseTxDropIface(line);
+}
+
+export function parseLinkDeliveryTimeoutDestForTests(line: string): string | null {
+  return parseLinkDeliveryTimeoutDest(line);
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1395,6 +1395,18 @@ function AppContent() {
     }
   }, [tabsByProtocol]);
 
+  const [reticulumPropagationNavKey, setReticulumPropagationNavKey] = useState(0);
+  const handleOpenReticulumPropagationSettings = useCallback(() => {
+    const radioTabIndex = findFilteredTabIndexForPanel(
+      selectByProtocol(tabsByProtocol, 'reticulum'),
+      RADIO_TAB_PANEL_INDEX,
+    );
+    if (radioTabIndex >= 0) {
+      setActiveTab(radioTabIndex);
+    }
+    setReticulumPropagationNavKey((key) => key + 1);
+  }, [tabsByProtocol]);
+
   const handleRefreshReticulumDiagnostics = useCallback(() => {
     void reticulumRuntime.syncDiagnostics?.();
   }, [reticulumRuntime]);
@@ -2691,6 +2703,17 @@ function AppContent() {
                                     })
                                 : undefined
                             }
+                            onOpenPropagationSettings={
+                              protocol === 'reticulum'
+                                ? handleOpenReticulumPropagationSettings
+                                : undefined
+                            }
+                            reticulumStackLive={
+                              protocol === 'reticulum' &&
+                              (reticulumConnectionView.state.status === 'configured' ||
+                                reticulumConnectionView.state.status === 'connected' ||
+                                reticulumConnectionView.state.status === 'stale')
+                            }
                           />
                         </Suspense>
                       </div>
@@ -2896,6 +2919,7 @@ function AppContent() {
                               <ReticulumNetworkPanel
                                 connecting={reticulumConnectionView.state.status === 'connecting'}
                                 onStartStack={() => reticulumConnection.connectAutomatic('http')}
+                                propagationSectionOpenKey={reticulumPropagationNavKey}
                                 onOpenAppGpsSettings={() => {
                                   const appTabIdx = tabSlotIds.indexOf('App');
                                   if (appTabIdx >= 0) {

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -134,6 +134,7 @@ import { HelpTooltip } from './HelpTooltip';
 import { MessageStatusBadge } from './MessageStatusBadge';
 import { ReticulumAttachmentLine } from './ReticulumAttachmentLine';
 import { ReticulumMessageStatusBadge } from './ReticulumMessageStatusBadge';
+import { ReticulumPropagationNotice } from './ReticulumPropagationNotice';
 import { useToast } from './Toast';
 
 function chatPanelIsLinux(): boolean {
@@ -434,6 +435,10 @@ export interface ChatPanelProps {
   lxmfReplyHashReplies?: boolean;
   /** Reticulum LXMF file/image attachments in DM composer. */
   onSendAttachment?: (file: File, destination: number) => Promise<void>;
+  /** Reticulum: open Network tab propagation settings. */
+  onOpenPropagationSettings?: () => void;
+  /** Reticulum: stack is configured and sidecar is live. */
+  reticulumStackLive?: boolean;
 }
 
 function ChatPanel({
@@ -465,6 +470,8 @@ function ChatPanel({
   composerPayloadLimit,
   lxmfReplyHashReplies = false,
   onSendAttachment,
+  onOpenPropagationSettings,
+  reticulumStackLive = false,
 }: ChatPanelProps) {
   const { t } = useTranslation();
   const parentIconTrigger = useParentIconTrigger();
@@ -1794,6 +1801,13 @@ function ChatPanel({
           </ChatToolbarTooltipButton>
         </div>
       </div>
+
+      {protocol === 'reticulum' ? (
+        <ReticulumPropagationNotice
+          stackLive={reticulumStackLive}
+          onOpenPropagationSettings={onOpenPropagationSettings}
+        />
+      ) : null}
 
       {protocol === 'reticulum' && reticulumPropagationSync.active && (
         <div

--- a/src/renderer/components/ReticulumNetworkPanel.tsx
+++ b/src/renderer/components/ReticulumNetworkPanel.tsx
@@ -78,6 +78,8 @@ export interface ReticulumNetworkPanelProps {
   connecting: boolean;
   onStartStack: () => Promise<void>;
   onOpenAppGpsSettings?: () => void;
+  /** When incremented, opens the propagation collapsible section. */
+  propagationSectionOpenKey?: number;
 }
 
 /** Network tab: identity, stack settings, propagation, config import. */
@@ -85,6 +87,7 @@ export function ReticulumNetworkPanel({
   connecting,
   onStartStack,
   onOpenAppGpsSettings,
+  propagationSectionOpenKey = 0,
 }: ReticulumNetworkPanelProps) {
   const { t } = useTranslation();
   const sidecarEventRef = useRef<(evt: ReticulumSidecarEvent) => void>(() => {});
@@ -615,7 +618,11 @@ export function ReticulumNetworkPanel({
             ) : null}
           </ReticulumCollapsibleSection>
 
-          <ReticulumCollapsibleSection title={t('connectionPanel.reticulumPropagation.title')}>
+          <ReticulumCollapsibleSection
+            key={`propagation-${propagationSectionOpenKey}`}
+            title={t('connectionPanel.reticulumPropagation.title')}
+            defaultOpen={propagationSectionOpenKey > 0}
+          >
             <ReticulumPropagationSection embedded />
           </ReticulumCollapsibleSection>
         </>

--- a/src/renderer/components/ReticulumPropagationNotice.test.tsx
+++ b/src/renderer/components/ReticulumPropagationNotice.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useReticulumPropagationStore } from '@/renderer/stores/reticulumPropagationStore';
+
+import { ReticulumPropagationNotice } from './ReticulumPropagationNotice';
+
+describe('ReticulumPropagationNotice', () => {
+  const originalRefresh = useReticulumPropagationStore.getState().refreshFromSidecar;
+
+  beforeEach(() => {
+    useReticulumPropagationStore.setState({
+      nodes: [],
+      preferredId: null,
+      refreshFromSidecar: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    useReticulumPropagationStore.setState({
+      nodes: [],
+      preferredId: null,
+      refreshFromSidecar: originalRefresh,
+    });
+  });
+
+  it('shows notice when stack is live and no remote propagation target exists', () => {
+    useReticulumPropagationStore.setState({
+      nodes: [{ id: 'local-prop', name: 'Local', enabled: true, status: 'online' }],
+      preferredId: null,
+    });
+    render(<ReticulumPropagationNotice stackLive onOpenPropagationSettings={vi.fn()} />);
+    expect(screen.getByRole('alert')).toHaveTextContent(/propagation node/i);
+  });
+
+  it('hides when an effective remote propagation target exists', () => {
+    useReticulumPropagationStore.setState({
+      nodes: [
+        {
+          id: 'remote-1',
+          name: 'Remote',
+          enabled: true,
+          status: 'online',
+          hops: 1,
+        },
+      ],
+      preferredId: 'remote-1',
+    });
+    const { container } = render(
+      <ReticulumPropagationNotice stackLive onOpenPropagationSettings={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('refreshes propagation from sidecar when stack is live', async () => {
+    const refreshFromSidecar = vi.fn().mockResolvedValue(undefined);
+    useReticulumPropagationStore.setState({
+      nodes: [],
+      preferredId: null,
+      refreshFromSidecar,
+    });
+    render(<ReticulumPropagationNotice stackLive onOpenPropagationSettings={vi.fn()} />);
+    await waitFor(() => {
+      expect(refreshFromSidecar).toHaveBeenCalled();
+    });
+  });
+
+  it('calls navigation callback when set up propagation is clicked', async () => {
+    useReticulumPropagationStore.setState({ nodes: [], preferredId: null });
+    const onOpen = vi.fn();
+    render(<ReticulumPropagationNotice stackLive onOpenPropagationSettings={onOpen} />);
+    await userEvent.click(screen.getByRole('button', { name: /propagation/i }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+});

--- a/src/renderer/components/ReticulumPropagationNotice.tsx
+++ b/src/renderer/components/ReticulumPropagationNotice.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { hasEffectiveReticulumPropagationTarget } from '@/renderer/lib/reticulum/reticulumPropagationEffective';
+import { readReticulumPropagationMode } from '@/renderer/lib/reticulum/reticulumPropagationMode';
+import { useReticulumPropagationStore } from '@/renderer/stores/reticulumPropagationStore';
+
+export interface ReticulumPropagationNoticeProps {
+  stackLive: boolean;
+  onOpenPropagationSettings?: () => void;
+}
+
+/** Persistent banner when the stack is up but no remote propagation node is configured. */
+export function ReticulumPropagationNotice({
+  stackLive,
+  onOpenPropagationSettings,
+}: ReticulumPropagationNoticeProps) {
+  const { t } = useTranslation();
+  const nodes = useReticulumPropagationStore((s) => s.nodes);
+  const preferredId = useReticulumPropagationStore((s) => s.preferredId);
+  const refreshFromSidecar = useReticulumPropagationStore((s) => s.refreshFromSidecar);
+
+  useEffect(() => {
+    if (!stackLive) return;
+    void refreshFromSidecar();
+  }, [stackLive, refreshFromSidecar]);
+
+  if (!stackLive) return null;
+  if (hasEffectiveReticulumPropagationTarget(nodes, preferredId, readReticulumPropagationMode())) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className="mb-2 rounded-lg border border-amber-700/50 bg-amber-900/20 px-3 py-2 text-xs text-amber-100"
+    >
+      <p>{t('reticulumPropagation.notice.body')}</p>
+      {onOpenPropagationSettings ? (
+        <button
+          type="button"
+          className="mt-1.5 font-medium text-amber-200 underline hover:text-amber-100"
+          aria-label={t('reticulumPropagation.notice.openSettingsAria')}
+          onClick={onOpenPropagationSettings}
+        >
+          {t('reticulumPropagation.notice.openSettings')}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/renderer/components/ReticulumSidecarIssueAlertsBlock.tsx
+++ b/src/renderer/components/ReticulumSidecarIssueAlertsBlock.tsx
@@ -4,15 +4,36 @@ import type { ReticulumInterfaceIssueAlert } from '@/shared/reticulum-types';
 
 export interface ReticulumSidecarIssueAlertsBlockProps {
   alert: ReticulumInterfaceIssueAlert;
+  /** When true, hint that other Reticulum apps may conflict via shared instance. */
+  shareInstanceEnabled?: boolean;
 }
 
-/** Sidecar stderr/stdout issues: unreachable TCP hubs and TX queue drops. */
-export function ReticulumSidecarIssueAlertsBlock({ alert }: ReticulumSidecarIssueAlertsBlockProps) {
+function countSidecarIssues(alert: ReticulumInterfaceIssueAlert): number {
+  return (
+    alert.tcpConnectFailed.length +
+    alert.txQueueDrops.length +
+    alert.linkDeliveryTimeouts.length +
+    (alert.transportSaturatedCount > 0 ? 1 : 0) +
+    (alert.slowTransportQueryCount > 0 ? 1 : 0)
+  );
+}
+
+/** Sidecar stderr/stdout issues: unreachable TCP hubs, TX queue drops, and transport health. */
+export function ReticulumSidecarIssueAlertsBlock({
+  alert,
+  shareInstanceEnabled = false,
+}: ReticulumSidecarIssueAlertsBlockProps) {
   const { t } = useTranslation();
-  const issueCount = alert.tcpConnectFailed.length + alert.txQueueDrops.length;
+  const issueCount = countSidecarIssues(alert);
   if (issueCount === 0) {
     return null;
   }
+
+  const showShareInstanceHint =
+    shareInstanceEnabled &&
+    (alert.linkDeliveryTimeouts.length > 0 ||
+      alert.transportSaturatedCount > 0 ||
+      alert.txQueueDrops.length > 0);
 
   return (
     <div
@@ -44,7 +65,49 @@ export function ReticulumSidecarIssueAlertsBlock({ alert }: ReticulumSidecarIssu
             </p>
           </li>
         ))}
+        {alert.linkDeliveryTimeouts.map(({ destinationHash, count }) => (
+          <li key={`link-${destinationHash}`}>
+            <p>
+              {t('connectionPanel.reticulumSidecarIssues.linkDeliveryTimeout', {
+                hash: destinationHash.slice(0, 8),
+                count,
+              })}
+            </p>
+            <p className="text-muted mt-0.5 text-[11px]">
+              {t('connectionPanel.reticulumSidecarIssues.linkDeliveryTimeoutHint')}
+            </p>
+          </li>
+        ))}
+        {alert.transportSaturatedCount > 0 ? (
+          <li key="transport-saturated">
+            <p>
+              {t('connectionPanel.reticulumSidecarIssues.transportSaturated', {
+                count: alert.transportSaturatedCount,
+              })}
+            </p>
+            <p className="text-muted mt-0.5 text-[11px]">
+              {t('connectionPanel.reticulumSidecarIssues.transportSaturatedHint')}
+            </p>
+          </li>
+        ) : null}
+        {alert.slowTransportQueryCount > 0 ? (
+          <li key="slow-transport">
+            <p>
+              {t('connectionPanel.reticulumSidecarIssues.slowTransportQuery', {
+                count: alert.slowTransportQueryCount,
+              })}
+            </p>
+            <p className="text-muted mt-0.5 text-[11px]">
+              {t('connectionPanel.reticulumSidecarIssues.slowTransportQueryHint')}
+            </p>
+          </li>
+        ) : null}
       </ul>
+      {showShareInstanceHint ? (
+        <p className="text-muted mt-2 text-[11px]">
+          {t('connectionPanel.reticulumSidecarIssues.shareInstanceHint')}
+        </p>
+      ) : null}
       {alert.suppressedCount > 0 ? (
         <p className="text-muted mt-2 text-[11px]">
           {t('connectionPanel.reticulumSidecarIssues.suppressed', {

--- a/src/renderer/components/ReticulumStackPanel.test.tsx
+++ b/src/renderer/components/ReticulumStackPanel.test.tsx
@@ -59,6 +59,14 @@ describe('ReticulumStackPanel', () => {
           ports: [{ path: '/dev/cu.usbserial-0001', label: 'usbserial-0001' }],
         });
       }
+      if (path === '/api/v1/stack/settings') {
+        return Promise.resolve({
+          enable_transport: true,
+          share_instance: false,
+          loglevel: 4,
+          announce_interval_sec: 3600,
+        });
+      }
       return Promise.resolve({});
     });
     window.electronAPI.reticulum.onStatus = vi.fn().mockReturnValue(() => {});
@@ -234,6 +242,9 @@ describe('ReticulumStackPanel', () => {
     const issueAlert = {
       tcpConnectFailed: ['RNS HAM RADIO'],
       txQueueDrops: [{ name: 'RNS HAM RADIO', dropCount: 128 }],
+      linkDeliveryTimeouts: [],
+      transportSaturatedCount: 0,
+      slowTransportQueryCount: 0,
       suppressedCount: 0,
       lastAtMs: Date.now(),
     };

--- a/src/renderer/components/ReticulumStackPanel.tsx
+++ b/src/renderer/components/ReticulumStackPanel.tsx
@@ -7,6 +7,7 @@ import {
   collectReticulumLocalInterfaceConnecting,
   type ReticulumLocalInterfaceAlert,
 } from '@/renderer/lib/reticulum/reticulumLocalInterfaceHealth';
+import { parseReticulumStackSettingsPayload } from '@/renderer/lib/reticulum/reticulumStackSettings';
 import { useReticulumInterfaceSnapshot } from '@/renderer/lib/reticulum/useReticulumInterfaceSnapshot';
 import { useReticulumSidecarApi } from '@/renderer/lib/reticulum/useReticulumSidecarApi';
 import type { ReticulumSidecarEvent } from '@/shared/reticulum-types';
@@ -37,6 +38,7 @@ export function ReticulumStackPanel({
 }: ReticulumStackPanelProps) {
   const { t } = useTranslation();
   const [restartError, setRestartError] = useState<string | null>(null);
+  const [shareInstanceSetting, setShareInstanceSetting] = useState(false);
   const sidecarEventRef = useRef<(evt: ReticulumSidecarEvent) => void>(() => {});
 
   const {
@@ -81,6 +83,25 @@ export function ReticulumStackPanel({
       void refreshSidecarStatus();
     }
   }, [interfaces, sidecarApiReady, sidecarUiRunning, refreshSidecarStatus]);
+
+  useEffect(() => {
+    if (!sidecarApiReady || !sidecarUiRunning) return;
+    let cancelled = false;
+    void window.electronAPI.reticulum
+      .proxyGet('/api/v1/stack/settings')
+      .then((raw) => {
+        if (cancelled) return;
+        setShareInstanceSetting(parseReticulumStackSettingsPayload(raw).share_instance);
+      })
+      .catch(() => {
+        if (!cancelled) setShareInstanceSetting(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sidecarApiReady, sidecarUiRunning, sidecarStatus.interfaceIssueAlert?.lastAtMs]);
+
+  const shareInstanceEnabled = sidecarApiReady && sidecarUiRunning && shareInstanceSetting;
 
   const localAlerts = useMemo(
     (): ReticulumLocalInterfaceAlert[] =>
@@ -156,7 +177,10 @@ export function ReticulumStackPanel({
           <>
             <ReticulumLocalInterfaceConnectingBlock interfaces={connectingInterfaces} />
             {sidecarStatus.interfaceIssueAlert ? (
-              <ReticulumSidecarIssueAlertsBlock alert={sidecarStatus.interfaceIssueAlert} />
+              <ReticulumSidecarIssueAlertsBlock
+                alert={sidecarStatus.interfaceIssueAlert}
+                shareInstanceEnabled={shareInstanceEnabled}
+              />
             ) : null}
             <ReticulumLocalInterfaceAlertsBlock
               alerts={localAlerts}

--- a/src/renderer/lib/diagnostics/ReticulumDiagnosticEngine.test.ts
+++ b/src/renderer/lib/diagnostics/ReticulumDiagnosticEngine.test.ts
@@ -82,6 +82,9 @@ describe('ReticulumDiagnosticEngine', () => {
         interfaceIssueAlert: {
           tcpConnectFailed: ['RNS HAM RADIO'],
           txQueueDrops: [{ name: 'RNS HAM RADIO', dropCount: 128 }],
+          linkDeliveryTimeouts: [],
+          transportSaturatedCount: 0,
+          slowTransportQueryCount: 0,
           suppressedCount: 0,
           lastAtMs: Date.now(),
         },
@@ -97,6 +100,37 @@ describe('ReticulumDiagnosticEngine', () => {
       (r): r is RfDiagnosticRow => r.kind === 'rf' && r.condition === 'reticulum/tx-queue-drops',
     );
     expect(dropRow?.severity).toBe('error');
+  });
+
+  it('adds link timeout and transport saturation rows from sidecar alerts', () => {
+    const rows = buildReticulumDiagnosticRows(
+      { rns_ready: true, lxmf_ready: true, interface_count: 1, peer_count: 1 },
+      {
+        interfaceIssueAlert: {
+          tcpConnectFailed: [],
+          txQueueDrops: [],
+          linkDeliveryTimeouts: [{ destinationHash: '5526a65d0b4d23448206fd3485b76f5b', count: 3 }],
+          transportSaturatedCount: 42,
+          slowTransportQueryCount: 2,
+          suppressedCount: 0,
+          lastAtMs: Date.now(),
+        },
+        shareInstanceEnabled: true,
+      },
+    );
+    expect(
+      rows.some((r) => r.kind === 'rf' && r.condition === 'reticulum/link-delivery-timeout'),
+    ).toBe(true);
+    const saturated = rows.find(
+      (r): r is RfDiagnosticRow =>
+        r.kind === 'rf' && r.condition === 'reticulum/transport-saturated',
+    );
+    expect(saturated?.causeI18n?.key).toBe(
+      'diagnosticsPanel.reticulum.runtime.transportSaturatedShareInstance',
+    );
+    expect(
+      rows.some((r) => r.kind === 'rf' && r.condition === 'reticulum/slow-transport-query'),
+    ).toBe(true);
   });
 
   it('flags stale local serial port separately from generic interface-down', () => {

--- a/src/renderer/lib/diagnostics/ReticulumDiagnosticEngine.ts
+++ b/src/renderer/lib/diagnostics/ReticulumDiagnosticEngine.ts
@@ -33,6 +33,8 @@ export interface ReticulumDiagnosticsBuildOptions {
   auditIssues?: ReticulumConfigAuditIssue[];
   autoBeaconAlert?: ReticulumAutoBeaconAlert | null;
   interfaceIssueAlert?: ReticulumInterfaceIssueAlert | null;
+  /** When true, append shared-instance conflict hint on transport saturation rows. */
+  shareInstanceEnabled?: boolean;
 }
 
 function runtimeCauseI18n(
@@ -55,6 +57,10 @@ export const RETICULUM_RUNTIME_CAUSE_I18N_KEYS = [
   'diagnosticsPanel.reticulum.runtime.noPeers',
   'diagnosticsPanel.reticulum.runtime.autoBeaconTunnelOnly',
   'diagnosticsPanel.reticulum.runtime.autoBeaconPhysicalFailures',
+  'diagnosticsPanel.reticulum.runtime.linkDeliveryTimeout',
+  'diagnosticsPanel.reticulum.runtime.transportSaturated',
+  'diagnosticsPanel.reticulum.runtime.transportSaturatedShareInstance',
+  'diagnosticsPanel.reticulum.runtime.slowTransportQuery',
 ] as const;
 
 /** Build Reticulum-native diagnostic rows (interface/path/LXMF — not LoRa RF). */
@@ -220,6 +226,55 @@ export function buildReticulumDiagnosticRows(
         detectedAt: now,
         reticulumInterfaceId: iface?.id,
         reticulumRepairKind: 'disable',
+      });
+    }
+    for (const timeout of interfaceIssueAlert.linkDeliveryTimeouts) {
+      rows.push({
+        kind: 'rf',
+        id: rfRowId(homeNodeId, `reticulum/link-delivery-timeout/${timeout.destinationHash}`),
+        nodeId: homeNodeId,
+        condition: 'reticulum/link-delivery-timeout',
+        cause: `Direct LXMF link to ${timeout.destinationHash.slice(0, 8)}… timed out (${timeout.count}×)`,
+        causeI18n: runtimeCauseI18n('linkDeliveryTimeout', {
+          hash: timeout.destinationHash.slice(0, 8),
+          count: String(timeout.count),
+        }),
+        severity: 'error',
+        detectedAt: now,
+        reticulumRepairKind: 'restart_stack',
+      });
+    }
+    if (interfaceIssueAlert.transportSaturatedCount > 0) {
+      rows.push({
+        kind: 'rf',
+        id: rfRowId(homeNodeId, 'reticulum/transport-saturated'),
+        nodeId: homeNodeId,
+        condition: 'reticulum/transport-saturated',
+        cause: `RNS transport saturated (${interfaceIssueAlert.transportSaturatedCount} path-request drops)`,
+        causeI18n: runtimeCauseI18n(
+          options?.shareInstanceEnabled ? 'transportSaturatedShareInstance' : 'transportSaturated',
+          {
+            count: String(interfaceIssueAlert.transportSaturatedCount),
+          },
+        ),
+        severity: 'error',
+        detectedAt: now,
+        reticulumRepairKind: 'restart_stack',
+      });
+    }
+    if (interfaceIssueAlert.slowTransportQueryCount > 0) {
+      rows.push({
+        kind: 'rf',
+        id: rfRowId(homeNodeId, 'reticulum/slow-transport-query'),
+        nodeId: homeNodeId,
+        condition: 'reticulum/slow-transport-query',
+        cause: `RNS transport queries slow or failing (${interfaceIssueAlert.slowTransportQueryCount}×)`,
+        causeI18n: runtimeCauseI18n('slowTransportQuery', {
+          count: String(interfaceIssueAlert.slowTransportQueryCount),
+        }),
+        severity: 'warning',
+        detectedAt: now,
+        reticulumRepairKind: 'restart_stack',
       });
     }
   }

--- a/src/renderer/lib/reticulum/reticulumOutboundFailureBridge.test.ts
+++ b/src/renderer/lib/reticulum/reticulumOutboundFailureBridge.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  registerReticulumDestinationHash,
+  reticulumHashToNodeId,
+} from '@/renderer/lib/reticulum/destHash';
+import { failReticulumSendingOutboundToDestHash } from '@/renderer/lib/reticulum/reticulumOutboundFailureBridge';
+import { useMessageStore } from '@/renderer/stores/messageStore';
+
+const DEST = '5526a65d0b4d23448206fd3485b76f5b';
+const identityId = 'reticulum-test';
+
+describe('failReticulumSendingOutboundToDestHash', () => {
+  beforeEach(() => {
+    useMessageStore.setState({ messages: {} });
+  });
+
+  it('marks sending outbound messages to the destination as failed', () => {
+    const toNodeId = reticulumHashToNodeId(DEST);
+    registerReticulumDestinationHash(toNodeId, DEST);
+    useMessageStore.setState({
+      messages: {
+        [identityId]: {
+          'msg-hash': {
+            id: 'msg-hash',
+            from: 1,
+            senderName: 'self',
+            payload: 'hello',
+            channelIndex: 0,
+            timestamp: Date.now(),
+            status: 'sending',
+            to: toNodeId,
+          },
+        },
+      },
+    });
+
+    const count = failReticulumSendingOutboundToDestHash(identityId, DEST, 'send failed');
+    expect(count).toBe(1);
+    expect(useMessageStore.getState().messages[identityId]?.['msg-hash']?.status).toBe('failed');
+  });
+});

--- a/src/renderer/lib/reticulum/reticulumOutboundFailureBridge.ts
+++ b/src/renderer/lib/reticulum/reticulumOutboundFailureBridge.ts
@@ -1,0 +1,43 @@
+import { resolveReticulumDestinationHash } from '@/renderer/lib/reticulum/destHash';
+import type { IdentityId } from '@/renderer/lib/types';
+import { updateMessageStatus, useMessageStore } from '@/renderer/stores/messageStore';
+import { reticulumHashForNodeId } from '@/renderer/stores/reticulumPeerStore';
+
+function normalizeDestHash(hash: string): string {
+  return hash.replace(/[^0-9a-f]/gi, '').toLowerCase();
+}
+
+function destHashMatchesPeer(storedHash: string, targetNorm: string): boolean {
+  const storedNorm = normalizeDestHash(storedHash);
+  if (!storedNorm || !targetNorm) return false;
+  if (storedNorm === targetNorm) return true;
+  if (storedNorm.length >= 32 && targetNorm.length >= 16) {
+    return storedNorm.startsWith(targetNorm) || targetNorm.startsWith(storedNorm);
+  }
+  return false;
+}
+
+function resolveOutboundDestHash(toNodeId: number | undefined): string | null {
+  if (toNodeId == null) return null;
+  return reticulumHashForNodeId(toNodeId) ?? resolveReticulumDestinationHash(toNodeId);
+}
+
+/** Mark in-memory outbound LXMF rows as failed when direct link delivery times out. */
+export function failReticulumSendingOutboundToDestHash(
+  identityId: IdentityId,
+  destinationHash: string,
+  errorMessage: string,
+): number {
+  const targetNorm = normalizeDestHash(destinationHash);
+  if (!targetNorm) return 0;
+  const bucket = useMessageStore.getState().messages[identityId] ?? {};
+  let count = 0;
+  for (const msg of Object.values(bucket)) {
+    if (msg.status !== 'sending' || msg.to == null) continue;
+    const destHash = resolveOutboundDestHash(msg.to);
+    if (!destHash || !destHashMatchesPeer(destHash, targetNorm)) continue;
+    updateMessageStatus(identityId, msg.id, 'failed', errorMessage);
+    count += 1;
+  }
+  return count;
+}

--- a/src/renderer/lib/reticulum/reticulumPropagationEffective.test.ts
+++ b/src/renderer/lib/reticulum/reticulumPropagationEffective.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PropagationNodeRow } from '@/renderer/stores/reticulumPropagationStore';
+
+import { hasEffectiveReticulumPropagationTarget } from './reticulumPropagationEffective';
+
+const remoteNode: PropagationNodeRow = {
+  id: 'remote-1',
+  name: 'Remote lxmd',
+  enabled: true,
+  status: 'online',
+  hops: 2,
+};
+
+describe('hasEffectiveReticulumPropagationTarget', () => {
+  it('returns false when mode is off and nothing is preferred', () => {
+    expect(hasEffectiveReticulumPropagationTarget([remoteNode], null, 'off')).toBe(false);
+  });
+
+  it('returns true when preferred remote is set even if sync mode is off', () => {
+    expect(hasEffectiveReticulumPropagationTarget([remoteNode], 'remote-1', 'off')).toBe(true);
+  });
+
+  it('returns false when only local-prop is enabled', () => {
+    const localOnly: PropagationNodeRow = {
+      id: 'local-prop',
+      name: 'Local inbox',
+      enabled: true,
+      status: 'online',
+    };
+    expect(hasEffectiveReticulumPropagationTarget([localOnly], null, 'auto')).toBe(false);
+  });
+
+  it('returns true when auto mode finds an enabled remote node', () => {
+    expect(hasEffectiveReticulumPropagationTarget([remoteNode], null, 'auto')).toBe(true);
+  });
+
+  it('returns true when preferred id is set before the node list loads', () => {
+    expect(hasEffectiveReticulumPropagationTarget([], 'remote-1', 'auto')).toBe(true);
+  });
+
+  it('returns true when preferred matches destination_hash', () => {
+    const withHash: PropagationNodeRow = {
+      ...remoteNode,
+      destination_hash: 'aa'.repeat(16),
+    };
+    expect(hasEffectiveReticulumPropagationTarget([withHash], 'aa'.repeat(16), 'manual')).toBe(
+      true,
+    );
+  });
+
+  it('returns false when preferred remote is disabled', () => {
+    const disabled: PropagationNodeRow = { ...remoteNode, enabled: false };
+    expect(hasEffectiveReticulumPropagationTarget([disabled], 'remote-1', 'manual')).toBe(false);
+  });
+
+  it('returns true when a node is flagged preferred and enabled', () => {
+    const flagged: PropagationNodeRow = { ...remoteNode, preferred: true };
+    expect(hasEffectiveReticulumPropagationTarget([flagged], null, 'manual')).toBe(true);
+  });
+
+  it('returns true when manual mode has a preferred remote node', () => {
+    expect(hasEffectiveReticulumPropagationTarget([remoteNode], 'remote-1', 'manual')).toBe(true);
+  });
+});

--- a/src/renderer/lib/reticulum/reticulumPropagationEffective.ts
+++ b/src/renderer/lib/reticulum/reticulumPropagationEffective.ts
@@ -1,0 +1,47 @@
+import {
+  pickAutoPropagationNodeId,
+  readReticulumPropagationMode,
+  type ReticulumPropagationMode,
+} from '@/renderer/lib/reticulum/reticulumPropagationMode';
+import type { PropagationNodeRow } from '@/renderer/stores/reticulumPropagationStore';
+
+function isRemotePropagationId(id: string | null | undefined): id is string {
+  return Boolean(id && id !== 'local-prop');
+}
+
+function findPropagationNode(
+  nodes: PropagationNodeRow[],
+  id: string,
+): PropagationNodeRow | undefined {
+  return nodes.find((n) => n.id === id || n.destination_hash === id);
+}
+
+/**
+ * True when a remote (non-local-prop) propagation node can carry offline LXMF.
+ *
+ * Preferred sidecar outbound node wins over App sync mode — Mode "Off" only
+ * disables periodic sync, not the presence of an outbound propagation target.
+ */
+export function hasEffectiveReticulumPropagationTarget(
+  nodes: PropagationNodeRow[],
+  preferredId: string | null,
+  mode: ReticulumPropagationMode = readReticulumPropagationMode(),
+): boolean {
+  if (isRemotePropagationId(preferredId)) {
+    const preferred = findPropagationNode(nodes, preferredId);
+    // Prefer sidecar preferred_id even while the node list is still loading.
+    if (!preferred) return true;
+    return preferred.enabled;
+  }
+
+  if (nodes.some((n) => n.preferred === true && isRemotePropagationId(n.id) && n.enabled)) {
+    return true;
+  }
+
+  // Auto / manual without preferred: any enabled remote counts for offline fallback
+  // capacity. Mode "off" skips inventing a target when none is preferred.
+  if (mode === 'off') return false;
+  if (mode === 'manual') return false;
+
+  return pickAutoPropagationNodeId(nodes) != null;
+}

--- a/src/renderer/lib/reticulum/useReticulumPropagationAutoSync.ts
+++ b/src/renderer/lib/reticulum/useReticulumPropagationAutoSync.ts
@@ -23,6 +23,9 @@ export function useReticulumPropagationAutoSync(sidecarReady: boolean): void {
   useEffect(() => {
     if (!sidecarReady) return;
 
+    // Keep preferred/nodes fresh for Chat notice + auto-sync even if Network tab was never opened.
+    void useReticulumPropagationStore.getState().refreshFromSidecar();
+
     const tick = () => {
       const { autoSyncIntervalSec, preferredId, sync, lastPropagationSyncAt, startSync } =
         useReticulumPropagationStore.getState();

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Zakažte toto rozhraní v níže uvedeném seznamu nebo potvrďte, že je spuštěn vzdálený rozbočovač.",
       "txQueueDrops": "{{name}}: odchozí pakety byly vyhozeny ({{count}} ve frontě)",
       "txQueueDropsHint": "Obvykle je to způsobeno stále povoleným mrtvým rozhraním TCP. Zakažte nedosažitelné rozbočovače pro zastavení přetečení fronty.",
-      "suppressed": "{{count}} podobné řádky protokolu postranního vozíku byly nedávno potlačeny."
+      "suppressed": "{{count}} podobné řádky protokolu postranního vozíku byly nedávno potlačeny.",
+      "linkDeliveryTimeout": "Přímý odkaz LXMF na {{hash}}… vypršel ({{count}}×)",
+      "linkDeliveryTimeoutHint": "Protějšek může být offline nebo je transport RNS přetížen. DM mohou zůstat na Odesílání, dokud se odkaz nezdaří.",
+      "transportSaturated": "Nasycený transport RNS ({{count}} kapek s požadavkem na cestu)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "Transportní dotazy RNS pomalé nebo selhávající ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "Sdílená instance je povolena — zcela ukončete ostatní aplikace Reticulum (MeshChatX, Ratspeak, samostatný rnsd) a restartujte tento zásobník před opakováním DM."
     },
     "reticulumSidecarBundledMissing": "V této instalaci chybí přibalený Reticulum sidecar. Upgradujte na novější verzi nebo nahlaste problém – sestavení ze zdroje není v balených instalacích k dispozici.",
     "radioMqttRootDivergesWarning": "Kořenové téma rádia MQTT je {{radioRoot}}, ale tento panel odebírá {{appPrefix}}. Přizpůsobením rádia omezíte celostátní provoz uzlů — aktualizujte předponu tématu a znovu připojte MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "Beacon AutoInterface TX selhává na {{ifaces}} — lokální zjišťování LAN nemusí fungovat, dokud to nebude opraveno.",
         "tcpUnreachable": "Centrum TCP „{{name}}“ je nedosažitelné ({{host}}:{{port}})",
         "tcpConnectFailed": "Připojení TCP hub „{{name}}“ bylo odmítnuto nebo vypršel časový limit",
-        "txQueueDrops": "Rozhraní „{{name}}“ upustilo {{count}} odchozí pakety (fronta TX je plná)"
+        "txQueueDrops": "Rozhraní „{{name}}“ upustilo {{count}} odchozí pakety (fronta TX je plná)",
+        "linkDeliveryTimeout": "Přímý odkaz LXMF na {{hash}}… vypršel ({{count}}×)",
+        "transportSaturated": "Nasycený transport RNS ({{count}} LXMF kapek vyžadujících cestu)",
+        "transportSaturatedShareInstance": "Nasycený transport RNS ({{count}} kapek s požadavkem na cestu). Sdílená instance je zapnutá — ukončete ostatní aplikace Reticulum (MeshChatX, Ratspeak, rnsd) a restartujte zásobník.",
+        "slowTransportQuery": "Transportní dotazy RNS pomalé nebo selhávající ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Každých 12 hodin",
     "autoSyncOption24h": "Každých 24 hodin",
     "lastSynced": "Poslední synchronizace: {{time}}",
-    "lastRefreshed": "Poslední aktualizace {{time}}"
+    "lastRefreshed": "Poslední aktualizace {{time}}",
+    "notice": {
+      "body": "Není nakonfigurován žádný propagační uzel. Offline nebo nedosažitelné protějšky potřebují propagační uzel pro doručování LXMF v obchodě a dopředu.",
+      "openSettings": "Nastavit propagaci",
+      "openSettingsAria": "Otevřít nastavení propagace sítě Reticulum"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Režim propagace",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Deaktivieren Sie diese Schnittstelle in der folgenden Liste oder bestätigen Sie, dass der Remote-Hub ausgeführt wird.",
       "txQueueDrops": "{{name}}: ausgehende Pakete abgelegt ({{count}} in der Warteschlange)",
       "txQueueDropsHint": "In der Regel verursacht durch eine tote TCP-Schnittstelle, die immer noch aktiviert ist. Deaktivieren Sie nicht erreichbare Hubs, um den Warteschlangenüberlauf zu stoppen.",
-      "suppressed": "{{count}} ähnliche Sidecar-Log-Linien wurden kürzlich unterdrückt."
+      "suppressed": "{{count}} ähnliche Sidecar-Log-Linien wurden kürzlich unterdrückt.",
+      "linkDeliveryTimeout": "Direkter LXMF-Link zu {{hash}}… Zeitüberschreitung ({{count}}×)",
+      "linkDeliveryTimeoutHint": "Der Peer kann offline sein oder der RNS-Transport ist überlastet. DMs können beim Senden bleiben, bis der Link ausfällt.",
+      "transportSaturated": "RNS-Transport gesättigt ({{count}} Path-Request-Drops)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "RNS-Transportabfragen langsam oder fehlgeschlagen ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "Share-Instanz ist aktiviert — beenden Sie vollständig andere Reticulum-Apps (MeshChatX, Ratspeak, Standalone-RNSD) und starten Sie diesen Stack neu, bevor Sie DMs erneut versuchen."
     },
     "reticulumSidecarBundledMissing": "Bei dieser Installation fehlt der mitgelieferte Reticulum-Sidecar. Führen Sie ein Upgrade auf eine neuere Version durch oder melden Sie das Problem – das Erstellen aus dem Quellcode ist bei Paketinstallationen nicht verfügbar.",
     "radioMqttRootDivergesWarning": "Das Hauptthema von Radio MQTT ist {{radioRoot}}, aber dieses Panel abonniert {{appPrefix}}. Passen Sie das Funkgerät an, um den landesweiten Knotenverkehr zu begrenzen — aktualisieren Sie das Themenpräfix und verbinden Sie MQTT erneut.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "AutoInterface-Beacon TX schlägt auf {{ifaces}} fehl — die lokale LAN-Erkennung funktioniert möglicherweise nicht, bis dies behoben ist.",
         "tcpUnreachable": "TCP-Hub „{{name}}“ ist nicht erreichbar ({{host}}:{{port}})",
         "tcpConnectFailed": "TCP Hub \"{{name}}\" Verbindung abgelehnt oder Zeitüberschreitung",
-        "txQueueDrops": "Schnittstelle „{{name}}“ abgeworfen {{count}} ausgehende Pakete (TX-Warteschlange voll)"
+        "txQueueDrops": "Schnittstelle „{{name}}“ abgeworfen {{count}} ausgehende Pakete (TX-Warteschlange voll)",
+        "linkDeliveryTimeout": "Direkter LXMF-Link zu {{hash}}… Zeitüberschreitung ({{count}}×)",
+        "transportSaturated": "RNS-Transport gesättigt ({{count}} LXMF-Pfadanforderung fällt ab)",
+        "transportSaturatedShareInstance": "RNS-Transport gesättigt ({{count}} Path-Request-Drops). Share-Instanz ist aktiviert — beenden Sie andere Reticulum-Apps (MeshChatX, Ratspeak, rnsd) und starten Sie den Stack neu.",
+        "slowTransportQuery": "RNS-Transportabfragen langsam oder fehlgeschlagen ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Alle 12 Stunden",
     "autoSyncOption24h": "Alle 24 Stunden",
     "lastSynced": "Zuletzt synchronisiert: {{time}}",
-    "lastRefreshed": "Letzte Aktualisierung {{time}}"
+    "lastRefreshed": "Letzte Aktualisierung {{time}}",
+    "notice": {
+      "body": "Es ist kein Ausbreitungsknoten konfiguriert. Offline- oder nicht erreichbare Peers benötigen einen Ausbreitungsknoten für die Store-and-Forward-LXMF-Bereitstellung.",
+      "openSettings": "Ausbreitung einrichten",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Ausbreitungsmodus",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -716,6 +716,13 @@
       "tcpConnectFailedHint": "Disable this interface in the list below or confirm the remote hub is running.",
       "txQueueDrops": "{{name}}: outbound packets dropped ({{count}} queued)",
       "txQueueDropsHint": "Usually caused by a dead TCP interface still enabled. Disable unreachable hubs to stop queue overflow.",
+      "linkDeliveryTimeout": "Direct LXMF link to {{hash}}… timed out ({{count}}×)",
+      "linkDeliveryTimeoutHint": "The peer may be offline or the RNS transport is overloaded. DMs may stay on Sending until the link fails.",
+      "transportSaturated": "RNS transport saturated ({{count}} path-request drops)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "RNS transport queries slow or failing ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "Share instance is enabled — fully quit other Reticulum apps (MeshChatX, Ratspeak, standalone rnsd) and restart this stack before retrying DMs.",
       "suppressed": "{{count}} similar sidecar log lines suppressed recently."
     },
     "reticulumNetworkEmpty": "No interfaces reported yet.",
@@ -1350,6 +1357,10 @@
         "interfaceDown": "{{type}} interface \"{{name}}\" is enabled but {{status}}",
         "tcpConnectFailed": "TCP hub \"{{name}}\" connection refused or timed out",
         "txQueueDrops": "Interface \"{{name}}\" dropped {{count}} outbound packets (TX queue full)",
+        "linkDeliveryTimeout": "Direct LXMF link to {{hash}}… timed out ({{count}}×)",
+        "transportSaturated": "RNS transport saturated ({{count}} LXMF path-request drops)",
+        "transportSaturatedShareInstance": "RNS transport saturated ({{count}} path-request drops). Share instance is on — quit other Reticulum apps (MeshChatX, Ratspeak, rnsd) and restart the stack.",
+        "slowTransportQuery": "RNS transport queries slow or failing ({{count}}×)",
         "noPeers": "No known peers in path table yet",
         "autoBeaconTunnelOnly": "AutoInterface beacon TX is failing on VPN tunnel interface(s) {{ifaces}}. Rebuild the Reticulum sidecar or temporarily disable AutoInterface if logs are flooded.",
         "autoBeaconPhysicalFailures": "AutoInterface beacon TX is failing on {{ifaces}} — local LAN discovery may not work until this is fixed."
@@ -3545,6 +3556,11 @@
     "iconUser": "User"
   },
   "reticulumPropagation": {
+    "notice": {
+      "body": "No propagation node is configured. Offline or unreachable peers need a propagation node for store-and-forward LXMF delivery.",
+      "openSettings": "Set up propagation",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    },
     "preferred": "Preferred",
     "setPreferred": "Set preferred",
     "syncNow": "Sync messages",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Deshabilite esta interfaz en la lista a continuación o confirme que el concentrador remoto se está ejecutando.",
       "txQueueDrops": "{{name}}: paquetes salientes descartados ({{count}} en cola)",
       "txQueueDropsHint": "Por lo general, es causada por una interfaz TCP muerta que aún está habilitada. Deshabilite los concentradores inalcanzables para detener el desbordamiento de la cola.",
-      "suppressed": "{{count}} líneas de registro de sidecar similares suprimidas recientemente."
+      "suppressed": "{{count}} líneas de registro de sidecar similares suprimidas recientemente.",
+      "linkDeliveryTimeout": "Enlace directo de LXMF a {{hash}}… agotado ({{count}}×)",
+      "linkDeliveryTimeoutHint": "El par puede estar fuera de línea o el transporte RNS está sobrecargado. Los DM pueden permanecer en Envío hasta que el enlace falle.",
+      "transportSaturated": "Transporte RNS saturado (caídas de solicitud de ruta {{count}})",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "Consultas de transporte RNS lentas o fallidas ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "La instancia compartida está habilitada: salga por completo de otras aplicaciones de Reticulum (MeshChatX, Ratspeak, rnsd independiente) y reinicie esta pila antes de volver a intentar DM."
     },
     "reticulumSidecarBundledMissing": "A esta instalación le falta el sidecar Reticulum incluido. Actualice a una versión más reciente o informe el problema: la compilación desde el código fuente no está disponible en instalaciones empaquetadas.",
     "radioMqttRootDivergesWarning": "El tema raíz de MQTT de radio es {{radioRoot}}, pero este panel se suscribe a {{appPrefix}}. Haga coincidir la radio para limitar el tráfico de nodos a nivel nacional: actualice el prefijo del tema y vuelva a conectar MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "La baliza de interfaz automática TX está fallando en {{ifaces}}; es posible que el descubrimiento de LAN local no funcione hasta que se solucione.",
         "tcpUnreachable": "No se puede acceder al centro TCP \"{{name}}\" ({{host}}:{{port}})",
         "tcpConnectFailed": "Conexión TCP Hub \"{{name}}\" rechazada o agotada",
-        "txQueueDrops": "La interfaz \"{{name}}\" eliminó {{count}} paquetes salientes (cola TX llena)"
+        "txQueueDrops": "La interfaz \"{{name}}\" eliminó {{count}} paquetes salientes (cola TX llena)",
+        "linkDeliveryTimeout": "Enlace directo de LXMF a {{hash}}… agotado ({{count}}×)",
+        "transportSaturated": "Transporte RNS saturado (caídas de solicitud de ruta {{count}} LXMF)",
+        "transportSaturatedShareInstance": "Transporte RNS saturado (caídas de solicitud de ruta {{count}}). La instancia de Share está activada: salga de otras aplicaciones de Reticulum (MeshChatX, Ratspeak, rnsd) y reinicie la pila.",
+        "slowTransportQuery": "Consultas de transporte RNS lentas o fallidas ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Cada 12 horas",
     "autoSyncOption24h": "Cada 24 horas",
     "lastSynced": "Última sincronización: {{time}}",
-    "lastRefreshed": "Última actualización {{time}}"
+    "lastRefreshed": "Última actualización {{time}}",
+    "notice": {
+      "body": "No hay ningún nodo de propagación configurado. Los pares fuera de línea o inalcanzables necesitan un nodo de propagación para la entrega de LXMF de almacenamiento y reenvío.",
+      "openSettings": "Configurar propagación",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "modo de propagación",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Désactivez cette interface dans la liste ci-dessous ou confirmez que le concentrateur distant est en cours d'exécution.",
       "txQueueDrops": "{{name}} : paquets sortants abandonnés ({{count}} en file d'attente)",
       "txQueueDropsHint": "Généralement causé par une interface TCP morte toujours activée. Désactivez les concentrateurs inaccessibles pour arrêter le débordement de la file d'attente.",
-      "suppressed": "{{count}} lignes de bûches de side-car similaires supprimées récemment."
+      "suppressed": "{{count}} lignes de bûches de side-car similaires supprimées récemment.",
+      "linkDeliveryTimeout": "Lien LXMF direct vers {{hash}}… expiré ({{count}}×)",
+      "linkDeliveryTimeoutHint": "L'homologue peut être hors ligne ou le transport RNS est surchargé. Les DM peuvent rester à l'envoi jusqu'à ce que le lien échoue.",
+      "transportSaturated": "Transport RNS saturé ({{count}} gouttes de demande de chemin)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "Requêtes de transport RNS lentes ou en échec ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "L'instance de partage est activée — quittez complètement les autres applications Reticulum (MeshChatX, Ratspeak, rnsd autonome) et redémarrez cette pile avant de réessayer les DM."
     },
     "reticulumSidecarBundledMissing": "Cette installation ne dispose pas du side-car Reticulum fourni. Effectuez une mise à niveau vers une version plus récente ou signalez le problème : la création à partir des sources n'est pas disponible dans les installations packagées.",
     "radioMqttRootDivergesWarning": "Le sujet racine du MQTT radio est {{radioRoot}}, mais ce panneau est abonné à {{appPrefix}}. Faites correspondre la radio pour limiter le trafic des nœuds à l'échelle nationale — mettez à jour le préfixe du sujet et reconnectez le MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "La balise AutoInterface TX échoue sur {{ifaces}} — la découverte du LAN local peut ne pas fonctionner tant que cela n'est pas corrigé.",
         "tcpUnreachable": "Le concentrateur TCP « {{name}} » est inaccessible ({{host}} :{{port}})",
         "tcpConnectFailed": "La connexion du concentrateur TCP « {{name}} » a été refusée ou a expiré",
-        "txQueueDrops": "L'interface « {{name}} » a supprimé {{count}} paquets sortants (file d'attente TX pleine)"
+        "txQueueDrops": "L'interface « {{name}} » a supprimé {{count}} paquets sortants (file d'attente TX pleine)",
+        "linkDeliveryTimeout": "Lien LXMF direct vers {{hash}}… expiré ({{count}}×)",
+        "transportSaturated": "Transport RNS saturé ({{count}} LXMF path-request drops)",
+        "transportSaturatedShareInstance": "RNS transport saturé ({{count}} path-request drops). L'instance de partage est activée — quittez les autres applications Reticulum (MeshChatX, Ratspeak, rnsd) et redémarrez la pile.",
+        "slowTransportQuery": "Requêtes de transport RNS lentes ou en échec ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Toutes les 12 heures",
     "autoSyncOption24h": "Toutes les 24 heures",
     "lastSynced": "Dernière synchronisation : {{time}}",
-    "lastRefreshed": "Dernière mise à jour {{time}}"
+    "lastRefreshed": "Dernière mise à jour {{time}}",
+    "notice": {
+      "body": "Aucun nœud de propagation n'est configuré. Les pairs hors ligne ou inaccessibles ont besoin d'un nœud de propagation pour la livraison LXMF de stockage et de transfert.",
+      "openSettings": "Configurer la propagation",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "mode de propagation",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Nonaktifkan antarmuka ini dalam daftar di bawah ini atau konfirmasikan bahwa hub jarak jauh sedang berjalan.",
       "txQueueDrops": "{{name}}: paket keluar dijatuhkan (antrean {{count}})",
       "txQueueDropsHint": "Biasanya disebabkan oleh antarmuka TCP mati yang masih diaktifkan. Nonaktifkan hub yang tidak dapat dijangkau untuk menghentikan overflow antrean.",
-      "suppressed": "{{count}} garis log sespan serupa baru - baru ini ditekan."
+      "suppressed": "{{count}} garis log sespan serupa baru - baru ini ditekan.",
+      "linkDeliveryTimeout": "Tautan LXMF langsung ke {{hash}}… waktu habis ({{count}}×)",
+      "linkDeliveryTimeoutHint": "Rekan mungkin offline atau transportasi RNS kelebihan beban. DM mungkin tetap aktif Mengirim sampai tautan gagal.",
+      "transportSaturated": "Transportasi RNS jenuh ({{count}} permintaan jalur turun)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "Kueri transportasi RNS lambat atau gagal ({{count}}×)",
+      "slowTransportQueryHint": "Aktor transportasi sidecar dapat terjepit — nyalakan kembali tumpukan Reticulum.",
+      "shareInstanceHint": "Contoh berbagi diaktifkan — sepenuhnya keluar dari aplikasi Reticulum lainnya (MeshChatX, Ratspeak, rnsd mandiri) dan mulai ulang tumpukan ini sebelum mencoba DM lagi."
     },
     "reticulumSidecarBundledMissing": "Instalasi ini tidak memiliki sespan Reticulum yang dibundel. Tingkatkan versi ke rilis yang lebih baru atau laporkan masalahnya — pembuatan dari sumber tidak tersedia dalam paket instalasi.",
     "radioMqttRootDivergesWarning": "Topik utama Radio MQTT adalah {{radioRoot}} tetapi panel ini berlangganan {{appPrefix}}. Cocokkan radio untuk membatasi lalu lintas simpul nasional — perbarui Prefiks Topik dan sambungkan kembali MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "Suar Antarmuka Otomatis TX gagal pada {{ifaces}} — penemuan Lan lokal mungkin tidak berfungsi sampai ini diperbaiki.",
         "tcpUnreachable": "Hub TCP \"{{name}}\" tidak dapat dijangkau ({{host}}:{{port}})",
         "tcpConnectFailed": "Koneksi hub TCP \"{{name}}\" ditolak atau kehabisan waktu",
-        "txQueueDrops": "Antarmuka \"{{name}}\" menjatuhkan paket keluar {{count}} (antrean TX penuh)"
+        "txQueueDrops": "Antarmuka \"{{name}}\" menjatuhkan paket keluar {{count}} (antrean TX penuh)",
+        "linkDeliveryTimeout": "Tautan LXMF langsung ke {{hash}}… waktu habis ({{count}}×)",
+        "transportSaturated": "Transportasi RNS jenuh ({{count}} permintaan jalur LXMF turun)",
+        "transportSaturatedShareInstance": "Transportasi RNS jenuh ({{count}} permintaan jalur turun). Bagikan instance aktif — keluar dari aplikasi Reticulum lainnya (MeshChatX, Ratspeak, rnsd) dan mulai ulang tumpukan.",
+        "slowTransportQuery": "Kueri transportasi RNS lambat atau gagal ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Setiap 12 jam",
     "autoSyncOption24h": "Setiap 24 jam",
     "lastSynced": "Terakhir disinkronkan: {{time}}",
-    "lastRefreshed": "Terakhir diperbarui {{time}}"
+    "lastRefreshed": "Terakhir diperbarui {{time}}",
+    "notice": {
+      "body": "Tidak ada simpul propagasi yang dikonfigurasi. Peer offline atau tidak terjangkau membutuhkan simpul propagasi untuk pengiriman LXMF store - and - forward.",
+      "openSettings": "Atur propagasi",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Mode propagasi",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Disabilitare questa interfaccia nell'elenco sottostante o confermare che l'hub remoto sia in esecuzione.",
       "txQueueDrops": "{{name}}: pacchetti in uscita scartati ({{count}} in coda)",
       "txQueueDropsHint": "Di solito causato da un'interfaccia TCP morta ancora abilitata. Disabilita gli hub non raggiungibili per interrompere l'overflow della coda.",
-      "suppressed": "{{count}} righe di registro sidecar simili soppresse di recente."
+      "suppressed": "{{count}} righe di registro sidecar simili soppresse di recente.",
+      "linkDeliveryTimeout": "Collegamento LXMF diretto a {{hash}}… scaduto ({{count}}×)",
+      "linkDeliveryTimeoutHint": "Il peer potrebbe essere offline o il trasporto RNS è sovraccarico. I DM possono rimanere su Invio fino a quando il collegamento non si interrompe.",
+      "transportSaturated": "Trasporto RNS saturo ({{count}} gocce path-request)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "Query di trasporto RNS lente o non riuscite ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "L'istanza di condivisione è abilitata: chiudi completamente altre app Reticulum (MeshChatX, Ratspeak, rnsd autonomo) e riavvia questo stack prima di riprovare i DM."
     },
     "reticulumSidecarBundledMissing": "In questa installazione manca il sidecar Reticulum in bundle. Esegui l'upgrade a una versione più recente o segnala il problema: la creazione dal codice sorgente non è disponibile nelle installazioni in pacchetto.",
     "radioMqttRootDivergesWarning": "L'argomento principale di Radio MQTT è {{radioRoot}}, ma questo panel si iscrive a {{appPrefix}}. Abbina la radio per limitare il traffico dei nodi a livello nazionale: aggiorna il prefisso dell'argomento e ricollega MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "AutoInterface beacon TX non funziona su {{ifaces}} — il rilevamento della LAN locale potrebbe non funzionare fino a quando questo problema non viene risolto.",
         "tcpUnreachable": "L'hub TCP \"{{name}}\" non è raggiungibile ({{host}}:{{port}})",
         "tcpConnectFailed": "Connessione TCP hub \"{{name}}\" rifiutata o scaduta",
-        "txQueueDrops": "L'interfaccia \"{{name}}\" ha rilasciato {{count}} pacchetti in uscita (coda TX piena)"
+        "txQueueDrops": "L'interfaccia \"{{name}}\" ha rilasciato {{count}} pacchetti in uscita (coda TX piena)",
+        "linkDeliveryTimeout": "Collegamento LXMF diretto a {{hash}}… scaduto ({{count}}×)",
+        "transportSaturated": "Trasporto RNS saturo ({{count}} LXMF path-request drop)",
+        "transportSaturatedShareInstance": "Trasporto RNS saturo ({{count}} gocce path-request). L'istanza di condivisione è attiva: esci da altre app Reticulum (MeshChatX, Ratspeak, rnsd) e riavvia lo stack.",
+        "slowTransportQuery": "Query di trasporto RNS lente o non riuscite ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Ogni 12 ore",
     "autoSyncOption24h": "Ogni 24 ore",
     "lastSynced": "Ultima sincronizzazione: {{time}}",
-    "lastRefreshed": "Ultimo aggiornamento {{time}}"
+    "lastRefreshed": "Ultimo aggiornamento {{time}}",
+    "notice": {
+      "body": "Non è configurato alcun nodo di propagazione. I peer offline o non raggiungibili hanno bisogno di un nodo di propagazione per la consegna LXMF store-and-forward.",
+      "openSettings": "Imposta la propagazione",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Modalità di propagazione",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "以下のリストでこのインターフェースを無効にするか、リモートハブが実行されていることを確認します。",
       "txQueueDrops": "{{name}} ：送信パケットがドロップされました（ {{count}}がキューに入れられました）",
       "txQueueDropsHint": "通常は、デッドTCPインターフェイスがまだ有効になっていることが原因です。キューオーバーフローを停止するには、到達不能なハブを無効にします。",
-      "suppressed": "{{count}}類似のサイドカーログ行は最近抑制されました。"
+      "suppressed": "{{count}}類似のサイドカーログ行は最近抑制されました。",
+      "linkDeliveryTimeout": "{{hash}} …への直接LXMFリンクがタイムアウトしました（ {{count}} × ）",
+      "linkDeliveryTimeoutHint": "ピアはオフラインであってもよく、またはRNSトランスポートが過負荷であってもよい。DMは、リンクが失敗するまで送信を続けることができます。",
+      "transportSaturated": "RNSトランスポート飽和（ {{count}}パス要求ドロップ）",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "RNSトランスポートクエリが遅いか失敗しました({{count}} ×)",
+      "slowTransportQueryHint": "サイドカーの輸送アクターがくさび形になっている可能性があります。Reticulumスタックを再起動してください。",
+      "shareInstanceHint": "共有インスタンスが有効になっています—他のReticulumアプリ（ MeshChatX、Ratspeak、スタンドアロンrnsd ）を完全に終了し、DMを再試行する前にこのスタックを再起動します。"
     },
     "reticulumSidecarBundledMissing": "このインストールには、バンドルされている Reticulum サイドカーがありません。新しいリリースにアップグレードするか、問題を報告してください。パッケージ化されたインストールではソースからのビルドは利用できません。",
     "radioMqttRootDivergesWarning": "ラジオMQTTルートトピックは{{radioRoot}}ですが、このパネルは{{appPrefix}}に加入しています。全国のノードトラフィックを制限するために無線を一致させます—トピックプレフィックスを更新し、MQTTを再接続します。",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "オートインターフェイスビーコンTXが{{ifaces}}で失敗しています—これが修正されるまで、ローカルLAN検出が機能しない可能性があります。",
         "tcpUnreachable": "TCPハブ\"{{name}}\"に到達できません({{host}}: {{port}})",
         "tcpConnectFailed": "TCPハブ\"{{name}}\"接続が拒否されたか、タイムアウトしました",
-        "txQueueDrops": "インターフェース「{{name}}」が{{count}}個のアウトバウンドパケットをドロップしました（ TXキューがいっぱいです）"
+        "txQueueDrops": "インターフェース「{{name}}」が{{count}}個のアウトバウンドパケットをドロップしました（ TXキューがいっぱいです）",
+        "linkDeliveryTimeout": "{{hash}} …への直接LXMFリンクがタイムアウトしました（ {{count}} × ）",
+        "transportSaturated": "RNSトランスポート飽和（ {{count}} LXMFパス要求ドロップ）",
+        "transportSaturatedShareInstance": "RNSトランスポートが飽和しました（ {{count}}パス要求ドロップ）。共有インスタンスがオンになっています—他のReticulumアプリ（ MeshChatX、Ratspeak、rnsd ）を終了し、スタックを再起動します。",
+        "slowTransportQuery": "RNSトランスポートクエリが遅いか失敗しました({{count}} ×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "12時間ごと",
     "autoSyncOption24h": "24時間ごと",
     "lastSynced": "最終同期: {{time}}",
-    "lastRefreshed": "最終更新日 {{time}}"
+    "lastRefreshed": "最終更新日 {{time}}",
+    "notice": {
+      "body": "伝播ノードが設定されていません。オフラインまたは到達不能なピアには、ストアアンドフォワードLXMF配信用の伝播ノードが必要です。",
+      "openSettings": "伝播の設定",
+      "openSettingsAria": "Reticulumネットワーク伝播設定を開く"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "伝播モード",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "아래 목록에서 이 인터페이스를 비활성화하거나 원격 허브가 실행 중인지 확인하십시오.",
       "txQueueDrops": "{{name}}: 아웃바운드 패킷이 삭제됨 ({{count}} 대기 중)",
       "txQueueDropsHint": "일반적으로 죽은 TCP 인터페이스가 여전히 활성화되어 있기 때문에 발생합니다. 연결할 수 없는 허브를 비활성화하여 대기열 오버플로를 중지합니다.",
-      "suppressed": "{{count}} 최근 유사한 사이드카 로그 라인이 억제되었습니다."
+      "suppressed": "{{count}} 최근 유사한 사이드카 로그 라인이 억제되었습니다.",
+      "linkDeliveryTimeout": "{{hash}} 에 대한 직접 LXMF 링크… 시간 초과 ({{count}} ×)",
+      "linkDeliveryTimeoutHint": "피어가 오프라인이거나 RNS 전송이 과부하 상태일 수 있습니다. DM은 링크가 실패할 때까지 전송을 유지할 수 있습니다.",
+      "transportSaturated": "RNS 전송 포화 ({{count}} 경로 요청 드롭)",
+      "transportSaturatedHint": "죽은 인터페이스를 비활성화하고 스택을 다시 시작하십시오. 동시 Reticulum 트래픽을 줄입니다.",
+      "slowTransportQuery": "RNS 전송 쿼리가 느리거나 실패함 ({{count}} ×)",
+      "slowTransportQueryHint": "사이드카 트랜스포트 액터에 쐐기를 박을 수 있습니다. Reticulum 스택을 다시 시작하십시오.",
+      "shareInstanceHint": "공유 인스턴스가 활성화되었습니다. DM을 다시 시도하기 전에 다른 Reticulum 앱 (MeshChatX, Ratspeak, 독립 실행형 rnsd) 을 완전히 종료하고 이 스택을 다시 시작하십시오."
     },
     "reticulumSidecarBundledMissing": "이 설치에는 번들로 제공되는 Reticulum 사이드카가 없습니다. 최신 릴리스로 업그레이드하거나 문제를 보고하세요. 패키지 설치에서는 소스에서 빌드할 수 없습니다.",
     "radioMqttRootDivergesWarning": "라디오 MQTT 루트 주제는 {{radioRoot}} 이지만 이 패널은 {{appPrefix}} 을 (를) 구독합니다. 라디오를 일치시켜 전국 노드 트래픽을 제한하십시오 — 주제 접두사를 업데이트하고 MQTT를 다시 연결하십시오.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "AutoInterface 비콘 TX가 {{ifaces}} 에서 실패하고 있습니다. 이 문제가 해결될 때까지 로컬 LAN 검색이 작동하지 않을 수 있습니다.",
         "tcpUnreachable": "TCP 허브 \"{{name}}\" 에 연결할 수 없습니다 ({{host}}: {{port}})",
         "tcpConnectFailed": "TCP 허브 \"{{name}}\" 연결이 거부되었거나 시간이 초과되었습니다",
-        "txQueueDrops": "인터페이스 \"{{name}}\" 삭제됨 {{count}} 아웃바운드 패킷 (TX 대기열 가득 참)"
+        "txQueueDrops": "인터페이스 \"{{name}}\" 삭제됨 {{count}} 아웃바운드 패킷 (TX 대기열 가득 참)",
+        "linkDeliveryTimeout": "{{hash}} 에 대한 직접 LXMF 링크… 시간 초과 ({{count}} ×)",
+        "transportSaturated": "RNS 전송 포화 ({{count}} LXMF 경로 요청 드롭)",
+        "transportSaturatedShareInstance": "RNS 전송 포화 ({{count}} 경로 요청 드롭). 인스턴스 공유 켜짐 — 다른 Reticulum 앱 (MeshChatX, Ratspeak, rnsd) 을 종료하고 스택을 다시 시작합니다.",
+        "slowTransportQuery": "RNS 전송 쿼리가 느리거나 실패함 ({{count}} ×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "12시간마다",
     "autoSyncOption24h": "24시간마다",
     "lastSynced": "마지막 동기화: {{time}}",
-    "lastRefreshed": "마지막 업데이트: {{time}}"
+    "lastRefreshed": "마지막 업데이트: {{time}}",
+    "notice": {
+      "body": "전파 노드가 구성되지 않았습니다. 오프라인 또는 연락이 닿지 않는 동료에게는 스토어 앤 포워드 LXMF 배송을 위한 전파 노드가 필요합니다.",
+      "openSettings": "전파 설정",
+      "openSettingsAria": "Reticulum Network 전파 설정 열기"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "전파 모드",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Schakel deze interface uit in de onderstaande lijst of bevestig dat de externe hub actief is.",
       "txQueueDrops": "{{name}}: uitgaande pakketten verwijderd ({{count}} in de wachtrij)",
       "txQueueDropsHint": "Meestal veroorzaakt door een dode TCP-interface die nog steeds is ingeschakeld. Schakel onbereikbare hubs uit om wachtrijoverloop te stoppen.",
-      "suppressed": "{{count}} vergelijkbare zijspanlogregels die onlangs zijn onderdrukt."
+      "suppressed": "{{count}} vergelijkbare zijspanlogregels die onlangs zijn onderdrukt.",
+      "linkDeliveryTimeout": "Directe LXMF-link naar {{hash}}… time-out ({{count}}×)",
+      "linkDeliveryTimeoutHint": "De peer kan offline zijn of het RNS-transport is overbelast. DM's kunnen op Verzenden blijven totdat de link mislukt.",
+      "transportSaturated": "RNS-transport verzadigd ({{count}} pad-aanvraagdruppels)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "RNS-transportvragen traag of mislukt ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "Deel instantie is ingeschakeld — sluit andere Reticulum-apps (MeshChatX, Ratspeak, standalone rnsd) volledig af en start deze stapel opnieuw voordat u DM's opnieuw probeert."
     },
     "reticulumSidecarBundledMissing": "Bij deze installatie ontbreekt het gebundelde Reticulum sidecar. Upgrade naar een nieuwere release of rapporteer het probleem: bouwen vanaf de broncode is niet beschikbaar in pakketinstallaties.",
     "radioMqttRootDivergesWarning": "Radio MQTT-hoofdonderwerp is {{radioRoot}}, maar dit paneel is geabonneerd op {{appPrefix}}. Koppel de radio om landelijk knooppuntverkeer te beperken — werk het onderwerpvoorvoegsel bij en sluit MQTT opnieuw aan.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "AutoInterface-baken TX faalt op {{ifaces}} — lokale LAN-detectie werkt mogelijk niet totdat dit is opgelost.",
         "tcpUnreachable": "TCP-hub \"{{name}}\" is onbereikbaar ({{host}}:{{port}})",
         "tcpConnectFailed": "TCP-hub \"{{name}}\" -verbinding geweigerd of er is een time-out opgetreden",
-        "txQueueDrops": "Interface \"{{name}}\" liet {{count}} uitgaande pakketten vallen (TX-wachtrij vol)"
+        "txQueueDrops": "Interface \"{{name}}\" liet {{count}} uitgaande pakketten vallen (TX-wachtrij vol)",
+        "linkDeliveryTimeout": "Directe LXMF-link naar {{hash}}… time-out ({{count}}×)",
+        "transportSaturated": "RNS-transport verzadigd ({{count}} LXMF-pad-aanvraagdruppels)",
+        "transportSaturatedShareInstance": "RNS-transport verzadigd ({{count}} pad-aanvraagdruppels). Deel instantie is ingeschakeld — sluit andere Reticulum-apps (MeshChatX, Ratspeak, rnsd) en start de stapel opnieuw.",
+        "slowTransportQuery": "RNS-transportvragen traag of mislukt ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Elke 12 uur",
     "autoSyncOption24h": "Elke 24 uur",
     "lastSynced": "Laatst gesynchroniseerd: {{time}}",
-    "lastRefreshed": "Laatst bijgewerkt {{time}}"
+    "lastRefreshed": "Laatst bijgewerkt {{time}}",
+    "notice": {
+      "body": "Er is geen propagatieknooppunt geconfigureerd. Offline of onbereikbare collega's hebben een propagatieknooppunt nodig voor store-and-forward LXMF-levering.",
+      "openSettings": "Propagatie instellen",
+      "openSettingsAria": "Open Reticulum Network propagatie-instellingen"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "voortplantingsmodus",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Wyłącz ten interfejs na poniższej liście lub potwierdź, że zdalny koncentrator jest uruchomiony.",
       "txQueueDrops": "{{name}}: pakiety wychodzące odrzucone ({{count}} w kolejce)",
       "txQueueDropsHint": "Zwykle spowodowane przez nadal włączony martwy interfejs TCP. Wyłącz niedostępne koncentratory, aby zatrzymać przepełnienie kolejki.",
-      "suppressed": "Ostatnio zablokowano podobne wiersze dziennika wózka bocznego {{count}}."
+      "suppressed": "Ostatnio zablokowano podobne wiersze dziennika wózka bocznego {{count}}.",
+      "linkDeliveryTimeout": "Upłynął limit czasu bezpośredniego łącza LXMF do {{hash}}… ({{count}}×)",
+      "linkDeliveryTimeoutHint": "Partner może być offline lub transport RNS jest przeciążony. SMS-y mogą pozostać w trybie wysyłania do czasu awarii linku.",
+      "transportSaturated": "Transport RNS nasycony (krople żądania ścieżki {{count}})",
+      "transportSaturatedHint": "Wyłącz martwe interfejsy i uruchom ponownie stos. Zmniejsz równoczesny ruch Reticulum.",
+      "slowTransportQuery": "Powolne lub nieudane zapytania transportowe RNS ({{count}}×)",
+      "slowTransportQueryHint": "Aktor transportowy wózka bocznego może być zaklinowany — uruchom ponownie stos Reticulum.",
+      "shareInstanceHint": "Instancja udostępniania jest włączona — całkowicie zamknij inne aplikacje Reticulum (MeshChatX, Ratspeak, standalone rnsd) i uruchom ponownie ten stos przed ponowną próbą wysłania wiadomości SMS."
     },
     "reticulumSidecarBundledMissing": "W tej instalacji brakuje dołączonego sidecar Reticulum. Uaktualnij do nowszej wersji lub zgłoś problem — budowanie ze źródła nie jest możliwe w przypadku instalacji pakietowych.",
     "radioMqttRootDivergesWarning": "Główny temat radia MQTT to {{radioRoot}}, ale ten panel subskrybuje {{appPrefix}}. Dopasuj radio, aby ograniczyć ogólnokrajowy ruch w węzłach — zaktualizuj prefiks tematu i ponownie połącz MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "Lampa sygnalizacyjna AutoInterface TX nie działa w {{ifaces}} — lokalne wykrywanie sieci LAN może nie działać, dopóki nie zostanie to naprawione.",
         "tcpUnreachable": "Koncentrator TCP „{{name}}” jest nieosiągalny ({{host}}:{{port}})",
         "tcpConnectFailed": "Odmowa lub przekroczenie limitu czasu połączenia koncentratora TCP „{{name}}”",
-        "txQueueDrops": "Interfejs \"{{name}}\" upuścił pakiety wychodzące {{count}} (kolejka TX pełna)"
+        "txQueueDrops": "Interfejs \"{{name}}\" upuścił pakiety wychodzące {{count}} (kolejka TX pełna)",
+        "linkDeliveryTimeout": "Upłynął limit czasu bezpośredniego łącza LXMF do {{hash}}… ({{count}}×)",
+        "transportSaturated": "Transport RNS nasycony (spadki {{count}} LXMF)",
+        "transportSaturatedShareInstance": "Transport RNS nasycony (krople z żądaniem ścieżki {{count}}). Udostępnij instancję jest włączona — zamknij inne aplikacje Reticulum (MeshChatX, Ratspeak, rnsd) i uruchom ponownie stos.",
+        "slowTransportQuery": "Powolne lub nieudane zapytania transportowe RNS ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Co 12 godzin",
     "autoSyncOption24h": "Co 24 godziny",
     "lastSynced": "Ostatnia synchronizacja: {{time}}",
-    "lastRefreshed": "Ostatnia aktualizacja {{time}}"
+    "lastRefreshed": "Ostatnia aktualizacja {{time}}",
+    "notice": {
+      "body": "Brak skonfigurowanego węzła propagacji. Partnerzy offline lub nieosiągalni potrzebują węzła propagacji do przechowywania i przekazywania LXMF.",
+      "openSettings": "Skonfiguruj propagację",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Tryb propagacji:",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Desative esta interface na lista abaixo ou confirme se o hub remoto está em execução.",
       "txQueueDrops": "{{name}}: pacotes de saída descartados ({{count}} na fila)",
       "txQueueDropsHint": "Geralmente causado por uma interface TCP inativa ainda ativada. Desative os hubs inacessíveis para interromper o estouro da fila.",
-      "suppressed": "{{count}} linhas de registro de sidecar semelhantes foram suprimidas recentemente."
+      "suppressed": "{{count}} linhas de registro de sidecar semelhantes foram suprimidas recentemente.",
+      "linkDeliveryTimeout": "O link LXMF direto para {{hash}}… expirou ({{count}}×)",
+      "linkDeliveryTimeoutHint": "O par pode estar offline ou o transporte RNs está sobrecarregado. Os DMs podem permanecer no Envio até que o link falhe.",
+      "transportSaturated": "Transporte RNs saturado ({{count}} path-request drops)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "Consultas de transporte RNs lentas ou com falha ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "Share instance is enabled — fully quit other Reticulum apps (MeshChatX, Ratspeak, standalone rnsd) and restart this stack before retrying DMs."
     },
     "reticulumSidecarBundledMissing": "Esta instalação não contém o sidecar Reticulum incluído. Atualize para uma versão mais recente ou relate o problema – a compilação a partir do código-fonte não está disponível em instalações empacotadas.",
     "radioMqttRootDivergesWarning": "O tópico raiz do MQTT de rádio é {{radioRoot}}, mas este painel assina {{appPrefix}}. Combine o rádio para limitar o tráfego de nós em todo o país — atualize o Prefixo do Tópico e reconecte o MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "AutoInterface beacon TX está falhando em {{ifaces}} — a descoberta de LAN local pode não funcionar até que isso seja corrigido.",
         "tcpUnreachable": "O hub TCP \"{{name}}\" está inacessível ({{host}}:{{port}})",
         "tcpConnectFailed": "Ligação TCP Hub \"{{name}}\" recusada ou tempo esgotado",
-        "txQueueDrops": "Interface \"{{name}}\" descartou {{count}} pacotes de saída (fila TX cheia)"
+        "txQueueDrops": "Interface \"{{name}}\" descartou {{count}} pacotes de saída (fila TX cheia)",
+        "linkDeliveryTimeout": "O link LXMF direto para {{hash}}… expirou ({{count}}×)",
+        "transportSaturated": "RNS transport saturated ({{count}} LXMF path-request drops)",
+        "transportSaturatedShareInstance": "RNS transport saturated ({{count}} path-request drops). Share instance is on — quit other Reticulum apps (MeshChatX, Ratspeak, rnsd) and restart the stack.",
+        "slowTransportQuery": "RNS transport queries slow or failing ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "A cada 12 horas",
     "autoSyncOption24h": "A cada 24 horas",
     "lastSynced": "Última sincronização: {{time}}",
-    "lastRefreshed": "Última atualização {{time}}"
+    "lastRefreshed": "Última atualização {{time}}",
+    "notice": {
+      "body": "Nenhum nó de propagação está configurado. Os pares offline ou inacessíveis precisam de um nó de propagação para a entrega de LXMF de armazenamento e encaminhamento.",
+      "openSettings": "Configurar propagação",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Modo de propagação",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Отключите этот интерфейс в списке ниже или убедитесь, что удаленный концентратор работает.",
       "txQueueDrops": "{{name}}: исходящие пакеты отброшены ({{count}} в очереди)",
       "txQueueDropsHint": "Обычно вызвано мертвым TCP-интерфейсом, который все еще включен. Отключите недоступные концентраторы, чтобы остановить переполнение очереди.",
-      "suppressed": "{{count}} аналогичные линии бревна коляски подавлены в последнее время."
+      "suppressed": "{{count}} аналогичные линии бревна коляски подавлены в последнее время.",
+      "linkDeliveryTimeout": "Время ожидания прямой связи LXMF с {{hash}}… истекло ({{count}}×)",
+      "linkDeliveryTimeoutHint": "Одноранговый узел может быть отключен или транспорт RNS перегружен. DM могут оставаться на отправке до тех пор, пока ссылка не выйдет из строя.",
+      "transportSaturated": "RNS транспорт насыщенный ({{count}} path-request drops)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "Транспортные запросы RNS медленные или сбойные ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "Экземпляр Share включен — полностью закройте другие приложения Reticulum (MeshChatX, Ratspeak, автономный rnsd) и перезапустите этот стек перед повторной попыткой DM."
     },
     "reticulumSidecarBundledMissing": "В этой установке отсутствует входящая в комплект Reticulum sidecar. Обновите версию до более новой или сообщите о проблеме — сборка из исходного кода недоступна при пакетной установке.",
     "radioMqttRootDivergesWarning": "Корневая тема радио MQTT - {{radioRoot}}, но эта панель подписана на {{appPrefix}}. Сопоставьте радиостанцию, чтобы ограничить трафик узлов по всей стране — обновите префикс темы и повторно подключите MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "Сбой маяка AutoInterface TX на {{ifaces}} — обнаружение локальной сети может не работать, пока это не будет исправлено.",
         "tcpUnreachable": "Концентратор TCP \"{{name}}\" недоступен ({{host}}:{{port}})",
         "tcpConnectFailed": "TCP Hub \"{{name}}\" соединение отклонено или истекло",
-        "txQueueDrops": "Интерфейс \"{{name}}\" сбросил {{count}} исходящих пакетов (очередь TX заполнена)"
+        "txQueueDrops": "Интерфейс \"{{name}}\" сбросил {{count}} исходящих пакетов (очередь TX заполнена)",
+        "linkDeliveryTimeout": "Время ожидания прямой связи LXMF с {{hash}}… истекло ({{count}}×)",
+        "transportSaturated": "Насыщенный транспорт RNS ({{count}} LXMF path-request drops)",
+        "transportSaturatedShareInstance": "RNS транспорт насыщенный ({{count}} path-request drops). Экземпляр Share включен — закройте другие приложения Reticulum (MeshChatX, Ratspeak, rnsd) и перезапустите стек.",
+        "slowTransportQuery": "Транспортные запросы RNS медленные или сбойные ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Каждые 12 часов",
     "autoSyncOption24h": "Каждые 24 часа",
     "lastSynced": "Последняя синхронизация: {{time}}",
-    "lastRefreshed": "Последнее обновление {{time}}"
+    "lastRefreshed": "Последнее обновление {{time}}",
+    "notice": {
+      "body": "Узел распространения не настроен. Автономным или недоступным одноранговым узлам требуется узел распространения для доставки LXMF с сохранением и пересылкой.",
+      "openSettings": "Настроить распространение",
+      "openSettingsAria": "Настройки распространения сети Open Reticulum"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Режим распространения",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Aşağıdaki listeden bu arayüzü devre dışı bırakın veya uzak hub'ın çalıştığını onaylayın.",
       "txQueueDrops": "{{name}}: giden paketler düştü ({{count}} kuyruğa alındı)",
       "txQueueDropsHint": "Genellikle ölü bir TCP arayüzü hala etkindir. Kuyruk taşmasını durdurmak için erişilemeyen hub'ları devre dışı bırakın.",
-      "suppressed": "{{count}} benzer sepet günlük satırları yakın zamanda bastırıldı."
+      "suppressed": "{{count}} benzer sepet günlük satırları yakın zamanda bastırıldı.",
+      "linkDeliveryTimeout": "{{hash}} 'a doğrudan LXMF bağlantısı… zaman aşımına uğradı ({{count}}×)",
+      "linkDeliveryTimeoutHint": "Eş çevrimdışı olabilir veya RNS aktarımı aşırı yüklenmiş olabilir. DM'ler, bağlantı başarısız olana kadar Gönderme işleminde kalabilir.",
+      "transportSaturated": "RNS transport saturated ({{count}} path - request drops)",
+      "transportSaturatedHint": "Ölü arayüzleri devre dışı bırakın ve yığını yeniden başlatın. Eşzamanlı Reticulum trafiğini azaltın.",
+      "slowTransportQuery": "RNS taşıma sorguları yavaş veya başarısız ({{count}}×)",
+      "slowTransportQueryHint": "Sepet taşıma aktörü sıkışmış olabilir — Reticulum yığınını yeniden başlatın.",
+      "shareInstanceHint": "Paylaşım örneği etkinleştirildi — diğer Reticulum uygulamalarından (MeshChatX, Ratspeak, standalone rnsd) tamamen çıkın ve DM'leri yeniden denemeden önce bu yığını yeniden başlatın."
     },
     "reticulumSidecarBundledMissing": "Bu kurulumda birlikte verilen Reticulum sidecar eksik. Daha yeni bir sürüme yükseltin veya sorunu bildirin; kaynaktan derleme, paketli kurulumlarda mevcut değildir.",
     "radioMqttRootDivergesWarning": "Radyo MQTT kök konusu {{radioRoot}} 'dır, ancak bu panel {{appPrefix}}' e abone olur. Ülke çapındaki düğüm trafiğini sınırlamak için radyoyu eşleştirin — Konu Önekini güncelleyin ve MQTT'yi yeniden bağlayın.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "AutoInterface beacon TX {{ifaces}} üzerinde başarısız oluyor — bu düzeltilinceye kadar yerel lan keşfi çalışmayabilir.",
         "tcpUnreachable": "TCP merkezi \"{{name}}\" ulaşılamıyor ({{host}}:{{port}})",
         "tcpConnectFailed": "TCP hub \"{{name}}\" bağlantısı reddedildi veya zaman aşımına uğradı",
-        "txQueueDrops": "Arayüz \"{{name}}\" düştü {{count}} giden paketler (TX kuyruğu dolu)"
+        "txQueueDrops": "Arayüz \"{{name}}\" düştü {{count}} giden paketler (TX kuyruğu dolu)",
+        "linkDeliveryTimeout": "{{hash}} 'a doğrudan LXMF bağlantısı… zaman aşımına uğradı ({{count}}×)",
+        "transportSaturated": "RNS transport saturated ({{count}} LXMF path - request drops)",
+        "transportSaturatedShareInstance": "RNS nakli doymuş ({{count}} yol talebi düşer). Paylaşım örneği açık — diğer Reticulum uygulamalarından (MeshChatX, Ratspeak, rnsd) çıkın ve yığını yeniden başlatın.",
+        "slowTransportQuery": "RNS taşıma sorguları yavaş veya başarısız ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Her 12 saatte bir",
     "autoSyncOption24h": "Her 24 saatte bir",
     "lastSynced": "Son senkronizasyon: {{time}}",
-    "lastRefreshed": "Son güncelleme {{time}}"
+    "lastRefreshed": "Son güncelleme {{time}}",
+    "notice": {
+      "body": "Hiçbir yayılma düğümü yapılandırılmamış. Çevrimdışı veya erişilemeyen eşler, LXMF teslimatı için bir yayılma düğümüne ihtiyaç duyar.",
+      "openSettings": "Yayılımı ayarla",
+      "openSettingsAria": "Reticulum Ağı yayılım ayarlarını aç"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Yayılma modu",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "Вимкніть цей інтерфейс у списку нижче або переконайтеся, що віддалений концентратор працює.",
       "txQueueDrops": "{{name}}: вихідні пакети скинуто ({{count}} в черзі)",
       "txQueueDropsHint": "Зазвичай це викликано тим, що непрацездатний інтерфейс TCP все ще увімкнено. Вимкніть недоступні концентратори, щоб зупинити переповнення черги.",
-      "suppressed": "{{count}} аналогічні лінії журналу коляски нещодавно придушено."
+      "suppressed": "{{count}} аналогічні лінії журналу коляски нещодавно придушено.",
+      "linkDeliveryTimeout": "Пряме посилання LXMF на {{hash}}… вичерпано час очікування ({{count}}×)",
+      "linkDeliveryTimeoutHint": "Одноранговий вузол може бути в автономному режимі або транспорт RNS перевантажений. DM можуть залишатися в режимі надсилання, доки посилання не вийде з ладу.",
+      "transportSaturated": "Транспорт RNS насичений ({{count}} краплі запиту шляху)",
+      "transportSaturatedHint": "Disable dead interfaces and restart the stack. Reduce concurrent Reticulum traffic.",
+      "slowTransportQuery": "Транспортні запити RNS повільні або невдалі ({{count}}×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "Екземпляр Share увімкнено — повністю закрийте інші програми Reticulum (MeshChatX, Ratspeak, автономний rnsd) і перезапустіть цей стек перед повторною спробою DM."
     },
     "reticulumSidecarBundledMissing": "У цій інсталяції відсутній Reticulum sidecar. Оновіть до новішого випуску або повідомте про проблему — збірка з вихідного коду недоступна в пакетних встановленнях.",
     "radioMqttRootDivergesWarning": "Коренева тема радіо MQTT - {{radioRoot}}, але ця панель підписується на {{appPrefix}}. Підключіть радіоприймач, щоб обмежити загальнонаціональний трафік вузлів — оновіть префікс теми та повторно підключіть MQTT.",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "AutoInterface beacon TX зазнає невдачі на {{ifaces}} — виявлення локальної мережі може не працювати, поки це не буде виправлено.",
         "tcpUnreachable": "Концентратор TCP \"{{name}}\" недоступний ({{host}}:{{port}})",
         "tcpConnectFailed": "З'єднання TCP Hub \"{{name}}\" відхилено або вичерпано час очікування",
-        "txQueueDrops": "Інтерфейс \"{{name}}\" скинув {{count}} вихідних пакетів (черга TX заповнена)"
+        "txQueueDrops": "Інтерфейс \"{{name}}\" скинув {{count}} вихідних пакетів (черга TX заповнена)",
+        "linkDeliveryTimeout": "Пряме посилання LXMF на {{hash}}… вичерпано час очікування ({{count}}×)",
+        "transportSaturated": "Транспорт RNS насичений ({{count}} LXMF path-request drops)",
+        "transportSaturatedShareInstance": "Транспорт RNS насичений ({{count}} краплі запиту шляху). Екземпляр Share увімкнено — закрийте інші програми Reticulum (MeshChatX, Ratspeak, rnsd) і перезапустіть стек.",
+        "slowTransportQuery": "Транспортні запити RNS повільні або невдалі ({{count}}×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "Кожні 12 годин",
     "autoSyncOption24h": "Кожні 24 години",
     "lastSynced": "Остання синхронізація: {{time}}",
-    "lastRefreshed": "Останнє оновлення {{time}}"
+    "lastRefreshed": "Останнє оновлення {{time}}",
+    "notice": {
+      "body": "Вузол поширення не налаштовано. Автономні або недоступні вузли потребують вузла розповсюдження для доставки LXMF.",
+      "openSettings": "Налаштувати поширення",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "Режим поширення",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -1037,7 +1037,14 @@
       "tcpConnectFailedHint": "在下面的列表中禁用此接口，或确认远程集线器正在运行。",
       "txQueueDrops": "{{name}} ：出站数据包已丢弃（ {{count}}已排队）",
       "txQueueDropsHint": "通常是由死TCP接口仍处于启用状态引起的。禁用无法访问的集线器以停止队列溢出。",
-      "suppressed": "{{count}}最近取消了类似的侧车日志行。"
+      "suppressed": "{{count}}最近取消了类似的侧车日志行。",
+      "linkDeliveryTimeout": "直接LXMF链接到{{hash}} …超时（ {{count}} × ）",
+      "linkDeliveryTimeoutHint": "对等节点可能处于离线状态，或者RNS传输过载。DM可以继续发送，直到链接失败。",
+      "transportSaturated": "RNS传输饱和（ {{count}}路径请求丢弃）",
+      "transportSaturatedHint": "禁用失效接口并重新启动堆栈。减少并发Reticulum流量。",
+      "slowTransportQuery": "RNS传输查询缓慢或失败({{count}} ×)",
+      "slowTransportQueryHint": "The sidecar transport actor may be wedged — restart the Reticulum stack.",
+      "shareInstanceHint": "共享实例已启用—在重试DM之前，完全退出其他Reticulum应用程序（ MeshChatX、Ratspeak、独立rnsd ）并重新启动此堆栈。"
     },
     "reticulumSidecarBundledMissing": "此安装缺少捆绑的 Reticulum sidecar。升级到较新的版本或报告问题 - 在打包安装中无法从源代码构建。",
     "radioMqttRootDivergesWarning": "无线电MQTT根主题为{{radioRoot}} ，但此面板订阅了{{appPrefix}}。匹配无线电以限制全国节点流量—更新主题前缀并重新连接MQTT。",
@@ -1355,7 +1362,11 @@
         "autoBeaconPhysicalFailures": "自动接口信标TX在{{ifaces}}失败—在修复此问题之前，本地局域网发现可能无法正常工作。",
         "tcpUnreachable": "无法访问TCP集线器「{{name}}」（ {{host}} ： {{port}} ）",
         "tcpConnectFailed": "TCP集线器“{{name}}”连接被拒绝或超时",
-        "txQueueDrops": "接口“{{name}}”丢弃了{{count}}个出站数据包（ TX队列已满）"
+        "txQueueDrops": "接口“{{name}}”丢弃了{{count}}个出站数据包（ TX队列已满）",
+        "linkDeliveryTimeout": "直接LXMF链接到{{hash}} …超时（ {{count}} × ）",
+        "transportSaturated": "RNS传输饱和（ {{count}} LXMF路径请求丢弃）",
+        "transportSaturatedShareInstance": "RNS传输饱和（ {{count}}路径请求丢弃）。共享实例已打开—退出其他Reticulum应用程序（ MeshChatX、Ratspeak、rnsd ）并重新启动堆栈。",
+        "slowTransportQuery": "RNS传输查询缓慢或失败({{count}} ×)"
       }
     },
     "routingPort": {
@@ -3572,7 +3583,12 @@
     "autoSyncOption12h": "每12小时一次",
     "autoSyncOption24h": "每24小时一次",
     "lastSynced": "上次同步：{{time}}",
-    "lastRefreshed": "最后更新{{time}}"
+    "lastRefreshed": "最后更新{{time}}",
+    "notice": {
+      "body": "未配置传播节点。离线或无法访问的对等节点需要一个传播节点来存储和转发LXMF交付。",
+      "openSettings": "设置传播",
+      "openSettingsAria": "Open Reticulum Network propagation settings"
+    }
   },
   "reticulumPropagationHeader": {
     "modeLabel": "传播模式",

--- a/src/renderer/runtime/useReticulumRuntime.ts
+++ b/src/renderer/runtime/useReticulumRuntime.ts
@@ -38,6 +38,7 @@ import {
   pickReticulumLocalHealthPollMs,
   scheduleReticulumLocalInterfaceBurst,
 } from '@/renderer/lib/reticulum/reticulumLocalInterfaceRefresh';
+import { failReticulumSendingOutboundToDestHash } from '@/renderer/lib/reticulum/reticulumOutboundFailureBridge';
 import { applyPropagationSyncEvent } from '@/renderer/lib/reticulum/reticulumPropagationSync';
 import { reticulumWireRowToEntry } from '@/renderer/lib/reticulum/reticulumRawPacketLog';
 import {
@@ -48,6 +49,7 @@ import {
   invalidateReticulumInterfacesCache,
   type ReticulumSidecarInterfaceRow,
 } from '@/renderer/lib/reticulum/reticulumSidecarReads';
+import { parseReticulumStackSettingsPayload } from '@/renderer/lib/reticulum/reticulumStackSettings';
 import { useReticulumNobleBleYieldWatcher } from '@/renderer/lib/reticulum/useReticulumNobleBleYieldWatcher';
 import { useReticulumPropagationAutoSync } from '@/renderer/lib/reticulum/useReticulumPropagationAutoSync';
 import { registerReticulumSession } from '@/renderer/lib/sessions/reticulumSession';
@@ -134,6 +136,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
   const localInterfacePollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const stateRef = useRef(state);
   const localInterfacesRef = useRef<ReticulumSidecarInterfaceRow[]>([]);
+  const processedLinkTimeoutDestsRef = useRef(new Set<string>());
   const nodeStoreSlice = useNodeStore((s) => (identityId ? s.nodes[identityId] : undefined));
 
   const sidecarActiveForBleYield =
@@ -254,7 +257,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
 
   const syncDiagnosticsFromSidecar = useCallback(async () => {
     try {
-      const [snapshot, health, auditIssues, sidecarStatus] = await Promise.all([
+      const [snapshot, health, auditIssues, sidecarStatus, stackRaw] = await Promise.all([
         window.electronAPI.reticulum.proxyGet('/api/v1/diagnostics') as Promise<
           Parameters<typeof buildReticulumDiagnosticRows>[0]
         >,
@@ -264,9 +267,12 @@ export function useReticulumRuntime(): ProtocolRuntime {
           return [];
         }),
         window.electronAPI.reticulum.getStatus(),
+        window.electronAPI.reticulum.proxyGet('/api/v1/stack/settings').catch(() => null),
       ]);
       const { interfaces, osSerialPorts } = health;
       const selfNodeId = selfLxmfHash ? reticulumHashToNodeId(selfLxmfHash) : 0;
+      const shareInstanceEnabled =
+        stackRaw != null ? parseReticulumStackSettingsPayload(stackRaw).share_instance : false;
       const rows = buildReticulumDiagnosticRows(snapshot, {
         selfNodeId,
         interfaces,
@@ -274,6 +280,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
         auditIssues,
         autoBeaconAlert: sidecarStatus.autoBeaconAlert ?? null,
         interfaceIssueAlert: sidecarStatus.interfaceIssueAlert ?? null,
+        shareInstanceEnabled,
       });
       useDiagnosticsStore.setState((s) => ({
         diagnosticRows: mergeReticulumDiagnosticRows(s.diagnosticRows, rows),
@@ -465,6 +472,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
     rawPacketAppenderRef.current?.clearPending();
     setRawPackets([]);
     clearReticulumSessionStores();
+    processedLinkTimeoutDestsRef.current.clear();
     setState(INITIAL_STATE);
     syncConnectionStore(INITIAL_STATE);
   }, [syncConnectionStore]);
@@ -473,6 +481,19 @@ export function useReticulumRuntime(): ProtocolRuntime {
     const unsubStatus = window.electronAPI.reticulum.onStatus((status) => {
       if (status.interfaceIssueAlert || status.autoBeaconAlert) {
         void syncDiagnosticsFromSidecar();
+        const timeouts = status.interfaceIssueAlert?.linkDeliveryTimeouts;
+        if (identityId && timeouts?.length) {
+          for (const { destinationHash } of timeouts) {
+            const norm = destinationHash.replace(/[^0-9a-f]/gi, '').toLowerCase();
+            if (!norm || processedLinkTimeoutDestsRef.current.has(norm)) continue;
+            processedLinkTimeoutDestsRef.current.add(norm);
+            failReticulumSendingOutboundToDestHash(
+              identityId,
+              norm,
+              i18n.t('chatPanel.reticulumSendFailed'),
+            );
+          }
+        }
       }
       if (status.running) return;
       if (connectInFlightRef.current) return;
@@ -495,7 +516,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
     return () => {
       unsubStatus();
     };
-  }, [tearDownFromSidecarStop, syncDiagnosticsFromSidecar]);
+  }, [tearDownFromSidecarStop, syncDiagnosticsFromSidecar, identityId]);
 
   useEffect(() => {
     return () => {
@@ -586,6 +607,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
     rawPacketAppenderRef.current?.clearPending();
     setRawPackets([]);
     clearReticulumSessionStores();
+    processedLinkTimeoutDestsRef.current.clear();
     setState(INITIAL_STATE);
     syncConnectionStore(INITIAL_STATE);
   }, [syncConnectionStore]);

--- a/src/shared/reticulum-types.ts
+++ b/src/shared/reticulum-types.ts
@@ -23,10 +23,20 @@ export interface ReticulumInterfaceTxQueueDrop {
   dropCount: number;
 }
 
+export interface ReticulumLinkDeliveryTimeout {
+  /** 32-char LXMF destination hash (hex). */
+  destinationHash: string;
+  count: number;
+}
+
 /** Parsed from sidecar stdout when TCP peers are unreachable or TX queues overflow. */
 export interface ReticulumInterfaceIssueAlert {
   tcpConnectFailed: string[];
   txQueueDrops: ReticulumInterfaceTxQueueDrop[];
+  linkDeliveryTimeouts: ReticulumLinkDeliveryTimeout[];
+  /** Incremented when LXMF path requests fail with transport channel full. */
+  transportSaturatedCount: number;
+  slowTransportQueryCount: number;
   suppressedCount: number;
   lastAtMs: number;
 }


### PR DESCRIPTION
## Summary
- Stop the LXMF path-request retry storm that saturates the RNS transport when `try_send` fails (per-destination backoff + fail after max attempts).
- Surface link-establishment timeouts, transport saturation, and slow transport queries in Connection alerts and Reticulum diagnostics, with a `share_instance` hint for MeshChatX / leftover rnsd conflicts.
- Mark stuck Sending DMs failed on link timeout, and show a Chat notice when no remote propagation node is configured (preferred_id is treated as effective; refresh on stack live so the notice does not false-alarm).

## Test plan
- [ ] Unit: `cargo test path_gate --features rns-stack` in `reticulum-sidecar/`
- [ ] Unit: issue tracker, diagnostic engine, outbound failure bridge, propagation effective/notice tests
- [ ] With stack live and preferred+enabled remote propagation node set, Chat does **not** show the no-propagation notice
- [ ] With no preferred remote node, Chat shows notice; **Set up propagation** opens Network → Propagation
- [ ] Under transport pressure / injected log markers, Connection shows link-timeout / saturated alerts; share_instance hint when enabled
- [ ] Outbound DM to an unreachable peer becomes **Failed** after link establishment timeout (not stuck Sending)
- [ ] Quit leftover MeshChatX/rnsd, restart stack, confirm DM path recovers when transport is healthy