### PR TITLE
chore: surface needs-interest backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Vote on Backlog Ideas
+    url: https://github.com/Colorado-Mesh/mesh-client/issues?q=is%3Aclosed+label%3A%22needs+interest%22
+    about: Browse parked feature ideas and cast your vote with a thumbs-up reaction.


### PR DESCRIPTION
## Summary
- disable blank issues while keeping the existing issue templates available
- add a New Issue contact link to closed issues labeled `needs interest`
- direct contributors to vote on parked ideas without adding noise to the active backlog

## Test plan
- [x] Pre-commit lint, typecheck, checks, audit, and test suite pass
- [x] Backlog filter returns closed `needs interest` issues
- [ ] Confirm the New Issue chooser after merge shows the templates and backlog link without a blank-issue option