### PR TITLE
fix: use pnpm store v11 for Flatpak offline installs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,15 @@ jobs:
       - name: Check Flatpak
         run: pnpm run check:flatpak
 
+      # PR-cycle only (not pre-commit): needs flatpak-node-generator to verify offline store vN.
+      - name: Install flatpak-node-generator
+        run: |
+          FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools
+          pip3 install "${FBTOOLS}@6f3f08759ac9859492b728f57f5163bf584c47ff#subdirectory=node"
+
+      - name: Check Flatpak offline pnpm sources
+        run: pnpm run check:flatpak-offline-pnpm
+
       - name: Install Flatpak validation tools
         run: sudo apt-get install -y desktop-file-utils appstream
 

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -90,7 +90,12 @@ jobs:
         run: |
           FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools
           pip3 install "${FBTOOLS}@6f3f08759ac9859492b728f57f5163bf584c47ff#subdirectory=node"
-          flatpak-node-generator pnpm pnpm-lock.yaml -o flatpak/generated-sources.json
+          # pnpm 11+ uses store v11; flatpak-node-generator defaults to v10 for lockfile 9.
+          PNPM_MAJOR="$(node -p "require('./package.json').packageManager.match(/^pnpm@(\\d+)/)[1]")"
+          STORE_VERSION="v${PNPM_MAJOR}"
+          flatpak-node-generator pnpm pnpm-lock.yaml \
+            --pnpm-store-version "$STORE_VERSION" \
+            -o flatpak/generated-sources.json
 
       # flatpak/flatpak-github-actions v6 appends -${arch} to the artifact name on upload;
       # keep bundle arch-agnostic here to avoid org.coloradomesh.MeshClient-aarch64-aarch64.flatpak.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -30,7 +30,7 @@ Runs on every push and pull request to `main`:
 6. Run typecheck (`pnpm run typecheck`)
 7. Run build (`pnpm run build`)
 8. Run `yamllint` on workflow/config YAML
-9. Run `check:flatpak`, `desktop-file-validate`, and `appstreamcli validate` on Flatpak metadata
+9. Run `check:flatpak`, `check:flatpak-offline-pnpm` (needs `flatpak-node-generator`), `desktop-file-validate`, and `appstreamcli validate` on Flatpak metadata
 
 All steps must pass before a PR can be merged.
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -275,10 +275,17 @@ flatpak install --user -y flathub org.electronjs.Electron2.BaseApp//24.08
 
 ```bash
 pip install flatpak-node-generator
-flatpak-node-generator pnpm pnpm-lock.yaml -o flatpak/generated-sources.json
+# Must match package.json packageManager major (pnpm 11 → v11). Generator defaults to v10.
+PNPM_MAJOR="$(node -p "require('./package.json').packageManager.match(/^pnpm@(\\d+)/)[1]")"
+STORE_VERSION="v${PNPM_MAJOR}"
+flatpak-node-generator pnpm pnpm-lock.yaml \
+  --pnpm-store-version "$STORE_VERSION" \
+  -o flatpak/generated-sources.json
 ```
 
 `flatpak/generated-sources.json` is generated automatically in the `flatpak.yaml` CI workflow and does not need to be committed. For local builds you generate it manually as shown above; the file is only required locally and in a Flathub submission repo.
+
+**PR-cycle offline check** (not pre-commit): after installing `flatpak-node-generator`, run `pnpm run check:flatpak-offline-pnpm` to assert the workflow passes the correct `--pnpm-store-version` and that generated sources cover lockfile tarballs (catches `ERR_PNPM_NO_OFFLINE_TARBALL`). CI / `act:pr` / `release.sh` run this automatically.
 
 Offline install inside the Flatpak sandbox uses `scripts/flatpak-pnpm-install.mjs`, which retries transient `@jsr/_tmp_*` rename races (same root cause as Windows `dist:win` hoisted installs).
 
@@ -365,29 +372,30 @@ flatpak run --command=flatpak-builder-lint org.freedesktop.Sdk \
 
 #### Quality checks
 
