### PR TITLE
fix(nomad): force path refresh on page-load retry

### DIFF
--- a/docs/reticulum-sidecar-ipc.md
+++ b/docs/reticulum-sidecar-ipc.md
@@ -104,22 +104,22 @@ The Connection tab UI edits a subset: **name** and **mode** for all types; **hos
 
 ### Nomad Network
 
-| Method | Path                                          | Body / notes                 | Response                                                                                                           |
-| ------ | --------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| GET    | `/api/v1/nomadnetwork/nodes`                  |                              | `{ nodes: [] }`                                                                                                    |
-| POST   | `/api/v1/nomadnetwork/nodes/favorite`         | `{ hash, favorited }`        | `{ ok }`                                                                                                           |
-| GET    | `/api/v1/nomadnetwork/page/{hash}?path=…`     |                              | page payload                                                                                                       |
-| GET    | `/api/v1/nomadnetwork/file/{hash}?path=…`     |                              | `{ ok, file_name?, content_base64? }`                                                                              |
-| GET    | `/api/v1/nomadnetwork/serving`                |                              | `{ ok, serving }` (local host status; includes `content_source`, `content_layout`, `watcher_status`, `last_error`) |
-| PUT    | `/api/v1/nomadnetwork/serving`                | `{ enabled, display_name? }` | `{ ok, serving }`                                                                                                  |
-| PUT    | `/api/v1/nomadnetwork/serving/content-source` | `{ path: string }`           | `{ ok, serving }` — set watched folder (site root or pages dir); required before start; restarts host if running   |
-| GET    | `/api/v1/nomadnetwork/serving/pages`          |                              | `{ ok, pages: [] }` — My Pages lists these read-only; edit pages on disk in the watched folder                     |
-| PUT    | `/api/v1/nomadnetwork/serving/pages`          | `{ path, content }`          | `{ ok }` — sidecar-only; not exposed in the My Pages UI                                                            |
-| DELETE | `/api/v1/nomadnetwork/serving/pages?path=…`   |                              | `{ ok }` — sidecar-only; not exposed in the My Pages UI                                                            |
-| GET    | `/api/v1/nomadnetwork/serving/page?path=…`    |                              | `{ ok, path, content }`                                                                                            |
-| GET    | `/api/v1/nomadnetwork/serving/files`          |                              | `{ ok, files: [] }` — My Pages lists these read-only                                                               |
-| PUT    | `/api/v1/nomadnetwork/serving/files`          | `{ path, content_base64 }`   | `{ ok }` — sidecar-only; not exposed in the My Pages UI                                                            |
-| DELETE | `/api/v1/nomadnetwork/serving/files?path=…`   |                              | `{ ok }` — sidecar-only; not exposed in the My Pages UI                                                            |
+| Method | Path                                          | Body / notes                                                  | Response                                                                                                           |
+| ------ | --------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| GET    | `/api/v1/nomadnetwork/nodes`                  |                                                               | `{ nodes: [] }`                                                                                                    |
+| POST   | `/api/v1/nomadnetwork/nodes/favorite`         | `{ hash, favorited }`                                         | `{ ok }`                                                                                                           |
+| GET    | `/api/v1/nomadnetwork/page/{hash}?path=…`     | optional `data`, `force_path_refresh=true` (stale-path retry) | page payload                                                                                                       |
+| GET    | `/api/v1/nomadnetwork/file/{hash}?path=…`     | optional `force_path_refresh=true`                            | `{ ok, file_name?, content_base64? }`                                                                              |
+| GET    | `/api/v1/nomadnetwork/serving`                |                                                               | `{ ok, serving }` (local host status; includes `content_source`, `content_layout`, `watcher_status`, `last_error`) |
+| PUT    | `/api/v1/nomadnetwork/serving`                | `{ enabled, display_name? }`                                  | `{ ok, serving }`                                                                                                  |
+| PUT    | `/api/v1/nomadnetwork/serving/content-source` | `{ path: string }`                                            | `{ ok, serving }` — set watched folder (site root or pages dir); required before start; restarts host if running   |
+| GET    | `/api/v1/nomadnetwork/serving/pages`          |                                                               | `{ ok, pages: [] }` — My Pages lists these read-only; edit pages on disk in the watched folder                     |
+| PUT    | `/api/v1/nomadnetwork/serving/pages`          | `{ path, content }`                                           | `{ ok }` — sidecar-only; not exposed in the My Pages UI                                                            |
+| DELETE | `/api/v1/nomadnetwork/serving/pages?path=…`   |                                                               | `{ ok }` — sidecar-only; not exposed in the My Pages UI                                                            |
+| GET    | `/api/v1/nomadnetwork/serving/page?path=…`    |                                                               | `{ ok, path, content }`                                                                                            |
+| GET    | `/api/v1/nomadnetwork/serving/files`          |                                                               | `{ ok, files: [] }` — My Pages lists these read-only                                                               |
+| PUT    | `/api/v1/nomadnetwork/serving/files`          | `{ path, content_base64 }`                                    | `{ ok }` — sidecar-only; not exposed in the My Pages UI                                                            |
+| DELETE | `/api/v1/nomadnetwork/serving/files?path=…`   |                                                               | `{ ok }` — sidecar-only; not exposed in the My Pages UI                                                            |
 
 Auto-restore order when the live stack comes up: load `nomad_serving_content_source` → if `nomad_serving_enabled` and a content source is set, start hosting → start FS watcher on `pages/` (and `files/` when that directory exists). If enabled without a content source, set `last_error=content_source_required` and do not start. Other failures keep `enabled=true` with `running=false` and `last_error` set; logs use the `[nomad-serving]` tag.
 

