### PR TITLE
fix: install pnpm dist/ for Flatpak offline builds

### DIFF
--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -39,10 +39,12 @@ modules:
         PNPM_HOME: /run/build/mesh-client/.pnpm
         pnpm_config_cache: /run/build/mesh-client/.npm
     build-commands:
-      # Install pnpm standalone binary from archived release (no network needed).
+      # Install pnpm standalone from archived release (no network needed).
       # Archive extracts to pnpm-vendor/ (strip-components: 0) so the root `pnpm` binary is
-      # kept and the bundled dist/ does not collide with app dist/.
+      # kept and the bundled dist/ does not collide with app dist/. pnpm 11+ requires
+      # dist/pnpm.mjs next to the wrapper binary (install alone is not enough).
       - install -Dm755 pnpm-vendor/pnpm /run/build/mesh-client/.pnpm-bin/pnpm
+      - cp -a pnpm-vendor/dist /run/build/mesh-client/.pnpm-bin/dist
       # Offline install using generated-sources.json (retries @jsr temp-dir races).
       # --store-dir must use the sandbox-absolute path because the type:shell
       # source that writes .npmrc runs outside the sandbox, so $PWD there is

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -160,6 +160,15 @@ function checkManifestPnpmVersion(pkg) {
     }
   }
 
+  // The standalone wrapper requires dist/pnpm.mjs beside .pnpm-bin/pnpm.
+  if (!/cp\s+-a\s+pnpm-vendor\/dist\s+\/run\/build\/mesh-client\/\.pnpm-bin\/dist\b/.test(yaml)) {
+    violations.push({
+      file: rel,
+      message:
+        'manifest must copy pnpm-vendor/dist into .pnpm-bin/dist (pnpm 11+ wrapper needs dist/pnpm.mjs)',
+    });
+  }
+
   return violations;
 }
 

--- a/scripts/flatpak-pnpm-bin.test.mjs
+++ b/scripts/flatpak-pnpm-bin.test.mjs
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MANIFEST = path.join(ROOT, 'org.coloradomesh.MeshClient.yml');
+
+describe('Flatpak pnpm standalone install', () => {
+  it('copies pnpm-vendor/dist beside the wrapper binary (pnpm 11+ needs dist/pnpm.mjs)', () => {
+    const yaml = fs.readFileSync(MANIFEST, 'utf8');
+    expect(yaml).toMatch(
+      /install -Dm755 pnpm-vendor\/pnpm \/run\/build\/mesh-client\/\.pnpm-bin\/pnpm/,
+    );
+    expect(yaml).toMatch(/cp -a pnpm-vendor\/dist \/run\/build\/mesh-client\/\.pnpm-bin\/dist/);
+  });
+});


### PR DESCRIPTION
## Summary
- Flatpak CI failed after #700 because the pnpm 11 standalone wrapper was installed without its sibling `dist/` (`Cannot find module '.../.pnpm-bin/dist/pnpm.mjs'`).
- Copy `pnpm-vendor/dist` into `.pnpm-bin/dist` during the Flatpak build, and guard that contract in `check:flatpak` plus a manifest unit test.

## Test plan
- [x] `pnpm run check:flatpak`
- [x] `pnpm exec vitest run scripts/flatpak-pnpm-bin.test.mjs`
- [ ] Re-run **Build Flatpak (no release)** workflow on this branch (or confirm Flatpak jobs on the PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Flatpak builds by installing pnpm’s required supporting files alongside the pnpm executable.
  * Prevented build failures caused by missing pnpm runtime components.

* **Tests**
  * Added validation to ensure Flatpak manifests include all required pnpm installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->