### PR TITLE
chore: speed up pre-commit with staged-related Vitest

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,9 @@
 #!/bin/sh
 # Run format check, lint, and tests before every commit.
 # To skip in an emergency: git commit --no-verify
+#
+# Tests: staged-only related Vitest via scripts/precommit-tests.mjs.
+# Full Vitest suite runs on PRs (tests.yaml). Green pre-commit ≠ green CI.
 
 # Ensure locally installed tooling (e.g. `actionlint`) is on PATH.
 REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
@@ -18,6 +21,10 @@ fail() {
 STAGED_LIST=$(mktemp)
 trap 'rm -f "$STAGED_LIST"' EXIT
 git diff --cached --name-only --diff-filter=ACM > "$STAGED_LIST" || fail 'git diff --cached (staged file list)'
+
+staged_match() {
+  grep -qE "$1" "$STAGED_LIST" 2> /dev/null
+}
 
 # If dependency manifests changed, ensure local node_modules matches lockfile
 # so lint/typecheck run with the same toolchain CI/release will use.
@@ -45,7 +52,7 @@ if [ -s "$STAGED_LIST" ]; then
 
   # Lint only staged .md files
   MARKDOWN_LIST=$(mktemp)
-  trap 'rm -f "$MARKDOWN_LIST"' EXIT
+  trap 'rm -f "$STAGED_LIST" "$MARKDOWN_LIST"' EXIT
   while IFS= read -r f || [ -n "$f" ]; do
     case "$f" in
       *.md) printf '%s\n' "$f" >> "$MARKDOWN_LIST" ;;
@@ -72,53 +79,110 @@ if [ -s "$STAGED_LIST" ]; then
   done < "$STAGED_LIST"
 fi
 
-if grep -q 'src/renderer/locales/en/translation.json' "$STAGED_LIST" 2> /dev/null; then
+if staged_match 'src/renderer/locales/en/translation\.json'; then
   pnpm run i18n:auto-translate || fail 'pnpm run i18n:auto-translate'
   git add src/renderer/locales/ || fail 'git add (i18n locales)'
 fi
 
-pnpm run lint || fail 'pnpm run lint'
+# ESLint: staged JS/TS only with cache (CI still runs full `pnpm run lint`).
+ESLINT_LIST=$(mktemp)
+trap 'rm -f "$STAGED_LIST" "$MARKDOWN_LIST" "$ESLINT_LIST"' EXIT
+: > "$ESLINT_LIST"
+if [ -s "$STAGED_LIST" ]; then
+  while IFS= read -r f || [ -n "$f" ]; do
+    case "$f" in
+      *.js | *.jsx | *.mjs | *.cjs | *.ts | *.tsx | *.mts | *.cts)
+        [ -e "$f" ] || continue
+        printf '%s\n' "$f" >> "$ESLINT_LIST"
+        ;;
+    esac
+  done < "$STAGED_LIST"
+fi
+if [ -s "$ESLINT_LIST" ]; then
+  # xargs avoids ARG_MAX issues on large staged sets; -n batches keep argv reasonable.
+  xargs -n 50 pnpm exec eslint --cache --max-warnings 0 < "$ESLINT_LIST" || fail 'eslint (staged)'
+else
+  printf 'pre-commit: skip eslint (no staged JS/TS)\n' >&2
+fi
+
 pnpm run typecheck || fail 'pnpm run typecheck'
 pnpm run check:electron-security || fail 'pnpm run check:electron-security'
-pnpm run check:flatpak || fail 'pnpm run check:flatpak'
+
+if staged_match '^(flatpak/|org\.coloradomesh\.MeshClient\.yml|package\.json|scripts/check-flatpak\.mjs|scripts/sync-flatpak-electron)'; then
+  pnpm run check:flatpak || fail 'pnpm run check:flatpak'
+else
+  printf 'pre-commit: skip check:flatpak (no flatpak-related paths staged)\n' >&2
+fi
+
 pnpm run check:log-injection || fail 'pnpm run check:log-injection'
 pnpm run check:log-service-sinks || fail 'pnpm run check:log-service-sinks'
 pnpm run check:codeql-extensions || fail 'pnpm run check:codeql-extensions'
 pnpm run check:insecure-temp-files || fail 'pnpm run check:insecure-temp-files'
-pnpm run check:db-migrations || fail 'pnpm run check:db-migrations'
-pnpm run check:ipc-contract || fail 'pnpm run check:ipc-contract'
-pnpm run check:reticulum-interface-modes || fail 'pnpm run check:reticulum-interface-modes'
-pnpm run check:reticulum-decommissioned-hubs || fail 'pnpm run check:reticulum-decommissioned-hubs'
+
+if staged_match '^(src/main/database\.ts|src/main/db-schema-sync\.ts|src/main/db-compat\.ts|scripts/check-db-migrations\.mjs)'; then
+  pnpm run check:db-migrations || fail 'pnpm run check:db-migrations'
+else
+  printf 'pre-commit: skip check:db-migrations (no DB schema paths staged)\n' >&2
+fi
+
+if staged_match '^(src/shared/electron-api\.types\.ts|src/preload/|src/main/index\.ts|src/main/ipc/|src/main/updater\.ts|src/main/database\.ts|src/main/mqtt-manager\.ts|src/main/meshcore-mqtt-adapter\.ts|src/main/log-service\.ts|scripts/check-ipc-contract\.mjs)'; then
+  pnpm run check:ipc-contract || fail 'pnpm run check:ipc-contract'
+else
+  printf 'pre-commit: skip check:ipc-contract (no IPC contract paths staged)\n' >&2
+fi
+
+if staged_match '^(reticulum-sidecar/src/stack/config\.rs|src/renderer/lib/reticulum/reticulumInterfaceMode\.ts|scripts/check-reticulum-interface-modes\.mjs)'; then
+  pnpm run check:reticulum-interface-modes || fail 'pnpm run check:reticulum-interface-modes'
+else
+  printf 'pre-commit: skip check:reticulum-interface-modes (no interface-mode paths staged)\n' >&2
+fi
+
+if staged_match '^(reticulum-sidecar/src/stack/config\.rs|src/shared/reticulumDecommissionedHubs\.ts|scripts/check-reticulum-decommissioned-hubs\.mjs)'; then
+  pnpm run check:reticulum-decommissioned-hubs || fail 'pnpm run check:reticulum-decommissioned-hubs'
+else
+  printf 'pre-commit: skip check:reticulum-decommissioned-hubs (no decommissioned-hub paths staged)\n' >&2
+fi
+
 if command -v cargo > /dev/null 2>&1; then
-  pnpm run check:reticulum-sidecar || fail 'pnpm run check:reticulum-sidecar'
+  if staged_match '^(reticulum-sidecar/|scripts/check-reticulum-sidecar\.sh|scripts/clone-ratspeak-stack\.sh|scripts/check-rsnomad\.sh)'; then
+    pnpm run check:reticulum-sidecar || fail 'pnpm run check:reticulum-sidecar'
+  else
+    printf 'pre-commit: skip check:reticulum-sidecar (no sidecar paths staged)\n' >&2
+  fi
 else
   printf 'pre-commit: skip Rust checks (cargo not on PATH)\n' >&2
 fi
+
 pnpm run check:console-log || fail 'pnpm run check:console-log'
 pnpm run check:silent-catches || fail 'pnpm run check:silent-catches'
 pnpm run check:url-hostname-sanitization || fail 'pnpm run check:url-hostname-sanitization'
 pnpm run check:xss-patterns || fail 'pnpm run check:xss-patterns'
 pnpm run check:protocol-string-gates || fail 'pnpm run check:protocol-string-gates'
 pnpm run check:log-panel-filter || fail 'pnpm run check:log-panel-filter'
-if grep -q 'src/renderer/locales/en/translation.json' "$STAGED_LIST" 2> /dev/null; then
+if staged_match 'src/renderer/locales/en/translation\.json'; then
   pnpm run check:i18n || fail 'pnpm run check:i18n'
 else
   pnpm run check:i18n:branch || fail 'pnpm run check:i18n:branch'
 fi
 pnpm run check:licenses || fail 'pnpm run check:licenses'
