### PR TITLE
fix: raise Dependabot security floors for postcss, electron-builder, and pymdown

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ mkdocs
 mkdocs-material
 idna>=3.15
 urllib3>=2.7.0
-pymdown-extensions>=10.21.3
+pymdown-extensions>=11.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,14 @@ overrides:
   '@meshtastic/core': npm:@jsr/meshtastic__core@^2.6.6
   cacheable-request: ^10.0.0
   form-data: ^4.0.6
+  app-builder-lib: ^26.15.0
   brace-expansion@<1.1.16: 1.1.16
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  builder-util-runtime: 9.7.0
   js-yaml: ^4.3.0
   markdown-it@<=14.1.1: '>=14.2.0 <15'
+  postcss: ^8.5.18
   shell-quote: ^1.9.0
   tar: ^7.5.18
   tmp: ^0.2.6
@@ -243,7 +246,7 @@ importers:
         specifier: ^0.22.1
         version: 0.22.1(supports-color@8.1.1)
       postcss:
-        specifier: ^8.5.22
+        specifier: ^8.5.18
         version: 8.5.22
       prettier:
         specifier: ^3.9.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,12 +38,16 @@ overrides:
   cacheable-request: ^10.0.0
   form-data: ^4.0.6
   # Security floors (Dependabot GHSA-52cp-r559-cp3m / GHSA-395f-4hp3-45gv /
-  # GHSA-w8wr-v893-vjvp / GHSA-3jxr-9vmj-r5cp). Keep majors separate for brace-expansion.
+  # GHSA-w8wr-v893-vjvp / GHSA-3jxr-9vmj-r5cp / GHSA-r28c-9q8g-f849 /
+  # GHSA-p2f4-r6v6-j797 / GHSA-7g7r-gx96-252g). Keep majors separate for brace-expansion.
+  app-builder-lib: ^26.15.0
   'brace-expansion@<1.1.16': 1.1.16
   'brace-expansion@>=2.0.0 <2.1.2': 2.1.2
   'brace-expansion@>=3.0.0 <5.0.7': 5.0.7
+  builder-util-runtime: 9.7.0
   js-yaml: ^4.3.0
   markdown-it@<=14.1.1: '>=14.2.0 <15'
+  postcss: ^8.5.18
   shell-quote: ^1.9.0
   tar: ^7.5.18
   tmp: ^0.2.6


### PR DESCRIPTION
## Summary
- Raise `pymdown-extensions` floor to `>=11.0.1` in `docs/requirements.txt` (Dependabot #61 / GHSA-9xwg-3r6f-jcx2).
- Add pnpm security-floor overrides for `postcss` (`^8.5.18`), `builder-util-runtime` (`9.7.0`), and `app-builder-lib` (`^26.15.0`) so alerts #62–#65 cannot regress (lockfile already resolved to patched versions; GitHub SBOM was stale).

## Test plan
- [x] `pnpm audit` (clean)
- [x] Pre-commit hooks (typecheck, scanners, staged Vitest)
- [ ] Confirm Dependabot alerts #61–#65 auto-close after merge (dismiss #62–#65 if SBOM lag keeps them open; lockfile already satisfies patched floors)