### PR TITLE
fix: clear remaining low-hanging Sonar findings

### DIFF
--- a/src/renderer/components/NodeListPanel.tsx
+++ b/src/renderer/components/NodeListPanel.tsx
@@ -113,7 +113,7 @@ function meshcoreContactTypeLabel(
 }
 
 /** Sort fields that do not apply when the Nodes table is in MeshCore (contacts) layout. */
-const MESHCORE_INAPPLICABLE_SORT_FIELDS: readonly SortField[] = [
+const MESHCORE_INAPPLICABLE_SORT_FIELDS: ReadonlySet<SortField> = new Set([
   'short_name',
   'role',
   'via_mqtt',
@@ -122,7 +122,7 @@ const MESHCORE_INAPPLICABLE_SORT_FIELDS: readonly SortField[] = [
   'air_util_tx',
   'altitude',
   'redundancy',
-];
+]);
 
 function SortIcon({
   field,
@@ -234,7 +234,7 @@ export default function NodeListPanel({
   } = useMeshcoreContactCapacity({ enabled: mode === 'meshcore' });
 
   useEffect(() => {
-    if (mode === 'meshcore' && MESHCORE_INAPPLICABLE_SORT_FIELDS.includes(sortField)) {
+    if (mode === 'meshcore' && MESHCORE_INAPPLICABLE_SORT_FIELDS.has(sortField)) {
       setSortField('last_heard');
       setSortAsc(false);
     }

--- a/src/renderer/components/NomadMicronPageView.tsx
+++ b/src/renderer/components/NomadMicronPageView.tsx
@@ -113,7 +113,7 @@ export default function NomadMicronPageView({
       if (!element || !container.contains(element)) return;
       const href = element.getAttribute('href') ?? '';
       const title = element.getAttribute('title') ?? '';
-      const dataDestination = element.getAttribute('data-destination') ?? '';
+      const dataDestination = element.dataset.destination ?? '';
       // In-page Micron anchors (`#slug`) — let the browser scroll; do not treat as Nomad nav.
       if (href.startsWith('#') || dataDestination.startsWith('#')) {
         return;
@@ -123,7 +123,7 @@ export default function NomadMicronPageView({
       const lxmfSource = [href, title].find((v) => v && isReticulumLxmfLink(v));
       const destination = (lxmfSource ?? dataDestination) || href;
       if (!destination) return;
-      const dataFields = element.getAttribute('data-fields');
+      const dataFields = element.dataset.fields;
       handleNomadLink(destination, dataFields);
     };
     container.addEventListener('click', onActivate);

--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -1113,10 +1113,9 @@ export default function RadioPanel({
     input.onchange = () => {
       const file = input.files?.[0];
       if (!file) return;
-      const reader = new FileReader();
-      reader.onload = async (ev) => {
+      void (async () => {
         try {
-          const cfg = JSON.parse(ev.target?.result as string);
+          const cfg = JSON.parse(await file.text());
           console.debug('[RadioPanel] parsed config JSON:', cfg);
           console.debug(
             `[RadioPanel] current device state before import: radioFreqHz=${radioFreqHz} bandwidth=${bandwidth}`,
@@ -1278,8 +1277,7 @@ export default function RadioPanel({
             'error',
           );
         }
-      };
-      reader.readAsText(file);
+      })();
     };
     input.click();
   }, [addToast, onSetOwner, onApplyLoraParams, shortName, isLicensed, bandwidth, radioFreqHz, t]);

--- a/src/renderer/components/ReticulumLocalInterfaceAlertsBlock.tsx
+++ b/src/renderer/components/ReticulumLocalInterfaceAlertsBlock.tsx
@@ -27,7 +27,7 @@ function ifaceHasBleBondRemoved(
   bleBondRemovedNames: readonly string[] | undefined,
 ): boolean {
   if (!bleBondRemovedNames || bleBondRemovedNames.length === 0) return false;
-  return bleBondRemovedNames.some((n) => n === ifaceName);
+  return bleBondRemovedNames.includes(ifaceName);
 }
 
 /** User-visible summary when local/USB Reticulum interfaces need attention. */

--- a/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
+++ b/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
@@ -1555,7 +1555,7 @@ function InterfacesSection({
     if (health === 'enabled_down') {
       const kind = reticulumLocalOfflineDisplayKind(iface);
       if (kind === 'ble') {
-        if (bleBondRemovedNames?.some((n) => n === iface.name)) {
+        if (bleBondRemovedNames?.includes(iface.name)) {
           return t('connectionPanel.reticulumInterfaces.localOfflineRowBleBondStale');
         }
         return t('connectionPanel.reticulumInterfaces.localOfflineRowBle');

--- a/src/renderer/components/rrc/RrcRoomSidebar.tsx
+++ b/src/renderer/components/rrc/RrcRoomSidebar.tsx
@@ -297,7 +297,7 @@ export function RrcRoomSidebar({
         </div>
       )}
       <ul className="min-h-0 flex-1 overflow-y-auto px-1 pb-2">
-        {!collapsed && joinedDeduped.filter((r) => filterName(r.name)).length > 0 && (
+        {!collapsed && joinedDeduped.some((r) => filterName(r.name)) && (
           <li className="px-2 py-1 text-[10px] tracking-wide text-amber-500/70 uppercase">
             {t('rrc.joinedRooms')}
           </li>

--- a/src/renderer/lib/appTabMappings.ts
+++ b/src/renderer/lib/appTabMappings.ts
@@ -114,7 +114,7 @@ export function findFilteredTabIndexForPanel(
   tabs: ProtocolTabMappings,
   panelIndex: number,
 ): number {
-  return tabs.tabIndexToPanelIndex.findIndex((p) => p === panelIndex);
+  return tabs.tabIndexToPanelIndex.indexOf(panelIndex);
 }
 
 export function resolveSavedTabOnProtocolSwitch(

--- a/src/renderer/lib/bleConnectErrors.ts
+++ b/src/renderer/lib/bleConnectErrors.ts
@@ -52,7 +52,7 @@ const BLUEZ_PAIRING_ERROR_RE =
  * - SecurityError: Authentication failure, permission denied
  * - NetworkError: Connection attempt failed (includes BlueZ pairing failures)
  */
-const CHROME_PAIRING_ERROR_NAMES = ['SecurityError', 'NetworkError'];
+const CHROME_PAIRING_ERROR_NAMES = new Set(['SecurityError', 'NetworkError']);
 
 /**
  * Check if a DOMException from Web Bluetooth is likely a pairing-related error.
@@ -60,7 +60,7 @@ const CHROME_PAIRING_ERROR_NAMES = ['SecurityError', 'NetworkError'];
  */
 export function isWebBluetoothPairingError(err: unknown): boolean {
   if (err instanceof DOMException) {
-    if (CHROME_PAIRING_ERROR_NAMES.includes(err.name)) {
+    if (CHROME_PAIRING_ERROR_NAMES.has(err.name)) {
       return true;
     }
     if (BLUEZ_PAIRING_ERROR_RE.test(err.message)) {

--- a/src/renderer/lib/chatMentionSegments.ts
+++ b/src/renderer/lib/chatMentionSegments.ts
@@ -39,23 +39,22 @@ function splitByUrls(text: string): ChatMentionSegment[] {
  * Split `input` into plain text runs, `mention` runs (brackets stripped for display),
  * and `url` runs (http/https links). Unclosed `@[` is left as plain text.
  */
-export function parseChatMentionSegments(input: string): ChatMentionSegment[] {
-  const s = input ?? '';
-  if (!s) return [];
+export function parseChatMentionSegments(input = ''): ChatMentionSegment[] {
+  if (!input) return [];
 
   const out: ChatMentionSegment[] = [];
   let last = 0;
   BRACKET_MENTION.lastIndex = 0;
   let m: RegExpExecArray | null;
-  while ((m = BRACKET_MENTION.exec(s)) !== null) {
+  while ((m = BRACKET_MENTION.exec(input)) !== null) {
     if (m.index > last) {
-      out.push(...splitByUrls(s.slice(last, m.index)));
+      out.push(...splitByUrls(input.slice(last, m.index)));
     }
     out.push({ kind: 'mention', label: (m[1] ?? '').trim() });
     last = m.index + m[0].length;
   }
-  if (last < s.length) {
-    out.push(...splitByUrls(s.slice(last)));
+  if (last < input.length) {
+    out.push(...splitByUrls(input.slice(last)));
   }
   return out;
 }

--- a/src/renderer/lib/chatScrollUtils.ts
+++ b/src/renderer/lib/chatScrollUtils.ts
@@ -145,7 +145,7 @@ export function createStableChatMeasureElement(
 
     if (instance.scrollDirection === 'backward' && hasMeasuredSize) {
       // Allow growth (async previews, layout) but prevent shrink jitter while scrolling up.
-      return domSize > cached ? domSize : cached;
+      return Math.max(domSize, cached);
     }
 
     return domSize;

--- a/src/renderer/lib/decodeQrFromImageSource.ts
+++ b/src/renderer/lib/decodeQrFromImageSource.ts
@@ -14,8 +14,7 @@ export function decodeQrFromImageData(imageData: ImageData): string | null {
   const code = jsQR(imageData.data, imageData.width, imageData.height, {
     inversionAttempts: 'attemptBoth',
   });
-  const text = code?.data?.trim();
-  return text ? text : null;
+  return code?.data?.trim() || null;
 }
 
 function assertDecodableBlob(blob: Blob): void {

--- a/src/renderer/lib/forceDirectedGraphLayout.ts
+++ b/src/renderer/lib/forceDirectedGraphLayout.ts
@@ -115,7 +115,7 @@ export function stepForceSimulation(
     if (si == null || ti == null) continue;
     const dx = nodes[ti].x - nodes[si].x;
     const dy = nodes[ti].y - nodes[si].y;
-    const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+    const dist = Math.hypot(dx, dy) || 1;
     const targetLen = springLengthForEdge(edge);
     const force = FORCE_GRAPH_DEFAULTS.springK * (dist - targetLen);
     fx[si] += (force * dx) / dist;

--- a/src/renderer/lib/hydrateIdentityStoresFromDb.ts
+++ b/src/renderer/lib/hydrateIdentityStoresFromDb.ts
@@ -339,7 +339,7 @@ const IDENTITY_STORE_HYDRATORS: Record<MeshProtocol, IdentityHydratorFn> = {
 export async function hydrateIdentityStoresFromDb(
   protocol: MeshProtocol,
   identityId: IdentityId,
-  opts: HydrateIdentityStoresOptions = { nodes: true, messages: true },
+  opts: HydrateIdentityStoresOptions = {},
 ): Promise<void> {
   const loadNodes = opts.nodes !== false;
   const loadMessages = opts.messages !== false;

--- a/src/renderer/lib/meshcoreGifWire.ts
+++ b/src/renderer/lib/meshcoreGifWire.ts
@@ -5,7 +5,7 @@
 
 const MESHCORE_GIF_SHORT_WIRE = /^g:([A-Za-z0-9_-]+)$/;
 const MESHCORE_GIF_ID = /^[A-Za-z0-9_-]+$/;
-const MESHCORE_GIF_PAGE_ID = /^[A-Za-z0-9_]+$/;
+const MESHCORE_GIF_PAGE_ID = /^\w+$/;
 
 const GIPHY_MEDIA_ORIGIN = 'https://media.giphy.com';
 const GIPHY_PAGE_ORIGIN = 'https://giphy.com';

--- a/src/renderer/lib/meshcoreKeyBackupStorage.ts
+++ b/src/renderer/lib/meshcoreKeyBackupStorage.ts
@@ -5,7 +5,7 @@ import { MESHCORE_PUBLIC_KEY_LENGTH } from './letsMeshJwt';
 export const MESHCORE_KEY_BACKUP_PREFIX = 'mesh-client:meshcore-key-backup:';
 export const MESHCORE_KEY_BACKUP_INDEX_KEY = 'mesh-client:meshcore-key-backup-index';
 
-const MESHCORE_PRIVATE_LENS = [MESHCORE_PUBLIC_KEY_LENGTH, MESHCORE_PUBLIC_KEY_LENGTH * 2] as const;
+const MESHCORE_PRIVATE_LENS = new Set([MESHCORE_PUBLIC_KEY_LENGTH, MESHCORE_PUBLIC_KEY_LENGTH * 2]);
 
 export interface MeshcoreKeyBackupPayload {
   protocol: 'meshcore';
@@ -24,7 +24,7 @@ export interface MeshcoreKeyBackupIndexEntry {
 }
 
 function isValidMeshcorePrivateKeyLength(len: number): boolean {
-  return MESHCORE_PRIVATE_LENS.some((n) => n === len);
+  return MESHCORE_PRIVATE_LENS.has(len);
 }
 
 function validateMeshcoreKeyPair(publicKey: Uint8Array, privateKey: Uint8Array): void {

--- a/src/renderer/lib/meshcoreOpenReaction.ts
+++ b/src/renderer/lib/meshcoreOpenReaction.ts
@@ -221,7 +221,7 @@ function finalizeDartHash(hash: number, hashBits: number): number {
     hash = hash & ((1 << hashBits) - 1);
   }
   const finalized = hash === 0 ? 1 : hash;
-  return finalized > 0x7fffffff ? finalized - 0x1_0000_0000 : finalized;
+  return finalized > 0x7fffffff ? finalized - 0x100000000 : finalized;
 }
 
 /** 4-char hex reaction target hash (MeshCore Open). */

--- a/src/renderer/lib/webbluetooth-ble-manager.ts
+++ b/src/renderer/lib/webbluetooth-ble-manager.ts
@@ -78,7 +78,7 @@ function withGattTimeout<T>(promise: Promise<T>, ms: number, context: string): P
 }
 
 // Chrome DOMException names that often indicate pairing issues on Linux
-const CHROME_PAIRING_ERROR_NAMES = ['SecurityError', 'NetworkError'];
+const CHROME_PAIRING_ERROR_NAMES = new Set(['SecurityError', 'NetworkError']);
 
 /**
  * Chromium exposes `maximumWriteValueLength` on some builds; Web Bluetooth has no standard negotiated-MTU API.
@@ -98,7 +98,7 @@ export function probeWebBluetoothToRadioChunkLimitBytes(
 
 export function isWebBluetoothPairingError(err: unknown): boolean {
   if (err instanceof DOMException) {
-    if (CHROME_PAIRING_ERROR_NAMES.includes(err.name)) {
+    if (CHROME_PAIRING_ERROR_NAMES.has(err.name)) {
       return true;
     }
     if (BLUEZ_PAIRING_ERROR_RE.test(err.message)) {

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -5396,8 +5396,8 @@ export function useMeshcoreRuntime() {
         let result: { expectedAckCrc?: number; estTimeout?: number };
         try {
           result = await runPostRpc(sendOnce);
-        } catch (first: unknown) {
-          const postErr = meshcoreRoomPostSendErrorMessage(first);
+        } catch (error_: unknown) {
+          const postErr = meshcoreRoomPostSendErrorMessage(error_);
           const adminPassword = session?.adminPassword?.trim() ?? '';
           if (
             adminPassword.length > 0 &&
@@ -5420,7 +5420,7 @@ export function useMeshcoreRuntime() {
             });
             result = await runPostRpc(sendOnce);
           } else {
-            throw first;
+            throw error_;
           }
         }
         void fetchAndUpdateLocalStats().catch((e: unknown) => {

--- a/src/renderer/stores/blockStore.ts
+++ b/src/renderer/stores/blockStore.ts
@@ -71,6 +71,4 @@ export const useBlockStore = create<BlockStoreState>((set, get) => ({
 }));
 
 /** Node id string for Meshtastic/MeshCore block rows. */
-export function blockHashForNodeNum(nodeNum: number): string {
-  return String(nodeNum);
-}
+export const blockHashForNodeNum: (nodeNum: number) => string = String;

--- a/src/renderer/vitest.setup.ts
+++ b/src/renderer/vitest.setup.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 /** Fail tests on [object Object] in console.warn (use mockConsoleWarn when expecting warnings). */
 const originalConsoleWarn = console.warn.bind(console);
 console.warn = (...args: Parameters<typeof console.warn>) => {
-  const text = args.map((a) => String(a)).join(' ');
+  const text = args.map(String).join(' ');
   if (text.includes('[object Object]')) {
     throw new Error(`Unexpected console.warn containing [object Object]: ${text}`);
   }

--- a/src/renderer/workers/messageEncoder.worker.ts
+++ b/src/renderer/workers/messageEncoder.worker.ts
@@ -10,16 +10,16 @@ import type { WorkerCommand, WorkerEvent } from '../lib/transport/types';
 const TEXT_MESSAGE_APP = Portnums.PortNum.TEXT_MESSAGE_APP;
 
 // Only accept messages from our renderer (Electron: file/null in prod, localhost in dev).
-const ALLOWED_ORIGINS = [
+const ALLOWED_ORIGINS = new Set([
   'null',
   'file://',
   'http://localhost:5173',
   'http://localhost:5174',
   'http://127.0.0.1:5173',
-];
+]);
 
 self.onmessage = (event: MessageEvent<WorkerCommand>) => {
-  if (!ALLOWED_ORIGINS.includes(event.origin)) {
+  if (!ALLOWED_ORIGINS.has(event.origin)) {
     return;
   }
   const data: unknown = event.data;

--- a/src/shared/connectHost.ts
+++ b/src/shared/connectHost.ts
@@ -207,7 +207,7 @@ export function parseConnectHostPort(
     const sep = addr.lastIndexOf(':');
     const maybePort = addr.slice(sep + 1);
     const port = parseTrailingPort(maybePort);
-    if (port !== null && maybePort.length > 0 && /^[0-9]+$/.test(maybePort) && port > 255) {
+    if (port !== null && maybePort.length > 0 && /^\d+$/.test(maybePort) && port > 255) {
       const host = addr.slice(0, sep);
       if (host) {
         return { host, port };


### PR DESCRIPTION
## Summary
- Fix the remaining low-count SonarCloud smells after bulk code-smell acceptance (dataset accessors, `Set` membership, `Blob.text()`, `Math.max`/`Math.hypot`, concise regex classes, default params, and related micro-cleanups).
- Leave intentional PATH/CSP/tmpdir/demo-password findings suppressed; no behavior change intended beyond equivalent APIs.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full Vitest suite (650 files, 5,719 tests) via pre-commit
- [x] Pre-commit lint / typecheck / audit / repository checks
- [ ] Confirm SonarCloud PR decoration clears the previously open low-count smell keys after analysis