-# npm retired legacy audit APIs (HTTP 410); pnpm 10.x still calls them. Use pnpm 11+ audit
-# via dlx until packageManager is bumped (pnpm.io migration / issue #11265).
-pnpm dlx --config.minimumReleaseAge=0 pnpm@11.13.0 --config.manage-package-manager-versions=false --config.pm-on-fail=ignore audit --audit-level=high \
-  || fail 'pnpm audit --audit-level=high'
-if grep -qE '^\.github/workflows/' "$STAGED_LIST" 2> /dev/null; then
+
+# Audit only when dependency manifests change (CI / release still audit as configured).
+if [ "$deps_changed" -eq 1 ]; then
+  # npm retired legacy audit APIs (HTTP 410); pnpm 10.x still calls them. Use pnpm 11+ audit
+  # via dlx until packageManager is bumped (pnpm.io migration / issue #11265).
+  pnpm dlx --config.minimumReleaseAge=0 pnpm@11.13.0 --config.manage-package-manager-versions=false --config.pm-on-fail=ignore audit --audit-level=high \
+    || fail 'pnpm audit --audit-level=high'
+else
+  printf 'pre-commit: skip pnpm audit (no package.json / lockfile staged)\n' >&2
+fi
+
+if staged_match '^\.github/workflows/'; then
   actionlint || fail 'actionlint'
 fi
-if grep -qE '\.(ya?ml)$' "$STAGED_LIST" 2> /dev/null; then
+if staged_match '\.(ya?ml)$'; then
   yamllint -f github -s . || fail 'yamllint'
 fi
-# Run affected tests; full suite when test infra or shared contracts change
-if grep -qE '^(vitest\.(config|harness)|src/shared/|src/preload/|src/renderer/vitest\.(setup|electronApiMock)|package\.json|pnpm-lock\.yaml)' "$STAGED_LIST" 2> /dev/null; then
-  pnpm run test:run -- --bail 1 || fail 'pnpm run test:run'
-else
-  pnpm run test:run -- --changed HEAD --bail 1 || fail 'pnpm run test:run'
-fi
+
+# Staged-only related Vitest (full suite on vitest infra / deps; skip docs-only).
+node "$REPO_ROOT/scripts/precommit-tests.mjs" --staged-list "$STAGED_LIST" \
+  || fail 'precommit-tests (vitest)'

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -99,8 +99,18 @@ if [ -s "$STAGED_LIST" ]; then
   done < "$STAGED_LIST"
 fi
 if [ -s "$ESLINT_LIST" ]; then
-  # xargs avoids ARG_MAX issues on large staged sets; -n batches keep argv reasonable.
-  xargs -n 50 pnpm exec eslint --cache --max-warnings 0 < "$ESLINT_LIST" || fail 'eslint (staged)'
+  # Batch argv safely (preserve spaces/quotes; `--` blocks option-like paths).
+  (
+    set --
+    while IFS= read -r f || [ -n "$f" ]; do
+      set -- "$@" "$f"
+      if [ "$#" -eq 50 ]; then
+        pnpm exec eslint --cache --max-warnings 0 -- "$@" || exit 1
+        set --
+      fi
+    done < "$ESLINT_LIST"
+    [ "$#" -eq 0 ] || pnpm exec eslint --cache --max-warnings 0 -- "$@"
+  ) || fail 'eslint (staged)'
 else
   printf 'pre-commit: skip eslint (no staged JS/TS)\n' >&2
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ release/
 test-results/
 coverage/
 .vitest-reports/
+.eslintcache
 .context-os
 .rtk
 .githooks/bin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file is self-contained. ARCHITECTURE.md and CONTRIBUTING.md are human refer
 - Only change what was asked. No drive-by refactors, reformatting, or types/comments outside scope.
 - **Testing:** Ship a passing test for behavioral changes; do not call the task done without it.
 - **Stateful/I/O code:** Preserve integrity on failure; document failure point, fallback, and logging where it matters.
-- **Pre-commit patience:** Pre-commit runs staged-related Vitest (`pnpm run test:staged`), staged ESLint, full typecheck, and path-gated `check:*` scripts. Typical small commits are much faster than a full suite; vitest infra / lockfile changes still force a full Vitest run. Be patient and let hooks finish — do not interrupt or force-skip. **PR CI** ([`tests.yaml`](.github/workflows/tests.yaml)) always runs the full suite with coverage; green pre-commit ≠ green CI.
+- **Pre-commit patience:** Pre-commit runs staged-related Vitest (`pnpm run test:staged`), staged ESLint, full typecheck, and path-gated `check:*` scripts. Typical small commits are much faster than a full suite; vitest infra / lockfile changes still force a full Vitest run. Be patient and let hooks finish — do not interrupt or force-skip. **PR CI** ([`tests.yaml`](.github/workflows/tests.yaml)) and **`pnpm run release`** (`scripts/release.sh`) always run the **full** Vitest suite (`pnpm run test:run`) plus ungated `check:*` scanners — never `test:staged` / `test:changed` / `vitest related`. Green pre-commit ≠ green CI or release.
 - **Fresh clone:** Before other setup work, run `node scripts/check-environment.mjs` (works before pnpm is installed). After `pnpm install`, re-run `pnpm run check:environment`. Fix required failures using the printed hints and `setup:*` scripts; optional warnings can wait.
 
 ### Platform parity
@@ -129,7 +129,7 @@ Adding a cross-boundary feature:
 8. `pnpm audit` only when dependency manifests staged; `actionlint` / `yamllint` when workflows / YAML staged
 9. `pnpm run test:staged` → `scripts/precommit-tests.mjs` (staged-only `vitest related`; full suite for vitest config/setup/deps; skip when no source/test staged)
 
-Before PR: `pnpm run lint`, `typecheck`, `test:run` (full suite), plus any relevant `check:*`.
+Before PR: `pnpm run lint`, `typecheck`, `test:run` (full suite), plus any relevant `check:*`. Release pre-flight (`pnpm run release`) always uses `test:run` + full `check:*` (no path-gating / soft-skips).
 
 ## 7. Git & PR Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file is self-contained. ARCHITECTURE.md and CONTRIBUTING.md are human refer
 - Only change what was asked. No drive-by refactors, reformatting, or types/comments outside scope.
 - **Testing:** Ship a passing test for behavioral changes; do not call the task done without it.
 - **Stateful/I/O code:** Preserve integrity on failure; document failure point, fallback, and logging where it matters.
-- **Pre-commit patience:** This repo has a very long pre-commit hook chain (lint, typecheck, thousands of tests, audit, actionlint, yamllint, many check:\* scripts). Commits can take 2+ minutes. Be patient and let them finish — do not interrupt or force-skip hooks.
+- **Pre-commit patience:** Pre-commit runs staged-related Vitest (`pnpm run test:staged`), staged ESLint, full typecheck, and path-gated `check:*` scripts. Typical small commits are much faster than a full suite; vitest infra / lockfile changes still force a full Vitest run. Be patient and let hooks finish — do not interrupt or force-skip. **PR CI** ([`tests.yaml`](.github/workflows/tests.yaml)) always runs the full suite with coverage; green pre-commit ≠ green CI.
 - **Fresh clone:** Before other setup work, run `node scripts/check-environment.mjs` (works before pnpm is installed). After `pnpm install`, re-run `pnpm run check:environment`. Fix required failures using the printed hints and `setup:*` scripts; optional warnings can wait.
 
 ### Platform parity
@@ -90,7 +90,7 @@ Adding a cross-boundary feature:
 ## 5. Testing
 
 - Renderer: jsdom (`src/renderer/**/*.test.{ts,tsx}`). Main: node (`src/main/**/*.test.ts`).