--- a/reticulum-sidecar/Cargo.lock
+++ b/reticulum-sidecar/Cargo.lock
@@ -1423,6 +1423,7 @@ dependencies = [
  "rns-wire",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/reticulum-sidecar/Cargo.toml
+++ b/reticulum-sidecar/Cargo.toml
@@ -38,6 +38,7 @@ futures-util = "0.3"
 http = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"

--- a/reticulum-sidecar/src/api/nomad.rs
+++ b/reticulum-sidecar/src/api/nomad.rs
@@ -34,6 +34,9 @@ pub async fn favorite_nomad_node(
 pub struct NomadPageQuery {
     pub path: String,
     pub data: Option<String>,
+    /// When true, RequestPath even if a cached path exists (stale-route retry).
+    #[serde(default)]
+    pub force_path_refresh: bool,
 }
 
 pub async fn get_nomad_page(
@@ -43,7 +46,12 @@ pub async fn get_nomad_page(
 ) -> Json<serde_json::Value> {
     Json(
         stack
-            .nomad_page(&hash, &query.path, query.data.as_deref())
+            .nomad_page(
+                &hash,
+                &query.path,
+                query.data.as_deref(),
+                query.force_path_refresh,
+            )
             .await,
     )
 }
@@ -51,6 +59,9 @@ pub async fn get_nomad_page(
 #[derive(Debug, Deserialize)]
 pub struct NomadFileQuery {
     pub path: String,
+    /// When true, RequestPath even if a cached path exists (stale-route retry).
+    #[serde(default)]
+    pub force_path_refresh: bool,
 }
 
 pub async fn get_nomad_file(
@@ -58,7 +69,11 @@ pub async fn get_nomad_file(
     Path(hash): Path<String>,
     Query(query): Query<NomadFileQuery>,
 ) -> Json<serde_json::Value> {
-    Json(stack.nomad_file(&hash, &query.path).await)
+    Json(
+        stack
+            .nomad_file(&hash, &query.path, query.force_path_refresh)
+            .await,
+    )
 }
 
 pub async fn get_nomad_serving(State(stack): State<Arc<StackHandle>>) -> Json<serde_json::Value> {
@@ -191,5 +206,35 @@ pub async fn put_nomad_serving_content_source(
     match stack.set_nomad_content_source(body.path).await {
         Ok(serving) => Json(serde_json::json!({ "ok": true, "serving": serving })),
         Err(e) => Json(serde_json::json!({ "ok": false, "error": e })),
+    }
+}
+
+#[cfg(test)]
+mod force_path_refresh_query_tests {
+    use super::*;
+
+    #[test]
+    fn nomad_page_query_defaults_force_path_refresh_false() {
+        let q: NomadPageQuery =
+            serde_urlencoded::from_str("path=%2Fpage%2Findex.mu").expect("query");
+        assert!(!q.force_path_refresh);
+        assert_eq!(q.path, "/page/index.mu");
+    }
+
+    #[test]
+    fn nomad_page_query_parses_force_path_refresh_true() {
+        let q: NomadPageQuery =
+            serde_urlencoded::from_str("path=%2Fpage%2Findex.mu&force_path_refresh=true")
+                .expect("query");
+        assert!(q.force_path_refresh);
+    }
+
+    #[test]
+    fn nomad_file_query_parses_force_path_refresh_true() {
+        let q: NomadFileQuery =
+            serde_urlencoded::from_str("path=%2Ffile%2Fx.bin&force_path_refresh=true")
+                .expect("query");
+        assert!(q.force_path_refresh);
+        assert_eq!(q.path, "/file/x.bin");
     }
 }

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -784,7 +784,19 @@ impl LiveBridge {
         path: &str,
         payload: Vec<u8>,
         interfaces: &[InterfaceRow],
+        force_path_refresh: bool,
     ) -> Result<Vec<u8>, String> {
+        // Stale cached hops often survive LinkClient pubkey recall; force a
+        // RequestPath on retry so the second attempt is not a no-op.
+        if force_path_refresh {
+            let path_ok = self.ensure_path_for_direct(hash_hex, true).await;
+            tracing::info!(
+                target: "nomad",
+                dest = %hash_hex,
+                path_ok,
+                "forced path refresh before Nomad query"
+            );
+        }
         let remote_hash = parse_hash16(identity_hash_hex)?;
         let hops = self.hops_to_destination(hash_hex).await.unwrap_or(8);
         let timeout_secs = nomad_timeouts::nomad_page_timeout_secs_for_interfaces(interfaces, hops);
@@ -813,6 +825,7 @@ impl LiveBridge {
         identity_hash_hex: Option<&str>,
         path: &str,
         interfaces: &[InterfaceRow],
+        force_path_refresh: bool,
     ) -> serde_json::Value {
         if let Some(local) = self.nomad_server.try_read_local_route(hash_hex, path).await {
             return match local {
@@ -836,7 +849,14 @@ impl LiveBridge {
             return serde_json::json!({ "ok": false, "error": "missing_identity_hash" });
         };
         match self
-            .query_nomad_node(hash_hex, identity_hash_hex, path, Vec::new(), interfaces)
+            .query_nomad_node(
+                hash_hex,
+                identity_hash_hex,
+                path,
+                Vec::new(),
+                interfaces,
+                force_path_refresh,
+            )
             .await
         {
             Ok(bytes) => {
@@ -867,6 +887,7 @@ impl LiveBridge {
         path: &str,
         data_b64: Option<&str>,
         interfaces: &[InterfaceRow],
+        force_path_refresh: bool,
     ) -> serde_json::Value {
         // Self-preview: read hosted content without a Link query to ourselves.
         if let Some(local) = self.nomad_server.try_read_local_route(hash_hex, path).await {
@@ -896,7 +917,14 @@ impl LiveBridge {
         };
         let payload = nomad_page_request_payload(data_b64);
         match self
-            .query_nomad_node(hash_hex, identity_hash_hex, path, payload, interfaces)
+            .query_nomad_node(
+                hash_hex,
+                identity_hash_hex,
+                path,
+                payload,
+                interfaces,
+                force_path_refresh,
+            )
             .await
         {
             Ok(bytes) => {

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -1788,7 +1788,8 @@ impl LiveBridge {
             }
             return true;
         }
-        // Forced refresh: path may never come back after DropPath.
+        // Forced refresh: only accept a path that passed the same absence gate as
+        // the wait loop — never the never-invalidated stale route.
         let _ = self.refresh_outbound_path_table().await;
         let has_path = self
             .outbound
@@ -1796,14 +1797,18 @@ impl LiveBridge {
             .map(|d| d.has_path_to(destination_hex))
             .unwrap_or(false);
         if force && already {
+            let accept =
+                force_path_refresh_accepts_after_timeout(force, already, saw_path_absent, has_path);
             tracing::info!(
                 target: "propagation-sync",
                 dest = %destination_hex,
                 hops = ?hops_before,
                 has_path,
+                saw_path_absent,
+                accept,
                 "path refresh timed out after dropping cached route"
             );
-            return has_path;
+            return accept;
         }
         false
     }
@@ -2990,6 +2995,18 @@ fn force_path_refresh_accepts_current_path(
     saw_path_absent
 }
 
+/// Timeout fallback for forced refresh: require both a live path and the same
+/// absence/reinstall gate used in the wait loop.
+fn force_path_refresh_accepts_after_timeout(
+    force: bool,
+    had_path_at_start: bool,
+    saw_path_absent: bool,
+    has_path_now: bool,
+) -> bool {
+    has_path_now
+        && force_path_refresh_accepts_current_path(force, had_path_at_start, saw_path_absent)
+}
+
 /// Hashes present in `next` but not in `prev` (path-table membership growth).
 fn path_table_added_hashes(prev: &HashSet<String>, next: &HashSet<String>) -> Vec<String> {
     next.difference(prev).cloned().collect()
@@ -3202,6 +3219,26 @@ mod announce_display_name_tests {
         ));
         assert!(has_path);
         assert_eq!(hops_after, Some(2));
+    }
+
+    #[test]
+    fn force_path_refresh_timeout_rejects_never_absent_stale_route() {
+        // DropPath failed / path never cleared — timeout must not accept stale route.
+        assert!(!force_path_refresh_accepts_after_timeout(
+            true, true, false, true
+        ));
+        // Absence observed then path reinstalled — timeout may accept.
+        assert!(force_path_refresh_accepts_after_timeout(
+            true, true, true, true
+        ));
+        // Absence observed but no path came back — reject.
+        assert!(!force_path_refresh_accepts_after_timeout(
+            true, true, true, false
+        ));
+        // Non-force discovery timeout with a path present — accept.
+        assert!(force_path_refresh_accepts_after_timeout(
+            false, false, false, true
+        ));
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -1797,8 +1797,8 @@ impl LiveBridge {
             .map(|d| d.has_path_to(destination_hex))
             .unwrap_or(false);
         if force && already {
-            let accept =
-                force_path_refresh_accepts_after_timeout(force, already, saw_path_absent, has_path);
+            let accept = has_path
+                && force_path_refresh_accepts_current_path(force, already, saw_path_absent);
             tracing::info!(
                 target: "propagation-sync",
                 dest = %destination_hex,
@@ -2995,18 +2995,6 @@ fn force_path_refresh_accepts_current_path(
     saw_path_absent
 }
 
-/// Timeout fallback for forced refresh: require both a live path and the same
-/// absence/reinstall gate used in the wait loop.
-fn force_path_refresh_accepts_after_timeout(
-    force: bool,
-    had_path_at_start: bool,
-    saw_path_absent: bool,
-    has_path_now: bool,
-) -> bool {
-    has_path_now
-        && force_path_refresh_accepts_current_path(force, had_path_at_start, saw_path_absent)
-}
-
 /// Hashes present in `next` but not in `prev` (path-table membership growth).
 fn path_table_added_hashes(prev: &HashSet<String>, next: &HashSet<String>) -> Vec<String> {
     next.difference(prev).cloned().collect()
@@ -3224,21 +3212,19 @@ mod announce_display_name_tests {
     #[test]
     fn force_path_refresh_timeout_rejects_never_absent_stale_route() {
         // DropPath failed / path never cleared — timeout must not accept stale route.
-        assert!(!force_path_refresh_accepts_after_timeout(
-            true, true, false, true
-        ));
+        let has_path = true;
+        let saw_path_absent = false;
+        assert!(
+            !(has_path && force_path_refresh_accepts_current_path(true, true, saw_path_absent))
+        );
         // Absence observed then path reinstalled — timeout may accept.
-        assert!(force_path_refresh_accepts_after_timeout(
-            true, true, true, true
-        ));
+        assert!(has_path && force_path_refresh_accepts_current_path(true, true, true));
         // Absence observed but no path came back — reject.
-        assert!(!force_path_refresh_accepts_after_timeout(
-            true, true, true, false
-        ));
-        // Non-force discovery timeout with a path present — accept.
-        assert!(force_path_refresh_accepts_after_timeout(
-            false, false, false, true
-        ));
+        let has_path = false;
+        assert!(!(has_path && force_path_refresh_accepts_current_path(true, true, true)));
+        // Non-force discovery with a path present — accept.
+        let has_path = true;
+        assert!(has_path && force_path_refresh_accepts_current_path(false, false, false));
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -1712,7 +1712,8 @@ impl LiveBridge {
     }
 
     /// Discover a path to the destination before falling back to the propagation node.
-    /// When `force` is true, always RequestPath even if a path already exists (stale hop refresh).
+    /// When `force` is true, drop any cached path and RequestPath so we wait for a
+    /// fresh route response instead of returning on the stale `has_path_to` entry.
     async fn ensure_path_for_direct(&self, destination_hex: &str, force: bool) -> bool {
         let already = self
             .outbound
@@ -1726,6 +1727,31 @@ impl LiveBridge {
         let Ok(dest) = parse_hash16(destination_hex) else {
             return false;
         };
+
+        // Drop the installed route first so the wait loop cannot succeed on the
+        // same stale path-table entry (mirrors LXMF `drop_existing` path requests).
+        let mut saw_path_absent = !(force && already);
+        if force && already {
+            let _ = self
+                .query_control_timed(TransportQuery::DropPath { dest })
+                .await;
+            if let Ok(mut driver) = self.outbound.lock() {
+                driver.clear_path_to(destination_hex);
+            }
+            if let Ok(mut cache) = self.peer_via_cache.lock() {
+                cache.remove(&destination_hex.to_lowercase());
+            }
+            let _ = self.refresh_outbound_path_table().await;
+            let still_present = self
+                .outbound
+                .lock()
+                .map(|d| d.has_path_to(destination_hex))
+                .unwrap_or(false);
+            if !still_present {
+                saw_path_absent = true;
+            }
+        }
+
         let _ = self
             .handle
             .transport_tx
@@ -1736,35 +1762,48 @@ impl LiveBridge {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
         while tokio::time::Instant::now() < deadline {
             let _ = self.refresh_outbound_path_table().await;
-            if self
+            let has_path = self
                 .outbound
                 .lock()
                 .map(|d| d.has_path_to(destination_hex))
-                .unwrap_or(false)
-            {
-                let hops_after = self.hops_to_destination(destination_hex).await;
-                if force && hops_before != hops_after {
-                    tracing::info!(
-                        target: "propagation-sync",
-                        dest = %destination_hex,
-                        hops_before = ?hops_before,
-                        hops_after = ?hops_after,
-                        "refreshed path hops before propagation sync"
-                    );
-                }
-                return true;
+                .unwrap_or(false);
+            if !has_path {
+                saw_path_absent = true;
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                continue;
             }
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            if !force_path_refresh_accepts_current_path(force, already, saw_path_absent) {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                continue;
+            }
+            let hops_after = self.hops_to_destination(destination_hex).await;
+            if force && hops_before != hops_after {
+                tracing::info!(
+                    target: "propagation-sync",
+                    dest = %destination_hex,
+                    hops_before = ?hops_before,
+                    hops_after = ?hops_after,
+                    "refreshed path hops before propagation sync"
+                );
+            }
+            return true;
         }
-        // Forced refresh may leave the prior path intact if RequestPath timed out.
+        // Forced refresh: path may never come back after DropPath.
+        let _ = self.refresh_outbound_path_table().await;
+        let has_path = self
+            .outbound
+            .lock()
+            .map(|d| d.has_path_to(destination_hex))
+            .unwrap_or(false);
         if force && already {
             tracing::info!(
                 target: "propagation-sync",
                 dest = %destination_hex,
                 hops = ?hops_before,
-                "path refresh timed out; keeping existing path for propagation sync"
+                has_path,
+                "path refresh timed out after dropping cached route"
             );
-            return true;
+            return has_path;
         }
         false
     }
@@ -2938,6 +2977,19 @@ fn resolve_inbound_sender_name_map(names: &HashMap<String, String>, sender_hash:
         .unwrap_or_else(|| prefix.to_string())
 }
 
+/// After a forced DropPath, accept a path only once it has been observed absent
+/// and then reinstalled — otherwise the first refresh succeeds on the stale route.
+fn force_path_refresh_accepts_current_path(
+    force: bool,
+    had_path_at_start: bool,
+    saw_path_absent: bool,
+) -> bool {
+    if !force || !had_path_at_start {
+        return true;
+    }
+    saw_path_absent
+}
+
 /// Hashes present in `next` but not in `prev` (path-table membership growth).
 fn path_table_added_hashes(prev: &HashSet<String>, next: &HashSet<String>) -> Vec<String> {
     next.difference(prev).cloned().collect()
@@ -3101,6 +3153,55 @@ mod announce_display_name_tests {
         let mut added = path_table_added_hashes(&prev, &next);
         added.sort();
         assert_eq!(added, vec!["cc".to_string()]);
+    }
+
+    #[test]
+    fn force_path_refresh_rejects_stale_route_until_absent_then_accepts_refresh() {
+        // Existing stale route still installed — must not accept yet.
+        assert!(!force_path_refresh_accepts_current_path(true, true, false));
+        // After DropPath absence was observed, a reinstalled path is acceptable.
+        assert!(force_path_refresh_accepts_current_path(true, true, true));
+        // Non-force / first discovery: any installed path is fine.
+        assert!(force_path_refresh_accepts_current_path(false, true, false));
+        assert!(force_path_refresh_accepts_current_path(true, false, false));
+    }
+
+    #[test]
+    fn force_path_refresh_simulates_stale_then_refreshed_route() {
+        // Simulate ensure_path_for_direct force wait: start with stale path present.
+        let had_path_at_start = true;
+        let force = true;
+        let mut saw_path_absent = false;
+
+        // Tick 1: stale path still present → do not accept.
+        let has_path = true;
+        assert!(
+            has_path
+                && !force_path_refresh_accepts_current_path(
+                    force,
+                    had_path_at_start,
+                    saw_path_absent
+                ),
+            "must not accept stale route before DropPath absence"
+        );
+
+        // Tick 2: DropPath cleared the route.
+        let has_path = false;
+        if !has_path {
+            saw_path_absent = true;
+        }
+        assert!(saw_path_absent);
+
+        // Tick 3: RequestPath installed a refreshed route (fewer hops).
+        let has_path = true;
+        let hops_after = Some(2u8);
+        assert!(force_path_refresh_accepts_current_path(
+            force,
+            had_path_at_start,
+            saw_path_absent
+        ));
+        assert!(has_path);
+        assert_eq!(hops_after, Some(2));
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/lxmf_outbound.rs
+++ b/reticulum-sidecar/src/stack/lxmf_outbound.rs
@@ -186,6 +186,16 @@ impl LxmfOutboundDriver {
         }
     }
 
+    /// Remove a single destination from the local path cache (e.g. after transport DropPath).
+    pub fn clear_path_to(&mut self, destination_hex: &str) {
+        let key = destination_hex.to_lowercase();
+        self.path_table_hashes.remove(&key);
+        if let Ok(dest) = parse_hash16(&key) {
+            self.route_hops.remove(&dest);
+            self.path_request_gate.clear_destination(dest);
+        }
+    }
+
     pub fn has_path_to(&self, destination_hex: &str) -> bool {
         self.path_table_hashes
             .contains(&destination_hex.to_lowercase())
@@ -874,6 +884,27 @@ mod tests {
         gate.record_queue_failure(dest(3), 100.0);
         gate.clear_destination(dest(3));
         assert_eq!(gate.decide(dest(3), 101.0), PathRequestDecision::Send);
+    }
+
+    #[test]
+    fn clear_path_to_removes_stale_route_so_refresh_can_reinstall() {
+        let identity = Identity::new();
+        let (tx, _rx) = mpsc::channel(8);
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let dest_hash = dest(0xab);
+        let dest_hex = hex::encode(dest_hash);
+        // Stale cached route (5 hops).
+        driver.update_path_table(&[(dest_hash, 5, dest_hex.clone())]);
+        assert!(driver.has_path_to(&dest_hex));
+
+        // Force refresh: drop local cache (transport DropPath happens in live.rs).
+        driver.clear_path_to(&dest_hex);
+        assert!(!driver.has_path_to(&dest_hex));
+
+        // Fresh route response reinstalls with updated hops.
+        driver.update_path_table(&[(dest_hash, 2, dest_hex.clone())]);
+        assert!(driver.has_path_to(&dest_hex));
+        assert_eq!(driver.route_hops.get(&dest_hash).copied(), Some(2));
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/mod.rs
+++ b/reticulum-sidecar/src/stack/mod.rs
@@ -1963,32 +1963,51 @@ impl StackHandle {
         hash: &str,
         path: &str,
         data_b64: Option<&str>,
+        force_path_refresh: bool,
     ) -> serde_json::Value {
         #[cfg(feature = "rns-stack")]
         if let Some(live) = &self.live {
             let interfaces = self.inner.read().await.interfaces.clone();
             let identity_hash = self.nomad_identity_hash_for(hash).await;
             return live
-                .fetch_nomad_page(hash, identity_hash.as_deref(), path, data_b64, &interfaces)
+                .fetch_nomad_page(
+                    hash,
+                    identity_hash.as_deref(),
+                    path,
+                    data_b64,
+                    &interfaces,
+                    force_path_refresh,
+                )
                 .await;
         }
-        let _ = (hash, path, data_b64);
+        let _ = (hash, path, data_b64, force_path_refresh);
         serde_json::json!({
             "ok": false,
             "error": "nomad page fetch requires live rns-stack sidecar"
         })
     }
 
-    pub async fn nomad_file(&self, hash: &str, path: &str) -> serde_json::Value {
+    pub async fn nomad_file(
+        &self,
+        hash: &str,
+        path: &str,
+        force_path_refresh: bool,
+    ) -> serde_json::Value {
         #[cfg(feature = "rns-stack")]
         if let Some(live) = &self.live {
             let interfaces = self.inner.read().await.interfaces.clone();
             let identity_hash = self.nomad_identity_hash_for(hash).await;
             return live
-                .fetch_nomad_file(hash, identity_hash.as_deref(), path, &interfaces)
+                .fetch_nomad_file(
+                    hash,
+                    identity_hash.as_deref(),
+                    path,
+                    &interfaces,
+                    force_path_refresh,
+                )
                 .await;
         }
-        let _ = (hash, path);
+        let _ = (hash, path, force_path_refresh);
         serde_json::json!({
             "ok": false,
             "error": "nomad file fetch requires live rns-stack sidecar"

--- a/src/renderer/components/NomadNetworkPanel.test.tsx
+++ b/src/renderer/components/NomadNetworkPanel.test.tsx
@@ -419,9 +419,14 @@ describe('NomadNetworkPanel', () => {
     expect(screen.getByLabelText('nomadNetwork.urlBarAria')).toHaveValue(
       'abc1234567890:/page/forum/thread.mu`thread_id=aaa',
     );
-    expect(fetchNomadPage).toHaveBeenCalledWith('abc1234567890', '/page/forum/thread.mu', {
-      var_thread_id: 'aaa',
-    });
+    expect(fetchNomadPage).toHaveBeenCalledWith(
+      'abc1234567890',
+      '/page/forum/thread.mu',
+      {
+        var_thread_id: 'aaa',
+      },
+      undefined,
+    );
 
     await user.click(screen.getByRole('button', { name: 'nomadNetwork.homePage' }));
     await waitFor(() => {
@@ -435,9 +440,14 @@ describe('NomadNetworkPanel', () => {
     expect(screen.getByLabelText('nomadNetwork.urlBarAria')).toHaveValue(
       'abc1234567890:/page/forum/thread.mu`thread_id=bbb',
     );
-    expect(fetchNomadPage).toHaveBeenCalledWith('abc1234567890', '/page/forum/thread.mu', {
-      var_thread_id: 'bbb',
-    });
+    expect(fetchNomadPage).toHaveBeenCalledWith(
+      'abc1234567890',
+      '/page/forum/thread.mu',
+      {
+        var_thread_id: 'bbb',
+      },
+      undefined,
+    );
 
     const threadFetches = fetchNomadPage.mock.calls.filter(
       (call) => call[1] === '/page/forum/thread.mu',
@@ -804,6 +814,20 @@ describe('NomadNetworkPanel', () => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(2);
         expect(document.querySelector('.nomad-micron-page')).toBeTruthy();
       });
+      expect(fetchNomadPage).toHaveBeenNthCalledWith(
+        1,
+        'abc1234567890',
+        '/page/index.mu',
+        undefined,
+        undefined,
+      );
+      expect(fetchNomadPage).toHaveBeenNthCalledWith(
+        2,
+        'abc1234567890',
+        '/page/index.mu',
+        undefined,
+        { forcePathRefresh: true },
+      );
       expect(screen.queryByText(/nomadNetwork.pageFailed/)).not.toBeInTheDocument();
     } finally {
       restore();
@@ -920,6 +944,20 @@ describe('NomadNetworkPanel', () => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(3);
         expect(document.querySelector('.nomad-micron-page')).toBeTruthy();
       });
+      expect(fetchNomadPage).toHaveBeenNthCalledWith(
+        2,
+        'abc1234567890',
+        '/page/index.mu',
+        undefined,
+        { forcePathRefresh: true },
+      );
+      expect(fetchNomadPage).toHaveBeenNthCalledWith(
+        3,
+        'abc1234567890',
+        '/page/index.mu',
+        undefined,
+        { forcePathRefresh: true },
+      );
 
       act(() => {
         useNomadNetworkStore.setState({

--- a/src/renderer/components/NomadNetworkPanel.tsx
+++ b/src/renderer/components/NomadNetworkPanel.tsx
@@ -60,6 +60,8 @@ interface NomadHistoryEntry {
 interface LoadNodePageOptions {
   fromHistory?: boolean;
   forceReload?: boolean;
+  /** Force sidecar path rediscovery (stale-route retry / post-error reload). */
+  forcePathRefresh?: boolean;
   requestData?: NomadPageRequestData;
 }
 
@@ -458,7 +460,12 @@ export default function NomadNetworkPanel({
       setPageContentType(undefined);
       let res: NomadPageResponse;
       try {
-        res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
+        res = await fetchNomadPage(
+          hash,
+          normalizedPath,
+          normalizedRequest,
+          options.forcePathRefresh ? { forcePathRefresh: true } : undefined,
+        );
         if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
 
         if ((!res.ok || !res.content) && isRetryableNomadPageError(res.error)) {
@@ -468,7 +475,9 @@ export default function NomadNetworkPanel({
             window.setTimeout(resolve, NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
           });
           if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
-          res = await fetchNomadPage(hash, normalizedPath, normalizedRequest);
+          res = await fetchNomadPage(hash, normalizedPath, normalizedRequest, {
+            forcePathRefresh: true,
+          });
           if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
         }
       } catch (e) {
@@ -531,6 +540,7 @@ export default function NomadNetworkPanel({
     console.warn('[NomadNetwork] page reload after announce refresh');
     void loadNodePage(selectedHash, pagePath, {
       forceReload: true,
+      forcePathRefresh: true,
       requestData: pageRequestData,
     });
   }, [
@@ -1049,6 +1059,7 @@ export default function NomadNetworkPanel({
                     onClick={() => {
                       void loadNodePage(selectedNode.destination_hash, pagePath, {
                         forceReload: true,
+                        forcePathRefresh: isRetryableNomadPageError(pageErrorCode),
                         requestData: pageRequestData,
                       });
                     }}

--- a/src/renderer/stores/nomadNetworkStore.test.ts
+++ b/src/renderer/stores/nomadNetworkStore.test.ts
@@ -142,6 +142,20 @@ describe('nomadNetworkStore', () => {
     expect(res).toEqual({ ok: true, content: 'page body', content_type: 'micron' });
   });
 
+  it('fetchNomadPage includes force_path_refresh when requested', async () => {
+    getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
+    fetchReticulumInterfaces.mockResolvedValue([{ type: 'tcp', enabled: true }]);
+    proxyGet.mockResolvedValue({ ok: true, content: 'page body', content_type: 'micron' });
+
+    await useNomadNetworkStore
+      .getState()
+      .fetchNomadPage('abc', '/page/index.mu', undefined, { forcePathRefresh: true });
+
+    expect(proxyGet).toHaveBeenCalledWith(
+      '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=8&egress=tcp&force_path_refresh=true',
+    );
+  });
+
   it('fetchNomadFile requests file path with hops and egress', async () => {
     getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
     fetchReticulumInterfaces.mockResolvedValue([{ type: 'tcp', enabled: true }]);

--- a/src/renderer/stores/nomadNetworkStore.ts
+++ b/src/renderer/stores/nomadNetworkStore.ts
@@ -79,6 +79,7 @@ async function fetchNomadResource<T extends { ok: boolean; error?: string }>(
     path: string;
     nodes: Map<string, NomadNodeRow>;
     requestData?: NomadPageRequestData;
+    forcePathRefresh?: boolean;
   },
 ): Promise<T> {
   const hops = hopsForNomadHash(opts.nodes, opts.hash);
@@ -101,6 +102,9 @@ async function fetchNomadResource<T extends { ok: boolean; error?: string }>(
     });
     if (opts.requestData && Object.keys(opts.requestData).length > 0) {
       qs.set('data', btoa(JSON.stringify(opts.requestData)));
+    }
+    if (opts.forcePathRefresh) {
+      qs.set('force_path_refresh', 'true');
     }
     const cleanHash = opts.hash.replace(/[^a-fA-F0-9]/g, '');
     const res = (await window.electronAPI.reticulum.proxyGet(
@@ -130,6 +134,10 @@ async function fetchNomadResource<T extends { ok: boolean; error?: string }>(
   }
 }
 
+export interface FetchNomadPageOpts {
+  forcePathRefresh?: boolean;
+}
+
 interface NomadNetworkStoreState {
   nodes: Map<string, NomadNodeRow>;
   lastRefreshAt: number | null;
@@ -139,8 +147,13 @@ interface NomadNetworkStoreState {
     hash: string,
     path: string,
     requestData?: NomadPageRequestData,
+    opts?: FetchNomadPageOpts,
   ) => Promise<NomadPageResponse>;
-  fetchNomadFile: (hash: string, path: string) => Promise<NomadFileResponse>;
+  fetchNomadFile: (
+    hash: string,
+    path: string,
+    opts?: FetchNomadPageOpts,
+  ) => Promise<NomadFileResponse>;
   toggleFavorite: (hash: string, favorited: boolean) => Promise<void>;
   getNode: (hash: string) => NomadNodeRow | undefined;
 }
@@ -172,19 +185,21 @@ export const useNomadNetworkStore = create<NomadNetworkStoreState>((set, get) =>
     }
   },
 
-  fetchNomadPage: async (hash, path, requestData) =>
+  fetchNomadPage: async (hash, path, requestData, opts) =>
     fetchNomadResource<NomadPageResponse>('page', {
       hash,
       path,
       nodes: get().nodes,
       requestData,
+      forcePathRefresh: opts?.forcePathRefresh,
     }),
 
-  fetchNomadFile: async (hash, path) =>
+  fetchNomadFile: async (hash, path, opts) =>
     fetchNomadResource<NomadFileResponse>('file', {
       hash,
       path,
       nodes: get().nodes,
+      forcePathRefresh: opts?.forcePathRefresh,
     }),
 
   toggleFavorite: async (hash, favorited) => {


### PR DESCRIPTION
## Summary
- After #726 auto-retry, Nomad page loads were still failing on stale cached paths (`has_path=true` → same `link_timeout` twice).
- Sidecar accepts `force_path_refresh=true` on Nomad page/file fetch and runs `ensure_path_for_direct(hash, true)` before the Link query.
- Renderer passes the flag on auto-retry, announce-driven reload, and manual reload while a retryable error is showing (first open unchanged).

## Test plan
- [x] `vitest` NomadNetworkPanel + nomadNetworkStore
- [x] `cargo test force_path_refresh` (sidecar query parse)
- [ ] Manually open a reachable Nomad node with a stale path; confirm retry succeeds and sidecar logs `forced path refresh before Nomad query`
- [ ] Confirm truly offline favorites still fail after dual timeout (expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional stale-path refresh controls for Nomad Network page/file loading (including UI, store, and sidecar/API support).
  * Added the ability to clear cached outbound LXMF destination paths.
* **Bug Fixes**
  * Improved recovery from stale cached routes by forcing rediscovery on retry/reload flows and tightening acceptance of refreshed paths.
* **Documentation**
  * Updated the Nomad Network REST API contract to document the new `force_path_refresh` query behavior and shapes.
* **Tests**
  * Added and updated unit/UI tests to verify correct parsing and `force_path_refresh=true` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->