### PR TITLE
fix: key Nomad page cache and history by requestData

### DIFF
--- a/src/renderer/components/NomadNetworkPanel.test.tsx
+++ b/src/renderer/components/NomadNetworkPanel.test.tsx
@@ -366,6 +366,92 @@ describe('NomadNetworkPanel', () => {
     expect(fetchNomadPage).toHaveBeenCalledTimes(2);
   });
 
+  it('fetches distinct content for same path with different requestData', async () => {
+    const user = userEvent.setup();
+    const fetchNomadPage = vi
+      .fn()
+      .mockImplementation((_hash: string, path: string, requestData?: Record<string, string>) => {
+        if (path === '/page/index.mu') {
+          return {
+            ok: true,
+            content:
+              '`[Thread A`:/page/forum/thread.mu`thread_id=aaa]`\n`[Thread B`:/page/forum/thread.mu`thread_id=bbb]`',
+            content_type: 'micron',
+          };
+        }
+        if (path === '/page/forum/thread.mu' && requestData?.var_thread_id === 'aaa') {
+          return { ok: true, content: '`!Thread A body:`!', content_type: 'micron' };
+        }
+        if (path === '/page/forum/thread.mu' && requestData?.var_thread_id === 'bbb') {
+          return { ok: true, content: '`!Thread B body:`!', content_type: 'micron' };
+        }
+        return { ok: false, error: 'Invalid thread.' };
+      });
+    useNomadNetworkStore.setState({
+      fetchNomadPage,
+      nodes: new Map([
+        [
+          'abc1234567890',
+          {
+            destination_hash: 'abc1234567890',
+            display_name: 'Forum Node',
+            favorited: false,
+          },
+        ],
+      ]),
+    });
+
+    render(<NomadNetworkPanel />);
+    await openAnnouncesNode(user);
+    await waitFor(() => {
+      expect(document.querySelector('.nomad-micron-page')?.textContent).toContain('Thread A');
+    });
+
+    const links = () =>
+      Array.from(document.querySelectorAll('.nomad-micron-page [data-action="openNode"]'));
+
+    await user.click(links().find((el) => el.textContent?.includes('Thread A'))!);
+    await waitFor(() => {
+      expect(document.querySelector('.nomad-micron-page')?.textContent).toContain('Thread A body');
+    });
+    expect(screen.getByLabelText('nomadNetwork.urlBarAria')).toHaveValue(
+      'abc1234567890:/page/forum/thread.mu`thread_id=aaa',
+    );
+    expect(fetchNomadPage).toHaveBeenCalledWith('abc1234567890', '/page/forum/thread.mu', {
+      var_thread_id: 'aaa',
+    });
+
+    await user.click(screen.getByRole('button', { name: 'nomadNetwork.homePage' }));
+    await waitFor(() => {
+      expect(document.querySelector('.nomad-micron-page')?.textContent).toContain('Thread B');
+    });
+
+    await user.click(links().find((el) => el.textContent?.includes('Thread B'))!);
+    await waitFor(() => {
+      expect(document.querySelector('.nomad-micron-page')?.textContent).toContain('Thread B body');
+    });
+    expect(screen.getByLabelText('nomadNetwork.urlBarAria')).toHaveValue(
+      'abc1234567890:/page/forum/thread.mu`thread_id=bbb',
+    );
+    expect(fetchNomadPage).toHaveBeenCalledWith('abc1234567890', '/page/forum/thread.mu', {
+      var_thread_id: 'bbb',
+    });
+
+    const threadFetches = fetchNomadPage.mock.calls.filter(
+      (call) => call[1] === '/page/forum/thread.mu',
+    );
+    expect(threadFetches).toHaveLength(2);
+
+    await user.click(screen.getByRole('button', { name: 'nomadNetwork.reloadPage' }));
+    await waitFor(() => {
+      expect(document.querySelector('.nomad-micron-page')?.textContent).toContain('Thread B body');
+    });
+    const reloadCalls = fetchNomadPage.mock.calls.filter(
+      (call) => call[1] === '/page/forum/thread.mu' && call[2]?.var_thread_id === 'bbb',
+    );
+    expect(reloadCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('navigates back without refetching when page is cached', async () => {
     const user = userEvent.setup();
     const fetchNomadPage = vi

--- a/src/renderer/components/NomadNetworkPanel.tsx
+++ b/src/renderer/components/NomadNetworkPanel.tsx
@@ -7,9 +7,13 @@ import { formatRelativeOrIsoDate } from '@/renderer/lib/formatRelativeOrIsoDate'
 import { ICON_MD } from '@/renderer/lib/icons/iconClass';
 import { useParentIconTrigger } from '@/renderer/lib/icons/iconMotionContext';
 import {
+  buildNomadLinkRequest,
   DEFAULT_NOMAD_NODE_PAGE_PATH,
+  formatNomadRequestDataForUrlBar,
   isNomadMicronPage,
+  nomadPageRequestDataEquals,
   normalizeNomadPagePath,
+  normalizeNomadPageRequestData,
   parseNomadNetworkLinkUrl,
 } from '@/renderer/lib/nomad/micronParser';
 import { downloadNomadFileFromBase64 } from '@/renderer/lib/nomad/nomadFileDownload';
@@ -46,6 +50,7 @@ import NomadPageServerPanel from './NomadPageServerPanel';
 interface NomadHistoryEntry {
   hash: string;
   path: string;
+  requestData?: NomadPageRequestData;
 }
 
 interface LoadNodePageOptions {
@@ -92,8 +97,10 @@ function nomadCollapsedLabel(displayName: string | null | undefined, hash: strin
   return hash.slice(0, 2).toUpperCase();
 }
 
-function formatNomadUrlBar(hash: string, path: string): string {
-  return `${hash}:${path}`;
+function formatNomadUrlBar(hash: string, path: string, requestData?: NomadPageRequestData): string {
+  const base = `${hash}:${path}`;
+  const varSuffix = formatNomadRequestDataForUrlBar(requestData);
+  return varSuffix ? `${base}\`${varSuffix}` : base;
 }
 
 function truncateNomadPageContent(content: string): { text: string; truncated: boolean } {
@@ -251,6 +258,9 @@ export default function NomadNetworkPanel({
   const [sidecarRunning, setSidecarRunning] = useState(false);
   const [selectedHash, setSelectedHash] = useState<string | null>(null);
   const [pagePath, setPagePath] = useState(DEFAULT_NOMAD_NODE_PAGE_PATH);
+  const [pageRequestData, setPageRequestData] = useState<NomadPageRequestData | undefined>(
+    undefined,
+  );
   const [urlBarValue, setUrlBarValue] = useState('');
   const [historyStack, setHistoryStack] = useState<NomadHistoryEntry[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
@@ -288,22 +298,30 @@ export default function NomadNetworkPanel({
     }
   }, [isActive, selectedHash]);
 
-  const pushHistoryEntry = useCallback((hash: string, path: string) => {
-    const normalizedPath = normalizeNomadPagePath(path);
-    setHistoryStack((prev) => {
-      const idx = historyIndexRef.current;
-      const last = prev[idx];
-      if (last?.hash.toLowerCase() === hash.toLowerCase() && last.path === normalizedPath) {
-        return prev;
-      }
-      const truncated = prev.slice(0, idx + 1);
-      const next = [...truncated, { hash, path: normalizedPath }];
-      const nextIndex = next.length - 1;
-      historyIndexRef.current = nextIndex;
-      setHistoryIndex(nextIndex);
-      return next;
-    });
-  }, []);
+  const pushHistoryEntry = useCallback(
+    (hash: string, path: string, requestData?: NomadPageRequestData) => {
+      const normalizedPath = normalizeNomadPagePath(path);
+      const normalizedRequest = normalizeNomadPageRequestData(requestData);
+      setHistoryStack((prev) => {
+        const idx = historyIndexRef.current;
+        const last = prev[idx];
+        if (
+          last?.hash.toLowerCase() === hash.toLowerCase() &&
+          last.path === normalizedPath &&
+          nomadPageRequestDataEquals(last.requestData, normalizedRequest)
+        ) {
+          return prev;
+        }
+        const truncated = prev.slice(0, idx + 1);
+        const next = [...truncated, { hash, path: normalizedPath, requestData: normalizedRequest }];
+        const nextIndex = next.length - 1;
+        historyIndexRef.current = nextIndex;
+        setHistoryIndex(nextIndex);
+        return next;
+      });
+    },
+    [],
+  );
 
   useEffect(() => {
     mountedRef.current = true;
@@ -358,10 +376,11 @@ export default function NomadNetworkPanel({
       content: string,
       contentType: string | undefined,
       truncated: boolean,
+      requestData?: NomadPageRequestData,
     ) => {
       setPageContent(truncated ? `${content}\n\n[${t('nomadNetwork.pageTruncated')}]` : content);
       setPageContentType(contentType);
-      setUrlBarValue(formatNomadUrlBar(hash, normalizedPath));
+      setUrlBarValue(formatNomadUrlBar(hash, normalizedPath, requestData));
     },
     [t],
   );
@@ -369,21 +388,34 @@ export default function NomadNetworkPanel({
   const loadNodePage = useCallback(
     async (hash: string, path: string, options: LoadNodePageOptions = {}) => {
       const normalizedPath = normalizeNomadPagePath(path);
+      const normalizedRequest = normalizeNomadPageRequestData(options.requestData);
       const requestSeq = ++pageRequestSeqRef.current;
       setSelectedHash(hash);
       setPagePath(normalizedPath);
+      setPageRequestData(normalizedRequest);
       setPageLoading(true);
       setPageError(null);
       setShowPageSource(false);
 
       if (!options.forceReload) {
-        const cached = getNomadPageCache({ hash, path: normalizedPath });
+        const cached = getNomadPageCache({
+          hash,
+          path: normalizedPath,
+          requestData: normalizedRequest,
+        });
         if (cached) {
           if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
           setPageLoading(false);
-          applyPageResult(hash, normalizedPath, cached.content, cached.content_type, false);
+          applyPageResult(
+            hash,
+            normalizedPath,
+            cached.content,
+            cached.content_type,
+            false,
+            normalizedRequest,
+          );
           if (!options.fromHistory) {
-            pushHistoryEntry(hash, normalizedPath);
+            pushHistoryEntry(hash, normalizedPath, normalizedRequest);
           }
           return;
         }
@@ -391,7 +423,7 @@ export default function NomadNetworkPanel({
 
       setPageContent(null);
       setPageContentType(undefined);
-      const res = await fetchNomadPage(hash, normalizedPath, options.requestData);
+      const res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
       if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
       setPageLoading(false);
       if (!res.ok || !res.content) {
@@ -399,11 +431,12 @@ export default function NomadNetworkPanel({
         return;
       }
       const { text, truncated } = truncateNomadPageContent(res.content);
-      applyPageResult(hash, normalizedPath, text, res.content_type, truncated);
+      applyPageResult(hash, normalizedPath, text, res.content_type, truncated, normalizedRequest);
       setNomadPageCache(
         {
           hash,
           path: normalizedPath,
+          requestData: normalizedRequest,
         },
         {
           content: truncated ? text : res.content,
@@ -411,7 +444,7 @@ export default function NomadNetworkPanel({
         },
       );
       if (!options.fromHistory) {
-        pushHistoryEntry(hash, normalizedPath);
+        pushHistoryEntry(hash, normalizedPath, normalizedRequest);
       }
     },
     [applyPageResult, fetchNomadPage, pushHistoryEntry, t],
@@ -463,7 +496,10 @@ export default function NomadNetworkPanel({
       if (!entry) return;
       historyIndexRef.current = targetIndex;
       setHistoryIndex(targetIndex);
-      void loadNodePage(entry.hash, entry.path, { fromHistory: true });
+      void loadNodePage(entry.hash, entry.path, {
+        fromHistory: true,
+        requestData: entry.requestData,
+      });
     },
     [historyIndex, historyStack, loadNodePage],
   );
@@ -478,20 +514,25 @@ export default function NomadNetworkPanel({
       target = `${selectedNode.destination_hash}${target}`;
     }
 
-    const parsed = parseNomadNetworkLinkUrl(target, DEFAULT_NOMAD_NODE_PAGE_PATH);
+    const { destination: baseDestination, requestData } = buildNomadLinkRequest(target, null, null);
+    const parsed = parseNomadNetworkLinkUrl(baseDestination, DEFAULT_NOMAD_NODE_PAGE_PATH);
     if (!parsed) {
       setPageError(t('nomadNetwork.invalidUrl'));
       return;
     }
 
     const hash = parsed.destination_hash ?? selectedNode.destination_hash;
-    void loadNodePage(hash, parsed.path);
+    const normalizedRequest = normalizeNomadPageRequestData(requestData);
+    void loadNodePage(hash, parsed.path, {
+      requestData: normalizedRequest,
+    });
   }, [loadNodePage, selectedNode, t, urlBarValue]);
 
   const closeViewer = useCallback(() => {
     setSelectedHash(null);
     setPageContent(null);
     setPageError(null);
+    setPageRequestData(undefined);
     setUrlBarValue('');
     setHistoryStack([]);
     historyIndexRef.current = -1;
@@ -913,6 +954,7 @@ export default function NomadNetworkPanel({
                     onClick={() => {
                       void loadNodePage(selectedNode.destination_hash, pagePath, {
                         forceReload: true,
+                        requestData: pageRequestData,
                       });
                     }}
                   >

--- a/src/renderer/lib/nomad/micronParser.test.ts
+++ b/src/renderer/lib/nomad/micronParser.test.ts
@@ -287,6 +287,14 @@ describe('nomad page requestData helpers', () => {
     );
   });
 
+  it('escapes delimiter characters so requestData maps do not collide', () => {
+    const withPipeInValue = serializeNomadPageRequestDataKey({ var_a: '1|var_b=2' });
+    const twoEntries = serializeNomadPageRequestDataKey({ var_a: '1', var_b: '2' });
+    expect(withPipeInValue).not.toBe(twoEntries);
+    expect(withPipeInValue).toBe(`var_a=${encodeURIComponent('1|var_b=2')}`);
+    expect(twoEntries).toBe('var_a=1|var_b=2');
+  });
+
   it('formats only var_* keys for the URL bar', () => {
     expect(formatNomadRequestDataForUrlBar(undefined)).toBe('');
     expect(

--- a/src/renderer/lib/nomad/micronParser.test.ts
+++ b/src/renderer/lib/nomad/micronParser.test.ts
@@ -5,13 +5,17 @@ import {
   bindNomadMicronPartials,
   buildNomadLinkRequest,
   collectNomadFormFieldValues,
+  formatNomadRequestDataForUrlBar,
   isNomadFilePath,
   isNomadMicronPage,
   loadNomadMicronPartial,
   mountNomadMicronHtml,
+  nomadPageRequestDataEquals,
+  normalizeNomadPageRequestData,
   parseNomadLinkFieldsSpec,
   parseNomadNetworkLinkUrl,
   renderNomadMicronPage,
+  serializeNomadPageRequestDataKey,
   splitNomadLinkDestination,
 } from './micronParser';
 
@@ -268,5 +272,37 @@ describe('buildNomadLinkRequest', () => {
       baseDestination: ':/page/foo.mu',
       embeddedFieldsSpec: 'a=1|b=2',
     });
+  });
+});
+
+describe('nomad page requestData helpers', () => {
+  it('serializes request data with sorted keys for stable cache identity', () => {
+    expect(serializeNomadPageRequestDataKey(undefined)).toBe('');
+    expect(serializeNomadPageRequestDataKey({})).toBe('');
+    expect(serializeNomadPageRequestDataKey({ var_b: '2', var_a: '1', field_q: 'x' })).toBe(
+      'field_q=x|var_a=1|var_b=2',
+    );
+    expect(serializeNomadPageRequestDataKey({ var_a: '1', var_b: '2' })).toBe(
+      serializeNomadPageRequestDataKey({ var_b: '2', var_a: '1' }),
+    );
+  });
+
+  it('formats only var_* keys for the URL bar', () => {
+    expect(formatNomadRequestDataForUrlBar(undefined)).toBe('');
+    expect(
+      formatNomadRequestDataForUrlBar({
+        var_thread_id: 'abc',
+        field_q: 'ignored',
+        var_mode: 'live',
+      }),
+    ).toBe('mode=live|thread_id=abc');
+  });
+
+  it('normalizes empty maps and compares by serialized key', () => {
+    expect(normalizeNomadPageRequestData({})).toBeUndefined();
+    expect(normalizeNomadPageRequestData({ var_id: '1' })).toEqual({ var_id: '1' });
+    expect(nomadPageRequestDataEquals({ var_a: '1' }, { var_a: '1' })).toBe(true);
+    expect(nomadPageRequestDataEquals({ var_a: '1' }, { var_a: '2' })).toBe(false);
+    expect(nomadPageRequestDataEquals(undefined, {})).toBe(true);
   });
 });

--- a/src/renderer/lib/nomad/micronParser.ts
+++ b/src/renderer/lib/nomad/micronParser.ts
@@ -353,7 +353,7 @@ export function serializeNomadPageRequestDataKey(data?: NomadPageRequestData | n
   const normalized = normalizeNomadPageRequestData(data);
   if (!normalized) return '';
   return Object.keys(normalized)
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .map((key) => `${key}=${normalized[key]}`)
     .join('|');
 }
@@ -367,7 +367,7 @@ export function formatNomadRequestDataForUrlBar(data?: NomadPageRequestData | nu
   const normalized = normalizeNomadPageRequestData(data);
   if (!normalized) return '';
   const parts: string[] = [];
-  for (const key of Object.keys(normalized).sort()) {
+  for (const key of Object.keys(normalized).sort((a, b) => a.localeCompare(b))) {
     if (!key.startsWith('var_')) continue;
     const name = key.slice('var_'.length);
     if (!name) continue;

--- a/src/renderer/lib/nomad/micronParser.ts
+++ b/src/renderer/lib/nomad/micronParser.ts
@@ -1,3 +1,5 @@
+import type { NomadPageRequestData } from '@/shared/nomad-types';
+
 import MicronParser, {
   type MicronPartialCleanup,
   type MicronPartialFetchResult,
@@ -331,4 +333,53 @@ export function buildNomadLinkRequest(
         };
 
   return { destination: baseDestination, requestData };
+}
+
+/** Normalize empty/undefined request maps to undefined for identity comparisons. */
+export function normalizeNomadPageRequestData(
+  data?: NomadPageRequestData | null,
+): NomadPageRequestData | undefined {
+  if (!data) return undefined;
+  const entries = Object.entries(data).filter(([, v]) => v != null && v !== '');
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(entries);
+}
+
+/**
+ * Stable cache/history key fragment for Nomad page request data.
+ * Empty or undefined data → `""`.
+ */
+export function serializeNomadPageRequestDataKey(data?: NomadPageRequestData | null): string {
+  const normalized = normalizeNomadPageRequestData(data);
+  if (!normalized) return '';
+  return Object.keys(normalized)
+    .sort()
+    .map((key) => `${key}=${normalized[key]}`)
+    .join('|');
+}
+
+/**
+ * Micron-style backtick URL suffix from `var_*` request keys (strip `var_` prefix).
+ * Form-only `field_*` keys are omitted (not URL-bar round-trippable as static link vars).
+ * Returns `""` when there are no displayable vars (caller should not append a backtick).
+ */
+export function formatNomadRequestDataForUrlBar(data?: NomadPageRequestData | null): string {
+  const normalized = normalizeNomadPageRequestData(data);
+  if (!normalized) return '';
+  const parts: string[] = [];
+  for (const key of Object.keys(normalized).sort()) {
+    if (!key.startsWith('var_')) continue;
+    const name = key.slice('var_'.length);
+    if (!name) continue;
+    parts.push(`${name}=${normalized[key]}`);
+  }
+  return parts.join('|');
+}
+
+/** Compare two request-data maps by stable serialized key. */
+export function nomadPageRequestDataEquals(
+  a?: NomadPageRequestData | null,
+  b?: NomadPageRequestData | null,
+): boolean {
+  return serializeNomadPageRequestDataKey(a) === serializeNomadPageRequestDataKey(b);
 }

--- a/src/renderer/lib/nomad/micronParser.ts
+++ b/src/renderer/lib/nomad/micronParser.ts
@@ -354,7 +354,7 @@ export function serializeNomadPageRequestDataKey(data?: NomadPageRequestData | n
   if (!normalized) return '';
   return Object.keys(normalized)
     .sort((a, b) => a.localeCompare(b))
-    .map((key) => `${key}=${normalized[key]}`)
+    .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(normalized[key] ?? '')}`)
     .join('|');
 }
 

--- a/src/renderer/lib/nomad/nomadPageCache.test.ts
+++ b/src/renderer/lib/nomad/nomadPageCache.test.ts
@@ -25,6 +25,29 @@ describe('nomadPageCache', () => {
     expect(hit?.content_type).toBe('micron');
   });
 
+  it('treats different requestData as distinct cache entries', () => {
+    const hash = 'abc1234567890abcdef1234567890ab';
+    const path = '/page/forum/thread.mu';
+    setNomadPageCache({ hash, path, requestData: { var_thread_id: 'a' } }, { content: 'thread-a' });
+    setNomadPageCache({ hash, path, requestData: { var_thread_id: 'b' } }, { content: 'thread-b' });
+    expect(getNomadPageCache({ hash, path, requestData: { var_thread_id: 'a' } })?.content).toBe(
+      'thread-a',
+    );
+    expect(getNomadPageCache({ hash, path, requestData: { var_thread_id: 'b' } })?.content).toBe(
+      'thread-b',
+    );
+    expect(getNomadPageCache({ hash, path })?.content).toBeUndefined();
+  });
+
+  it('hits cache when requestData matches regardless of key order', () => {
+    const hash = 'abc1234567890abcdef1234567890ab';
+    const path = '/page/forum/thread.mu';
+    setNomadPageCache({ hash, path, requestData: { var_b: '2', var_a: '1' } }, { content: 'same' });
+    expect(
+      getNomadPageCache({ hash, path, requestData: { var_a: '1', var_b: '2' } })?.content,
+    ).toBe('same');
+  });
+
   it('evicts oldest entries when over capacity', () => {
     for (let i = 0; i < 33; i++) {
       const hash = `${i}`.padStart(32, 'a');

--- a/src/renderer/lib/nomad/nomadPageCache.ts
+++ b/src/renderer/lib/nomad/nomadPageCache.ts
@@ -1,4 +1,6 @@
-import { normalizeNomadPagePath } from './micronParser';
+import type { NomadPageRequestData } from '@/shared/nomad-types';
+
+import { normalizeNomadPagePath, serializeNomadPageRequestDataKey } from './micronParser';
 
 /** Cap cached page size — aligned with NomadNetworkPanel display limit. */
 export const MAX_NOMAD_PAGE_CACHE_CHARS = 256 * 1024;
@@ -14,13 +16,16 @@ export interface NomadPageCacheEntry {
 export interface NomadPageCacheKeyInput {
   hash: string;
   path: string;
+  /** NomadNet link request vars (`var_*` / `field_*`); part of cache identity. */
+  requestData?: NomadPageRequestData;
 }
 
 const cache = new Map<string, NomadPageCacheEntry>();
 
-function cacheKey({ hash, path }: NomadPageCacheKeyInput): string {
+function cacheKey({ hash, path, requestData }: NomadPageCacheKeyInput): string {
   const cleanHash = hash.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
-  return `${cleanHash}:${normalizeNomadPagePath(path)}`;
+  const dataKey = serializeNomadPageRequestDataKey(requestData);
+  return `${cleanHash}:${normalizeNomadPagePath(path)}:${dataKey}`;
 }
 
 export function getNomadPageCache(input: NomadPageCacheKeyInput): NomadPageCacheEntry | undefined {


### PR DESCRIPTION
## Summary
- Include Nomad `requestData` (`var_*` / `field_*`) in the session page cache key, history stack, reload, and URL bar so same-path pages (e.g. `/page/forum/thread.mu`) load distinct threads instead of the first cached one.
- Parse Micron-style backtick vars from the URL bar on submit so reload and manual navigation round-trip thread identity.

Fixes #715

## Test plan
- [ ] Open RNS.recipes Forum (or similar multi-thread Micron site) in Nomad Network
- [ ] Click thread A, go home, click thread B — expect thread B content (not A)
- [ ] Confirm URL bar shows backtick vars (e.g. `…/thread.mu`thread_id=…`)
- [ ] Reload on thread B — expect same thread, not “Invalid thread”
- [ ] Back/forward across distinct threads with the same path restores the correct content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NomadNet pages now preserve request-specific variables across navigation, reload, and back/forward history.
  * The URL bar now includes relevant request variable context for clearer sharing.
  * Page caching and cache lookups now differentiate pages by the requested variable set.
* **Bug Fixes**
  * Reloading and revisiting threads now restores the correct content for the selected variable set.
* **Tests**
  * Added coverage for request-data normalization, URL-bar formatting, cache identity, and history reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->