### PR TITLE
chore: track upstream patch PRs and harden Meshtastic disconnect teardown

### DIFF
--- a/patches/@jsr__meshtastic__core@2.6.6.patch
+++ b/patches/@jsr__meshtastic__core@2.6.6.patch
@@ -1,5 +1,5 @@
 diff --git a/src/meshDevice.js b/src/meshDevice.js
-index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..31017c3425231e3c31f39c85e1c19343504d56c6 100755
+index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..5dc13d3027c44a93b1b62e1ac4514c24e6926d7e 100755
 --- a/src/meshDevice.js
 +++ b/src/meshDevice.js
 @@ -20,6 +20,8 @@ export class MeshDevice {
@@ -11,7 +11,7 @@ index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..31017c3425231e3c31f39c85e1c19343
    constructor(transport, configId){
      this.log = new Logger({
        name: "iMeshDevice",
-@@ -48,7 +50,15 @@ export class MeshDevice {
+@@ -48,7 +50,16 @@ export class MeshDevice {
      this.events.onPendingSettingsChange.subscribe((state)=>{
        this.pendingSettingsChanges = state;
      });
@@ -21,14 +21,15 @@ index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..31017c3425231e3c31f39c85e1c19343
 +      signal: this._fromDeviceAc.signal
 +    });
 +    void this._fromDevicePipe.catch((err)=>{
-+      if (err instanceof Error && err.name !== "AbortError") {
-+        this.log.error(Emitter[Emitter.ReadFromRadio], `Device decoding pipe failed: ${err.message}`);
++      if (err?.name !== "AbortError") {
++        const message = err instanceof Error ? err.message : String(err);
++        this.log.error(Emitter[Emitter.ReadFromRadio], `Device decoding pipe failed: ${message}`);
 +      }
 +    });
    }
    /** Abstract method that connects to the radio */ // protected abstract connect(
    //   parameters: Types.ConnectionParameters,
-@@ -447,7 +457,23 @@ export class MeshDevice {
+@@ -447,7 +458,23 @@ export class MeshDevice {
        clearInterval(this._heartbeatIntervalId);
      }
      this.complete();
@@ -38,8 +39,8 @@ index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..31017c3425231e3c31f39c85e1c19343
 +    }
 +    try {
 +      await this.transport.toDevice.close();
-+    } catch  {
-+      this.log.debug(Emitter[Emitter.Disconnect], "Writable stream already closed or errored");
++    } catch (err) {
++      this.log.debug(Emitter[Emitter.Disconnect], `Writable stream already closed or errored: ${err instanceof Error ? err.message : String(err)}`);
 +    }
 +    if (this._fromDevicePipe) {
 +      try {
@@ -54,7 +55,7 @@ index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..31017c3425231e3c31f39c85e1c19343
    }
    /**
 diff --git a/src/meshDevice.ts b/src/meshDevice.ts
-index ddca80fc9134fa56ac273b17387e62af087c95c6..5e2d3b953c14fe439b1f5555c4a177e02ff1e140 100755
+index ddca80fc9134fa56ac273b17387e62af087c95c6..365b64b0e60cce8f23cb9d6a6d463b6d9591e190 100755
 --- a/src/meshDevice.ts
 +++ b/src/meshDevice.ts
 @@ -41,6 +41,10 @@ export class MeshDevice {
@@ -68,7 +69,7 @@ index ddca80fc9134fa56ac273b17387e62af087c95c6..5e2d3b953c14fe439b1f5555c4a177e0
    constructor(transport: Transport, configId?: number) {
      this.log = new Logger({
        name: "iMeshDevice",
-@@ -75,7 +79,20 @@ export class MeshDevice {
+@@ -75,7 +79,22 @@ export class MeshDevice {
        this.pendingSettingsChanges = state;
      });
  
@@ -80,17 +81,19 @@ index ddca80fc9134fa56ac273b17387e62af087c95c6..5e2d3b953c14fe439b1f5555c4a177e0
 +    // Swallow abort/cancel rejection so an unhandled rejection does not
 +    // surface, but log unexpected transport/stream failures.
 +    void this._fromDevicePipe.catch((err) => {
-+      if (err instanceof Error && err.name !== "AbortError") {
++      // Abort rejections may be DOMException, so do not require instanceof Error.
++      if ((err as { name?: string } | null)?.name !== "AbortError") {
++        const message = err instanceof Error ? err.message : String(err);
 +        this.log.error(
 +          Emitter[Emitter.ReadFromRadio],
-+          `Device decoding pipe failed: ${err.message}`,
++          `Device decoding pipe failed: ${message}`,
 +        );
 +      }
 +    });
    }
  
    /** Abstract method that connects to the radio */
-@@ -817,7 +834,30 @@ export class MeshDevice {
+@@ -817,7 +836,32 @@ export class MeshDevice {
      }
  
      this.complete();
@@ -102,10 +105,10 @@ index ddca80fc9134fa56ac273b17387e62af087c95c6..5e2d3b953c14fe439b1f5555c4a177e0
 +
 +    try {
 +      await this.transport.toDevice.close();
-+    } catch {
++    } catch (err) {
 +      this.log.debug(
 +        Emitter[Emitter.Disconnect],
-+        "Writable stream already closed or errored",
++        `Writable stream already closed or errored: ${err instanceof Error ? err.message : String(err)}`,
 +      );
 +    }
 +
@@ -116,6 +119,8 @@ index ddca80fc9134fa56ac273b17387e62af087c95c6..5e2d3b953c14fe439b1f5555c4a177e0
 +        // catch-no-log-ok pipe aborted during disconnect
 +      }
 +    }
++    // Yield a few microtask ticks so stream teardown callbacks queued by the
++    // abort settle before the transport releases the underlying port.
 +    await Promise.resolve();
 +    await Promise.resolve();
 +    await Promise.resolve();

--- a/patches/@jsr__meshtastic__core@2.6.6.patch
+++ b/patches/@jsr__meshtastic__core@2.6.6.patch
@@ -1,5 +1,5 @@
 diff --git a/src/meshDevice.js b/src/meshDevice.js
-index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..4a5825db35031f37e23c208b372c49f090320c25 100755
+index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..31017c3425231e3c31f39c85e1c19343504d56c6 100755
 --- a/src/meshDevice.js
 +++ b/src/meshDevice.js
 @@ -20,6 +20,8 @@ export class MeshDevice {
@@ -11,7 +11,7 @@ index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..4a5825db35031f37e23c208b372c49f0
    constructor(transport, configId){
      this.log = new Logger({
        name: "iMeshDevice",
-@@ -48,7 +50,11 @@ export class MeshDevice {
+@@ -48,7 +50,15 @@ export class MeshDevice {
      this.events.onPendingSettingsChange.subscribe((state)=>{
        this.pendingSettingsChanges = state;
      });
@@ -20,16 +20,28 @@ index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..4a5825db35031f37e23c208b372c49f0
 +    this._fromDevicePipe = this.transport.fromDevice.pipeTo(decodePacket(this), {
 +      signal: this._fromDeviceAc.signal
 +    });
-+    void this._fromDevicePipe.catch(()=>{});
++    void this._fromDevicePipe.catch((err)=>{
++      if (err instanceof Error && err.name !== "AbortError") {
++        this.log.error(Emitter[Emitter.ReadFromRadio], `Device decoding pipe failed: ${err.message}`);
++      }
++    });
    }
    /** Abstract method that connects to the radio */ // protected abstract connect(
    //   parameters: Types.ConnectionParameters,
-@@ -448,6 +454,16 @@ export class MeshDevice {
+@@ -447,7 +457,23 @@ export class MeshDevice {
+       clearInterval(this._heartbeatIntervalId);
      }
      this.complete();
-     await this.transport.toDevice.close();
+-    await this.transport.toDevice.close();
 +    if (this._fromDeviceAc) {
 +      this._fromDeviceAc.abort();
++    }
++    try {
++      await this.transport.toDevice.close();
++    } catch  {
++      this.log.debug(Emitter[Emitter.Disconnect], "Writable stream already closed or errored");
++    }
++    if (this._fromDevicePipe) {
 +      try {
 +        await this._fromDevicePipe;
 +      } catch  {
@@ -42,7 +54,7 @@ index 8c58dc7d43f91d1a7c0759f2172950f1c987dd95..4a5825db35031f37e23c208b372c49f0
    }
    /**
 diff --git a/src/meshDevice.ts b/src/meshDevice.ts
-index ddca80fc9134fa56ac273b17387e62af087c95c6..11539785db789bfb261cd3b8d084fc71bf38d095 100755
+index ddca80fc9134fa56ac273b17387e62af087c95c6..5e2d3b953c14fe439b1f5555c4a177e02ff1e140 100755
 --- a/src/meshDevice.ts
 +++ b/src/meshDevice.ts
 @@ -41,6 +41,10 @@ export class MeshDevice {
@@ -56,7 +68,7 @@ index ddca80fc9134fa56ac273b17387e62af087c95c6..11539785db789bfb261cd3b8d084fc71
    constructor(transport: Transport, configId?: number) {
      this.log = new Logger({
        name: "iMeshDevice",
-@@ -75,7 +79,11 @@ export class MeshDevice {
+@@ -75,7 +79,20 @@ export class MeshDevice {
        this.pendingSettingsChanges = state;
      });
  
@@ -65,16 +77,39 @@ index ddca80fc9134fa56ac273b17387e62af087c95c6..11539785db789bfb261cd3b8d084fc71
 +    this._fromDevicePipe = this.transport.fromDevice.pipeTo(decodePacket(this), {
 +      signal: this._fromDeviceAc.signal,
 +    });
-+    void this._fromDevicePipe.catch(() => {});
++    // Swallow abort/cancel rejection so an unhandled rejection does not
++    // surface, but log unexpected transport/stream failures.
++    void this._fromDevicePipe.catch((err) => {
++      if (err instanceof Error && err.name !== "AbortError") {
++        this.log.error(
++          Emitter[Emitter.ReadFromRadio],
++          `Device decoding pipe failed: ${err.message}`,
++        );
++      }
++    });
    }
  
    /** Abstract method that connects to the radio */
-@@ -818,6 +826,17 @@ export class MeshDevice {
+@@ -817,7 +834,30 @@ export class MeshDevice {
+     }
  
      this.complete();
-     await this.transport.toDevice.close();
-+    if (this._fromDeviceAc) {
-+      this._fromDeviceAc.abort();
+-    await this.transport.toDevice.close();
++
++    // Signal the inbound pipe abort before blocking on IO so teardown still
++    // completes when the transport is already gone (e.g. unplugged serial).
++    this._fromDeviceAc?.abort();
++
++    try {
++      await this.transport.toDevice.close();
++    } catch {
++      this.log.debug(
++        Emitter[Emitter.Disconnect],
++        "Writable stream already closed or errored",
++      );
++    }
++
++    if (this._fromDevicePipe) {
 +      try {
 +        await this._fromDevicePipe;
 +      } catch {

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,99 @@
+# pnpm patchedDependencies
+
+Local overlays applied via `package.json` → `pnpm.patchedDependencies`. When bumping a patched package version, regenerate the patch hash under `patches/` and keep `WATCH_ENTRIES` in `scripts/update.sh` in sync.
+
+| Patch | Upstream | Upstream PR / status |
+| ----- | -------- | -------------------- |
+| `@liamcottle__meshcore.js@1.13.0.patch` | [meshcore-dev/meshcore.js](https://github.com/meshcore-dev/meshcore.js) | Split: [#29](https://github.com/meshcore-dev/meshcore.js/pull/29), [#30](https://github.com/meshcore-dev/meshcore.js/pull/30), [#31](https://github.com/meshcore-dev/meshcore.js/pull/31), [#32](https://github.com/meshcore-dev/meshcore.js/pull/32), [#33](https://github.com/meshcore-dev/meshcore.js/pull/33) |
+| `@jsr__meshtastic__core@2.6.6.patch` | [meshtastic/web](https://github.com/meshtastic/web) (`packages/sdk`) | [#1312](https://github.com/meshtastic/web/pull/1312) |
+| `@jsr__meshtastic__transport-web-serial@0.2.5.patch` | [meshtastic/web](https://github.com/meshtastic/web) (`packages/transport-web-serial`) | Fixed on upstream `main` (per-instance `toDeviceStream` + abort); keep patch until npm/`@jsr` package bump includes it |
+| `@stoprocent__noble@2.5.7.patch` | [stoprocent/noble](https://github.com/stoprocent/noble) | [#94](https://github.com/stoprocent/noble/pull/94) |
+| `usb@2.18.0.patch` | [node-usb/node-usb](https://github.com/node-usb/node-usb) | [#964](https://github.com/node-usb/node-usb/pull/964) |
+| `readable-stream@4.7.0.patch` | [nodejs/readable-stream](https://github.com/nodejs/readable-stream) | **Intentionally local** — upstream uses `require('process/')` for browser bundlers; Electron/Node needs bare `process` |
+| `debug@4.4.3.patch` | [debug-js/debug](https://github.com/debug-js/debug) | **Intentionally local** — inlines `ms`/`humanize` so electron-vite does not fail resolving the `ms` dependency |
+
+## @liamcottle/meshcore.js@1.13.0
+
+Protocol / companion-radio fixes. Upstreamed as five focused PRs (npm package name remains `@liamcottle/meshcore.js`; repo lives under `meshcore-dev`).
+
+| PR | Change |
+| -- | ------ |
+| [#29](https://github.com/meshcore-dev/meshcore.js/pull/29) | Empty login password → zero-byte payload (read-only ACL) |
+| [#30](https://github.com/meshcore-dev/meshcore.js/pull/30) | TraceData SNR count from `path_sz` flags |
+| [#31](https://github.com/meshcore-dev/meshcore.js/pull/31) | DeviceInfo v3+ fields + `setPathHashMode` (cmd 61) |
+| [#32](https://github.com/meshcore-dev/meshcore.js/pull/32) | `LoginFail` (0x86) push handler |
+| [#33](https://github.com/meshcore-dev/meshcore.js/pull/33) | `readString` stops at embedded NUL |
+
+**Kept local-only (not upstreamed):** silence companion push codes `25` / `0x8E` / `0x8F`, and downgrade unhandled-frame `console.log` → `console.debug`.
+
+### Sunset
+
+When the five PRs merge and a release newer than `1.13.0` includes them, drop the corresponding hunks (or the whole patch if only local-only hunks remain), bump the dependency, and remove this entry from `WATCH_ENTRIES` if no patch remains.
+
+## @jsr/meshtastic__core@2.6.6
+
+Abort `fromDevice.pipeTo(decodePacket)` on disconnect so serial/BLE ports are not left locked (“port is already open” on reconnect).
+
+| Field | Value |
+| ----- | ----- |
+| **Upstream PR** | https://github.com/meshtastic/web/pull/1312 (ported to `MeshClient` in the monorepo; JSR `@meshtastic/core` 2.6.6 still ships legacy `MeshDevice`) |
+
+### Sunset
+
+When a published `@meshtastic/core` / `@jsr/meshtastic__core` release includes equivalent inbound-pipe abort on disconnect, remove the patch and bump the dependency.
+
+## @jsr/meshtastic__transport-web-serial@0.2.5
+
+Per-instance `toDeviceStream` (instead of shared `Utils.toDeviceStream`) and swallow pipe errors on disconnect so Web Serial reconnects cleanly.
+
+| Field | Value |
+| ----- | ----- |
+| **Upstream status** | Already fixed on [meshtastic/web](https://github.com/meshtastic/web) `main` (`packages/transport-web-serial`); not yet in the pinned `@jsr` `0.2.5` package |
+
+### Sunset
+
+When the published `@jsr/meshtastic__transport-web-serial` (or successor package) includes per-instance framing + abort teardown, remove the patch and bump the dependency.
+
+## @stoprocent/noble@2.5.7
+
+Windows `binding.gyp`: drop `/await` under `/std:c++20`, add `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS`.
+
+| Field | Value |
+| ----- | ----- |
+| **Upstream PR** | https://github.com/stoprocent/noble/pull/94 |
+
+### Sunset
+
+When the PR merges and a release includes it, remove the patch and bump `@stoprocent/noble`.
+
+## usb@2.18.0
+
+Bump native build flags from C++14 / `c++1y` to C++17 for current Xcode/Clang/Electron toolchains.
+
+| Field | Value |
+| ----- | ----- |
+| **Upstream PR** | https://github.com/node-usb/node-usb/pull/964 |
+
+### Sunset
+
+When the PR merges and a release (or a version bump past `2.18.0` that includes C++17 flags) ships, remove the patch and bump `usb`.
+
+## readable-stream@4.7.0
+
+Replace `require('process/')` with `require('process')` in stream internals.
+
+**Intentionally local.** Upstream deliberately uses the `process/` package path for browser bundler compatibility; changing that would break browser consumers. mesh-client needs the Node built-in under Electron packaging (see also `docs/troubleshooting.md` Linux asar notes).
+
+### Sunset
+
+Only if packaging/bundling no longer requires the bare `process` require, or upstream offers a Node-first build entry that avoids `process/`.
+
+## debug@4.4.3
+
+Inline a minimal `ms`/`humanize` implementation instead of `require('ms')`.
+
+**Intentionally local.** electron-vite / the main-process bundle path can fail to resolve the transitive `ms` package; inlining avoids that without changing upstream’s dependency graph for all consumers.
+
+### Sunset
+
+Only if the bundler resolves `ms` reliably without the inline, or upstream ships a build that does not require a separate `ms` package at runtime.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
 
 patchedDependencies:
   '@jsr/meshtastic__core@2.6.6':
-    hash: 714af0fd567c3a11b0ee94c68743dce951b199d388f217bd3cb5770a7b3e278a
+    hash: df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc
     path: patches/@jsr__meshtastic__core@2.6.6.patch
   '@jsr/meshtastic__transport-web-serial@0.2.5':
     hash: 27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74
@@ -139,7 +139,7 @@ importers:
         version: 1.13.0(patch_hash=1f95835871af6026efa9def5d5bed54749cdb34ff0ff013a9d52005db9db3220)
       '@meshtastic/core':
         specifier: npm:@jsr/meshtastic__core@^2.6.6
-        version: '@jsr/meshtastic__core@2.6.6(patch_hash=714af0fd567c3a11b0ee94c68743dce951b199d388f217bd3cb5770a7b3e278a)(buffer@6.0.3)'
+        version: '@jsr/meshtastic__core@2.6.6(patch_hash=df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc)(buffer@6.0.3)'
       '@meshtastic/transport-http':
         specifier: npm:@jsr/meshtastic__transport-http@^0.2.1
         version: '@jsr/meshtastic__transport-http@0.2.1(buffer@6.0.3)'
@@ -5162,7 +5162,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jsr/meshtastic__core@2.6.6(patch_hash=714af0fd567c3a11b0ee94c68743dce951b199d388f217bd3cb5770a7b3e278a)(buffer@6.0.3)':
+  '@jsr/meshtastic__core@2.6.6(patch_hash=df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc)(buffer@6.0.3)':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       '@jsr/meshtastic__protobufs': 2.7.23
@@ -5178,13 +5178,13 @@ snapshots:
 
   '@jsr/meshtastic__transport-http@0.2.1(buffer@6.0.3)':
     dependencies:
-      '@jsr/meshtastic__core': 2.6.6(patch_hash=714af0fd567c3a11b0ee94c68743dce951b199d388f217bd3cb5770a7b3e278a)(buffer@6.0.3)
+      '@jsr/meshtastic__core': 2.6.6(patch_hash=df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc)(buffer@6.0.3)
     transitivePeerDependencies:
       - buffer
 
   '@jsr/meshtastic__transport-web-serial@0.2.5(patch_hash=27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74)(buffer@6.0.3)':
     dependencies:
-      '@meshtastic/core': '@jsr/meshtastic__core@2.6.6(patch_hash=714af0fd567c3a11b0ee94c68743dce951b199d388f217bd3cb5770a7b3e278a)(buffer@6.0.3)'
+      '@meshtastic/core': '@jsr/meshtastic__core@2.6.6(patch_hash=df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc)(buffer@6.0.3)'
     transitivePeerDependencies:
       - buffer
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
 
 patchedDependencies:
   '@jsr/meshtastic__core@2.6.6':
-    hash: df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc
+    hash: de16755c559d2387594c6bdcd76c7e643f15af1b8398fc1fd3e067fa93f7be6a
     path: patches/@jsr__meshtastic__core@2.6.6.patch
   '@jsr/meshtastic__transport-web-serial@0.2.5':
     hash: 27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74
@@ -139,7 +139,7 @@ importers:
         version: 1.13.0(patch_hash=1f95835871af6026efa9def5d5bed54749cdb34ff0ff013a9d52005db9db3220)
       '@meshtastic/core':
         specifier: npm:@jsr/meshtastic__core@^2.6.6
-        version: '@jsr/meshtastic__core@2.6.6(patch_hash=df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc)(buffer@6.0.3)'
+        version: '@jsr/meshtastic__core@2.6.6(patch_hash=de16755c559d2387594c6bdcd76c7e643f15af1b8398fc1fd3e067fa93f7be6a)(buffer@6.0.3)'
       '@meshtastic/transport-http':
         specifier: npm:@jsr/meshtastic__transport-http@^0.2.1
         version: '@jsr/meshtastic__transport-http@0.2.1(buffer@6.0.3)'
@@ -5162,7 +5162,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jsr/meshtastic__core@2.6.6(patch_hash=df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc)(buffer@6.0.3)':
+  '@jsr/meshtastic__core@2.6.6(patch_hash=de16755c559d2387594c6bdcd76c7e643f15af1b8398fc1fd3e067fa93f7be6a)(buffer@6.0.3)':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       '@jsr/meshtastic__protobufs': 2.7.23
@@ -5178,13 +5178,13 @@ snapshots:
 
   '@jsr/meshtastic__transport-http@0.2.1(buffer@6.0.3)':
     dependencies:
-      '@jsr/meshtastic__core': 2.6.6(patch_hash=df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc)(buffer@6.0.3)
+      '@jsr/meshtastic__core': 2.6.6(patch_hash=de16755c559d2387594c6bdcd76c7e643f15af1b8398fc1fd3e067fa93f7be6a)(buffer@6.0.3)
     transitivePeerDependencies:
       - buffer
 
   '@jsr/meshtastic__transport-web-serial@0.2.5(patch_hash=27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74)(buffer@6.0.3)':
     dependencies:
-      '@meshtastic/core': '@jsr/meshtastic__core@2.6.6(patch_hash=df278504d7892fc3c333cff7512fe4834b4667ac71a769f0129f5fb8ca424cdc)(buffer@6.0.3)'
+      '@meshtastic/core': '@jsr/meshtastic__core@2.6.6(patch_hash=de16755c559d2387594c6bdcd76c7e643f15af1b8398fc1fd3e067fa93f7be6a)(buffer@6.0.3)'
     transitivePeerDependencies:
       - buffer
 

--- a/reticulum-sidecar/patches/README.md
+++ b/reticulum-sidecar/patches/README.md
@@ -52,7 +52,7 @@ Skip macOS/iOS VPN tunnel interfaces (`utun*`, `ipsec*`, `ppp*`) for AutoInterfa
 | Field | Value |
 | ----- | ----- |
 | **Base commit** | `6d2b28475321bc15c8f60796513d8878b47ed3ab` |
-| **Upstream PR** | _(open against [ratspeak/rsReticulum](https://github.com/ratspeak/rsReticulum))_ |
+| **Upstream PR** | https://github.com/ratspeak/rsReticulum/pull/11 |
 
 **Modifies (1 file):**
 
@@ -86,7 +86,7 @@ git -C /tmp/rsReticulum-patch-test apply --check ../mesh-client/reticulum-sideca
 
 ### Sunset
 
-When the upstream PR merges, remove this patch and drop the CI apply step (same as packet-tap).
+When [ratspeak/rsReticulum#11](https://github.com/ratspeak/rsReticulum/pull/11) merges, remove this patch and drop the CI apply step (same as packet-tap).
 
 ## rsReticulum-link-client-nomad.patch
 
@@ -144,7 +144,7 @@ LinkIdentify + peering stamp before LXMF `/offer`, plus `set_local_identity` / `
 | Field | Value |
 | ----- | ----- |
 | **Base commit** | `68ad7c835187c052c763bb28c41b04a655f35c64` |
-| **Upstream** | local patch until merged to [ratspeak/rsLXMF](https://github.com/ratspeak/rsLXMF) |
+| **Upstream PR** | https://github.com/ratspeak/rsLXMF/pull/4 |
 
 **Modifies (1 file):**
 
@@ -171,4 +171,4 @@ git diff 68ad7c835187c052c763bb28c41b04a655f35c64 -- crates/lxmf-core/src/propag
 
 ### Sunset
 
-When the peering/identity APIs land on `ratspeak/rsLXMF` `main`, remove this patch and drop the apply step from `clone-ratspeak-stack.sh` / `ensure-rsReticulum-patches.sh`.
+When [ratspeak/rsLXMF#4](https://github.com/ratspeak/rsLXMF/pull/4) merges, remove this patch and drop the apply step from `clone-ratspeak-stack.sh` / `ensure-rsReticulum-patches.sh`.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -175,9 +175,9 @@ check_ratspeak_patches() {
   # Format: "patch-basename|github-owner/repo|pr-number-or-empty|display-label|review-url"
   local RATSPEAK_PATCH_ENTRIES=(
     'rsReticulum-packet-tap.patch|ratspeak/rsReticulum|10|rsReticulum packet-tap|https://github.com/ratspeak/rsReticulum/pull/10'
-    'rsReticulum-auto-beacon-utun.patch|ratspeak/rsReticulum||rsReticulum auto-beacon utun|https://github.com/ratspeak/rsReticulum'
+    'rsReticulum-auto-beacon-utun.patch|ratspeak/rsReticulum|11|rsReticulum auto-beacon utun|https://github.com/ratspeak/rsReticulum/pull/11'
     'rsReticulum-link-client-nomad.patch|ratspeak/rsReticulum|14|rsReticulum LinkClient Nomad|https://github.com/ratspeak/rsReticulum/pull/14'
-    'rsLXMF-propagation-sync-peering.patch|ratspeak/rsLXMF||rsLXMF propagation sync peering|https://github.com/ratspeak/rsLXMF'
+    'rsLXMF-propagation-sync-peering.patch|ratspeak/rsLXMF|4|rsLXMF propagation sync peering|https://github.com/ratspeak/rsLXMF/pull/4'
   )
   local patches_dir='reticulum-sidecar/patches'
   local has_ratspeak_warning=0


### PR DESCRIPTION
## Summary

- Add [`patches/README.md`](patches/README.md) documenting every `pnpm.patchedDependencies` overlay with upstream PR links (meshcore.js, Meshtastic, noble, usb) or intentionally-local rationale (`readable-stream`, `debug`).
- Record already-open Ratspeak overlays [rsReticulum#11](https://github.com/ratspeak/rsReticulum/pull/11) and [rsLXMF#4](https://github.com/ratspeak/rsLXMF/pull/4) in the overlay README and `scripts/update.sh` `RATSPEAK_PATCH_ENTRIES` so `pnpm run update` can warn when they merge.
- Align the `@jsr/meshtastic__core` patch with review feedback on [meshtastic/web#1312](https://github.com/meshtastic/web/pull/1312): abort the inbound `fromDevice` pipe before awaiting `toDevice.close()`, tolerate writable close errors on abrupt disconnect, and log non-`AbortError` decoding pipe failures.

Upstream PRs filed as part of this work (not in this repo): meshcore-dev/meshcore.js #29–#33, meshtastic/web #1312, stoprocent/noble #94, node-usb/node-usb #964.

## Test plan

- [ ] Confirm `pnpm install` applies the updated `@jsr/meshtastic__core` patch cleanly
- [ ] Spot-check Meshtastic serial/BLE disconnect then reconnect (no “port is already open”)
- [ ] `pnpm run update` (or dry-read `RATSPEAK_PATCH_ENTRIES`) shows PR numbers for auto-beacon-utun and LXMF peering overlays
- [ ] Markdownlint / pre-commit already passed on this commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disconnect/shutdown behavior to prevent unhandled errors during inbound packet processing.
  - Added more resilient stream closing and coordinated cleanup to avoid errors when streams are already closed.

- **Documentation**
  - Expanded patch tracking documentation, including upstream PR references and guidance for retiring temporary patches.
  - Updated patch registry metadata for specific Reticulum and LXMF overlay patches to reflect newly merged upstream work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->