### PR TITLE
fix: bump flatpak-node-generator for valid pnpm v11 storeDir YAML

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,8 @@ jobs:
       - name: Install flatpak-node-generator
         run: |
           FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools
-          pip3 install "${FBTOOLS}@6f3f08759ac9859492b728f57f5163bf584c47ff#subdirectory=node"
+          # Keep in sync with scripts/flatpakPnpmStoreVersion.mjs FLATPAK_NODE_GENERATOR_COMMIT.
+          pip3 install "${FBTOOLS}@ac5a296ac6111aa2319daf532f609a067b88d8a9#subdirectory=node"
 
       - name: Check Flatpak offline pnpm sources
         run: pnpm run check:flatpak-offline-pnpm

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -89,7 +89,8 @@ jobs:
       - name: Generate offline pnpm sources
         run: |
           FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools
-          pip3 install "${FBTOOLS}@6f3f08759ac9859492b728f57f5163bf584c47ff#subdirectory=node"
+          # ac5a296a+: YAML storeDir: for pnpm v11 (storeDir= breaks pnpm-workspace.yaml).
+          pip3 install "${FBTOOLS}@ac5a296ac6111aa2319daf532f609a067b88d8a9#subdirectory=node"
           # pnpm 11+ uses store v11; flatpak-node-generator defaults to v10 for lockfile 9.
           PNPM_MAJOR="$(node -p "require('./package.json').packageManager.match(/^pnpm@(\\d+)/)[1]")"
           STORE_VERSION="v${PNPM_MAJOR}"

--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -50,8 +50,9 @@ modules:
       - cp -a pnpm-vendor/dist /run/build/mesh-client/.pnpm-bin/dist
       # Offline install using generated-sources.json (retries @jsr temp-dir races).
       # --store-dir must use the sandbox-absolute path because the type:shell
-      # source that writes .npmrc runs outside the sandbox, so $PWD there is
-      # the host cache path, not the in-sandbox /run/build/mesh-client path.
+      # source that writes storeDir into pnpm-workspace.yaml (pnpm store v11) or
+      # .npmrc (older) runs outside the sandbox, so $PWD there is the host cache
+      # path, not the in-sandbox /run/build/mesh-client path.
       - node scripts/flatpak-pnpm-install.mjs
       # Build renderer, main, and preload
       - pnpm run build