-- **Reticulum sidecar (Rust):** Clippy + rustfmt via `pnpm run check:reticulum-sidecar` (stub build in pre-commit when `cargo` is on `PATH`) and full-feature lint in `reticulum-sidecar.yaml`. Coverage threshold (`cargo llvm-cov --fail-under-lines`) is enforced only in `tests.yaml` when sidecar paths change — not in pre-commit.
+- **Reticulum sidecar (Rust):** Clippy + rustfmt via `pnpm run check:reticulum-sidecar` (stub build in pre-commit when `cargo` is on `PATH` **and** sidecar-related paths are staged) and full-feature lint in `reticulum-sidecar.yaml`. Coverage threshold (`cargo llvm-cov --fail-under-lines`) is enforced only in `tests.yaml` when sidecar paths change — not in pre-commit.
 - **Temp dirs in tests:** Use `mkdtempSync(path.join(os.tmpdir(), 'prefix-'))` — never write to a fixed name under `os.tmpdir()` (CodeQL + `check:insecure-temp-files`).
 - Vitest worker pool sizes and shared Vite dep inline lists live in `vitest.harness.ts` — update when adding deps that need inlining.
 - Prefer `mockConsoleWarn` / `withMockedConsoleWarn` from `src/renderer/lib/vitestConsoleMock.ts` over ad-hoc `vi.spyOn(console, 'warn')` in renderer tests.
@@ -124,12 +124,12 @@ Adding a cross-boundary feature:
 3. markdownlint on **staged** `.md` files only
 4. When dependency manifests staged: `pnpm dedupe`, re-stage lockfile and originally staged paths
 5. When `en/translation.json` is staged: `pnpm run i18n:auto-translate` and re-stage `src/renderer/locales/`
-6. `pnpm run lint`, `pnpm run typecheck`, full `check:*` chain (`check:reticulum-sidecar` when `cargo` is on `PATH`; `check:i18n` when English locale staged, else `check:i18n:branch`)
-7. `pnpm audit --audit-level=high`
-8. `actionlint` when workflows staged; `yamllint` when YAML staged
-9. `pnpm run test:run -- --changed HEAD --bail 1` (full suite when vitest/shared/preload/setup mocks or deps change)
+6. ESLint on **staged** JS/TS with `--cache` (CI still runs full `pnpm run lint`); full `typecheck`
+7. Always-on cheap `check:*` scanners; path-gated checks for flatpak / DB migrations / IPC / reticulum interface modes / decommissioned hubs / `check:reticulum-sidecar` (when `cargo` on `PATH` and sidecar paths staged); `check:i18n` when English locale staged else `check:i18n:branch`; `check:licenses`
+8. `pnpm audit` only when dependency manifests staged; `actionlint` / `yamllint` when workflows / YAML staged
+9. `pnpm run test:staged` → `scripts/precommit-tests.mjs` (staged-only `vitest related`; full suite for vitest config/setup/deps; skip when no source/test staged)
 
-Before PR: `pnpm run lint`, `typecheck`, `test:run`, plus any relevant `check:*`.
+Before PR: `pnpm run lint`, `typecheck`, `test:run` (full suite), plus any relevant `check:*`.
 
 ## 7. Git & PR Workflow
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -234,7 +234,7 @@ The pre-commit hook (`.githooks/pre-commit`) runs checks beyond what GitHub Acti
 - **Staged-file** Prettier + markdownlint (not a full-tree `pnpm run format` / `lint:md`)
 - `pnpm dedupe` when dependency manifests are staged
 - `pnpm run i18n:auto-translate` when `en/translation.json` is staged (fills new English keys vs `HEAD`) + re-stages locales
-- Staged ESLint (`--cache`) + full `typecheck`; always-on cheap `check:*` scanners; path-gated flatpak / DB / IPC / reticulum catalog / sidecar stub checks (`check:i18n` when English locale staged, else `check:i18n:branch`)
+- Staged ESLint (`--cache`) + full `typecheck`; always-on cheap `check:*` scanners; path-gated flatpak / DB / IPC / reticulum catalog / sidecar stub checks (sidecar stub also requires `cargo` on `PATH` when sidecar paths are staged; `check:i18n` when English locale staged, else `check:i18n:branch`)
 - `pnpm audit` only when dependency manifests staged; `actionlint` / `yamllint` only when relevant files are staged
 - `pnpm run test:staged` (`scripts/precommit-tests.mjs`: staged-only `vitest related`; full suite when vitest config/setup mocks or dependency manifests change; skip when no source/test staged)
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -234,9 +234,11 @@ The pre-commit hook (`.githooks/pre-commit`) runs checks beyond what GitHub Acti
 - **Staged-file** Prettier + markdownlint (not a full-tree `pnpm run format` / `lint:md`)
 - `pnpm dedupe` when dependency manifests are staged
 - `pnpm run i18n:auto-translate` when `en/translation.json` is staged (fills new English keys vs `HEAD`) + re-stages locales
-- `pnpm run lint`, `typecheck`, and the full `check:*` chain (`check:i18n` when English locale staged, else `check:i18n:branch`)
-- `pnpm audit --audit-level=high`; `actionlint` / `yamllint` only when relevant files are staged
-- `pnpm run test:run -- --changed HEAD --bail 1` (full suite when vitest config, shared/preload, vitest setup mocks, or dependency manifests change)
+- Staged ESLint (`--cache`) + full `typecheck`; always-on cheap `check:*` scanners; path-gated flatpak / DB / IPC / reticulum catalog / sidecar stub checks (`check:i18n` when English locale staged, else `check:i18n:branch`)
+- `pnpm audit` only when dependency manifests staged; `actionlint` / `yamllint` only when relevant files are staged
+- `pnpm run test:staged` (`scripts/precommit-tests.mjs`: staged-only `vitest related`; full suite when vitest config/setup mocks or dependency manifests change; skip when no source/test staged)
+
+**PR CI** ([`tests.yaml`](../.github/workflows/tests.yaml)) always runs the **full** Vitest suite with coverage. Green pre-commit does not replace that gate.
 
 CI focuses on lint, typecheck, build, Flatpak metadata validation, and coverage tests. i18n quality is enforced locally via pre-commit and indirectly in CI through Vitest (`locale-quality.test.ts`).
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -238,7 +238,7 @@ The pre-commit hook (`.githooks/pre-commit`) runs checks beyond what GitHub Acti
 - `pnpm audit` only when dependency manifests staged; `actionlint` / `yamllint` only when relevant files are staged
 - `pnpm run test:staged` (`scripts/precommit-tests.mjs`: staged-only `vitest related`; full suite when vitest config/setup mocks or dependency manifests change; skip when no source/test staged)
 
