### PR TITLE
fix: preserve IFAC fields when merging live interface stats

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Full history: paths-filter on push fetches github.event.before then
+          # the base ref with --depth=1; concurrent shallow fetches fail with
+          # "shallow file has changed since we read it" (CI run 30406976369).
+          fetch-depth: 0
       # dorny/paths-filter v4.0.0
       - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c
         id: filter

--- a/reticulum-sidecar/src/stack/via.rs
+++ b/reticulum-sidecar/src/stack/via.rs
@@ -227,6 +227,11 @@ pub fn merge_live_interfaces_with_config(
             live_row.announce_interval_min = cfg.announce_interval_min;
             live_row.connectable = cfg.connectable;
             live_row.reachable_on = cfg.reachable_on.clone();
+            // Config is source of truth for IFAC / extras / BLE seeds (live stats omit them).
+            live_row.network_name = cfg.network_name.clone();
+            live_row.passphrase = cfg.passphrase.clone();
+            live_row.extra_config = cfg.extra_config.clone();
+            live_row.seed_addresses = cfg.seed_addresses.clone();
             // Config INI is the source of truth for user enable/disable; live stats only
             // report carrier status (online), which must not flip `enabled` in the UI.
             live_row.enabled = cfg.enabled;
@@ -606,5 +611,89 @@ mod tests {
         assert_eq!(merged.len(), 1);
         assert!(merged[0].enabled);
         assert_eq!(merged[0].status, "down");
+    }
+
+    #[test]
+    fn merge_live_interfaces_preserves_ifac_and_extra_config() {
+        // Matches TTP-shaped TCP from user report: IFAC on disk, live stats sparse.
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("forward_interval".into(), "300".into());
+        let config = vec![InterfaceRow {
+            id: "ttp-tcp".into(),
+            name: "TTP_TCP".into(),
+            iface_type: "tcp".into(),
+            enabled: true,
+            status: "down".into(),
+            host: Some("rns.thetechprepper.com".into()),
+            port: Some(11312),
+            preset: None,
+            serial_port: None,
+            frequency: None,
+            bandwidth: None,
+            txpower: None,
+            spreading_factor: None,
+            coding_rate: None,
+            callsign: None,
+            id_interval: None,
+            mode: Some("boundary".into()),
+            seed_addresses: vec!["AA:BB:CC:DD:EE:FF".into()],
+            discoverable: None,
+            latitude: None,
+            longitude: None,
+            height: None,
+            discovery_name: None,
+            announce_interval_min: None,
+            connectable: None,
+            reachable_on: None,
+            network_name: Some("ttp_internal".into()),
+            passphrase: Some("resistance202606".into()),
+            extra_config: extra.clone(),
+        }];
+        let live = vec![InterfaceRow {
+            id: "rns-0".into(),
+            name: "TTP_TCP".into(),
+            iface_type: "Full".into(),
+            enabled: true,
+            status: "up".into(),
+            host: None,
+            port: None,
+            preset: None,
+            serial_port: None,
+            frequency: None,
+            bandwidth: None,
+            txpower: None,
+            spreading_factor: None,
+            coding_rate: None,
+            callsign: None,
+            id_interval: None,
+            mode: None,
+            seed_addresses: Vec::new(),
+            discoverable: None,
+            latitude: None,
+            longitude: None,
+            height: None,
+            discovery_name: None,
+            announce_interval_min: None,
+            connectable: None,
+            reachable_on: None,
+            network_name: None,
+            passphrase: None,
+            extra_config: std::collections::HashMap::new(),
+        }];
+        let merged = merge_live_interfaces_with_config(&config, live);
+        assert_eq!(merged.len(), 1);
+        let row = &merged[0];
+        assert_eq!(row.id, "ttp-tcp");
+        assert_eq!(row.status, "up");
+        assert_eq!(row.host.as_deref(), Some("rns.thetechprepper.com"));
+        assert_eq!(row.port, Some(11312));
+        assert_eq!(row.mode.as_deref(), Some("boundary"));
+        assert_eq!(row.network_name.as_deref(), Some("ttp_internal"));
+        assert_eq!(row.passphrase.as_deref(), Some("resistance202606"));
+        assert_eq!(
+            row.extra_config.get("forward_interval").map(String::as_str),
+            Some("300")
+        );
+        assert_eq!(row.seed_addresses, vec!["AA:BB:CC:DD:EE:FF".to_string()]);
     }
 }

--- a/src/renderer/components/reticulum/ReticulumInterfacesPanel.test.tsx
+++ b/src/renderer/components/reticulum/ReticulumInterfacesPanel.test.tsx
@@ -481,6 +481,37 @@ describe('ReticulumInterfacesPanel', () => {
     });
   });
 
+  it('prefills IFAC and advanced fields when opening edit', async () => {
+    const user = userEvent.setup();
+    render(
+      <ReticulumInterfacesPanel
+        {...defaultProps}
+        interfaces={[
+          {
+            id: 'ttp-tcp',
+            name: 'TTP_TCP',
+            type: 'tcp',
+            enabled: true,
+            status: 'up',
+            host: 'rns.thetechprepper.com',
+            port: 11312,
+            mode: 'boundary',
+            network_name: 'ttp_internal',
+            passphrase: 'resistance202606',
+            extra_config: { forward_interval: '300' },
+          },
+        ]}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'connectionPanel.reticulumInterfaces.edit' }),
+    );
+    expect(document.getElementById('edit-ifac-ttp-tcp-network-name')).toHaveValue('ttp_internal');
+    expect(document.getElementById('edit-ifac-ttp-tcp-passphrase')).toHaveValue('resistance202606');
+    expect(document.getElementById('edit-advanced-ttp-tcp')).toHaveValue('forward_interval = 300');
+  });
+
   it('includes IFAC and extra_config in edit save patch', async () => {
     const user = userEvent.setup();
     const proxyPut = vi.fn().mockResolvedValue({ ok: true });


### PR DESCRIPTION
## Summary
- Live interface merge now copies `network_name`, `passphrase`, `extra_config`, and `seed_addresses` from config so edit forms show saved IFAC values while the stack is running
- Regression tests cover TTP-shaped merge and edit-form prefilling

Follow-up to #722: values were on disk but dropped from `GET /api/v1/interfaces` during live merge.

## Test plan
- [ ] Add TCP interface with Network name + Passphrase; leave stack running
- [ ] Click Edit — fields should show the saved values (not empty)
- [ ] Advanced textarea should show any `extra_config` lines when present
- [ ] Sidecar: `cargo test merge_live_interfaces_preserves_ifac`
- [ ] Vitest: `prefills IFAC and advanced fields when opening edit`