-| Script                                | Description                                                            |
-| ------------------------------------- | ---------------------------------------------------------------------- |
-| `check:codeql-extensions`             | Verify CodeQL extension allowlist for custom queries                   |
-| `check:console-log`                   | Fail on bare `console.log` in production paths                         |
-| `check:db-migrations`                 | Verify SQLite migrations are valid                                     |
-| `check:electron-security`             | Verify Electron security settings (CSP, sandbox, etc.)                 |
-| `check:environment`                   | Verify local dev prerequisites (run after clone)                       |
-| `check:flatpak`                       | Lint Flatpak manifest and wrapper scripts                              |
-| `check:i18n`                          | Verify English keys, unused keys, and locale quality rules             |
-| `check:i18n:branch`                   | Run i18n quality checks on keys new/changed vs `HEAD` only             |
-| `check:insecure-temp-files`           | Predictable `os.tmpdir()` writes (CodeQL `js/insecure-temporary-file`) |
-| `check:ipc-contract`                  | Verify IPC channel contracts between main/preload/renderer             |
-| `check:licenses`                      | Summarize dependency licenses (`license-checker-rseidelsohn`)          |
-| `check:log-injection`                 | Detect unsanitized user data in log calls                              |
-| `check:log-panel-filter`              | Verify log panel filter wiring                                         |
-| `check:log-service-sinks`             | Verify log service sink configuration                                  |
-| `check:protocol-string-gates`         | Enforce protocol capability gates over string compares                 |
-| `check:reticulum-decommissioned-hubs` | Keep TS/Rust decommissioned hub lists aligned                          |
-| `check:reticulum-interface-modes`     | Keep TS/Rust Reticulum interface-mode catalogs aligned                 |
-| `check:reticulum-sidecar`             | Stub `cargo fmt` + Clippy + test (skips when `cargo` missing)          |
-| `check:silent-catches`                | Detect empty or unlogged catch blocks                                  |
-| `check:url-hostname-sanitization`     | Verify URL hostname sanitization helpers                               |
-| `check:xss-patterns`                  | Detect risky DOM/HTML sink patterns                                    |
+| Script                                | Description                                                                 |
+| ------------------------------------- | --------------------------------------------------------------------------- |
+| `check:codeql-extensions`             | Verify CodeQL extension allowlist for custom queries                        |
+| `check:console-log`                   | Fail on bare `console.log` in production paths                              |
+| `check:db-migrations`                 | Verify SQLite migrations are valid                                          |
+| `check:electron-security`             | Verify Electron security settings (CSP, sandbox, etc.)                      |
+| `check:environment`                   | Verify local dev prerequisites (run after clone)                            |
+| `check:flatpak`                       | Lint Flatpak manifest and wrapper scripts                                   |
+| `check:flatpak-offline-pnpm`          | PR/release: regenerate offline sources; assert store vN + lockfile coverage |
+| `check:i18n`                          | Verify English keys, unused keys, and locale quality rules                  |
+| `check:i18n:branch`                   | Run i18n quality checks on keys new/changed vs `HEAD` only                  |
+| `check:insecure-temp-files`           | Predictable `os.tmpdir()` writes (CodeQL `js/insecure-temporary-file`)      |
+| `check:ipc-contract`                  | Verify IPC channel contracts between main/preload/renderer                  |
+| `check:licenses`                      | Summarize dependency licenses (`license-checker-rseidelsohn`)               |
+| `check:log-injection`                 | Detect unsanitized user data in log calls                                   |
+| `check:log-panel-filter`              | Verify log panel filter wiring                                              |
+| `check:log-service-sinks`             | Verify log service sink configuration                                       |
+| `check:protocol-string-gates`         | Enforce protocol capability gates over string compares                      |
+| `check:reticulum-decommissioned-hubs` | Keep TS/Rust decommissioned hub lists aligned                               |
+| `check:reticulum-interface-modes`     | Keep TS/Rust Reticulum interface-mode catalogs aligned                      |
+| `check:reticulum-sidecar`             | Stub `cargo fmt` + Clippy + test (skips when `cargo` missing)               |
+| `check:silent-catches`                | Detect empty or unlogged catch blocks                                       |
+| `check:url-hostname-sanitization`     | Verify URL hostname sanitization helpers                                    |
+| `check:xss-patterns`                  | Detect risky DOM/HTML sink patterns                                         |
 
 #### Documentation
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -372,30 +372,30 @@ flatpak run --command=flatpak-builder-lint org.freedesktop.Sdk \
 
 #### Quality checks
 
-| Script                                | Description                                                                 |
-| ------------------------------------- | --------------------------------------------------------------------------- |
-| `check:codeql-extensions`             | Verify CodeQL extension allowlist for custom queries                        |
-| `check:console-log`                   | Fail on bare `console.log` in production paths                              |
-| `check:db-migrations`                 | Verify SQLite migrations are valid                                          |
-| `check:electron-security`             | Verify Electron security settings (CSP, sandbox, etc.)                      |
-| `check:environment`                   | Verify local dev prerequisites (run after clone)                            |
-| `check:flatpak`                       | Lint Flatpak manifest and wrapper scripts                                   |
-| `check:flatpak-offline-pnpm`          | PR/release: regenerate offline sources; assert store vN + lockfile coverage |
-| `check:i18n`                          | Verify English keys, unused keys, and locale quality rules                  |
-| `check:i18n:branch`                   | Run i18n quality checks on keys new/changed vs `HEAD` only                  |
-| `check:insecure-temp-files`           | Predictable `os.tmpdir()` writes (CodeQL `js/insecure-temporary-file`)      |
-| `check:ipc-contract`                  | Verify IPC channel contracts between main/preload/renderer                  |
-| `check:licenses`                      | Summarize dependency licenses (`license-checker-rseidelsohn`)               |
-| `check:log-injection`                 | Detect unsanitized user data in log calls                                   |
-| `check:log-panel-filter`              | Verify log panel filter wiring                                              |
-| `check:log-service-sinks`             | Verify log service sink configuration                                       |
-| `check:protocol-string-gates`         | Enforce protocol capability gates over string compares                      |
-| `check:reticulum-decommissioned-hubs` | Keep TS/Rust decommissioned hub lists aligned                               |
-| `check:reticulum-interface-modes`     | Keep TS/Rust Reticulum interface-mode catalogs aligned                      |
-| `check:reticulum-sidecar`             | Stub `cargo fmt` + Clippy + test (skips when `cargo` missing)               |
-| `check:silent-catches`                | Detect empty or unlogged catch blocks                                       |
-| `check:url-hostname-sanitization`     | Verify URL hostname sanitization helpers                                    |
-| `check:xss-patterns`                  | Detect risky DOM/HTML sink patterns                                         |
+| Script                                | Description                                                            |
+| ------------------------------------- | ---------------------------------------------------------------------- |
+| `check:codeql-extensions`             | Verify CodeQL extension allowlist for custom queries                   |
+| `check:console-log`                   | Fail on bare `console.log` in production paths                         |
+| `check:db-migrations`                 | Verify SQLite migrations are valid                                     |
+| `check:electron-security`             | Verify Electron security settings (CSP, sandbox, etc.)                 |
+| `check:environment`                   | Verify local dev prerequisites (run after clone)                       |
+| `check:flatpak`                       | Lint Flatpak manifest and wrapper scripts                              |
+| `check:flatpak-offline-pnpm`          | PR/release offline Flatpak pnpm store vN + lockfile coverage           |
+| `check:i18n`                          | Verify English keys, unused keys, and locale quality rules             |
+| `check:i18n:branch`                   | Run i18n quality checks on keys new/changed vs `HEAD` only             |
+| `check:insecure-temp-files`           | Predictable `os.tmpdir()` writes (CodeQL `js/insecure-temporary-file`) |
+| `check:ipc-contract`                  | Verify IPC channel contracts between main/preload/renderer             |
+| `check:licenses`                      | Summarize dependency licenses (`license-checker-rseidelsohn`)          |
+| `check:log-injection`                 | Detect unsanitized user data in log calls                              |
+| `check:log-panel-filter`              | Verify log panel filter wiring                                         |
+| `check:log-service-sinks`             | Verify log service sink configuration                                  |
+| `check:protocol-string-gates`         | Enforce protocol capability gates over string compares                 |
+| `check:reticulum-decommissioned-hubs` | Keep TS/Rust decommissioned hub lists aligned                          |
+| `check:reticulum-interface-modes`     | Keep TS/Rust Reticulum interface-mode catalogs aligned                 |
+| `check:reticulum-sidecar`             | Stub `cargo fmt` + Clippy + test (skips when `cargo` missing)          |
+| `check:silent-catches`                | Detect empty or unlogged catch blocks                                  |
+| `check:url-hostname-sanitization`     | Verify URL hostname sanitization helpers                               |
+| `check:xss-patterns`                  | Detect risky DOM/HTML sink patterns                                    |
 
 #### Documentation
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -38,7 +38,7 @@ The release script (`scripts/release.sh`) is the supported maintainer path. It:
 2. Runs **`pnpm update`** and **`pnpm dedupe`** (updates lockfile before the bump)
 3. Syncs **`org.coloradomesh.MeshClient.yml`** Electron vendored archives to match `package.json` (`node scripts/sync-flatpak-electron.mjs`)
 4. Auto-detects **patch / minor / major** from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag (or accept an explicit bump — see below)
