### PR TITLE
fix(NodeDetailModal): wire Meshtastic node delete to runtime deleteNode

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -894,6 +894,33 @@ describe('App accessibility', () => {
     expect(meshtasticRuntime.getRemoteAdminKeyForNode).not.toHaveBeenCalled();
   });
 
+  it('wires Meshtastic node detail delete to the runtime deleteNode', async () => {
+    const meshtasticRuntime = createDeviceMock();
+    useDeviceMock.mockReturnValue(meshtasticRuntime);
+
+    renderApp();
+    fireEvent.click(screen.getByRole('tab', { name: /^Chat/ }));
+
+    await waitFor(() => {
+      expect(lastChatPanelProps.current).not.toBeNull();
+    });
+    const onNodeClick = lastChatPanelProps.current?.onNodeClick as
+      ((nodeId: number) => void) | null;
+    expect(onNodeClick).toBeTruthy();
+    onNodeClick?.(0x23456789);
+
+    await waitFor(() => {
+      expect(lastNodeDetailModalProps.current).not.toBeNull();
+      expect(lastNodeDetailModalProps.current?.protocol).toBe('meshtastic');
+    });
+
+    const onDeleteNode = lastNodeDetailModalProps.current?.onDeleteNode as
+      ((nodeId: number) => Promise<void>) | undefined;
+    expect(onDeleteNode).toBeTruthy();
+    await onDeleteNode?.(0x23456789);
+    expect(meshtasticRuntime.deleteNode).toHaveBeenCalledWith(0x23456789);
+  });
+
   it('keeps MeshCore node detail connection props when Meshtastic tab is active', async () => {
     const peerNodeId = 0x23456789;
     const meshcoreSelfNodeId = 0x12345678;

--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -907,7 +907,9 @@ describe('App accessibility', () => {
     const onNodeClick = lastChatPanelProps.current?.onNodeClick as
       ((nodeId: number) => void) | null;
     expect(onNodeClick).toBeTruthy();
-    onNodeClick?.(0x23456789);
+    act(() => {
+      onNodeClick?.(0x23456789);
+    });
 
     await waitFor(() => {
       expect(lastNodeDetailModalProps.current).not.toBeNull();
@@ -917,7 +919,9 @@ describe('App accessibility', () => {
     const onDeleteNode = lastNodeDetailModalProps.current?.onDeleteNode as
       ((nodeId: number) => Promise<void>) | undefined;
     expect(onDeleteNode).toBeTruthy();
-    await onDeleteNode?.(0x23456789);
+    await act(async () => {
+      await onDeleteNode?.(0x23456789);
+    });
     expect(meshtasticRuntime.deleteNode).toHaveBeenCalledWith(0x23456789);
   });
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2449,6 +2449,18 @@ function AppContent() {
     setActiveTab(1); // Switch to Chat tab
   }, []);
 
+  const handleDeleteNode = useCallback(
+    async (nodeNum: number) => {
+      if (detailModalProtocol === 'meshcore') {
+        await meshcorePanelActions.deleteNode(nodeNum);
+      } else {
+        await meshtasticPanelActions.deleteNode(nodeNum);
+      }
+      setSelectedNodeId(null);
+    },
+    [detailModalProtocol, meshcorePanelActions, meshtasticPanelActions],
+  );
+
   const handleOpenReticulumDmByHash = useCallback(
     (hash: string) => {
       const nodeId = openReticulumDmFromHash(hash);
@@ -4284,17 +4296,9 @@ function AppContent() {
             }
             traceRouteHops={traceRouteHops}
             onDeleteNode={
-              detailModalProtocol === 'meshcore'
-                ? async (nodeNum) => {
-                    await meshcorePanelActions.deleteNode(nodeNum);
-                    setSelectedNodeId(null);
-                  }
-                : detailModalProtocol === 'meshtastic'
-                  ? async (nodeNum) => {
-                      await meshtasticPanelActions.deleteNode(nodeNum);
-                      setSelectedNodeId(null);
-                    }
-                  : undefined
+              detailModalProtocol === 'meshcore' || detailModalProtocol === 'meshtastic'
+                ? handleDeleteNode
+                : undefined
             }
             onMessageNode={
               selectedNode?.node_id !== detailMyNodeNum && selectedNode?.hw_model !== 'Room'

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4284,12 +4284,17 @@ function AppContent() {
             }
             traceRouteHops={traceRouteHops}
             onDeleteNode={
-              detailModalCapabilities.hasCompanionContactManagementConfig
+              detailModalProtocol === 'meshcore'
                 ? async (nodeNum) => {
                     await meshcorePanelActions.deleteNode(nodeNum);
                     setSelectedNodeId(null);
                   }
-                : undefined
+                : detailModalProtocol === 'meshtastic'
+                  ? async (nodeNum) => {
+                      await meshtasticPanelActions.deleteNode(nodeNum);
+                      setSelectedNodeId(null);
+                    }
+                  : undefined
             }
             onMessageNode={
               selectedNode?.node_id !== detailMyNodeNum && selectedNode?.hw_model !== 'Room'


### PR DESCRIPTION
## Summary
- `onDeleteNode` on `NodeDetailModal` was only ever wired to `meshcorePanelActions.deleteNode`, gated behind the MeshCore-only `hasCompanionContactManagementConfig` capability flag.
- On the Meshtastic tab `onDeleteNode` was therefore `undefined`. Clicking "Confirm delete" called `onDeleteNode?.(node.node_id)` → `undefined`, then chained `.then(onClose)` on `undefined`, throwing synchronously in the click handler — so the button appeared unresponsive.
- `useMeshtasticRuntime.ts` already has a fully working `deleteNode` (including the same MQTT-identity guard the modal's error handler expects), exposed via `meshtasticPanelActions.deleteNode`; it just was never wired up.
- Fix branches `onDeleteNode` by `detailModalProtocol`, matching the existing `onTraceRoute`/`onRequestPosition` pattern in the same file, so Meshtastic now calls `meshtasticPanelActions.deleteNode` and MeshCore keeps calling `meshcorePanelActions.deleteNode`.

## Test plan
- [x] Added `App.test.tsx` regression test: opens the node detail modal on the Meshtastic tab, invokes `onDeleteNode`, asserts the runtime's `deleteNode` was called.
- [x] Full `App.test.tsx` suite passes (32/32).
- [x] `pnpm run lint` / `pnpm run typecheck` clean on changed files.
- [ ] Manually verified via `pnpm start`: connected to a live node and successfully deleted it from the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled node deletion from detail views for both MeshCore and Meshtastic protocols.
  * Closing the node detail view now occurs automatically after deletion.

* **Tests**
  * Added coverage verifying that Meshtastic node deletion invokes the correct runtime action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->