### PR TITLE
fix(nomad): auto-retry page load after path/link timeout

### DIFF
--- a/src/renderer/components/NomadNetworkPanel.test.tsx
+++ b/src/renderer/components/NomadNetworkPanel.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import { hydrateAxeThemeColors } from '@/renderer/lib/a11yTestHelpers';
+import { NOMAD_PAGE_FETCH_RETRY_SETTLE_MS } from '@/renderer/lib/timeConstants';
 import { mockConsoleWarn } from '@/renderer/lib/vitestConsoleMock';
 
 vi.mock('react-i18next', () => ({
@@ -797,7 +798,7 @@ describe('NomadNetworkPanel', () => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(1);
       });
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(800);
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
       });
       await waitFor(() => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(2);
@@ -842,7 +843,7 @@ describe('NomadNetworkPanel', () => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(1);
       });
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(800);
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
       });
       await waitFor(() => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(2);
@@ -891,7 +892,7 @@ describe('NomadNetworkPanel', () => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(1);
       });
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(800);
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
       });
       await waitFor(() => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(2);

--- a/src/renderer/components/NomadNetworkPanel.test.tsx
+++ b/src/renderer/components/NomadNetworkPanel.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import { hydrateAxeThemeColors } from '@/renderer/lib/a11yTestHelpers';
+import { mockConsoleWarn } from '@/renderer/lib/vitestConsoleMock';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -758,5 +759,191 @@ describe('NomadNetworkPanel', () => {
       'nomad-micron-page--fit-width',
     );
     expect(screen.getByLabelText('nomadNetwork.fitWidth')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('auto-retries once after link_timeout and renders on success', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { restore } = mockConsoleWarn();
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const fetchNomadPage = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, error: 'link_timeout' })
+        .mockResolvedValueOnce({
+          ok: true,
+          content: '>>>hello after retry',
+          content_type: 'micron',
+        });
+      useNomadNetworkStore.setState({
+        nodes: new Map([
+          [
+            'abc1234567890',
+            {
+              destination_hash: 'abc1234567890',
+              display_name: 'Retry Node',
+              favorited: false,
+              last_seen: 100,
+              hops: 3,
+            },
+          ],
+        ]),
+        fetchNomadPage,
+      });
+
+      render(<NomadNetworkPanel />);
+      await openAnnouncesNode(user);
+
+      await waitFor(() => {
+        expect(fetchNomadPage).toHaveBeenCalledTimes(1);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+      await waitFor(() => {
+        expect(fetchNomadPage).toHaveBeenCalledTimes(2);
+        expect(document.querySelector('.nomad-micron-page')).toBeTruthy();
+      });
+      expect(screen.queryByText(/nomadNetwork.pageFailed/)).not.toBeInTheDocument();
+    } finally {
+      restore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows page error once when both fetch attempts fail', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { restore } = mockConsoleWarn();
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const fetchNomadPage = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, error: 'link_timeout' })
+        .mockResolvedValueOnce({ ok: false, error: 'link_timeout' });
+      useNomadNetworkStore.setState({
+        nodes: new Map([
+          [
+            'abc1234567890',
+            {
+              destination_hash: 'abc1234567890',
+              display_name: 'Fail Node',
+              favorited: false,
+              last_seen: 100,
+              hops: 3,
+            },
+          ],
+        ]),
+        fetchNomadPage,
+      });
+
+      render(<NomadNetworkPanel />);
+      await openAnnouncesNode(user);
+
+      await waitFor(() => {
+        expect(fetchNomadPage).toHaveBeenCalledTimes(1);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+      await waitFor(() => {
+        expect(fetchNomadPage).toHaveBeenCalledTimes(2);
+        expect(screen.getByText(/nomadNetwork.pageFailed/)).toBeInTheDocument();
+      });
+    } finally {
+      restore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('reloads once after announce refresh while a retryable error is showing', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { restore } = mockConsoleWarn();
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const fetchNomadPage = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, error: 'path_timeout' })
+        .mockResolvedValueOnce({ ok: false, error: 'path_timeout' })
+        .mockResolvedValueOnce({
+          ok: true,
+          content: '>>>hello after announce',
+          content_type: 'micron',
+        });
+      useNomadNetworkStore.setState({
+        nodes: new Map([
+          [
+            'abc1234567890',
+            {
+              destination_hash: 'abc1234567890',
+              display_name: 'Stale Node',
+              favorited: false,
+              last_seen: 100,
+              hops: 4,
+            },
+          ],
+        ]),
+        fetchNomadPage,
+      });
+
+      render(<NomadNetworkPanel />);
+      await openAnnouncesNode(user);
+
+      await waitFor(() => {
+        expect(fetchNomadPage).toHaveBeenCalledTimes(1);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+      await waitFor(() => {
+        expect(fetchNomadPage).toHaveBeenCalledTimes(2);
+        expect(screen.getByText(/nomadNetwork.pageFailed/)).toBeInTheDocument();
+      });
+
+      act(() => {
+        useNomadNetworkStore.setState({
+          nodes: new Map([
+            [
+              'abc1234567890',
+              {
+                destination_hash: 'abc1234567890',
+                display_name: 'Stale Node',
+                favorited: false,
+                last_seen: 200,
+                hops: 3,
+              },
+            ],
+          ]),
+        });
+      });
+
+      await waitFor(() => {
+        expect(fetchNomadPage).toHaveBeenCalledTimes(3);
+        expect(document.querySelector('.nomad-micron-page')).toBeTruthy();
+      });
+
+      act(() => {
+        useNomadNetworkStore.setState({
+          nodes: new Map([
+            [
+              'abc1234567890',
+              {
+                destination_hash: 'abc1234567890',
+                display_name: 'Stale Node',
+                favorited: false,
+                last_seen: 300,
+                hops: 2,
+              },
+            ],
+          ]),
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(fetchNomadPage).toHaveBeenCalledTimes(3);
+    } finally {
+      restore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/renderer/components/NomadNetworkPanel.tsx
+++ b/src/renderer/components/NomadNetworkPanel.tsx
@@ -45,7 +45,7 @@ import {
 } from '@/renderer/lib/nomad/nomadPageErrorHumanize';
 import { isReticulumSidecarRunning } from '@/renderer/lib/reticulum/reticulumSidecarReads';
 import { NOMAD_PAGE_FETCH_RETRY_SETTLE_MS } from '@/renderer/lib/timeConstants';
-import type { NomadNodeRow, NomadPageRequestData } from '@/shared/nomad-types';
+import type { NomadNodeRow, NomadPageRequestData, NomadPageResponse } from '@/shared/nomad-types';
 
 import { useNomadNetworkStore } from '../stores/nomadNetworkStore';
 import NomadMicronPageView from './NomadMicronPageView';
@@ -456,18 +456,29 @@ export default function NomadNetworkPanel({
 
       setPageContent(null);
       setPageContentType(undefined);
-      let res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
-      if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
-
-      if ((!res.ok || !res.content) && isRetryableNomadPageError(res.error)) {
-        const retryCode = res.error?.trim() || 'unknown';
-        console.warn(`[NomadNetwork] page fetch retry after ${retryCode}`);
-        await new Promise<void>((resolve) => {
-          window.setTimeout(resolve, NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
-        });
-        if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
+      let res: NomadPageResponse;
+      try {
         res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
         if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
+
+        if ((!res.ok || !res.content) && isRetryableNomadPageError(res.error)) {
+          const retryCode = res.error?.trim() || 'unknown';
+          console.warn(`[NomadNetwork] page fetch retry after ${retryCode}`);
+          await new Promise<void>((resolve) => {
+            window.setTimeout(resolve, NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
+          });
+          if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
+          res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
+          if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
+        }
+      } catch (e) {
+        // Failure point: unexpected fetchNomadPage reject. Fallback: clear loading + generic error.
+        console.warn('[NomadNetwork] page fetch ' + errLikeToLogString(e));
+        if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
+        setPageLoading(false);
+        setPageErrorCode(null);
+        setPageError(humanizeNomadPageError(undefined, t));
+        return;
       }
 
       setPageLoading(false);

--- a/src/renderer/components/NomadNetworkPanel.tsx
+++ b/src/renderer/components/NomadNetworkPanel.tsx
@@ -39,8 +39,12 @@ import {
   MAX_NOMAD_PAGE_CACHE_CHARS,
   setNomadPageCache,
 } from '@/renderer/lib/nomad/nomadPageCache';
-import { humanizeNomadPageError } from '@/renderer/lib/nomad/nomadPageErrorHumanize';
+import {
+  humanizeNomadPageError,
+  isRetryableNomadPageError,
+} from '@/renderer/lib/nomad/nomadPageErrorHumanize';
 import { isReticulumSidecarRunning } from '@/renderer/lib/reticulum/reticulumSidecarReads';
+import { NOMAD_PAGE_FETCH_RETRY_SETTLE_MS } from '@/renderer/lib/timeConstants';
 import type { NomadNodeRow, NomadPageRequestData } from '@/shared/nomad-types';
 
 import { useNomadNetworkStore } from '../stores/nomadNetworkStore';
@@ -121,6 +125,30 @@ function matchesSearch(node: NomadNodeRow, query: string): boolean {
   const name = (node.display_name ?? '').toLowerCase();
   const hash = node.destination_hash.toLowerCase();
   return name.includes(q) || hash.includes(q);
+}
+
+interface NomadPageErrorNodeSnapshot {
+  hash: string;
+  lastSeen: number | null;
+  hops: number | null;
+}
+
+function snapshotNomadNodeForPageError(
+  hash: string,
+  node: NomadNodeRow | undefined,
+): NomadPageErrorNodeSnapshot {
+  return {
+    hash: hash.toLowerCase(),
+    lastSeen: node?.last_seen ?? null,
+    hops: node?.hops ?? null,
+  };
+}
+
+function nomadNodeChangedSincePageError(
+  snap: NomadPageErrorNodeSnapshot,
+  node: NomadNodeRow,
+): boolean {
+  return (node.last_seen ?? null) !== snap.lastSeen || (node.hops ?? null) !== snap.hops;
 }
 
 function NomadCollapsedNodeItem({
@@ -269,6 +297,7 @@ export default function NomadNetworkPanel({
   const [showPageSource, setShowPageSource] = useState(false);
   const [pageLoading, setPageLoading] = useState(false);
   const [pageError, setPageError] = useState<string | null>(null);
+  const [pageErrorCode, setPageErrorCode] = useState<string | null>(null);
   const [fileDownloading, setFileDownloading] = useState(false);
   const [fileDownloadError, setFileDownloadError] = useState<string | null>(null);
   const [nodeListCollapsed, setNodeListCollapsed] = useState(
@@ -285,6 +314,8 @@ export default function NomadNetworkPanel({
   const fileDownloadInFlightRef = useRef(false);
   const mountedRef = useRef(true);
   const historyIndexRef = useRef(-1);
+  const pageErrorNodeSnapshotRef = useRef<NomadPageErrorNodeSnapshot | null>(null);
+  const announceReloadDoneRef = useRef(false);
   const listCollapseTrigger = useParentIconTrigger();
 
   useEffect(() => {
@@ -395,6 +426,8 @@ export default function NomadNetworkPanel({
       setPageRequestData(normalizedRequest);
       setPageLoading(true);
       setPageError(null);
+      setPageErrorCode(null);
+      pageErrorNodeSnapshotRef.current = null;
       setShowPageSource(false);
 
       if (!options.forceReload) {
@@ -423,11 +456,28 @@ export default function NomadNetworkPanel({
 
       setPageContent(null);
       setPageContentType(undefined);
-      const res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
+      let res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
       if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
+
+      if ((!res.ok || !res.content) && isRetryableNomadPageError(res.error)) {
+        const retryCode = res.error?.trim() || 'unknown';
+        console.warn(`[NomadNetwork] page fetch retry after ${retryCode}`);
+        await new Promise<void>((resolve) => {
+          window.setTimeout(resolve, NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
+        });
+        if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
+        res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
+        if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
+      }
+
       setPageLoading(false);
       if (!res.ok || !res.content) {
+        const rawCode = res.error?.trim() || null;
+        setPageErrorCode(rawCode);
         setPageError(humanizeNomadPageError(res.error, t));
+        const node = useNomadNetworkStore.getState().nodes.get(hash.toLowerCase());
+        pageErrorNodeSnapshotRef.current = snapshotNomadNodeForPageError(hash, node);
+        announceReloadDoneRef.current = false;
         return;
       }
       const { text, truncated } = truncateNomadPageContent(res.content);
@@ -449,6 +499,40 @@ export default function NomadNetworkPanel({
     },
     [applyPageResult, fetchNomadPage, pushHistoryEntry, t],
   );
+
+  useEffect(() => {
+    if (
+      pageLoading ||
+      !pageErrorCode ||
+      !isRetryableNomadPageError(pageErrorCode) ||
+      !selectedHash ||
+      !selectedNode
+    ) {
+      return;
+    }
+    if (announceReloadDoneRef.current) return;
+    const snap = pageErrorNodeSnapshotRef.current;
+    if (snap == null) return;
+    if (snap.hash !== selectedHash.toLowerCase()) return;
+    if (!nomadNodeChangedSincePageError(snap, selectedNode)) return;
+
+    announceReloadDoneRef.current = true;
+    console.warn('[NomadNetwork] page reload after announce refresh');
+    void loadNodePage(selectedHash, pagePath, {
+      forceReload: true,
+      requestData: pageRequestData,
+    });
+  }, [
+    loadNodePage,
+    pageErrorCode,
+    pageLoading,
+    pagePath,
+    pageRequestData,
+    selectedHash,
+    selectedNode,
+    selectedNode?.hops,
+    selectedNode?.last_seen,
+  ]);
 
   const downloadNodeFile = useCallback(
     async (hash: string, path: string) => {

--- a/src/renderer/lib/nomad/nomadPageErrorHumanize.test.ts
+++ b/src/renderer/lib/nomad/nomadPageErrorHumanize.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { humanizeNomadPageError, nomadPageErrorI18nKey } from './nomadPageErrorHumanize';
+import {
+  humanizeNomadPageError,
+  isRetryableNomadPageError,
+  nomadPageErrorI18nKey,
+} from './nomadPageErrorHumanize';
 
 describe('nomadPageErrorHumanize', () => {
   const t = (key: string) => `t:${key}`;
@@ -38,5 +42,18 @@ describe('nomadPageErrorHumanize', () => {
     );
     expect(humanizeNomadPageError('weird failure', t)).toBe('weird failure');
     expect(humanizeNomadPageError(null, t)).toBe('t:common.error');
+  });
+
+  it('classifies retryable path/link/identity errors', () => {
+    expect(isRetryableNomadPageError('path_timeout')).toBe(true);
+    expect(isRetryableNomadPageError('link_timeout')).toBe(true);
+    expect(isRetryableNomadPageError('response_timeout')).toBe(true);
+    expect(isRetryableNomadPageError('nomad_busy')).toBe(true);
+    expect(isRetryableNomadPageError('pubkey_not_found')).toBe(true);
+    expect(isRetryableNomadPageError('missing_identity_hash')).toBe(true);
+    expect(isRetryableNomadPageError('sidecar_not_running')).toBe(false);
+    expect(isRetryableNomadPageError('content_source_required')).toBe(false);
+    expect(isRetryableNomadPageError(null)).toBe(false);
+    expect(isRetryableNomadPageError('')).toBe(false);
   });
 });

--- a/src/renderer/lib/nomad/nomadPageErrorHumanize.ts
+++ b/src/renderer/lib/nomad/nomadPageErrorHumanize.ts
@@ -20,11 +20,28 @@ const NOMAD_ERROR_I18N_KEYS: Record<string, string> = {
   content_source_not_from_picker: 'nomadNetwork.serving.contentSourceNotFromPicker',
 };
 
+/** Transient path/link/identity errors worth one automatic page-fetch retry. */
+const RETRYABLE_NOMAD_PAGE_ERRORS = new Set([
+  'path_timeout',
+  'link_timeout',
+  'response_timeout',
+  'nomad_busy',
+  'pubkey_not_found',
+  'missing_identity_hash',
+]);
+
 export function nomadPageErrorI18nKey(error: string | null | undefined): string | null {
   if (error == null) return null;
   const trimmed = error.trim();
   if (!trimmed) return null;
   return NOMAD_ERROR_I18N_KEYS[trimmed] ?? null;
+}
+
+/** True when a Nomad page/file error code should trigger one-shot or announce reload. */
+export function isRetryableNomadPageError(error: string | null | undefined): boolean {
+  const trimmed = error?.trim();
+  if (!trimmed) return false;
+  return RETRYABLE_NOMAD_PAGE_ERRORS.has(trimmed);
 }
 
 /** Resolve a Nomad page/file error for display via i18n when known. */

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -266,3 +266,6 @@ export function meshcoreRepeaterRpcTimeoutMs(hopsAway?: number | null): number {
     MESHCORE_REPEATER_RPC_TIMEOUT_BASE_MS + hops * MESHCORE_REPEATER_RPC_TIMEOUT_PER_HOP_MS;
   return Math.min(MESHCORE_REPEATER_RPC_TIMEOUT_CAP_MS, scaled);
 }
+
+/** Brief settle before one-shot Nomad page re-fetch after a transient path/link error. */
+export const NOMAD_PAGE_FETCH_RETRY_SETTLE_MS = 750;

--- a/src/renderer/stores/nomadNetworkStore.test.ts
+++ b/src/renderer/stores/nomadNetworkStore.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { mockConsoleWarn } from '@/renderer/lib/vitestConsoleMock';
+
 const getStatus = vi.fn();
 const proxyGet = vi.fn();
 const proxyPost = vi.fn();
@@ -168,5 +170,50 @@ describe('nomadNetworkStore', () => {
       '/api/v1/nomadnetwork/file/abc?path=%2Ffile%2Freadme.txt&hops=2&egress=tcp',
     );
     expect(res).toEqual({ ok: true, file_name: 'readme.txt', content_base64: 'aGVsbG8=' });
+  });
+
+  it('logs a warning when page fetch returns ok:false', async () => {
+    const { spy, restore } = mockConsoleWarn();
+    try {
+      getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
+      fetchReticulumInterfaces.mockResolvedValue([{ type: 'tcp', enabled: true }]);
+      proxyGet.mockResolvedValue({ ok: false, error: 'link_timeout' });
+
+      const res = await useNomadNetworkStore
+        .getState()
+        .fetchNomadPage('abcdef12', '/page/index.mu');
+
+      expect(res).toEqual({ ok: false, error: 'link_timeout' });
+      expect(spy).toHaveBeenCalled();
+      const firstArg = spy.mock.calls[0]?.[0];
+      expect(typeof firstArg).toBe('string');
+      expect(firstArg).toContain('[nomadNetworkStore] page fetch failed');
+      expect(firstArg).toContain('error=link_timeout');
+      expect(firstArg).toContain('hash=abcdef12');
+    } finally {
+      restore();
+    }
+  });
+
+  it('logs a warning when file fetch returns ok:false', async () => {
+    const { spy, restore } = mockConsoleWarn();
+    try {
+      getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
+      fetchReticulumInterfaces.mockResolvedValue([{ type: 'tcp', enabled: true }]);
+      proxyGet.mockResolvedValue({ ok: false, error: 'path_timeout' });
+
+      const res = await useNomadNetworkStore
+        .getState()
+        .fetchNomadFile('abcdef12', '/file/readme.txt');
+
+      expect(res).toEqual({ ok: false, error: 'path_timeout' });
+      expect(spy).toHaveBeenCalled();
+      const firstArg = spy.mock.calls[0]?.[0];
+      expect(typeof firstArg).toBe('string');
+      expect(firstArg).toContain('[nomadNetworkStore] file fetch failed');
+      expect(firstArg).toContain('error=path_timeout');
+    } finally {
+      restore();
+    }
   });
 });

--- a/src/renderer/stores/nomadNetworkStore.ts
+++ b/src/renderer/stores/nomadNetworkStore.ts
@@ -68,6 +68,68 @@ function logNomadFetchFailure(
   );
 }
 
+function hopsForNomadHash(nodes: Map<string, NomadNodeRow>, hash: string): number {
+  return nodes.get(hash.toLowerCase())?.hops ?? 8;
+}
+
+async function fetchNomadResource<T extends { ok: boolean; error?: string }>(
+  kind: 'page' | 'file',
+  opts: {
+    hash: string;
+    path: string;
+    nodes: Map<string, NomadNodeRow>;
+    requestData?: NomadPageRequestData;
+  },
+): Promise<T> {
+  const hops = hopsForNomadHash(opts.nodes, opts.hash);
+  if (!(await isReticulumSidecarRunning())) {
+    logNomadFetchFailure(kind, {
+      hash: opts.hash,
+      path: opts.path,
+      hops,
+      egress: 'unknown',
+      error: 'sidecar_not_running',
+    });
+    return { ok: false, error: 'sidecar_not_running' } as T;
+  }
+  try {
+    const egress = await resolveNomadEgress();
+    const qs = new URLSearchParams({
+      path: opts.path,
+      hops: String(hops),
+      egress,
+    });
+    if (opts.requestData && Object.keys(opts.requestData).length > 0) {
+      qs.set('data', btoa(JSON.stringify(opts.requestData)));
+    }
+    const cleanHash = opts.hash.replace(/[^a-fA-F0-9]/g, '');
+    const res = (await window.electronAPI.reticulum.proxyGet(
+      `/api/v1/nomadnetwork/${kind}/${cleanHash}?${qs.toString()}`,
+    )) as T;
+    if (!res.ok) {
+      logNomadFetchFailure(kind, {
+        hash: cleanHash,
+        path: opts.path,
+        hops,
+        egress,
+        error: res.error?.trim() || 'unknown',
+      });
+    }
+    return res;
+  } catch (e) {
+    // catch-no-log-ok logged via logNomadFetchFailure below
+    const error = errLikeToLogString(e);
+    logNomadFetchFailure(kind, {
+      hash: opts.hash,
+      path: opts.path,
+      hops: hopsForNomadHash(opts.nodes, opts.hash),
+      egress: cachedNomadEgress,
+      error,
+    });
+    return { ok: false, error } as T;
+  }
+}
+
 interface NomadNetworkStoreState {
   nodes: Map<string, NomadNodeRow>;
   lastRefreshAt: number | null;
@@ -110,104 +172,20 @@ export const useNomadNetworkStore = create<NomadNetworkStoreState>((set, get) =>
     }
   },
 
-  fetchNomadPage: async (hash, path, requestData) => {
-    if (!(await isReticulumSidecarRunning())) {
-      logNomadFetchFailure('page', {
-        hash,
-        path,
-        hops: 8,
-        egress: 'unknown',
-        error: 'sidecar_not_running',
-      });
-      return { ok: false, error: 'sidecar_not_running' };
-    }
-    try {
-      const egress = await resolveNomadEgress();
-      const node = get().nodes.get(hash.toLowerCase());
-      const hops = node?.hops ?? 8;
-      const qs = new URLSearchParams({
-        path,
-        hops: String(hops),
-        egress,
-      });
-      if (requestData && Object.keys(requestData).length > 0) {
-        qs.set('data', btoa(JSON.stringify(requestData)));
-      }
-      const cleanHash = hash.replace(/[^a-fA-F0-9]/g, '');
-      const res = (await window.electronAPI.reticulum.proxyGet(
-        `/api/v1/nomadnetwork/page/${cleanHash}?${qs.toString()}`,
-      )) as NomadPageResponse;
-      if (!res.ok) {
-        logNomadFetchFailure('page', {
-          hash: cleanHash,
-          path,
-          hops,
-          egress,
-          error: res.error?.trim() || 'unknown',
-        });
-      }
-      return res;
-    } catch (e) {
-      // catch-no-log-ok logged via logNomadFetchFailure below
-      const error = errLikeToLogString(e);
-      logNomadFetchFailure('page', {
-        hash,
-        path,
-        hops: get().nodes.get(hash.toLowerCase())?.hops ?? 8,
-        egress: cachedNomadEgress,
-        error,
-      });
-      return { ok: false, error };
-    }
-  },
+  fetchNomadPage: async (hash, path, requestData) =>
+    fetchNomadResource<NomadPageResponse>('page', {
+      hash,
+      path,
+      nodes: get().nodes,
+      requestData,
+    }),
 
-  fetchNomadFile: async (hash, path) => {
-    if (!(await isReticulumSidecarRunning())) {
-      logNomadFetchFailure('file', {
-        hash,
-        path,
-        hops: 8,
-        egress: 'unknown',
-        error: 'sidecar_not_running',
-      });
-      return { ok: false, error: 'sidecar_not_running' };
-    }
-    try {
-      const egress = await resolveNomadEgress();
-      const node = get().nodes.get(hash.toLowerCase());
-      const hops = node?.hops ?? 8;
-      const qs = new URLSearchParams({
-        path,
-        hops: String(hops),
-        egress,
-      });
-      const cleanHash = hash.replace(/[^a-fA-F0-9]/g, '');
-      const res = (await window.electronAPI.reticulum.proxyGet(
-        `/api/v1/nomadnetwork/file/${cleanHash}?${qs.toString()}`,
-      )) as NomadFileResponse;
-      if (!res.ok) {
-        logNomadFetchFailure('file', {
-          hash: cleanHash,
-          path,
-          hops,
-          egress,
-          error: res.error?.trim() || 'unknown',
-        });
-      }
-      return res;
-    } catch (e) {
-      // catch-no-log-ok logged via logNomadFetchFailure below
-      const error = errLikeToLogString(e);
-      logNomadFetchFailure('file', {
-        hash,
-        path,
-        hops: get().nodes.get(hash.toLowerCase())?.hops ?? 8,
-        egress: cachedNomadEgress,
-        error,
-      });
-      return { ok: false, error };
-    }
-  },
+  fetchNomadFile: async (hash, path) =>
+    fetchNomadResource<NomadFileResponse>('file', {
+      hash,
+      path,
+      nodes: get().nodes,
+    }),
 
   toggleFavorite: async (hash, favorited) => {
     if (!(await isReticulumSidecarRunning())) return;

--- a/src/renderer/stores/nomadNetworkStore.ts
+++ b/src/renderer/stores/nomadNetworkStore.ts
@@ -51,6 +51,23 @@ export function resetNomadEgressCacheForTests(): void {
   invalidateNomadEgressCache();
 }
 
+function nomadHashPrefixForLog(hash: string): string {
+  const clean = hash.replace(/[^a-fA-F0-9]/g, '');
+  return clean.slice(0, 8) || 'unknown';
+}
+
+function logNomadFetchFailure(
+  kind: 'page' | 'file',
+  opts: { hash: string; path: string; hops: number; egress: string; error: string },
+): void {
+  const pathSafe = opts.path.replace(/[\r\n]+/g, ' ').slice(0, 200);
+  const errorSafe = opts.error.replace(/[\r\n]+/g, ' ').slice(0, 200);
+  console.warn(
+    `[nomadNetworkStore] ${kind} fetch failed hash=${nomadHashPrefixForLog(opts.hash)}… ` +
+      `path=${pathSafe} hops=${opts.hops} egress=${opts.egress} error=${errorSafe}`,
+  );
+}
+
 interface NomadNetworkStoreState {
   nodes: Map<string, NomadNodeRow>;
   lastRefreshAt: number | null;
@@ -95,6 +112,13 @@ export const useNomadNetworkStore = create<NomadNetworkStoreState>((set, get) =>
 
   fetchNomadPage: async (hash, path, requestData) => {
     if (!(await isReticulumSidecarRunning())) {
+      logNomadFetchFailure('page', {
+        hash,
+        path,
+        hops: 8,
+        egress: 'unknown',
+        error: 'sidecar_not_running',
+      });
       return { ok: false, error: 'sidecar_not_running' };
     }
     try {
@@ -110,17 +134,42 @@ export const useNomadNetworkStore = create<NomadNetworkStoreState>((set, get) =>
         qs.set('data', btoa(JSON.stringify(requestData)));
       }
       const cleanHash = hash.replace(/[^a-fA-F0-9]/g, '');
-      return (await window.electronAPI.reticulum.proxyGet(
+      const res = (await window.electronAPI.reticulum.proxyGet(
         `/api/v1/nomadnetwork/page/${cleanHash}?${qs.toString()}`,
       )) as NomadPageResponse;
+      if (!res.ok) {
+        logNomadFetchFailure('page', {
+          hash: cleanHash,
+          path,
+          hops,
+          egress,
+          error: res.error?.trim() || 'unknown',
+        });
+      }
+      return res;
     } catch (e) {
-      // catch-no-log-ok error returned to caller for page UI
-      return { ok: false, error: errLikeToLogString(e) };
+      // catch-no-log-ok logged via logNomadFetchFailure below
+      const error = errLikeToLogString(e);
+      logNomadFetchFailure('page', {
+        hash,
+        path,
+        hops: get().nodes.get(hash.toLowerCase())?.hops ?? 8,
+        egress: cachedNomadEgress,
+        error,
+      });
+      return { ok: false, error };
     }
   },
 
   fetchNomadFile: async (hash, path) => {
     if (!(await isReticulumSidecarRunning())) {
+      logNomadFetchFailure('file', {
+        hash,
+        path,
+        hops: 8,
+        egress: 'unknown',
+        error: 'sidecar_not_running',
+      });
       return { ok: false, error: 'sidecar_not_running' };
     }
     try {
@@ -133,12 +182,30 @@ export const useNomadNetworkStore = create<NomadNetworkStoreState>((set, get) =>
         egress,
       });
       const cleanHash = hash.replace(/[^a-fA-F0-9]/g, '');
-      return (await window.electronAPI.reticulum.proxyGet(
+      const res = (await window.electronAPI.reticulum.proxyGet(
         `/api/v1/nomadnetwork/file/${cleanHash}?${qs.toString()}`,
       )) as NomadFileResponse;
+      if (!res.ok) {
+        logNomadFetchFailure('file', {
+          hash: cleanHash,
+          path,
+          hops,
+          egress,
+          error: res.error?.trim() || 'unknown',
+        });
+      }
+      return res;
     } catch (e) {
-      // catch-no-log-ok error returned to caller for file download UI
-      return { ok: false, error: errLikeToLogString(e) };
+      // catch-no-log-ok logged via logNomadFetchFailure below
+      const error = errLikeToLogString(e);
+      logNomadFetchFailure('file', {
+        hash,
+        path,
+        hops: get().nodes.get(hash.toLowerCase())?.hops ?? 8,
+        egress: cachedNomadEgress,
+        error,
+      });
+      return { ok: false, error };
     }
   },
 


### PR DESCRIPTION
## Summary
- Auto-retry Nomad page fetches once after transient path/link/identity errors (`link_timeout`, `path_timeout`, etc.), keeping the existing loading UI instead of requiring a second click
- When a retryable page error is showing, reload once if the selected node’s `last_seen`/`hops` update from a fresher announce
- Log failed Nomad page/file fetches (and retry/announce reload) so support bundles capture error codes

## Test plan
- [ ] Open a stale Nomad announce page that previously failed on first click — confirm it succeeds after the automatic retry without a second click
- [ ] Confirm loading text stays on `pageLoading` during the retry (no error flash between attempts)
- [ ] Force a non-retryable failure (sidecar stopped) — confirm no auto-retry
- [ ] With a path/identity error showing, wait for/trigger a fresher announce for that node — confirm one automatic reload
- [ ] Bump announce again after success — confirm no extra reload
- [ ] Export a developer bundle after a failed page load — confirm `[nomadNetworkStore] page fetch failed` / `[NomadNetwork] page fetch retry` lines appear in the log
- [ ] `pnpm exec vitest run src/renderer/components/NomadNetworkPanel.test.tsx src/renderer/stores/nomadNetworkStore.test.ts src/renderer/lib/nomad/nomadPageErrorHumanize.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retry handling for temporary Nomad page-loading failures, including a brief settle delay before a one-shot re-fetch.
  * Pages now refresh once when updated node information can resolve a retryable error.
  * Improved classification of retryable Nomad error codes to drive the above behavior.

* **Bug Fixes**
  * Improved recovery from transient link and path timeout errors, with clearer user-facing error updates when retries fail.
  * Standardized diagnostic logging for failed page and file requests (including consistent warning details).  

* **Tests**
  * Expanded coverage for retryable error behavior and warning/logging on fetch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->