-5. Runs **pre-flight validation** (`check:environment`, format, lint, typecheck, **all** `check:*` scanners including path-gated pre-commit ones, **`check:flatpak`**, **`check:i18n`**, dedupe check, audit, **required** actionlint + yamllint, **full** Vitest via `pnpm run test:run`, Reticulum sidecar `cargo test`)
+5. Runs **pre-flight validation** (`check:environment`, format, lint, typecheck, **all** `check:*` scanners including path-gated pre-commit ones, **`check:flatpak`**, **`check:flatpak-offline-pnpm`**, **`check:i18n`**, dedupe check, audit, **required** actionlint + yamllint, **full** Vitest via `pnpm run test:run`, Reticulum sidecar `cargo test`)
 6. Prints **copy-paste release notes** grouped by feat/fix/other/breaking
 7. Bumps `package.json` via `pnpm version`
 8. Prepends a `<release>` entry to `flatpak/org.coloradomesh.MeshClient.metainfo.xml`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -27,6 +27,7 @@ Documentation deploys separately: [`docs.yml`](../.github/workflows/docs.yml) ru
 - On branch **`main`**, up to date with `origin/main`
 - Clean working directory (no uncommitted changes)
 - For `pnpm run release` pre-flight: **actionlint** and **yamllint** installed (or run `pnpm run setup:actionlint` and install yamllint via pip/brew — see [Development Guide](development-environment.md#8-helper-scripts-auto-install-where-possible))
+- For `pnpm run release` pre-flight: **flatpak-node-generator** on `PATH` (same pin as Flatpak CI — see [Building a Flatpak](development-environment.md#building-a-flatpak-linux) / `pnpm run check:flatpak-offline-pnpm` install hint)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "check:electron-security": "node scripts/check-electron-security.mjs",
     "check:environment": "node scripts/check-environment.mjs",
     "check:flatpak": "node scripts/check-flatpak.mjs",
+    "check:flatpak-offline-pnpm": "node scripts/check-flatpak-offline-pnpm.mjs",
     "check:i18n": "node scripts/check-i18n.mjs",
     "check:i18n:branch": "node scripts/check-i18n.mjs --branch",
     "check:insecure-temp-files": "node scripts/check-insecure-temp-files.mjs",

--- a/scripts/check-flatpak-offline-pnpm.mjs
+++ b/scripts/check-flatpak-offline-pnpm.mjs
@@ -18,6 +18,7 @@ import {
   FLATPAK_NODE_GENERATOR_COMMIT,
   FLATPAK_NODE_GENERATOR_GIT,
   flatpakWorkflowStoreVersionViolations,
+  lockfilePackageIdToTarballName,
   missingOfflineTarballs,
   parseGeneratedPnpmManifest,
   listLockfilePackageIds,
@@ -29,6 +30,9 @@ const ROOT = path.resolve(__dirname, '..');
 const PKG = path.join(ROOT, 'package.json');
 const LOCKFILE = path.join(ROOT, 'pnpm-lock.yaml');
 const WORKFLOW = path.join(ROOT, '.github/workflows/flatpak.yaml');
+
+/** Cap generator hangs (registry metadata) so CI fails with a clear message. */
+const GENERATOR_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * @returns {string | null}
@@ -69,10 +73,27 @@ function generateOfflineSources(expectedStoreVersion) {
   const result = spawnSync(
     bin,
     ['pnpm', LOCKFILE, '--pnpm-store-version', expectedStoreVersion, '-o', outPath],
-    { cwd: ROOT, encoding: 'utf8' },
+    {
+      cwd: ROOT,
+      encoding: 'utf8',
+      timeout: GENERATOR_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    },
   );
 
+  if (result.error) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    const timedOut = /** @type {{ code?: string }} */ (result.error).code === 'ETIMEDOUT';
+    return {
+      ok: false,
+      message: timedOut
+        ? `flatpak-node-generator timed out after ${GENERATOR_TIMEOUT_MS}ms`
+        : `flatpak-node-generator failed to start: ${result.error.message}`,
+    };
+  }
+
   if (result.status !== 0) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
     return {
       ok: false,
       message:
@@ -81,6 +102,7 @@ function generateOfflineSources(expectedStoreVersion) {
     };
   }
   if (!fs.existsSync(outPath)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
     return { ok: false, message: `generator did not write ${outPath}` };
   }
   return { ok: true, generatedPath: outPath };
@@ -130,12 +152,13 @@ function main() {
         }
 
         const lockIds = listLockfilePackageIds(fs.readFileSync(LOCKFILE, 'utf8'));
-        const missing = missingOfflineTarballs(lockIds, tarballNames);
+        const { missing, truncated } = missingOfflineTarballs(lockIds, tarballNames);
         if (missing.length > 0) {
+          const countLabel = truncated ? `${missing.length}+` : String(missing.length);
           violations.push({
             file: 'flatpak/generated-sources.json',
             message:
-              `offline store missing ${missing.length}+ lockfile tarball(s); sample: ${missing.slice(0, 5).join(', ')} ` +
+              `offline store missing ${countLabel} lockfile tarball(s); sample: ${missing.slice(0, 5).join(', ')} ` +
               `(pnpm install --offline would fail with ERR_PNPM_NO_OFFLINE_TARBALL)`,
           });
         }
@@ -143,8 +166,8 @@ function main() {
         // Explicit regression probe for scoped packages that failed Flatpak CI first.
         const bufbuildId = lockIds.find((id) => id.startsWith('@bufbuild/protobuf@'));
         if (bufbuildId) {
-          const bufTarball = `${bufbuildId.slice(0, bufbuildId.lastIndexOf('@')).replace('/', '__')}-${bufbuildId.slice(bufbuildId.lastIndexOf('@') + 1)}.tgz`;
-          if (!tarballNames.has(bufTarball)) {
+          const bufTarball = lockfilePackageIdToTarballName(bufbuildId);
+          if (bufTarball && !tarballNames.has(bufTarball)) {
             violations.push({
               file: 'flatpak/generated-sources.json',
               message: `missing ${bufTarball} (Flatpak CI offline install regression)`,

--- a/scripts/check-flatpak-offline-pnpm.mjs
+++ b/scripts/check-flatpak-offline-pnpm.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * PR/release-cycle check: Flatpak offline pnpm sources use the store version
+ * matching package.json packageManager, and cover lockfile tarballs.
+ *
+ * Failure point: flatpak-node-generator defaults to store v10 for lockfile 9 while
+ * pnpm 11 reads v11 → ERR_PNPM_NO_OFFLINE_TARBALL (@bufbuild/protobuf, etc.).
+ * Fallback: require --pnpm-store-version vN, regenerate, assert coverage.
+ *
+ * Not run in pre-commit (needs flatpak-node-generator). Used by CI / act:pr / release.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  FLATPAK_NODE_GENERATOR_COMMIT,
+  FLATPAK_NODE_GENERATOR_GIT,
+  flatpakWorkflowStoreVersionViolations,
+  missingOfflineTarballs,
+  parseGeneratedPnpmManifest,
+  listLockfilePackageIds,
+  storeVersionFromPackageManager,
+} from './flatpakPnpmStoreVersion.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const PKG = path.join(ROOT, 'package.json');
+const LOCKFILE = path.join(ROOT, 'pnpm-lock.yaml');
+const WORKFLOW = path.join(ROOT, '.github/workflows/flatpak.yaml');
+
+/**
+ * @returns {string | null}
+ */
+function resolveGeneratorBin() {
+  const fromEnv = process.env.FLATPAK_NODE_GENERATOR?.trim();
+  if (fromEnv) return fromEnv;
+
+  const which = spawnSync('which', ['flatpak-node-generator'], { encoding: 'utf8' });
+  if (which.status === 0) {
+    const bin = which.stdout.trim().split('\n')[0];
+    if (bin) return bin;
+  }
+  return null;
+}
+
+/**
+ * @param {string} expectedStoreVersion
+ * @returns {{ ok: true, generatedPath: string } | { ok: false, message: string }}
+ */
+function generateOfflineSources(expectedStoreVersion) {
+  const bin = resolveGeneratorBin();
+  if (!bin) {
+    return {
+      ok: false,
+      message:
+        `flatpak-node-generator not found on PATH (and FLATPAK_NODE_GENERATOR unset).\n` +
+        `  Install the CI pin, then re-run:\n` +
+        `    python3 -m venv .cache/flatpak-node-venv\n` +
+        `    .cache/flatpak-node-venv/bin/pip install '${FLATPAK_NODE_GENERATOR_GIT}'\n` +
+        `    export PATH="$PWD/.cache/flatpak-node-venv/bin:$PATH"\n` +
+        `    pnpm run check:flatpak-offline-pnpm`,
+    };
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-flatpak-offline-'));
+  const outPath = path.join(tmpDir, 'generated-sources.json');
+  const result = spawnSync(
+    bin,
+    ['pnpm', LOCKFILE, '--pnpm-store-version', expectedStoreVersion, '-o', outPath],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      message:
+        `flatpak-node-generator failed (exit ${result.status ?? 'null'}):\n` +
+        `${result.stderr || result.stdout || '(no output)'}`,
+    };
+  }
+  if (!fs.existsSync(outPath)) {
+    return { ok: false, message: `generator did not write ${outPath}` };
+  }
+  return { ok: true, generatedPath: outPath };
+}
+
+function main() {
+  /** @type {{ file: string, message: string }[]} */
+  const violations = [];
+
+  const pkg = JSON.parse(fs.readFileSync(PKG, 'utf8'));
+  const expectedStoreVersion = storeVersionFromPackageManager(pkg.packageManager);
+  if (!expectedStoreVersion) {
+    violations.push({
+      file: 'package.json',
+      message: 'missing valid packageManager pnpm@MAJOR.MINOR.PATCH',
+    });
+  } else {
+    const workflowYaml = fs.readFileSync(WORKFLOW, 'utf8');
+    violations.push(...flatpakWorkflowStoreVersionViolations(workflowYaml, expectedStoreVersion));
+
+    const pinCommit = FLATPAK_NODE_GENERATOR_COMMIT;
+    if (!workflowYaml.includes(pinCommit)) {
+      violations.push({
+        file: '.github/workflows/flatpak.yaml',
+        message: `flatpak-node-generator install pin must use commit ${pinCommit} (see scripts/flatpakPnpmStoreVersion.mjs)`,
+      });
+    }
+
+    const gen = generateOfflineSources(expectedStoreVersion);
+    if (!gen.ok) {
+      violations.push({ file: 'flatpak-node-generator', message: gen.message });
+    } else {
+      try {
+        const sources = JSON.parse(fs.readFileSync(gen.generatedPath, 'utf8'));
+        const { storeVersion, tarballNames } = parseGeneratedPnpmManifest(sources);
+        if (storeVersion !== expectedStoreVersion) {
+          violations.push({
+            file: 'flatpak/generated-sources.json',
+            message: `generated pnpm-manifest store_version is ${storeVersion ?? 'missing'}, expected ${expectedStoreVersion}`,
+          });
+        }
+        if (tarballNames.size === 0) {
+          violations.push({
+            file: 'flatpak/generated-sources.json',
+            message: 'generated pnpm-manifest has no packages',
+          });
+        }
+
+        const lockIds = listLockfilePackageIds(fs.readFileSync(LOCKFILE, 'utf8'));
+        const missing = missingOfflineTarballs(lockIds, tarballNames);
+        if (missing.length > 0) {
+          violations.push({
+            file: 'flatpak/generated-sources.json',
+            message:
+              `offline store missing ${missing.length}+ lockfile tarball(s); sample: ${missing.slice(0, 5).join(', ')} ` +
+              `(pnpm install --offline would fail with ERR_PNPM_NO_OFFLINE_TARBALL)`,
+          });
+        }
+
+        // Explicit regression probe for scoped packages that failed Flatpak CI first.
+        const bufbuildId = lockIds.find((id) => id.startsWith('@bufbuild/protobuf@'));
+        if (bufbuildId) {
+          const bufTarball = `${bufbuildId.slice(0, bufbuildId.lastIndexOf('@')).replace('/', '__')}-${bufbuildId.slice(bufbuildId.lastIndexOf('@') + 1)}.tgz`;
+          if (!tarballNames.has(bufTarball)) {
+            violations.push({
+              file: 'flatpak/generated-sources.json',
+              message: `missing ${bufTarball} (Flatpak CI offline install regression)`,
+            });
+          }
+        }
+      } finally {
+        fs.rmSync(path.dirname(gen.generatedPath), { recursive: true, force: true });
+      }
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `check-flatpak-offline-pnpm: ok (store ${expectedStoreVersion}, generator coverage)`,
+    );
+    process.exit(0);
+  }
+
+  console.error('check-flatpak-offline-pnpm:\n');
+  for (const v of violations) {
+    console.error(`  ${v.file}`);
+    console.error(`    ${v.message}`);
+    console.error('');
+  }
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -3,6 +3,10 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { offlinePnpmEnvContractViolations } from './flatpakOfflinePnpmEnv.mjs';
+import {
+  flatpakWorkflowStoreVersionViolations,
+  storeVersionFromPackageManager,
+} from './flatpakPnpmStoreVersion.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -10,6 +14,7 @@ const ROOT = path.resolve(__dirname, '..');
 const METAINFO = path.join(ROOT, 'flatpak', 'org.coloradomesh.MeshClient.metainfo.xml');
 const DESKTOP = path.join(ROOT, 'flatpak', 'org.coloradomesh.MeshClient.desktop');
 const MANIFEST = path.join(ROOT, 'org.coloradomesh.MeshClient.yml');
+const FLATPAK_WORKFLOW = path.join(ROOT, '.github/workflows/flatpak.yaml');
 const WRAPPER = path.join(ROOT, 'flatpak', 'mesh-client-wrapper.sh');
 const PKG = path.join(ROOT, 'package.json');
 const EXPECTED_APP_ID = 'org.coloradomesh.MeshClient';
@@ -174,6 +179,17 @@ function checkManifestPnpmVersion(pkg) {
   }
 
   return violations;
+}
+
+function checkFlatpakWorkflowStoreVersion(pkg) {
+  const violations = [];
+  if (!fs.existsSync(FLATPAK_WORKFLOW) || !pkg) return violations;
+
+  const expected = storeVersionFromPackageManager(pkg.packageManager);
+  if (!expected) return violations;
+
+  const yaml = fs.readFileSync(FLATPAK_WORKFLOW, 'utf8');
+  return flatpakWorkflowStoreVersionViolations(yaml, expected);
 }
 
 function checkManifestBranchAndElectronPayload(pkg) {
@@ -417,6 +433,7 @@ function main() {
     ...checkMetainfoAppId(),
     ...checkManifestAppId(),
     ...checkManifestPnpmVersion(PKG_JSON),
+    ...checkFlatpakWorkflowStoreVersion(PKG_JSON),
     ...checkManifestBranchAndElectronPayload(PKG_JSON),
     ...checkManifestReticulumSidecarPayload(),
     ...checkWrapperLaunchPaths(),

--- a/scripts/flatpakPnpmStoreVersion.mjs
+++ b/scripts/flatpakPnpmStoreVersion.mjs
@@ -1,0 +1,193 @@
+/**
+ * Flatpak offline pnpm store version must match the packageManager major
+ * (pnpm 11 → store v11). flatpak-node-generator defaults to v10 for lockfile 9.
+ */
+
+/** Pinned flatpak-builder-tools commit used by Flatpak CI + PR offline checks. */
+export const FLATPAK_NODE_GENERATOR_COMMIT = '6f3f08759ac9859492b728f57f5163bf584c47ff';
+
+export const FLATPAK_NODE_GENERATOR_GIT = `git+https://github.com/flatpak/flatpak-builder-tools@${FLATPAK_NODE_GENERATOR_COMMIT}#subdirectory=node`;
+
+/**
+ * @param {string | null | undefined} packageManager
+ * @returns {number | null}
+ */
+export function pnpmMajorFromPackageManager(packageManager) {
+  if (typeof packageManager !== 'string' || !packageManager.startsWith('pnpm@')) {
+    return null;
+  }
+  const version = packageManager.slice('pnpm@'.length).split('+', 1)[0];
+  const m = version.match(/^(\d+)\./);
+  if (!m) return null;
+  return Number(m[1]);
+}
+
+/**
+ * @param {number} pnpmMajor
+ * @returns {string}
+ */
+export function expectedPnpmStoreVersion(pnpmMajor) {
+  return `v${pnpmMajor}`;
+}
+
+/**
+ * @param {string} packageManager
+ * @returns {string | null}
+ */
+export function storeVersionFromPackageManager(packageManager) {
+  const major = pnpmMajorFromPackageManager(packageManager);
+  if (major == null) return null;
+  return expectedPnpmStoreVersion(major);
+}
+
+/**
+ * @param {string} workflowYaml
+ * @param {string} expectedStoreVersion e.g. v11
+ * @param {string} [fileRel]
+ * @returns {{ file: string, message: string }[]}
+ */
+export function flatpakWorkflowStoreVersionViolations(
+  workflowYaml,
+  expectedStoreVersion,
+  fileRel = '.github/workflows/flatpak.yaml',
+) {
+  /** @type {{ file: string, message: string }[]} */
+  const violations = [];
+
+  if (!/flatpak-node-generator\s+pnpm\b/.test(workflowYaml)) {
+    violations.push({
+      file: fileRel,
+      message: 'flatpak.yaml must invoke flatpak-node-generator pnpm …',
+    });
+    return violations;
+  }
+
+  // Accept an explicit --pnpm-store-version vN, or a shell var set from packageManager.
+  // Flag may be on a continued line after `flatpak-node-generator pnpm … \`.
+  const explicit = workflowYaml.match(
+    /flatpak-node-generator\s+pnpm\b[\s\S]{0,400}?--pnpm-store-version\s+(\S+)/,
+  );
+  if (explicit) {
+    const flag = explicit[1].replace(/^["']|["']$/g, '');
+    if (flag === expectedStoreVersion) {
+      return violations;
+    }
+    if (flag.startsWith('$') || flag.startsWith('${')) {
+      // Dynamic: require nearby derivation from package.json packageManager major.
+      if (
+        !/packageManager\.match\(/.test(workflowYaml) &&
+        !/packageManager.*pnpm@/.test(workflowYaml) &&
+        !/store.?version.*packageManager/i.test(workflowYaml) &&
+        !/PNPM_MAJOR=/.test(workflowYaml)
+      ) {
+        violations.push({
+          file: fileRel,
+          message: `flatpak.yaml uses --pnpm-store-version ${flag} but does not derive it from package.json packageManager (expected ${expectedStoreVersion} for current pin)`,
+        });
+      }
+      return violations;
+    }
+    violations.push({
+      file: fileRel,
+      message: `flatpak.yaml --pnpm-store-version is ${flag}, expected ${expectedStoreVersion} (pnpm packageManager major)`,
+    });
+    return violations;
+  }
+
+  violations.push({
+    file: fileRel,
+    message: `flatpak.yaml flatpak-node-generator must pass --pnpm-store-version ${expectedStoreVersion} (generator defaults to v10; pnpm ${expectedStoreVersion.slice(1)} needs ${expectedStoreVersion})`,
+  });
+  return violations;
+}
+
+/**
+ * Parse package keys from the lockfile `packages:` map (name@version).
+ * @param {string} lockfileText
+ * @returns {string[]}
+ */
+export function listLockfilePackageIds(lockfileText) {
+  const ids = [];
+  let inPackages = false;
+  for (const line of lockfileText.split('\n')) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages && /^\S/.test(line) && !line.startsWith(' ') && !line.startsWith('\t')) {
+      break;
+    }
+    if (!inPackages) continue;
+    const m = line.match(/^ {2}('([^']+)'|"([^"]+)"|([^:\s]+)):/);
+    if (!m) continue;
+    const id = m[2] ?? m[3] ?? m[4];
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * flatpak-node-generator tarball key for an npm package id (`@scope/name@1.2.3`).
+ * @param {string} packageId
+ * @returns {string | null}
+ */
+export function lockfilePackageIdToTarballName(packageId) {
+  // Skip non-registry / link peers that are not simple name@version.
+  if (packageId.includes('(') || packageId.includes('link:') || packageId.includes('file:')) {
+    return null;
+  }
+  const at = packageId.lastIndexOf('@');
+  if (at <= 0) return null;
+  const name = packageId.slice(0, at);
+  const version = packageId.slice(at + 1);
+  if (!name || !version || version.includes('/')) return null;
+  // Git / URL versions are not npm tarball names.
+  if (/^(https?:|git\+|github:)/i.test(version)) return null;
+  return `${name.replace('/', '__')}-${version}.tgz`;
+}
+
+/**
+ * @param {unknown} generatedSources
+ * @returns {{ storeVersion: string | null, tarballNames: Set<string> }}
+ */
+export function parseGeneratedPnpmManifest(generatedSources) {
+  if (!Array.isArray(generatedSources)) {
+    return { storeVersion: null, tarballNames: new Set() };
+  }
+  for (const item of generatedSources) {
+    if (!item || typeof item !== 'object') continue;
+    const destFilename = /** @type {{ 'dest-filename'?: unknown }} */ (item)['dest-filename'];
+    const contents = /** @type {{ contents?: unknown }} */ (item).contents;
+    if (destFilename !== 'pnpm-manifest.json' || typeof contents !== 'string') continue;
+    try {
+      const manifest = JSON.parse(contents);
+      const storeVersion =
+        typeof manifest.store_version === 'string' ? manifest.store_version : null;
+      const packages =
+        manifest.packages && typeof manifest.packages === 'object' ? manifest.packages : {};
+      return { storeVersion, tarballNames: new Set(Object.keys(packages)) };
+    } catch {
+      return { storeVersion: null, tarballNames: new Set() };
+    }
+  }
+  return { storeVersion: null, tarballNames: new Set() };
+}
+
+/**
+ * @param {string[]} lockfilePackageIds
+ * @param {Set<string>} tarballNames
+ * @param {number} [sampleLimit]
+ * @returns {string[]}
+ */
+export function missingOfflineTarballs(lockfilePackageIds, tarballNames, sampleLimit = 20) {
+  const missing = [];
+  for (const id of lockfilePackageIds) {
+    const tarball = lockfilePackageIdToTarballName(id);
+    if (!tarball) continue;
+    if (!tarballNames.has(tarball)) {
+      missing.push(tarball);
+      if (missing.length >= sampleLimit) break;
+    }
+  }
+  return missing;
+}

--- a/scripts/flatpakPnpmStoreVersion.mjs
+++ b/scripts/flatpakPnpmStoreVersion.mjs
@@ -177,17 +177,21 @@ export function parseGeneratedPnpmManifest(generatedSources) {
  * @param {string[]} lockfilePackageIds
  * @param {Set<string>} tarballNames
  * @param {number} [sampleLimit]
- * @returns {string[]}
+ * @returns {{ missing: string[], truncated: boolean }}
  */
 export function missingOfflineTarballs(lockfilePackageIds, tarballNames, sampleLimit = 20) {
   const missing = [];
+  let truncated = false;
   for (const id of lockfilePackageIds) {
     const tarball = lockfilePackageIdToTarballName(id);
     if (!tarball) continue;
     if (!tarballNames.has(tarball)) {
       missing.push(tarball);
-      if (missing.length >= sampleLimit) break;
+      if (missing.length >= sampleLimit) {
+        truncated = true;
+        break;
+      }
     }
   }
-  return missing;
+  return { missing, truncated };
 }

--- a/scripts/flatpakPnpmStoreVersion.test.mjs
+++ b/scripts/flatpakPnpmStoreVersion.test.mjs
@@ -79,6 +79,19 @@ packages:
     expect(storeVersion).toBe('v11');
     expect(
       missingOfflineTarballs(['@bufbuild/protobuf@2.12.1', 'lodash@4.17.21'], tarballNames),
-    ).toEqual(['@bufbuild__protobuf-2.12.1.tgz']);
+    ).toEqual({
+      missing: ['@bufbuild__protobuf-2.12.1.tgz'],
+      truncated: false,
+    });
+  });
+
+  it('signals truncation when missing samples hit the limit', () => {
+    const { missing, truncated } = missingOfflineTarballs(
+      ['a@1.0.0', 'b@1.0.0', 'c@1.0.0'],
+      new Set(),
+      2,
+    );
+    expect(missing).toEqual(['a-1.0.0.tgz', 'b-1.0.0.tgz']);
+    expect(truncated).toBe(true);
   });
 });

--- a/scripts/flatpakPnpmStoreVersion.test.mjs
+++ b/scripts/flatpakPnpmStoreVersion.test.mjs
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  expectedPnpmStoreVersion,
+  flatpakWorkflowStoreVersionViolations,
+  listLockfilePackageIds,
+  lockfilePackageIdToTarballName,
+  missingOfflineTarballs,
+  parseGeneratedPnpmManifest,
+  pnpmMajorFromPackageManager,
+  storeVersionFromPackageManager,
+} from './flatpakPnpmStoreVersion.mjs';
+
+describe('flatpakPnpmStoreVersion', () => {
+  it('maps packageManager major to store version', () => {
+    expect(pnpmMajorFromPackageManager('pnpm@11.15.1+sha512.abc')).toBe(11);
+    expect(storeVersionFromPackageManager('pnpm@11.15.1')).toBe('v11');
+    expect(expectedPnpmStoreVersion(11)).toBe('v11');
+    expect(storeVersionFromPackageManager('npm@10')).toBeNull();
+  });
+
+  it('requires --pnpm-store-version matching packageManager', () => {
+    const bad = `
+      flatpak-node-generator pnpm pnpm-lock.yaml -o flatpak/generated-sources.json
+    `;
+    expect(flatpakWorkflowStoreVersionViolations(bad, 'v11').length).toBe(1);
+
+    const good = `
+      flatpak-node-generator pnpm pnpm-lock.yaml --pnpm-store-version v11 -o flatpak/generated-sources.json
+    `;
+    expect(flatpakWorkflowStoreVersionViolations(good, 'v11')).toEqual([]);
+
+    const wrong = `
+      flatpak-node-generator pnpm pnpm-lock.yaml --pnpm-store-version v10 -o out.json
+    `;
+    expect(flatpakWorkflowStoreVersionViolations(wrong, 'v11')[0].message).toMatch(/v10/);
+  });
+
+  it('accepts store version derived from packageManager via shell var', () => {
+    const yaml = `
+      PNPM_MAJOR="$(node -p "require('./package.json').packageManager.match(/^pnpm@(\\\\d+)/)[1]")"
+      STORE_VERSION="v\${PNPM_MAJOR}"
+      flatpak-node-generator pnpm pnpm-lock.yaml \\
+        --pnpm-store-version "$STORE_VERSION" \\
+        -o flatpak/generated-sources.json
+    `;
+    expect(flatpakWorkflowStoreVersionViolations(yaml, 'v11')).toEqual([]);
+  });
+
+  it('parses lockfile package ids and tarball names', () => {
+    const lock = `
+packages:
+
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-abc==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-def==}
+`;
+    expect(listLockfilePackageIds(lock)).toEqual(['@bufbuild/protobuf@2.12.1', 'lodash@4.17.21']);
+    expect(lockfilePackageIdToTarballName('@bufbuild/protobuf@2.12.1')).toBe(
+      '@bufbuild__protobuf-2.12.1.tgz',
+    );
+    expect(lockfilePackageIdToTarballName('lodash@4.17.21')).toBe('lodash-4.17.21.tgz');
+  });
+
+  it('detects missing offline tarballs and parses generated manifest', () => {
+    const sources = [
+      {
+        type: 'inline',
+        'dest-filename': 'pnpm-manifest.json',
+        contents: JSON.stringify({
+          store_version: 'v11',
+          packages: { 'lodash-4.17.21.tgz': {} },
+        }),
+      },
+    ];
+    const { storeVersion, tarballNames } = parseGeneratedPnpmManifest(sources);
+    expect(storeVersion).toBe('v11');
+    expect(
+      missingOfflineTarballs(['@bufbuild/protobuf@2.12.1', 'lodash@4.17.21'], tarballNames),
+    ).toEqual(['@bufbuild__protobuf-2.12.1.tgz']);
+  });
+});

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -385,6 +385,11 @@ if ! pnpm run check:flatpak; then
   exit 1
 fi
 
+if ! pnpm run check:flatpak-offline-pnpm; then
+  print_error "Flatpak offline pnpm sources check failed (needs flatpak-node-generator; see script output)."
+  exit 1
+fi
+
 # Dependency checks
 echo "Checking dependencies..."
 if ! pnpm dedupe --check; then

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -29,6 +29,7 @@ const REQUIRED_PNPM_CHECKS = [
   'check:i18n',
   'check:licenses',
   'check:flatpak',
+  'check:flatpak-offline-pnpm',
   'test:run',
   'reticulum:sidecar:test',
 ];

--- a/scripts/run-act.mjs
+++ b/scripts/run-act.mjs
@@ -91,6 +91,12 @@ export const NATIVE_TARGETS = {
     { name: 'Build', command: 'pnpm', args: ['run', 'build'] },
     { name: 'Check Flatpak', command: 'pnpm', args: ['run', 'check:flatpak'] },
     {
+      name: 'Check Flatpak offline pnpm',
+      command: 'pnpm',
+      args: ['run', 'check:flatpak-offline-pnpm'],
+      optionalTool: 'flatpak-node-generator',
+    },
+    {
       name: 'Validate desktop file',
       command: 'desktop-file-validate',
       args: ['flatpak/org.coloradomesh.MeshClient.desktop'],

--- a/scripts/run-act.mjs
+++ b/scripts/run-act.mjs
@@ -94,7 +94,6 @@ export const NATIVE_TARGETS = {
       name: 'Check Flatpak offline pnpm',
       command: 'pnpm',
       args: ['run', 'check:flatpak-offline-pnpm'],
-      optionalTool: 'flatpak-node-generator',
     },
     {
       name: 'Validate desktop file',


### PR DESCRIPTION
## Summary
- Flatpak CI failed with `ERR_PNPM_NO_OFFLINE_TARBALL` for `@bufbuild/protobuf` because `flatpak-node-generator` defaults to store **v10** while pnpm 11 reads **v11**.
- `flatpak.yaml` now passes `--pnpm-store-version` derived from `package.json` `packageManager` major.
- Adds `pnpm run check:flatpak-offline-pnpm` (CI / `act:pr` / release only — not pre-commit) to regenerate offline sources and assert store version + lockfile tarball coverage; `check:flatpak` also asserts the workflow flag.

## Test plan
- [x] `pnpm run check:flatpak`
- [x] `pnpm run check:flatpak-offline-pnpm` (with flatpak-node-generator installed)
- [x] `pnpm exec vitest run scripts/flatpakPnpmStoreVersion.test.mjs scripts/flatpak-pnpm-*.test.mjs scripts/release.test.mjs`
- [ ] Re-run **Build Flatpak (no release)** workflow after merge (or on this PR if dispatched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Flatpak offline pnpm validation, including pnpm store-version consistency and offline package/tarball coverage checks.
  * Runs the new check in CI, Flatpak workflows, release pre-flight, and local native CI targets.
* **Bug Fixes**
  * Improved Flatpak offline source generation to use the pnpm version derived from the project’s `packageManager` setting.
* **Documentation**
  * Updated CI/development/release docs to reference the new offline pnpm validation step.
* **Tests**
  * Added automated tests for store-version mapping, lockfile parsing, and missing offline tarball detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->