--- a/scripts/check-flatpak-offline-pnpm.mjs
+++ b/scripts/check-flatpak-offline-pnpm.mjs
@@ -18,6 +18,7 @@ import {
   FLATPAK_NODE_GENERATOR_COMMIT,
   FLATPAK_NODE_GENERATOR_GIT,
   flatpakWorkflowStoreVersionViolations,
+  generatedSourcesStoreDirYamlViolations,
   lockfilePackageIdToTarballName,
   missingOfflineTarballs,
   parseGeneratedPnpmManifest,
@@ -137,6 +138,7 @@ function main() {
     } else {
       try {
         const sources = JSON.parse(fs.readFileSync(gen.generatedPath, 'utf8'));
+        violations.push(...generatedSourcesStoreDirYamlViolations(sources));
         const { storeVersion, tarballNames } = parseGeneratedPnpmManifest(sources);
         if (storeVersion !== expectedStoreVersion) {
           violations.push({

--- a/scripts/flatpakPnpmStoreVersion.mjs
+++ b/scripts/flatpakPnpmStoreVersion.mjs
@@ -256,13 +256,15 @@ export function probePnpmWorkspaceAfterStoreDirAppend(
       }
       return { ok: true, storeDir: /** @type {Record<string, unknown>} */ (doc).storeDir };
     }
-    if (/^storeDir\s*=/m.test(combined) && !/^storeDir\s*:/m.test(combined)) {
+    // Validate the appended line itself — an existing `storeDir:` in the
+    // workspace must not mask a newly appended npmrc-style `storeDir=`.
+    if (/^\s*storeDir\s*=/.test(storeDirLine)) {
       return {
         ok: false,
         reason: 'storeDir= npmrc line is not valid YAML in pnpm-workspace.yaml',
       };
     }
-    if (/^storeDir\s*:/m.test(combined)) {
+    if (/^\s*storeDir\s*:/.test(storeDirLine)) {
       return { ok: true };
     }
     return { ok: false, reason: 'missing storeDir YAML key after append' };

--- a/scripts/flatpakPnpmStoreVersion.mjs
+++ b/scripts/flatpakPnpmStoreVersion.mjs
@@ -3,8 +3,12 @@
  * (pnpm 11 → store v11). flatpak-node-generator defaults to v10 for lockfile 9.
  */
 
-/** Pinned flatpak-builder-tools commit used by Flatpak CI + PR offline checks. */
-export const FLATPAK_NODE_GENERATOR_COMMIT = '6f3f08759ac9859492b728f57f5163bf584c47ff';
+/**
+ * Pinned flatpak-builder-tools commit used by Flatpak CI + PR offline checks.
+ * Must include ac5a296a (YAML `storeDir: ` for pnpm store v11 — npmrc `storeDir=`
+ * appended to pnpm-workspace.yaml breaks Flatpak `pnpm install`).
+ */
+export const FLATPAK_NODE_GENERATOR_COMMIT = 'ac5a296ac6111aa2319daf532f609a067b88d8a9';
 
 export const FLATPAK_NODE_GENERATOR_GIT = `git+https://github.com/flatpak/flatpak-builder-tools@${FLATPAK_NODE_GENERATOR_COMMIT}#subdirectory=node`;
 
@@ -171,6 +175,101 @@ export function parseGeneratedPnpmManifest(generatedSources) {
     }
   }
   return { storeVersion: null, tarballNames: new Set() };
+}
+
+/**
+ * Shell commands from flatpak-node-generator that touch pnpm-workspace.yaml.
+ * @param {unknown} generatedSources
+ * @returns {string[]}
+ */
+export function listGeneratedPnpmWorkspaceShellCommands(generatedSources) {
+  /** @type {string[]} */
+  const commands = [];
+  if (!Array.isArray(generatedSources)) return commands;
+  for (const item of generatedSources) {
+    if (!item || typeof item !== 'object') continue;
+    const type = /** @type {{ type?: unknown }} */ (item).type;
+    const cmds = /** @type {{ commands?: unknown }} */ (item).commands;
+    if (type !== 'shell' || !Array.isArray(cmds)) continue;
+    for (const cmd of cmds) {
+      if (typeof cmd !== 'string') continue;
+      if (!cmd.includes('pnpm-workspace.yaml')) continue;
+      commands.push(cmd);
+    }
+  }
+  return commands;
+}
+
+/**
+ * flatpak-builder-tools before ac5a296a echoed npmrc `storeDir=` into
+ * pnpm-workspace.yaml, which is invalid YAML and fails Flatpak pnpm install.
+ *
+ * @param {unknown} generatedSources
+ * @param {string} [fileRel]
+ * @returns {{ file: string, message: string }[]}
+ */
+export function generatedSourcesStoreDirYamlViolations(
+  generatedSources,
+  fileRel = 'flatpak/generated-sources.json',
+) {
+  /** @type {{ file: string, message: string }[]} */
+  const violations = [];
+  const commands = listGeneratedPnpmWorkspaceShellCommands(generatedSources);
+
+  for (const cmd of commands) {
+    // npmrc-style key=value is not valid in pnpm-workspace.yaml.
+    if (/storeDir\s*=/.test(cmd) && !/storeDir\s*:\s*/.test(cmd)) {
+      violations.push({
+        file: fileRel,
+        message:
+          'shell command appends npmrc-style storeDir= to pnpm-workspace.yaml ' +
+          '(invalid YAML; Flatpak pnpm install fails). Bump flatpak-node-generator ' +
+          'to ac5a296a+ so it echoes "storeDir: $PWD/…".',
+      });
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Apply a generator-style storeDir append to workspace YAML and return whether
+ * the result still parses (same failure class as Flatpak `pnpm install`).
+ *
+ * @param {string} workspaceYaml
+ * @param {string} storeDirLine e.g. 'storeDir=/tmp/store' or 'storeDir: /tmp/store'
+ * @param {{ load?: (input: string) => unknown }} [yaml]
+ * @returns {{ ok: true, storeDir?: unknown } | { ok: false, reason: string }}
+ */
+export function probePnpmWorkspaceAfterStoreDirAppend(
+  workspaceYaml,
+  storeDirLine,
+  yaml = undefined,
+) {
+  const combined = `${workspaceYaml.replace(/\s*$/, '')}\n${storeDirLine}\n`;
+  try {
+    // Prefer real YAML parse when provided (vitest / check script); else heuristic.
+    if (yaml && typeof yaml.load === 'function') {
+      const doc = yaml.load(combined);
+      if (!doc || typeof doc !== 'object' || Array.isArray(doc)) {
+        return { ok: false, reason: 'parsed workspace is not a mapping' };
+      }
+      return { ok: true, storeDir: /** @type {Record<string, unknown>} */ (doc).storeDir };
+    }
+    if (/^storeDir\s*=/m.test(combined) && !/^storeDir\s*:/m.test(combined)) {
+      return {
+        ok: false,
+        reason: 'storeDir= npmrc line is not valid YAML in pnpm-workspace.yaml',
+      };
+    }
+    if (/^storeDir\s*:/m.test(combined)) {
+      return { ok: true };
+    }
+    return { ok: false, reason: 'missing storeDir YAML key after append' };
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    return { ok: false, reason: detail };
+  }
 }
 
 /**

--- a/scripts/flatpakPnpmStoreVersion.test.mjs
+++ b/scripts/flatpakPnpmStoreVersion.test.mjs
@@ -144,4 +144,26 @@ patchedDependencies:
       '/run/build/mesh-client/flatpak-node/pnpm-store',
     );
   });
+
+  it('rejects appended storeDir= even when workspace already has storeDir:', () => {
+    const workspace = `
+storeDir: /already/set
+patchedDependencies:
+  usb@2.18.0: patches/usb@2.18.0.patch
+`;
+    const withLoader = probePnpmWorkspaceAfterStoreDirAppend(
+      workspace,
+      'storeDir=/__w/mesh-client/bad-store',
+      yaml,
+    );
+    expect(withLoader.ok).toBe(false);
+
+    // No-loader fallback must inspect the appended line, not the existing key.
+    const heuristic = probePnpmWorkspaceAfterStoreDirAppend(
+      workspace,
+      'storeDir=/__w/mesh-client/bad-store',
+    );
+    expect(heuristic.ok).toBe(false);
+    expect(heuristic.ok === false && heuristic.reason).toMatch(/storeDir=/);
+  });
 });

--- a/scripts/flatpakPnpmStoreVersion.test.mjs
+++ b/scripts/flatpakPnpmStoreVersion.test.mjs
@@ -1,13 +1,17 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
 import {
   expectedPnpmStoreVersion,
   flatpakWorkflowStoreVersionViolations,
+  generatedSourcesStoreDirYamlViolations,
+  listGeneratedPnpmWorkspaceShellCommands,
   listLockfilePackageIds,
   lockfilePackageIdToTarballName,
   missingOfflineTarballs,
   parseGeneratedPnpmManifest,
   pnpmMajorFromPackageManager,
+  probePnpmWorkspaceAfterStoreDirAppend,
   storeVersionFromPackageManager,
 } from './flatpakPnpmStoreVersion.mjs';
 
@@ -93,5 +97,51 @@ packages:
     );
     expect(missing).toEqual(['a-1.0.0.tgz', 'b-1.0.0.tgz']);
     expect(truncated).toBe(true);
+  });
+
+  it('rejects npmrc-style storeDir= shell commands targeting pnpm-workspace.yaml', () => {
+    const bad = [
+      {
+        type: 'shell',
+        commands: [
+          'python3 flatpak-node/populate_pnpm_store.py …',
+          'echo "storeDir=$PWD/flatpak-node/pnpm-store" >> pnpm-workspace.yaml',
+        ],
+      },
+    ];
+    expect(listGeneratedPnpmWorkspaceShellCommands(bad)).toHaveLength(1);
+    expect(generatedSourcesStoreDirYamlViolations(bad)[0].message).toMatch(/storeDir=/);
+
+    const good = [
+      {
+        type: 'shell',
+        commands: ['echo "storeDir: $PWD/flatpak-node/pnpm-store" >> pnpm-workspace.yaml'],
+      },
+    ];
+    expect(generatedSourcesStoreDirYamlViolations(good)).toEqual([]);
+  });
+
+  it('reproduces Flatpak CI YAML break when storeDir= is appended to workspace', () => {
+    const workspace = `
+patchedDependencies:
+  usb@2.18.0: patches/usb@2.18.0.patch
+`;
+    const broken = probePnpmWorkspaceAfterStoreDirAppend(
+      workspace,
+      'storeDir=/__w/mesh-client/mesh-client/.flatpak-builder/…/flatpak-node/pnpm-store',
+      yaml,
+    );
+    expect(broken.ok).toBe(false);
+    expect(broken.ok === false && broken.reason).toMatch(/implicit key|YAML|storeDir=/i);
+
+    const fixed = probePnpmWorkspaceAfterStoreDirAppend(
+      workspace,
+      'storeDir: /run/build/mesh-client/flatpak-node/pnpm-store',
+      yaml,
+    );
+    expect(fixed.ok).toBe(true);
+    expect(fixed.ok === true && fixed.storeDir).toBe(
+      '/run/build/mesh-client/flatpak-node/pnpm-store',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Flatpak offline install failed because `flatpak-node-generator` (pre-`ac5a296a`) appended npmrc-style `storeDir=` into `pnpm-workspace.yaml`, which is invalid YAML (`multiline key may not be an implicit key`).
- Bump the Flatpak/CI pin to `ac5a296a` so generated sources echo `storeDir: …` instead.
- Extend `check:flatpak-offline-pnpm` and unit tests to reject the bad shell command and reproduce the workspace YAML failure.

Regression from [Build Flatpak run 29833612975](https://github.com/Colorado-Mesh/mesh-client/actions/runs/29833612975/job/88645084952) after enabling store v11.

## Test plan
- [x] `pnpm exec vitest run scripts/flatpakPnpmStoreVersion.test.mjs`
- [x] `pnpm run check:flatpak`
- [x] `pnpm run check:flatpak-offline-pnpm` (with pinned generator on PATH)
- [ ] Re-run **Build Flatpak (no release)** workflow and confirm x86_64/aarch64 Flatpak jobs pass `pnpm install`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Flatpak pnpm offline source generation for pnpm v11 with corrected `storeDir` formatting.
  * Added stronger validation to detect cases that would generate invalid `pnpm-workspace.yaml`.
  * Updated Flatpak/CI tooling to a newer compatible pinned revision.

* **Tests**
  * Expanded automated coverage for `storeDir` generation/probing, including failures for npmrc-style `storeDir=` snippets and success for YAML `storeDir:` format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->