-**PR CI** ([`tests.yaml`](../.github/workflows/tests.yaml)) always runs the **full** Vitest suite with coverage. Green pre-commit does not replace that gate.
+**PR CI** ([`tests.yaml`](../.github/workflows/tests.yaml)) and **`pnpm run release`** always run the **full** Vitest suite (`pnpm run test:run`). Green pre-commit does not replace those gates.
 
 CI focuses on lint, typecheck, build, Flatpak metadata validation, and coverage tests. i18n quality is enforced locally via pre-commit and indirectly in CI through Vitest (`locale-quality.test.ts`).
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -107,7 +107,7 @@ If you use Homebrew only, `pnpm run update` will try `brew upgrade rust` when ru
 
 Linux and Windows: use rustup; on Windows you may also need [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the C++ workload (same as native Node modules).
 
-[`reticulum-sidecar/rust-toolchain.toml`](../reticulum-sidecar/rust-toolchain.toml) pins **`stable`** and installs `clippy`, `rustfmt`, and `llvm-tools-preview` on the first `cargo` command run inside `reticulum-sidecar/` (rustup auto-install). When `cargo` is on your `PATH`, pre-commit runs `pnpm run check:reticulum-sidecar` (stub fmt + Clippy + test — no coverage).
+[`reticulum-sidecar/rust-toolchain.toml`](../reticulum-sidecar/rust-toolchain.toml) pins **`stable`** and installs `clippy`, `rustfmt`, and `llvm-tools-preview` on the first `cargo` command run inside `reticulum-sidecar/` (rustup auto-install). When `cargo` is on your `PATH` **and** sidecar-related paths are staged, pre-commit runs `pnpm run check:reticulum-sidecar` (stub fmt + Clippy + test — no coverage).
 
 #### Build the sidecar
 
@@ -529,7 +529,8 @@ pnpm run reticulum:sidecar:test
 Other useful commands:
 
 - `pnpm test` (watch mode — reruns only changed test files)
-- `pnpm run test:changed` (one-shot tests affected by edits vs `HEAD`)
+- `pnpm run test:staged` (pre-commit helper: Vitest related to **staged** files only)
+- `pnpm run test:changed` (one-shot tests for working-tree edits vs `HEAD`, including unstaged WIP)
 - `pnpm run test:ui` / `test:logic` / `test:main` (single Vitest project)
 - `pnpm run test:coverage` (CI coverage report; used by `act:tests:native`)
 - `pnpm run test:coverage:merge` (merge sharded CI blob reports locally)
@@ -539,7 +540,7 @@ Other useful commands:
 - `pnpm run i18n:auto-translate` (fill missing keys)
 - `pnpm run i18n:prune-unused -- --write` (drop orphaned locale keys)
 
-The pre-commit hook runs the full `check:*` suite — see [Git hooks](#6-git-hooks-and-pre-commit-behavior).
+The pre-commit hook runs path-gated `check:*` steps plus staged-related Vitest — see [Git hooks](#6-git-hooks-and-pre-commit-behavior).
 
 ### 5) Building a distributable
 
@@ -585,7 +586,9 @@ This generates `dist-electron/main/meta.json`. Upload this file to [esbuild's on
 
 ### 6) Git hooks and pre-commit behavior
 
-After `pnpm install`, repo hooks are enabled via `core.hooksPath` (see the `prepare` script in `package.json`). The pre-commit hook runs on every commit. Typical commits (without English locale or infra changes) run **affected tests only** (`vitest run --changed HEAD`); lint and typecheck still run on the full tree.
+After `pnpm install`, repo hooks are enabled via `core.hooksPath` (see the `prepare` script in `package.json`). The pre-commit hook runs on every commit. Typical commits run **staged-related Vitest only** (`pnpm run test:staged` → `vitest related` on staged source/test files, optionally narrowed to matching Vitest projects). Unstaged WIP is ignored. Full typecheck still runs every commit; ESLint runs on staged JS/TS with `--cache` (CI still runs full-tree lint). Several expensive `check:*` steps and `pnpm audit` / sidecar stub builds are **path-gated**.
+
+Green pre-commit does **not** replace PR CI: [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml) always runs the full Vitest suite with coverage.
 
 Hook order (authoritative source: [`.githooks/pre-commit`](../.githooks/pre-commit)):
 
@@ -594,12 +597,12 @@ Hook order (authoritative source: [`.githooks/pre-commit`](../.githooks/pre-comm
 3. markdownlint-cli2 on staged `.md` files only (not full `pnpm run lint:md` unless you run it manually)
 4. When `package.json` or `pnpm-lock.yaml` is staged: `pnpm dedupe`, re-stage `pnpm-lock.yaml`, then re-stage the originally staged paths
 5. When `src/renderer/locales/en/translation.json` is staged: `pnpm run i18n:auto-translate` (incremental vs `HEAD` English, not `--all`) and re-stage `src/renderer/locales/` — see [Internationalization](#9-internationalization-i18n)
-6. `pnpm run lint`
-7. `pnpm run typecheck`
-8. `check:electron-security`, `check:flatpak`, `check:log-injection`, `check:log-service-sinks`, `check:codeql-extensions`, `check:insecure-temp-files`, `check:db-migrations`, `check:ipc-contract`, `check:reticulum-interface-modes`, `check:reticulum-decommissioned-hubs`, `check:reticulum-sidecar` when `cargo` is on `PATH`, `check:console-log`, `check:silent-catches`, `check:url-hostname-sanitization`, `check:xss-patterns`, `check:protocol-string-gates`, `check:log-panel-filter`, `check:i18n` when English locale is staged else `check:i18n:branch`, `check:licenses`
-9. `pnpm audit --audit-level=high`
-10. `actionlint` when `.github/workflows/*` is staged; `yamllint` when any `*.yaml` / `*.yml` is staged
-11. `pnpm run test:run -- --changed HEAD --bail 1` (full suite when vitest config, shared/preload, vitest setup mocks, or dependency manifests change)
+6. ESLint on **staged** JS/TS with `--cache` (skip when none staged)
+7. `pnpm run typecheck` (full tree)
+8. Always-on: `check:electron-security`, `check:log-injection`, `check:log-service-sinks`, `check:codeql-extensions`, `check:insecure-temp-files`, `check:console-log`, `check:silent-catches`, `check:url-hostname-sanitization`, `check:xss-patterns`, `check:protocol-string-gates`, `check:log-panel-filter`, `check:licenses`; `check:i18n` when English locale staged else `check:i18n:branch`
+9. Path-gated: `check:flatpak`, `check:db-migrations`, `check:ipc-contract`, `check:reticulum-interface-modes`, `check:reticulum-decommissioned-hubs`, `check:reticulum-sidecar` (when `cargo` on `PATH` and sidecar paths staged)
+10. `pnpm audit --audit-level=high` only when dependency manifests staged; `actionlint` when `.github/workflows/*` staged; `yamllint` when any `*.yaml` / `*.yml` staged
+11. `pnpm run test:staged` (`scripts/precommit-tests.mjs`: staged-only `vitest related`; full suite when vitest config/setup mocks or dependency manifests change; skip when no source/test staged)
 
 Install hook dependencies via [Helper scripts](#8-helper-scripts-auto-install-where-possible) (`setup:actionlint`, yamllint via pip/brew/apt).
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -604,6 +604,8 @@ Hook order (authoritative source: [`.githooks/pre-commit`](../.githooks/pre-comm
 10. `pnpm audit --audit-level=high` only when dependency manifests staged; `actionlint` when `.github/workflows/*` staged; `yamllint` when any `*.yaml` / `*.yml` staged
 11. `pnpm run test:staged` (`scripts/precommit-tests.mjs`: staged-only `vitest related`; full suite when vitest config/setup mocks or dependency manifests change; skip when no source/test staged)
 
+**Release / CI full suite:** `pnpm run release` (`scripts/release.sh`) and PR [`tests.yaml`](../.github/workflows/tests.yaml) always run `pnpm run test:run` (full Vitest) — never `test:staged`. Release also runs the ungated `check:*` set and requires actionlint + yamllint.
+
 Install hook dependencies via [Helper scripts](#8-helper-scripts-auto-install-where-possible) (`setup:actionlint`, yamllint via pip/brew/apt).
 
 Emergency bypass (temporary only):

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -38,7 +38,7 @@ The release script (`scripts/release.sh`) is the supported maintainer path. It:
 2. Runs **`pnpm update`** and **`pnpm dedupe`** (updates lockfile before the bump)
 3. Syncs **`org.coloradomesh.MeshClient.yml`** Electron vendored archives to match `package.json` (`node scripts/sync-flatpak-electron.mjs`)
 4. Auto-detects **patch / minor / major** from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag (or accept an explicit bump — see below)
-5. Runs **pre-flight validation** (format, lint, typecheck, security `check:*`, **`check:flatpak`**, dedupe check, audit, actionlint, yamllint, tests)
+5. Runs **pre-flight validation** (format, lint, typecheck, **all** `check:*` scanners including path-gated pre-commit ones, **`check:flatpak`**, **`check:i18n`**, dedupe check, audit, **required** actionlint + yamllint, **full** Vitest via `pnpm run test:run`, Reticulum sidecar `cargo test`)
 6. Prints **copy-paste release notes** grouped by feat/fix/other/breaking
 7. Bumps `package.json` via `pnpm version`
 8. Prepends a `<release>` entry to `flatpak/org.coloradomesh.MeshClient.metainfo.xml`
@@ -54,6 +54,8 @@ pnpm run release --auto # explicit auto-detect
 ```
 
 The script prompts twice (start pre-flight, then confirm after checks pass). **Expect several minutes** for the full validation chain.
+
+**Full suite only:** Release must never use `test:staged`, `test:changed`, or `vitest related`. Pre-commit may run a staged subset for speed; release matches PR CI by running the unrestricted `pnpm run test:run` (`vitest run`) and does not soft-skip actionlint/yamllint when those tools are missing.
 
 If pre-flight fails, fix the issue on `main` and run `pnpm run release` again — do not tag manually until checks pass.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -38,7 +38,7 @@ The release script (`scripts/release.sh`) is the supported maintainer path. It:
 2. Runs **`pnpm update`** and **`pnpm dedupe`** (updates lockfile before the bump)
 3. Syncs **`org.coloradomesh.MeshClient.yml`** Electron vendored archives to match `package.json` (`node scripts/sync-flatpak-electron.mjs`)
 4. Auto-detects **patch / minor / major** from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag (or accept an explicit bump — see below)
-5. Runs **pre-flight validation** (format, lint, typecheck, **all** `check:*` scanners including path-gated pre-commit ones, **`check:flatpak`**, **`check:i18n`**, dedupe check, audit, **required** actionlint + yamllint, **full** Vitest via `pnpm run test:run`, Reticulum sidecar `cargo test`)
+5. Runs **pre-flight validation** (`check:environment`, format, lint, typecheck, **all** `check:*` scanners including path-gated pre-commit ones, **`check:flatpak`**, **`check:i18n`**, dedupe check, audit, **required** actionlint + yamllint, **full** Vitest via `pnpm run test:run`, Reticulum sidecar `cargo test`)
 6. Prints **copy-paste release notes** grouped by feat/fix/other/breaking
 7. Bumps `package.json` via `pnpm version`
 8. Prepends a `<release>` entry to `flatpak/org.coloradomesh.MeshClient.metainfo.xml`

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "test:logic": "vitest run --project renderer-logic",
     "test:main": "vitest run --project main",
     "test:run": "vitest run",
+    "test:staged": "node scripts/precommit-tests.mjs",
     "test:ui": "vitest run --project renderer-ui",
     "test:verbose": "vitest run --reporter=verbose",
     "trace-deprecation": "pnpm run build && NODE_OPTIONS='--trace-deprecation' node scripts/start-electron.mjs",

--- a/scripts/pre-commit.eslint-batch.test.mjs
+++ b/scripts/pre-commit.eslint-batch.test.mjs
@@ -7,11 +7,42 @@ import { describe, expect, it } from 'vitest';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PRE_COMMIT = path.join(ROOT, '.githooks/pre-commit');
 
+/**
+ * @param {string} line
+ * @returns {boolean}
+ */
+function isEslintInvocation(line) {
+  const trimmed = line.trimStart();
+  return trimmed.startsWith('pnpm exec eslint') || trimmed.startsWith('pnpm  exec eslint');
+}
+
+/**
+ * Safe form: `pnpm exec eslint --cache --max-warnings 0 -- "$@"` (+ optional `|| exit 1`).
+ * @param {string} line
+ * @returns {boolean}
+ */
+function isSafeEslintInvocation(line) {
+  const trimmed = line.trim();
+  const base = 'pnpm exec eslint --cache --max-warnings 0 -- "$@"';
+  return trimmed === base || trimmed === `${base} || exit 1`;
+}
+
 describe('pre-commit eslint batching', () => {
   const hook = fs.readFileSync(PRE_COMMIT, 'utf8');
 
   it('batches eslint with -- so spaced/option-like paths stay literal', () => {
-    expect(hook).toMatch(/pnpm exec eslint --cache --max-warnings 0 -- "\$@"/);
-    expect(hook).not.toMatch(/xargs\s+-n\s+50\s+pnpm exec eslint/);
+    const lines = hook.split(/\r?\n/);
+    const invocations = lines.filter(isEslintInvocation);
+    expect(invocations.length).toBeGreaterThan(0);
+
+    for (const line of invocations) {
+      expect(isSafeEslintInvocation(line), `unsafe eslint invocation: ${line}`).toBe(true);
+    }
+
+    for (const line of lines) {
+      const hasXargs = line.includes('xargs');
+      const hasEslint = line.includes('eslint');
+      expect(hasXargs && hasEslint, `xargs+eslint on one line: ${line}`).toBe(false);
+    }
   });
 });

--- a/scripts/pre-commit.eslint-batch.test.mjs
+++ b/scripts/pre-commit.eslint-batch.test.mjs
@@ -1,0 +1,17 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PRE_COMMIT = path.join(ROOT, '.githooks/pre-commit');
+
+describe('pre-commit eslint batching', () => {
+  const hook = fs.readFileSync(PRE_COMMIT, 'utf8');
+
+  it('batches eslint with -- so spaced/option-like paths stay literal', () => {
+    expect(hook).toMatch(/pnpm exec eslint --cache --max-warnings 0 -- "\$@"/);
+    expect(hook).not.toMatch(/xargs\s+-n\s+50\s+pnpm exec eslint/);
+  });
+});

--- a/scripts/precommit-tests.mjs
+++ b/scripts/precommit-tests.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit Vitest selector: run only tests related to staged files.
+ *
+ * - Force full suite for vitest infra / dependency manifests.
+ * - Otherwise `vitest related` on staged source/test paths (+ co-located siblings).
+ * - Restrict `--project` when the staged set clearly maps to one/few projects.
+ * - Skip Vitest when no relevant staged paths (docs-only, etc.).
+ *
+ * Failure point: vitest exit non-zero → propagate to pre-commit.
+ * Fallback: ambiguous project mapping runs all three projects.
+ * Logging: selected mode, file count, and projects to stderr.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+/** @typedef {'renderer-ui' | 'renderer-logic' | 'main'} VitestProject */
+
+const SOURCE_EXT_RE = /\.(?:[cm]?[jt]sx?)$/i;
+const TEST_SIBLING_RE = /\.test\.(?:[cm]?[jt]sx?)$/i;
+
+const FORCE_FULL_PATTERNS = [
+  /^vitest\.config\./,
+  /^vitest\.harness(\.|$)/,
+  /^src\/renderer\/vitest\.setup/,
+  /^src\/renderer\/vitest\.electronApiMock/,
+  /^package\.json$/,
+  /^pnpm-lock\.yaml$/,
+];
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export function isForceFullSuitePath(filePath) {
+  const normalized = filePath.replace(/\\/g, '/');
+  return FORCE_FULL_PATTERNS.some((re) => re.test(normalized));
+}
+
+/**
+ * @param {Iterable<string>} stagedPaths
+ * @returns {boolean}
+ */
+export function shouldForceFullSuite(stagedPaths) {
+  for (const p of stagedPaths) {
+    if (isForceFullSuitePath(p)) return true;
+  }
+  return false;
+}
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export function isVitestRelevantPath(filePath) {
+  const normalized = filePath.replace(/\\/g, '/');
+  if (isForceFullSuitePath(normalized)) return true;
+  if (SOURCE_EXT_RE.test(normalized)) return true;
+  return false;
+}
+
+/**
+ * When a non-test source file is staged, also include co-located `*.test.*` siblings.
+ * @param {string[]} stagedPaths
+ * @param {{ existsSync?: (p: string) => boolean, root?: string }} [opts]
+ * @returns {string[]}
+ */
+export function expandWithSiblingTests(stagedPaths, opts = {}) {
+  const existsSync = opts.existsSync ?? fs.existsSync;
+  const root = opts.root ?? ROOT;
+  const out = new Set();
+
+  for (const raw of stagedPaths) {
+    const normalized = raw.replace(/\\/g, '/');
+    if (!isVitestRelevantPath(normalized)) continue;
+    out.add(normalized);
+
+    if (TEST_SIBLING_RE.test(normalized)) continue;
+
+    const dir = path.posix.dirname(normalized);
+    const base = path.posix.basename(normalized);
+    const stem = base.replace(SOURCE_EXT_RE, '');
+    const siblingCandidates = [
+      `${dir}/${stem}.test.ts`,
+      `${dir}/${stem}.test.tsx`,
+      `${dir}/${stem}.test.mjs`,
+      `${dir}/${stem}.test.js`,
+      `${dir}/${stem}.test.jsx`,
+      `${dir}/${stem}.test.mts`,
+      `${dir}/${stem}.test.cts`,
+    ];
+    for (const candidate of siblingCandidates) {
+      const abs = path.join(root, candidate);
+      if (existsSync(abs)) out.add(candidate);
+    }
+  }
+
+  return [...out].sort();
+}
+
+/**
+ * Pick Vitest projects for a related-file set.
+ * Ambiguous / unknown paths fall back to all three projects.
+ * @param {string[]} relatedPaths
+ * @returns {VitestProject[]}
+ */
+export function pickProjects(relatedPaths) {
+  if (relatedPaths.length === 0) return [];
+
+  const normalized = relatedPaths.map((p) => p.replace(/\\/g, '/'));
+
+  const onlyMain = normalized.every(
+    (p) =>
+      p.startsWith('src/main/') ||
+      p.startsWith('src/shared/') ||
+      p.startsWith('src/preload/') ||
+      p.startsWith('scripts/') ||
+      p === 'vitest.harness.ts' ||
+      p === 'vitest.harness.test.ts',
+  );
+  if (onlyMain) return ['main'];
+
+  const onlyRendererLibOrStores = normalized.every(
+    (p) =>
+      p.startsWith('src/renderer/lib/') ||
+      p.startsWith('src/renderer/stores/') ||
+      p === 'src/renderer/locales/locale-quality.test.ts',
+  );
+  if (onlyRendererLibOrStores) {
+    // Logic owns most lib tests; UI owns borderline lib exclusions — run both, skip main.
+    return ['renderer-logic', 'renderer-ui'];
+  }
+
+  const onlyRenderer = normalized.every((p) => p.startsWith('src/renderer/'));
+  if (onlyRenderer) return ['renderer-ui', 'renderer-logic'];
+
+  const hasMain = normalized.some(
+    (p) =>
+      p.startsWith('src/main/') ||
+      p.startsWith('src/shared/') ||
+      p.startsWith('src/preload/') ||
+      p.startsWith('scripts/'),
+  );
+  const hasRenderer = normalized.some((p) => p.startsWith('src/renderer/'));
+  if (hasMain && hasRenderer) return ['renderer-ui', 'renderer-logic', 'main'];
+  if (hasMain) return ['main'];
+  if (hasRenderer) return ['renderer-ui', 'renderer-logic'];
+
+  return ['renderer-ui', 'renderer-logic', 'main'];
+}
+
+/**
+ * @param {string[]} stagedPaths
+ * @returns {{ mode: 'full' | 'related' | 'skip', relatedPaths: string[], projects: VitestProject[] }}
+ */
+export function planPrecommitTests(stagedPaths) {
+  if (shouldForceFullSuite(stagedPaths)) {
+    return {
+      mode: 'full',
+      relatedPaths: [],
+      projects: ['renderer-ui', 'renderer-logic', 'main'],
+    };
+  }
+
+  const relatedPaths = expandWithSiblingTests(stagedPaths);
+  if (relatedPaths.length === 0) {
+    return { mode: 'skip', relatedPaths: [], projects: [] };
+  }
+
+  return {
+    mode: 'related',
+    relatedPaths,
+    projects: pickProjects(relatedPaths),
+  };
+}
+
+/**
+ * @param {string[]} args
+ * @param {{ cwd?: string, env?: NodeJS.ProcessEnv, spawnSyncFn?: typeof spawnSync }} [opts]
+ * @returns {number}
+ */
+export function runVitestArgv(args, opts = {}) {
+  const spawnSyncFn = opts.spawnSyncFn ?? spawnSync;
+  const result = spawnSyncFn('pnpm', ['exec', 'vitest', ...args], {
+    cwd: opts.cwd ?? ROOT,
+    env: opts.env ?? process.env,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+  if (result.error) {
+    console.error('precommit-tests: failed to spawn vitest:', result.error.message);
+    return 1;
+  }
+  return typeof result.status === 'number' ? result.status : 1;
+}
+
+/**
+ * @param {string[]} stagedPaths
+ * @param {{
+ *   cwd?: string,
+ *   env?: NodeJS.ProcessEnv,
+ *   spawnSyncFn?: typeof spawnSync,
+ *   log?: (msg: string) => void,
+ * }} [opts]
+ * @returns {number}
+ */
+export function runPrecommitTests(stagedPaths, opts = {}) {
+  const log = opts.log ?? ((msg) => console.error(msg));
+  const plan = planPrecommitTests(stagedPaths);
+
+  if (plan.mode === 'skip') {
+    log('precommit-tests: skip Vitest (no staged source/test files)');
+    return 0;
+  }
+
+  if (plan.mode === 'full') {
+    log('precommit-tests: full suite (vitest infra or dependency manifests staged)');
+    return runVitestArgv(['run', '--bail', '1'], opts);
+  }
+
+  const projectArgs = plan.projects.flatMap((p) => ['--project', p]);
+  log(
+    `precommit-tests: related (${plan.relatedPaths.length} file(s); projects: ${plan.projects.join(', ')})`,
+  );
+  // Positional related files must NOT follow `--` (Vitest treats them as filters that way).
+  return runVitestArgv(
+    ['related', '--run', '--bail', '1', '--passWithNoTests', ...projectArgs, ...plan.relatedPaths],
+    opts,
+  );
+}
+
+/**
+ * @param {string | undefined} stagedListPath
+ * @returns {string[]}
+ */
+export function readStagedPathsFromFile(stagedListPath) {
+  if (!stagedListPath) return [];
+  if (!fs.existsSync(stagedListPath)) {
+    console.error(`precommit-tests: staged list not found: ${stagedListPath}`);
+    process.exit(1);
+  }
+  return fs
+    .readFileSync(stagedListPath, 'utf8')
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+/**
+ * @returns {string[]}
+ */
+export function readStagedPathsFromGit() {
+  const result = spawnSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACM'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    console.error('precommit-tests: git diff --cached failed');
+    process.exit(1);
+  }
+  return (result.stdout ?? '')
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+function main(argv = process.argv.slice(2)) {
+  let stagedPaths;
+  const listIdx = argv.indexOf('--staged-list');
+  if (listIdx !== -1) {
+    stagedPaths = readStagedPathsFromFile(argv[listIdx + 1]);
+  } else if (argv[0] && !argv[0].startsWith('-')) {
+    // Paths passed directly (for tests / manual runs).
+    stagedPaths = argv.filter((a) => !a.startsWith('-'));
+  } else {
+    stagedPaths = readStagedPathsFromGit();
+  }
+
+  const code = runPrecommitTests(stagedPaths);
+  process.exit(code);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  main();
+}

--- a/scripts/precommit-tests.mjs
+++ b/scripts/precommit-tests.mjs
@@ -180,17 +180,36 @@ export function planPrecommitTests(stagedPaths) {
 }
 
 /**
+ * Resolve the local Vitest CLI entry so we can spawn without a shell.
+ * @param {string} [root]
+ * @returns {string}
+ */
+export function resolveVitestCli(root = ROOT) {
+  return path.join(root, 'node_modules', 'vitest', 'vitest.mjs');
+}
+
+/**
  * @param {string[]} args
- * @param {{ cwd?: string, env?: NodeJS.ProcessEnv, spawnSyncFn?: typeof spawnSync }} [opts]
+ * @param {{
+ *   cwd?: string,
+ *   env?: NodeJS.ProcessEnv,
+ *   spawnSyncFn?: typeof spawnSync,
+ *   vitestCli?: string,
+ *   execPath?: string,
+ * }} [opts]
  * @returns {number}
  */
 export function runVitestArgv(args, opts = {}) {
   const spawnSyncFn = opts.spawnSyncFn ?? spawnSync;
-  const result = spawnSyncFn('pnpm', ['exec', 'vitest', ...args], {
-    cwd: opts.cwd ?? ROOT,
+  const cwd = opts.cwd ?? ROOT;
+  const vitestCli = opts.vitestCli ?? resolveVitestCli(cwd);
+  const execPath = opts.execPath ?? process.execPath;
+  // Shell-free: staged paths must stay literal argv (Windows cmd metacharacters).
+  const result = spawnSyncFn(execPath, [vitestCli, ...args], {
+    cwd,
     env: opts.env ?? process.env,
     stdio: 'inherit',
-    shell: process.platform === 'win32',
+    shell: false,
   });
   if (result.error) {
     console.error('precommit-tests: failed to spawn vitest:', result.error.message);

--- a/scripts/precommit-tests.test.mjs
+++ b/scripts/precommit-tests.test.mjs
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  expandWithSiblingTests,
+  isForceFullSuitePath,
+  pickProjects,
+  planPrecommitTests,
+  runPrecommitTests,
+  shouldForceFullSuite,
+} from './precommit-tests.mjs';
+
+describe('precommit-tests force-full', () => {
+  it('detects vitest harness and lockfile', () => {
+    expect(isForceFullSuitePath('vitest.harness.ts')).toBe(true);
+    expect(isForceFullSuitePath('vitest.config.ts')).toBe(true);
+    expect(isForceFullSuitePath('package.json')).toBe(true);
+    expect(isForceFullSuitePath('pnpm-lock.yaml')).toBe(true);
+    expect(isForceFullSuitePath('src/renderer/vitest.setup.ts')).toBe(true);
+    expect(isForceFullSuitePath('src/shared/appTagline.ts')).toBe(false);
+    expect(isForceFullSuitePath('src/preload/index.ts')).toBe(false);
+  });
+
+  it('plans full suite when lockfile staged', () => {
+    const plan = planPrecommitTests(['pnpm-lock.yaml', 'README.md']);
+    expect(plan.mode).toBe('full');
+  });
+});
+
+describe('precommit-tests skip', () => {
+  it('skips docs-only staged sets', () => {
+    const plan = planPrecommitTests(['docs/ci-cd.md', 'README.md']);
+    expect(plan.mode).toBe('skip');
+    expect(plan.relatedPaths).toEqual([]);
+  });
+});
+
+describe('precommit-tests related planning', () => {
+  it('appends co-located sibling tests when present', () => {
+    const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'precommit-tests-sib-'));
+    try {
+      const libDir = path.join(fakeRoot, 'src', 'renderer', 'lib');
+      fs.mkdirSync(libDir, { recursive: true });
+      fs.writeFileSync(path.join(libDir, 'foo.ts'), '');
+      fs.writeFileSync(path.join(libDir, 'foo.test.ts'), '');
+
+      const expanded = expandWithSiblingTests(['src/renderer/lib/foo.ts'], {
+        root: fakeRoot,
+        existsSync: (p) => fs.existsSync(p),
+      });
+      expect(expanded).toEqual(['src/renderer/lib/foo.test.ts', 'src/renderer/lib/foo.ts']);
+    } finally {
+      fs.rmSync(fakeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('picks main only for shared/main/scripts paths', () => {
+    expect(pickProjects(['src/shared/appTagline.ts', 'src/shared/appTagline.test.ts'])).toEqual([
+      'main',
+    ]);
+    expect(pickProjects(['src/main/database.ts'])).toEqual(['main']);
+    expect(pickProjects(['scripts/precommit-tests.mjs'])).toEqual(['main']);
+  });
+
+  it('picks renderer projects for lib paths (not main)', () => {
+    expect(pickProjects(['src/renderer/lib/appTabMappings.ts'])).toEqual([
+      'renderer-logic',
+      'renderer-ui',
+    ]);
+  });
+
+  it('plans related for a main source file', () => {
+    const plan = planPrecommitTests(['src/main/foo.ts']);
+    expect(plan.mode).toBe('related');
+    expect(plan.projects).toEqual(['main']);
+    expect(plan.relatedPaths).toContain('src/main/foo.ts');
+  });
+});
+
+describe('precommit-tests runPrecommitTests', () => {
+  it('skips spawn when docs-only', () => {
+    const spawnSyncFn = vi.fn();
+    const logs = [];
+    const code = runPrecommitTests(['docs/ci-cd.md'], {
+      spawnSyncFn,
+      log: (m) => logs.push(m),
+    });
+    expect(code).toBe(0);
+    expect(spawnSyncFn).not.toHaveBeenCalled();
+    expect(logs.some((l) => l.includes('skip Vitest'))).toBe(true);
+  });
+
+  it('spawns full vitest run for force-full', () => {
+    const spawnSyncFn = vi.fn(() => ({ status: 0 }));
+    const code = runPrecommitTests(['package.json'], {
+      spawnSyncFn,
+      log: () => {},
+    });
+    expect(code).toBe(0);
+    expect(spawnSyncFn).toHaveBeenCalledTimes(1);
+    const args = spawnSyncFn.mock.calls[0][1];
+    expect(args).toEqual(['exec', 'vitest', 'run', '--bail', '1']);
+  });
+
+  it('spawns vitest related with main project for shared file', () => {
+    const spawnSyncFn = vi.fn(() => ({ status: 0 }));
+    const code = runPrecommitTests(['src/shared/appTagline.ts'], {
+      spawnSyncFn,
+      log: () => {},
+    });
+    expect(code).toBe(0);
+    const args = spawnSyncFn.mock.calls[0][1];
+    expect(args[0]).toBe('exec');
+    expect(args[1]).toBe('vitest');
+    expect(args[2]).toBe('related');
+    expect(args).toContain('--project');
+    expect(args).toContain('main');
+    expect(args).toContain('src/shared/appTagline.ts');
+    // Should not use `--` before related paths (breaks Vitest related).
+    const relatedIdx = args.indexOf('src/shared/appTagline.ts');
+    expect(args[relatedIdx - 1]).not.toBe('--');
+  });
+});
+
+describe('precommit-tests shouldForceFullSuite', () => {
+  it('is true when any force-full path is present', () => {
+    expect(shouldForceFullSuite(['src/main/index.ts', 'vitest.config.ts'])).toBe(true);
+    expect(shouldForceFullSuite(['src/main/index.ts'])).toBe(false);
+  });
+});

--- a/scripts/precommit-tests.test.mjs
+++ b/scripts/precommit-tests.test.mjs
@@ -101,8 +101,11 @@ describe('precommit-tests runPrecommitTests', () => {
     });
     expect(code).toBe(0);
     expect(spawnSyncFn).toHaveBeenCalledTimes(1);
-    const args = spawnSyncFn.mock.calls[0][1];
-    expect(args).toEqual(['exec', 'vitest', 'run', '--bail', '1']);
+    const [cmd, args, opts] = spawnSyncFn.mock.calls[0];
+    expect(cmd).toBe(process.execPath);
+    expect(args[0]).toMatch(/vitest\.mjs$/);
+    expect(args.slice(1)).toEqual(['run', '--bail', '1']);
+    expect(opts.shell).toBe(false);
   });
 
   it('spawns vitest related with main project for shared file', () => {
@@ -112,16 +115,33 @@ describe('precommit-tests runPrecommitTests', () => {
       log: () => {},
     });
     expect(code).toBe(0);
-    const args = spawnSyncFn.mock.calls[0][1];
-    expect(args[0]).toBe('exec');
-    expect(args[1]).toBe('vitest');
-    expect(args[2]).toBe('related');
+    const [cmd, args, opts] = spawnSyncFn.mock.calls[0];
+    expect(cmd).toBe(process.execPath);
+    expect(args[0]).toMatch(/vitest\.mjs$/);
+    expect(args[1]).toBe('related');
     expect(args).toContain('--project');
     expect(args).toContain('main');
     expect(args).toContain('src/shared/appTagline.ts');
+    expect(opts.shell).toBe(false);
     // Should not use `--` before related paths (breaks Vitest related).
     const relatedIdx = args.indexOf('src/shared/appTagline.ts');
     expect(args[relatedIdx - 1]).not.toBe('--');
+  });
+
+  it('passes spaced/metacharacter paths as literal argv without a shell', () => {
+    const nasty = 'src/main/foo & bar|baz%.ts';
+    const spawnSyncFn = vi.fn(() => ({ status: 0 }));
+    const code = runPrecommitTests([nasty], {
+      spawnSyncFn,
+      log: () => {},
+    });
+    expect(code).toBe(0);
+    const [cmd, args, opts] = spawnSyncFn.mock.calls[0];
+    expect(cmd).toBe(process.execPath);
+    expect(args).toContain(nasty);
+    expect(opts.shell).toBe(false);
+    // Ensure the path is one argv entry, not split/shell-interpreted.
+    expect(args.filter((a) => a === nasty)).toHaveLength(1);
   });
 });
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -258,6 +258,12 @@ fi
 # 9. PRE-FLIGHT VALIDATION - Run all checks before making any changes
 print_header "Running pre-flight validation..."
 
+echo "Checking development environment..."
+if ! pnpm run check:environment; then
+  print_error "Environment check failed. Fix required failures from 'pnpm run check:environment'."
+  exit 1
+fi
+
 # Check formatting
 echo "Checking code formatting..."
 if ! pnpm run format:check; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -286,8 +286,14 @@ if ! pnpm run typecheck; then
   exit 1
 fi
 
-# Security checks
-echo "Running security checks..."
+# Security / policy scanners — always run the full set on release (pre-commit may
+# path-gate some of these; never skip them here).
+echo "Running security and policy checks..."
+if ! pnpm run check:electron-security; then
+  print_error "Electron security check failed."
+  exit 1
+fi
+
 if ! pnpm run check:log-injection; then
   print_error "Log injection check failed."
   exit 1
@@ -300,6 +306,11 @@ fi
 
 if ! pnpm run check:codeql-extensions; then
   print_error "CodeQL extensions layout check failed."
+  exit 1
+fi
+
+if ! pnpm run check:insecure-temp-files; then
+  print_error "Insecure temporary file check failed."
   exit 1
 fi
 
@@ -320,6 +331,41 @@ fi
 
 if ! pnpm run check:reticulum-decommissioned-hubs; then
   print_error "Reticulum decommissioned hub catalog check failed."
+  exit 1
+fi
+
+if ! pnpm run check:console-log; then
+  print_error "console.log policy check failed."
+  exit 1
+fi
+
+if ! pnpm run check:silent-catches; then
+  print_error "Silent catch policy check failed."
+  exit 1
+fi
+
+if ! pnpm run check:url-hostname-sanitization; then
+  print_error "URL hostname sanitization check failed."
+  exit 1
+fi
+
+if ! pnpm run check:xss-patterns; then
+  print_error "XSS pattern check failed."
+  exit 1
+fi
+
+if ! pnpm run check:protocol-string-gates; then
+  print_error "Protocol string gate check failed."
+  exit 1
+fi
+
+if ! pnpm run check:log-panel-filter; then
+  print_error "Log panel filter check failed."
+  exit 1
+fi
+
+if ! pnpm run check:i18n; then
+  print_error "i18n key check failed."
   exit 1
 fi
 
@@ -360,30 +406,31 @@ if echo "$DEPRECATION_OUTPUT" | grep -q "DEP0187"; then
   exit 1
 fi
 
-# GitHub Actions validation
+# GitHub Actions validation (required — do not soft-skip)
 echo "Validating GitHub Actions..."
 if ! command -v actionlint > /dev/null 2>&1; then
-  print_warning "actionlint not found, skipping GitHub Actions validation"
-else
-  if ! actionlint; then
-    print_error "GitHub Actions validation failed."
-    exit 1
-  fi
+  print_error "actionlint not found. Install via 'pnpm run setup:actionlint' — release does not skip workflow validation."
+  exit 1
+fi
+if ! actionlint; then
+  print_error "GitHub Actions validation failed."
+  exit 1
 fi
 
-# YAML validation
+# YAML validation (required — do not soft-skip)
 echo "Validating YAML files..."
 if ! command -v yamllint > /dev/null 2>&1; then
-  print_warning "yamllint not found, skipping YAML validation"
-else
-  if ! yamllint -f github -s .; then
-    print_error "YAML validation failed."
-    exit 1
-  fi
+  print_error "yamllint not found. Install via pip/brew/apt — release does not skip YAML validation."
+  exit 1
+fi
+if ! yamllint -f github -s .; then
+  print_error "YAML validation failed."
+  exit 1
 fi
 
-# Tests
-echo "Running tests..."
+# Full Vitest suite — never use the pre-commit staged subset or --changed filters here.
+# Pre-commit may run a staged subset; release must match PR CI coverage of all tests.
+echo "Running full Vitest suite (pnpm run test:run)..."
 if ! pnpm run test:run; then
   print_error "Tests failed."
   exit 1

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const RELEASE_SH = path.join(ROOT, 'scripts/release.sh');
+const PACKAGE_JSON = path.join(ROOT, 'package.json');
+
+/** Checks that must always run in release pre-flight (not path-gated like pre-commit). */
+const REQUIRED_PNPM_CHECKS = [
+  'check:electron-security',
+  'check:log-injection',
+  'check:log-service-sinks',
+  'check:codeql-extensions',
+  'check:insecure-temp-files',
+  'check:db-migrations',
+  'check:ipc-contract',
+  'check:reticulum-interface-modes',
+  'check:reticulum-decommissioned-hubs',
+  'check:console-log',
+  'check:silent-catches',
+  'check:url-hostname-sanitization',
+  'check:xss-patterns',
+  'check:protocol-string-gates',
+  'check:log-panel-filter',
+  'check:i18n',
+  'check:licenses',
+  'check:flatpak',
+  'test:run',
+  'reticulum:sidecar:test',
+];
+
+describe('release.sh full-suite gate', () => {
+  const script = fs.readFileSync(RELEASE_SH, 'utf8');
+  const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
+
+  it('package.json test:run is an unrestricted vitest run', () => {
+    expect(pkg.scripts['test:run']).toBe('vitest run');
+    expect(pkg.scripts['test:staged']).toMatch(/precommit-tests/);
+  });
+
+  it('runs pnpm run test:run for the full Vitest suite', () => {
+    expect(script).toMatch(/pnpm run test:run/);
+  });
+
+  it('never invokes staged/related/changed Vitest bypasses', () => {
+    expect(script).not.toMatch(/pnpm run test:staged/);
+    expect(script).not.toMatch(/pnpm run test:changed/);
+    expect(script).not.toMatch(/vitest related\b/);
+    expect(script).not.toMatch(/vitest run --changed\b/);
+    expect(script).not.toMatch(/precommit-tests\.mjs/);
+  });
+
+  it('requires actionlint and yamllint (no soft-skip)', () => {
+    expect(script).toMatch(/actionlint not found/);
+    expect(script).toMatch(/yamllint not found/);
+    expect(script).not.toMatch(/actionlint not found, skipping/i);
+    expect(script).not.toMatch(/yamllint not found, skipping/i);
+  });
+
+  it.each(REQUIRED_PNPM_CHECKS)('invokes pnpm run %s', (scriptName) => {
+    expect(script).toContain(`pnpm run ${scriptName}`);
+  });
+});

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -10,6 +10,7 @@ const PACKAGE_JSON = path.join(ROOT, 'package.json');
 
 /** Checks that must always run in release pre-flight (not path-gated like pre-commit). */
 const REQUIRED_PNPM_CHECKS = [
+  'check:environment',
   'check:electron-security',
   'check:log-injection',
   'check:log-service-sinks',
@@ -42,7 +43,7 @@ describe('release.sh full-suite gate', () => {
   });
 
   it('runs pnpm run test:run for the full Vitest suite', () => {
-    expect(script).toMatch(/pnpm run test:run/);
+    expect(script).toMatch(/^\s*if ! pnpm run test:run; then\s*$/m);
   });
 
   it('never invokes staged/related/changed Vitest bypasses', () => {


### PR DESCRIPTION
## Summary
- Replace full-suite pre-commit Vitest with staged-related selection via `scripts/precommit-tests.mjs` (`pnpm run test:staged`), including co-located sibling tests and project scoping.
- Path-gate slower `check:*` scripts (flatpak, DB migrations, IPC, Reticulum modes/hubs/sidecar) and run ESLint only on staged JS/TS with cache; keep full typecheck and security scanners always on.
- Document that green pre-commit ≠ green CI — PR `tests.yaml` still runs the full suite with coverage.

## Test plan
- [ ] Commit a docs-only change and confirm pre-commit skips Vitest / path-gated checks as expected
- [ ] Commit a single `src/main` source change and confirm related Vitest runs (main project) instead of the full suite
- [ ] Stage `package.json` or `pnpm-lock.yaml` and confirm pre-commit forces a full Vitest run
- [ ] Run `pnpm exec vitest run scripts/precommit-tests.test.mjs` and confirm planner unit tests pass
- [ ] Confirm CI `tests.yaml` still runs the full suite on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `test:staged` to run Vitest for staged changes with an optimized skip/full/related strategy.
  * Improved pre-commit behavior to run staged-first checks (including staged ESLint with caching and path-gated scanners).
* **Documentation**
  * Updated pre-commit vs CI/release guidance to clarify staged-only local checks and full-suite CI/release requirements.
* **Tests**
  * Added automated tests for staged test planning/execution and for the pre-commit ESLint batching approach.
  * Added release-script tests enforcing full-suite and “no staged/related” rules.
* **Chores**
  * Added `.eslintcache` to Git ignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->