### PR TITLE
fix: harden fire-and-forget promise rejection handling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -95,6 +95,12 @@ export default tseslint.config(
         'error',
         { checksVoidReturn: { attributes: false } },
       ],
+      // Explicit: already error via strictTypeChecked. ignoreVoid keeps intentional fire-and-forget
+      // (call sites must still attach .catch when the promise can reject).
+      '@typescript-eslint/no-floating-promises': [
+        'error',
+        { ignoreVoid: true, checkThenables: true },
+      ],
       // Off globally: defensive UI ?. / ?? churn. Re-enabled for shared + renderer/lib below.
       '@typescript-eslint/no-unnecessary-condition': 'off',
       // Autofix removes generics that TypeScript still needs for inference (tsc errors after

--- a/reticulum-sidecar/patches/README.md
+++ b/reticulum-sidecar/patches/README.md
@@ -164,7 +164,7 @@ When [ratspeak/rsReticulum#14](https://github.com/ratspeak/rsReticulum/pull/14) 
 
 ## Removed: rsReticulum-rnode-tcp-activity-keepalive.patch
 
-Sunset when upstream landed `RNodeIdleProbe` (`88d3d38` — *rnode: restore TCP application idle probes*). [ratspeak/rsReticulum#15](https://github.com/ratspeak/rsReticulum/pull/15) was closed as superseded; mesh-client no longer carries that overlay (pin `9928abed269a83ec5a7ef165ff1142d938cad706` or later already includes idle probes). `RATSPEAK_PATCH_ENTRIES` in `scripts/update.sh` still tracks `#15` so `pnpm run update` warns on closed-without-merge until the entry is dropped after sunset is confirmed.
+Sunset when upstream landed `RNodeIdleProbe` (`88d3d38` — *rnode: restore TCP application idle probes*). [ratspeak/rsReticulum#15](https://github.com/ratspeak/rsReticulum/pull/15) was closed as superseded; mesh-client no longer carries that overlay (pin `9928abed269a83ec5a7ef165ff1142d938cad706` or later already includes idle probes). Tracked entry removed from `RATSPEAK_PATCH_ENTRIES` in `scripts/update.sh` after sunset confirmation.
 
 ## rsReticulum-ble-rnode-pairing-transition-debounce.patch
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -210,7 +210,6 @@ check_ratspeak_patches() {
     'rsReticulum-packet-tap.patch|ratspeak/rsReticulum|10|rsReticulum packet-tap|https://github.com/ratspeak/rsReticulum/pull/10'
     'rsReticulum-auto-beacon-utun.patch|ratspeak/rsReticulum|11|rsReticulum auto-beacon utun|https://github.com/ratspeak/rsReticulum/pull/11'
     'rsReticulum-link-client-nomad.patch|ratspeak/rsReticulum|14|rsReticulum LinkClient Nomad|https://github.com/ratspeak/rsReticulum/pull/14'
-    'rsReticulum-rnode-tcp-activity-keepalive.patch|ratspeak/rsReticulum|15|rsReticulum RNode TCP activity keepalive|https://github.com/ratspeak/rsReticulum/pull/15'
     'rsReticulum-ble-rnode-pairing-transition-debounce.patch|ratspeak/rsReticulum|20|rsReticulum BLE RNode pairing-transition debounce|https://github.com/ratspeak/rsReticulum/pull/20'
     'rsReticulum-discovery-announce-egress.patch|ratspeak/rsReticulum|19|rsReticulum discovery announce egress|https://github.com/ratspeak/rsReticulum/pull/19'
     'rsLXMF-propagation-sync-peering.patch|ratspeak/rsLXMF|4|rsLXMF propagation sync peering|https://github.com/ratspeak/rsLXMF/pull/4'
@@ -297,7 +296,7 @@ check_ratspeak_patches() {
         ;;
       closed)
         # Still warn when the .patch is already gone so closed-without-merge stays visible
-        # (e.g. #15 superseded by upstream RNodeIdleProbe — confirm sunset, then drop entry).
+        # until sunset is confirmed and the entry is dropped from RATSPEAK_PATCH_ENTRIES.
         warn_box "${label} (Ratspeak overlay)" "local patch" "PR closed (not merged?)" "${url}"
         if [ "${patch_present}" -eq 1 ]; then
           echo "  Reason tracked: ${repo}#${pr} closed without merge — verify overlay still needed."

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2393,11 +2393,21 @@ ipcMain.handle('bluetooth-pair', async (event, macAddress: unknown, pin: unknown
         stderr.includes('AuthenticationCanceled');
       const pairingSucceededByOutput = stdout.includes('Pairing successful');
       if (!pairingFailedByOutput && (pairingSucceededByOutput || code === 0)) {
-        void trustDeviceBestEffort().then(() => {
-          if (settled) return;
-          console.debug('[IPC] bluetooth-pair success');
-          finishResolve();
-        });
+        void trustDeviceBestEffort()
+          .then(() => {
+            if (settled) return;
+            console.debug('[IPC] bluetooth-pair success');
+            finishResolve();
+          })
+          .catch((e: unknown) => {
+            // trustDeviceBestEffort is best-effort and should not reject; finish pairing anyway.
+            console.debug(
+              '[IPC] bluetooth-pair trust settle:',
+              sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
+            );
+            if (settled) return;
+            finishResolve();
+          });
       } else {
         console.warn(
           '[IPC] bluetooth-pair failed:',
@@ -6405,134 +6415,147 @@ app.on('child-process-gone', (_event, details) => {
   );
 });
 
-void app.whenReady().then(() => {
-  try {
-    initLogFile();
-    console.debug(`[Startup] runtime ${formatRuntimeLogTag()}`);
+void app
+  .whenReady()
+  .then(() => {
     try {
-      console.debug('[main] crashDumps path:', sanitizeLogMessage(app.getPath('crashDumps')));
-    } catch (e: unknown) {
-      console.warn(
-        '[main] crashDumps path unavailable:',
-        sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
-      );
-    }
-
-    // Register lxm:// deep links (dev + packaged). OS-specific: argv in defaultApp.
-    if (process.defaultApp) {
-      if (process.argv.length >= 2) {
-        app.setAsDefaultProtocolClient('lxm', process.execPath, [path.resolve(process.argv[1])]);
-      }
-    } else {
-      app.setAsDefaultProtocolClient('lxm');
-    }
-    const coldStartUrl = findLxmUrlInArgv(process.argv);
-    if (coldStartUrl) pendingOpenUrl = coldStartUrl;
-
-    initDatabase();
-
-    // Auto-restore TAK server if auto-start is enabled
-    const takSettingsPath = path.join(app.getPath('userData'), 'tak-settings.json');
-    try {
-      if (fs.existsSync(takSettingsPath)) {
-        const raw: unknown = JSON.parse(fs.readFileSync(takSettingsPath, 'utf-8'));
-        // Backfill autoStart for settings files saved before the field was added.
-        if (
-          raw != null &&
-          typeof raw === 'object' &&
-          typeof (raw as Record<string, unknown>).autoStart !== 'boolean'
-        ) {
-          (raw as Record<string, unknown>).autoStart = false;
-        }
-        const saved = raw;
-        validateTakSettings(saved);
-        if (saved.autoStart) {
-          void ensureTakServerManager()
-            .then((m) => m.start(saved))
-            .catch((e: unknown) => {
-              console.error(
-                '[TAK] Auto-start failed:',
-                sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
-              );
-            });
-        }
-      }
-    } catch (e: unknown) {
-      console.warn(
-        '[TAK] Settings restore failed:',
-        sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
-      );
-    }
-
-    // Force the dock icon in development on macOS
-    if (!app.isPackaged && process.platform === 'darwin') {
-      const iconPath = path.join(
-        __dirname,
-        '../../resources/icons/mac/iconset/icon_256x256@1x.png',
-      );
-      app.dock?.setIcon(iconPath);
-    }
-    createWindow();
-
-    const MAIN_PROCESS_HEALTH_LOG_INTERVAL_MS = 60 * 60 * 1000;
-    const MAIN_PROCESS_HEALTH_UPTIME_THRESHOLD_SEC = 24 * 60 * 60;
-    setInterval(() => {
-      if (process.uptime() < MAIN_PROCESS_HEALTH_UPTIME_THRESHOLD_SEC) return;
-      const uptimeSec = Math.floor(process.uptime());
-      const mem = process.memoryUsage();
-      const ble = nobleBleManager.getLongSessionHealthSnapshot();
-      console.debug(
-        `[main] long-session health uptimeSec=${uptimeSec} rss=${mem.rss} heapUsed=${mem.heapUsed} ble=${JSON.stringify(ble)}`,
-      );
-    }, MAIN_PROCESS_HEALTH_LOG_INTERVAL_MS).unref();
-
-    setupAppMenu();
-
-    // ─── Power monitor: notify renderer on suspend/resume ──────────
-    powerMonitor.on('suspend', () => {
-      console.debug('[main] System suspending');
-      rendererHeartbeatWatchdog.clearResumeWatchdog();
-      mqttManager.handlePowerSuspend();
-      meshcoreMqttAdapter.handlePowerSuspend();
-      mainWindow?.webContents.send('power:suspend');
-    });
-    powerMonitor.on('resume', () => {
-      console.debug('[main] System resumed');
-      rendererHeartbeatWatchdog.startResumeWatchdog();
-      mainWindow?.webContents.send('power:resume');
-    });
-  } catch (error) {
-    console.error(
-      '[main] Fatal startup error:',
-      sanitizeLogMessage(error instanceof Error ? (error.stack ?? error.message) : String(error)),
-    );
-    const isNativeModuleError =
-      error instanceof Error && (error as NodeJS.ErrnoException).code === 'ERR_DLOPEN_FAILED';
-    const message = isDatabaseSchemaTooNewError(error)
-      ? formatDatabaseSchemaTooNewMessage(error)
-      : isNativeModuleError
-        ? `A native module failed to load. This usually means the app needs to be rebuilt for this version of Electron.\n\nFix: run "pnpm install" in the project directory, then restart.\n\nDetails: ${error.message}`
-        : `The application failed to start:\n\n${error instanceof Error ? error.message : String(error)}\n\nPlease report this issue.`;
-    showFatalStartupError('Mesh-Client — Startup Error', message);
-    app.quit();
-    return;
-  }
-
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
+      initLogFile();
+      console.debug(`[Startup] runtime ${formatRuntimeLogTag()}`);
       try {
-        createWindow();
-      } catch (error) {
-        console.error(
-          '[main] Window creation error:',
-          sanitizeLogMessage(error instanceof Error ? error.message : String(error)),
+        console.debug('[main] crashDumps path:', sanitizeLogMessage(app.getPath('crashDumps')));
+      } catch (e: unknown) {
+        console.warn(
+          '[main] crashDumps path unavailable:',
+          sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
         );
       }
-    } else {
-      mainWindow?.show(); // Restore hidden window on dock click
+
+      // Register lxm:// deep links (dev + packaged). OS-specific: argv in defaultApp.
+      if (process.defaultApp) {
+        if (process.argv.length >= 2) {
+          app.setAsDefaultProtocolClient('lxm', process.execPath, [path.resolve(process.argv[1])]);
+        }
+      } else {
+        app.setAsDefaultProtocolClient('lxm');
+      }
+      const coldStartUrl = findLxmUrlInArgv(process.argv);
+      if (coldStartUrl) pendingOpenUrl = coldStartUrl;
+
+      initDatabase();
+
+      // Auto-restore TAK server if auto-start is enabled
+      const takSettingsPath = path.join(app.getPath('userData'), 'tak-settings.json');
+      try {
+        if (fs.existsSync(takSettingsPath)) {
+          const raw: unknown = JSON.parse(fs.readFileSync(takSettingsPath, 'utf-8'));
+          // Backfill autoStart for settings files saved before the field was added.
+          if (
+            raw != null &&
+            typeof raw === 'object' &&
+            typeof (raw as Record<string, unknown>).autoStart !== 'boolean'
+          ) {
+            (raw as Record<string, unknown>).autoStart = false;
+          }
+          const saved = raw;
+          validateTakSettings(saved);
+          if (saved.autoStart) {
+            void ensureTakServerManager()
+              .then((m) => m.start(saved))
+              .catch((e: unknown) => {
+                console.error(
+                  '[TAK] Auto-start failed:',
+                  sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
+                );
+              });
+          }
+        }
+      } catch (e: unknown) {
+        console.warn(
+          '[TAK] Settings restore failed:',
+          sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
+        );
+      }
+
+      // Force the dock icon in development on macOS
+      if (!app.isPackaged && process.platform === 'darwin') {
+        const iconPath = path.join(
+          __dirname,
+          '../../resources/icons/mac/iconset/icon_256x256@1x.png',
+        );
+        app.dock?.setIcon(iconPath);
+      }
+      createWindow();
+
+      const MAIN_PROCESS_HEALTH_LOG_INTERVAL_MS = 60 * 60 * 1000;
+      const MAIN_PROCESS_HEALTH_UPTIME_THRESHOLD_SEC = 24 * 60 * 60;
+      setInterval(() => {
+        if (process.uptime() < MAIN_PROCESS_HEALTH_UPTIME_THRESHOLD_SEC) return;
+        const uptimeSec = Math.floor(process.uptime());
+        const mem = process.memoryUsage();
+        const ble = nobleBleManager.getLongSessionHealthSnapshot();
+        console.debug(
+          `[main] long-session health uptimeSec=${uptimeSec} rss=${mem.rss} heapUsed=${mem.heapUsed} ble=${JSON.stringify(ble)}`,
+        );
+      }, MAIN_PROCESS_HEALTH_LOG_INTERVAL_MS).unref();
+
+      setupAppMenu();
+
+      // ─── Power monitor: notify renderer on suspend/resume ──────────
+      powerMonitor.on('suspend', () => {
+        console.debug('[main] System suspending');
+        rendererHeartbeatWatchdog.clearResumeWatchdog();
+        mqttManager.handlePowerSuspend();
+        meshcoreMqttAdapter.handlePowerSuspend();
+        mainWindow?.webContents.send('power:suspend');
+      });
+      powerMonitor.on('resume', () => {
+        console.debug('[main] System resumed');
+        rendererHeartbeatWatchdog.startResumeWatchdog();
+        mainWindow?.webContents.send('power:resume');
+      });
+    } catch (error) {
+      console.error(
+        '[main] Fatal startup error:',
+        sanitizeLogMessage(error instanceof Error ? (error.stack ?? error.message) : String(error)),
+      );
+      const isNativeModuleError =
+        error instanceof Error && (error as NodeJS.ErrnoException).code === 'ERR_DLOPEN_FAILED';
+      const message = isDatabaseSchemaTooNewError(error)
+        ? formatDatabaseSchemaTooNewMessage(error)
+        : isNativeModuleError
+          ? `A native module failed to load. This usually means the app needs to be rebuilt for this version of Electron.\n\nFix: run "pnpm install" in the project directory, then restart.\n\nDetails: ${error.message}`
+          : `The application failed to start:\n\n${error instanceof Error ? error.message : String(error)}\n\nPlease report this issue.`;
+      showFatalStartupError('Mesh-Client — Startup Error', message);
+      app.quit();
+      return;
     }
+
+    app.on('activate', () => {
+      if (BrowserWindow.getAllWindows().length === 0) {
+        try {
+          createWindow();
+        } catch (error) {
+          console.error(
+            '[main] Window creation error:',
+            sanitizeLogMessage(error instanceof Error ? error.message : String(error)),
+          );
+        }
+      } else {
+        mainWindow?.show(); // Restore hidden window on dock click
+      }
+    });
+  })
+  .catch((error: unknown) => {
+    console.error(
+      '[main] app.whenReady failed:',
+      sanitizeLogMessage(error instanceof Error ? (error.stack ?? error.message) : String(error)),
+    );
+    showFatalStartupError(
+      'Mesh-Client — Startup Error',
+      `The application failed to start:\n\n${error instanceof Error ? error.message : String(error)}\n\nPlease report this issue.`,
+    );
+    app.quit();
   });
-});
 
 app.on('before-quit', (event) => {
   // Clean up any pending Bluetooth device selection to prevent callback leak

--- a/src/renderer/components/ChatComposer.tsx
+++ b/src/renderer/components/ChatComposer.tsx
@@ -1050,7 +1050,9 @@ export function ChatComposer({
               if (isLinux) {
                 setShowComposePicker((prev) => !prev);
               } else {
-                void window.electronAPI.showEmojiPanel();
+                void window.electronAPI.showEmojiPanel().catch((e: unknown) => {
+                  console.debug('[ChatComposer] showEmojiPanel failed ' + errLikeToLogString(e));
+                });
               }
             }}
             disabled={disabled || !isConnected}

--- a/src/renderer/components/ChatPanel.tsx
+++ b/src/renderer/components/ChatPanel.tsx
@@ -2852,7 +2852,14 @@ function ChatPanel({
                                     } else {
                                       reactionPickerTarget.current = { id, channel: msg.channel };
                                       reactionCapturePendingRef.current = true;
-                                      void window.electronAPI.showEmojiPanel();
+                                      void window.electronAPI
+                                        .showEmojiPanel()
+                                        .catch((e: unknown) => {
+                                          console.debug(
+                                            '[ChatPanel] showEmojiPanel failed ' +
+                                              errLikeToLogString(e),
+                                          );
+                                        });
                                     }
                                   }}
                                   {...{ [PARENT_HOVER_ATTR]: '' }}

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -1242,7 +1242,9 @@ export default function ConnectionPanel({
           setWebBluetoothDevice(null);
         }
       } else {
-        void window.electronAPI.stopNobleBleScanning(protocol);
+        void window.electronAPI.stopNobleBleScanning(protocol).catch((e: unknown) => {
+          console.debug('[ConnectionPanel] stopNobleBleScanning failed ' + errLikeToLogString(e));
+        });
       }
     }
     if (showSerialPicker) {
@@ -1319,7 +1321,9 @@ export default function ConnectionPanel({
         // Don't call onConnect again - the original onConnect will continue from requestDevice()
         // and proceed to connect(), which triggers the pairing handler.
       } else {
-        void window.electronAPI.stopNobleBleScanning(protocol);
+        void window.electronAPI.stopNobleBleScanning(protocol).catch((e: unknown) => {
+          console.debug('[ConnectionPanel] stopNobleBleScanning failed ' + errLikeToLogString(e));
+        });
         // Trigger the actual connection with the peripheral ID
         onConnect('ble', undefined, deviceId).catch((err: unknown) => {
           const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/renderer/components/LanguageSelector.tsx
+++ b/src/renderer/components/LanguageSelector.tsx
@@ -7,6 +7,7 @@ import { ICON_MD } from '@/renderer/lib/icons/iconClass';
 import { useParentIconTrigger } from '@/renderer/lib/icons/iconMotionContext';
 
 import { mergeAppSetting } from '../lib/appSettingsStorage';
+import { errLikeToLogString } from '../lib/errLikeToLogString';
 import i18n from '../lib/i18n';
 import { ensureLocaleLoaded } from '../lib/localeResources';
 import { SUPPORTED_LANGUAGES } from '../locales/languages';
@@ -40,13 +41,18 @@ export default function LanguageSelector() {
 
   // Reconcile DB locale with current i18n locale on mount
   useEffect(() => {
-    void window.electronAPI.appSettings.getAll().then(async (settings) => {
-      const dbLocale = settings.locale;
-      if (dbLocale && dbLocale !== i18n.language) {
-        const ok = await ensureLocaleLoaded(i18n, dbLocale);
-        if (ok) await i18n.changeLanguage(dbLocale);
+    void (async () => {
+      try {
+        const settings = await window.electronAPI.appSettings.getAll();
+        const dbLocale = settings.locale;
+        if (dbLocale && dbLocale !== i18n.language) {
+          const ok = await ensureLocaleLoaded(i18n, dbLocale);
+          if (ok) await i18n.changeLanguage(dbLocale);
+        }
+      } catch (e: unknown) {
+        console.warn('[LanguageSelector] locale reconcile failed ' + errLikeToLogString(e));
       }
-    });
+    })();
   }, []);
 
   // Close dropdown on outside click (button + portaled menu)
@@ -88,7 +94,9 @@ export default function LanguageSelector() {
       }
       await i18n.changeLanguage(code);
       mergeAppSetting('locale', code, 'LanguageSelector');
-      void window.electronAPI.appSettings.set('locale', code);
+      void window.electronAPI.appSettings.set('locale', code).catch((e: unknown) => {
+        console.warn('[LanguageSelector] persist locale failed ' + errLikeToLogString(e));
+      });
       closeMenu();
     })();
   };

--- a/src/renderer/components/MeshcoreRepeaterPasswordControls.tsx
+++ b/src/renderer/components/MeshcoreRepeaterPasswordControls.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
+import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import {
   forgetMeshcoreRepeaterSavedSecret,
   getMeshcoreRepeaterSavedSecretsSummary,
@@ -43,12 +44,18 @@ export function MeshcoreRepeaterPasswordControls({
         <button
           type="button"
           onClick={() => {
-            void onPromptPassword(nodeId, nodeName).then((auth) => {
-              if (auth.ok && auth.saved) {
-                onSecretsChanged();
-                onStatusMessage(t('repeatersPanel.passwordSaved'));
-              }
-            });
+            void onPromptPassword(nodeId, nodeName)
+              .then((auth) => {
+                if (auth.ok && auth.saved) {
+                  onSecretsChanged();
+                  onStatusMessage(t('repeatersPanel.passwordSaved'));
+                }
+              })
+              .catch((e: unknown) => {
+                console.warn(
+                  '[MeshcoreRepeaterPasswordControls] prompt password ' + errLikeToLogString(e),
+                );
+              });
           }}
           className="rounded border border-gray-600 bg-gray-800 px-2 py-1 text-xs text-gray-200 hover:bg-gray-700"
           aria-label={
@@ -65,10 +72,16 @@ export function MeshcoreRepeaterPasswordControls({
           <button
             type="button"
             onClick={() => {
-              void forgetMeshcoreRepeaterSavedSecret(nodeId).then(() => {
-                onSecretsChanged();
-                onStatusMessage(t('repeatersPanel.passwordForgotten'));
-              });
+              void forgetMeshcoreRepeaterSavedSecret(nodeId)
+                .then(() => {
+                  onSecretsChanged();
+                  onStatusMessage(t('repeatersPanel.passwordForgotten'));
+                })
+                .catch((e: unknown) => {
+                  console.warn(
+                    '[MeshcoreRepeaterPasswordControls] forget password ' + errLikeToLogString(e),
+                  );
+                });
             }}
             className="rounded border border-red-900/50 bg-red-950/40 px-2 py-1 text-xs text-red-300 hover:bg-red-900/30"
             aria-label={t('repeatersPanel.forgetPasswordAria')}

--- a/src/renderer/components/NodeDetailModal.tsx
+++ b/src/renderer/components/NodeDetailModal.tsx
@@ -367,9 +367,14 @@ export default function NodeDetailModal({
     const nodeId = node.node_id;
     noteSaveAllowedRef.current = true;
     let cancelled = false;
-    void window.electronAPI.db.getNodeNote(nodeId).then((note: string | null) => {
-      if (!cancelled) setNodeNote(note ?? '');
-    });
+    void window.electronAPI.db
+      .getNodeNote(nodeId)
+      .then((note: string | null) => {
+        if (!cancelled) setNodeNote(note ?? '');
+      })
+      .catch((e: unknown) => {
+        console.warn('[NodeDetailModal] getNodeNote failed ' + errLikeToLogString(e));
+      });
     return () => {
       cancelled = true;
       noteSaveAllowedRef.current = false;
@@ -380,7 +385,9 @@ export default function NodeDetailModal({
       const pending = pendingNoteRef.current;
       pendingNoteRef.current = null;
       if (pending !== null) {
-        void window.electronAPI.db.setNodeNote(nodeId, pending);
+        void window.electronAPI.db.setNodeNote(nodeId, pending).catch((e: unknown) => {
+          console.warn('[NodeDetailModal] setNodeNote (unmount) failed ' + errLikeToLogString(e));
+        });
       }
     };
   }, [node?.node_id]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -2234,7 +2241,13 @@ export default function NodeDetailModal({
                   noteSaveTimerRef.current = setTimeout(() => {
                     if (!noteSaveAllowedRef.current) return;
                     pendingNoteRef.current = null;
-                    void window.electronAPI.db.setNodeNote(node.node_id, val);
+                    void window.electronAPI.db
+                      .setNodeNote(node.node_id, val)
+                      .catch((e: unknown) => {
+                        console.warn(
+                          '[NodeDetailModal] setNodeNote failed ' + errLikeToLogString(e),
+                        );
+                      });
                   }, 600);
                 }}
               />

--- a/src/renderer/components/NomadNetworkPanel.tsx
+++ b/src/renderer/components/NomadNetworkPanel.tsx
@@ -367,9 +367,14 @@ export default function NomadNetworkPanel({
   useEffect(() => {
     const applyRunning = (running: boolean) => {
       setSidecarRunning(running);
+      // floating-ok: refreshFromSidecar (store) catches/logs; Nomad refreshFromSidecar same pattern
       if (running) void refreshFromSidecar();
     };
-    void isReticulumSidecarRunning().then(applyRunning);
+    void isReticulumSidecarRunning()
+      .then(applyRunning)
+      .catch((e: unknown) => {
+        console.warn('[NomadNetworkPanel] sidecar status ' + errLikeToLogString(e));
+      });
     const unsub = window.electronAPI.reticulum.onStatus((status) => {
       applyRunning(status.running && status.port > 0);
     });

--- a/src/renderer/components/ReticulumPropagationControls.tsx
+++ b/src/renderer/components/ReticulumPropagationControls.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import {
   readReticulumPropagationMode,
   resolvePropagationSyncTargetId,
@@ -33,6 +34,7 @@ export function ReticulumPropagationControls({
 
   useEffect(() => {
     if (!sidecarReady) return;
+    // floating-ok: refreshFromSidecar catches and logs sidecar/IPC failures
     void refreshFromSidecar();
   }, [sidecarReady, refreshFromSidecar]);
 
@@ -46,6 +48,7 @@ export function ReticulumPropagationControls({
 
   useEffect(() => {
     if (!sidecarReady || mode !== 'auto' || nodes.length === 0) return;
+    // floating-ok: setPreferredOnSidecar never rejects (returns false on failure)
     void applyAutoPreferred();
   }, [applyAutoPreferred, mode, nodes.length, sidecarReady]);
 
@@ -57,10 +60,16 @@ export function ReticulumPropagationControls({
   const handleSync = () => {
     if (!syncTargetId) return;
     if (mode === 'auto' && syncTargetId !== preferredId) {
-      void setPreferredOnSidecar(syncTargetId).then(() => startSync(syncTargetId));
+      void setPreferredOnSidecar(syncTargetId)
+        .then(() => startSync(syncTargetId))
+        .catch((e: unknown) => {
+          console.warn('[ReticulumPropagationControls] sync ' + errLikeToLogString(e));
+        });
       return;
     }
-    void startSync(syncTargetId);
+    void startSync(syncTargetId).catch((e: unknown) => {
+      console.warn('[ReticulumPropagationControls] sync ' + errLikeToLogString(e));
+    });
   };
 
   const syncDisabled = disabled || !sidecarReady || mode === 'off' || !syncTargetId || sync.active;

--- a/src/renderer/components/ReticulumPropagationSection.tsx
+++ b/src/renderer/components/ReticulumPropagationSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import { formatRelativeOrIsoDate } from '@/renderer/lib/formatRelativeOrIsoDate';
 import { RETICULUM_PROPAGATION_REFRESH_MIN_VISIBLE_MS } from '@/renderer/lib/reticulum/reticulumPropagationSync';
 import {
@@ -269,14 +270,21 @@ export default function ReticulumPropagationSection({
                       disabled={!renameDraft.trim()}
                       aria-label={t('reticulumPropagation.renameSaveAria')}
                       onClick={() => {
-                        void renamePropagationNode(node.id, renameDraft.trim()).then((ok) => {
-                          if (ok) {
-                            setRenamingId(null);
-                            setRenameDraft('');
-                          } else {
+                        void renamePropagationNode(node.id, renameDraft.trim())
+                          .then((ok) => {
+                            if (ok) {
+                              setRenamingId(null);
+                              setRenameDraft('');
+                            } else {
+                              addToast(t('reticulumPropagation.renameFailed'), 'error');
+                            }
+                          })
+                          .catch((e: unknown) => {
+                            console.warn(
+                              '[ReticulumPropagationSection] rename ' + errLikeToLogString(e),
+                            );
                             addToast(t('reticulumPropagation.renameFailed'), 'error');
-                          }
-                        });
+                          });
                       }}
                     >
                       {t('reticulumPropagation.renameSave')}
@@ -527,13 +535,18 @@ export default function ReticulumPropagationSection({
           danger
           onConfirm={() => {
             const id = pendingDelete.id;
-            void removePropagationNode(id).then((ok) => {
-              if (ok) {
-                setPendingDelete(null);
-              } else {
+            void removePropagationNode(id)
+              .then((ok) => {
+                if (ok) {
+                  setPendingDelete(null);
+                } else {
+                  addToast(t('reticulumPropagation.deleteFailed'), 'error');
+                }
+              })
+              .catch((e: unknown) => {
+                console.warn('[ReticulumPropagationSection] remove ' + errLikeToLogString(e));
                 addToast(t('reticulumPropagation.deleteFailed'), 'error');
-              }
-            });
+              });
           }}
           onCancel={() => {
             setPendingDelete(null);

--- a/src/renderer/components/flasher/FirmwareDownloadLinks.tsx
+++ b/src/renderer/components/flasher/FirmwareDownloadLinks.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import {
   buildOfficialFirmwareDownloadUrl,
   resolveLatestOfficialFirmwareDownloadUrl,
@@ -25,11 +26,15 @@ export function FirmwareDownloadLinks({ recommendedFilename }: FirmwareDownloadL
       return undefined;
     }
     let cancelled = false;
-    void resolveLatestOfficialFirmwareDownloadUrl(recommendedFilename).then((url) => {
-      if (!cancelled) {
-        setResolvedUrl(url);
-      }
-    });
+    void resolveLatestOfficialFirmwareDownloadUrl(recommendedFilename)
+      .then((url) => {
+        if (!cancelled) {
+          setResolvedUrl(url);
+        }
+      })
+      .catch((e: unknown) => {
+        console.debug('[FirmwareDownloadLinks] resolve latest url ' + errLikeToLogString(e));
+      });
     return () => {
       cancelled = true;
     };

--- a/src/renderer/hooks/useAppStartupDbPrune.ts
+++ b/src/renderer/hooks/useAppStartupDbPrune.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import {
   runSessionDbPrune,
   runStartupDbPrune,
@@ -9,9 +10,17 @@ import {
 /** Run SQLite retention prune once at startup, then every {@link SESSION_DB_PRUNE_INTERVAL_MS}. */
 export function useAppStartupDbPrune(onAfterPrune: () => void): void {
   useEffect(() => {
-    void runStartupDbPrune().then(onAfterPrune);
+    // floating-ok: runStartupDbPrune swallows per-op IPC errors; catch covers unexpected throws.
+    void runStartupDbPrune()
+      .then(onAfterPrune)
+      .catch((e: unknown) => {
+        console.warn('[useAppStartupDbPrune] startup prune failed ' + errLikeToLogString(e));
+      });
     const intervalId = setInterval(() => {
-      void runSessionDbPrune();
+      // floating-ok: runSessionDbPrune swallows per-op IPC errors; catch covers unexpected throws.
+      void runSessionDbPrune().catch((e: unknown) => {
+        console.warn('[useAppStartupDbPrune] session prune failed ' + errLikeToLogString(e));
+      });
     }, SESSION_DB_PRUNE_INTERVAL_MS);
     return () => {
       clearInterval(intervalId);

--- a/src/renderer/hooks/useMeshcoreRepeaterRemoteAuth.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRepeaterRemoteAuth.test.tsx
@@ -41,10 +41,14 @@ function RepeaterAuthProbe({
       <button
         type="button"
         onClick={() => {
-          void ensureRepeaterAuth(nodeId, repeaterName).then((auth) => {
-            setResult(auth);
-            if (auth.ok) onAuthed?.();
-          });
+          void ensureRepeaterAuth(nodeId, repeaterName)
+            .then((auth) => {
+              setResult(auth);
+              if (auth.ok) onAuthed?.();
+            })
+            .catch(() => {
+              // catch-no-log-ok: test probe — rejection asserted via UI state absence
+            });
         }}
       >
         request-auth

--- a/src/renderer/hooks/useMeshcoreRoomAuth.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRoomAuth.test.tsx
@@ -36,7 +36,11 @@ function RoomAuthProbe({
       <button
         type="button"
         onClick={() => {
-          void ensureRoomAuth(nodeId, mode, roomName).then(setResult);
+          void ensureRoomAuth(nodeId, mode, roomName)
+            .then(setResult)
+            .catch(() => {
+              // catch-no-log-ok: test probe — rejection asserted via UI state absence
+            });
         }}
       >
         request-auth

--- a/src/renderer/hooks/useMeshcoreRuntime.repeater-admin-rpc.test.tsx
+++ b/src/renderer/hooks/useMeshcoreRuntime.repeater-admin-rpc.test.tsx
@@ -24,9 +24,13 @@ describe('repeater admin RPC sequencing', () => {
 
     const settlePromise = awaitMeshcoreRepeaterPingSettleForNode(42, 500);
     let settled = false;
-    void settlePromise.then(() => {
-      settled = true;
-    });
+    void settlePromise
+      .then(() => {
+        settled = true;
+      })
+      .catch(() => {
+        // catch-no-log-ok: settle may reject on timeout; test awaits settlePromise below
+      });
     await new Promise((r) => setTimeout(r, 80));
     expect(settled).toBe(false);
 

--- a/src/renderer/hooks/useNodeStatusNotifier.ts
+++ b/src/renderer/hooks/useNodeStatusNotifier.ts
@@ -25,9 +25,13 @@ function fireNotification(title: string, body: string): void {
     if (Notification.permission === 'granted') {
       new Notification(title, { body, silent: false });
     } else if (Notification.permission !== 'denied') {
-      void Notification.requestPermission().then((perm) => {
-        if (perm === 'granted') new Notification(title, { body, silent: false });
-      });
+      void Notification.requestPermission()
+        .then((perm) => {
+          if (perm === 'granted') new Notification(title, { body, silent: false });
+        })
+        .catch(() => {
+          // catch-no-log-ok: best-effort notification permission
+        });
     }
   } catch {
     // catch-no-log-ok: best-effort desktop notification

--- a/src/renderer/hooks/useRrcStartupAutoConnect.ts
+++ b/src/renderer/hooks/useRrcStartupAutoConnect.ts
@@ -170,9 +170,14 @@ export function useRrcStartupAutoConnect(): void {
               console.debug('[useRrcStartupAutoConnect] auto-join ' + errLikeToLogString(e));
             });
         });
-        void Promise.all(joinTasks).then(() => {
-          if (anyJoinFailed) roomAutoJoinDoneRef.current.delete(hub);
-        });
+        void Promise.all(joinTasks)
+          .then(() => {
+            if (anyJoinFailed) roomAutoJoinDoneRef.current.delete(hub);
+          })
+          .catch((e: unknown) => {
+            roomAutoJoinDoneRef.current.delete(hub);
+            console.debug('[useRrcStartupAutoConnect] auto-join batch ' + errLikeToLogString(e));
+          });
       }
     }
     for (const hub of listSentForHubRef.current) {

--- a/src/renderer/lib/appSettingsStorage.ts
+++ b/src/renderer/lib/appSettingsStorage.ts
@@ -86,7 +86,13 @@ export function isReticulumAutostartEnabled(): boolean {
 
 export function setReticulumAutostartEnabled(enabled: boolean): void {
   mergeAppSetting('reticulumAutostart', enabled, 'setReticulumAutostartEnabled');
-  void window.electronAPI.appSettings.set('reticulumAutostart', enabled ? '1' : '0');
+  void window.electronAPI.appSettings
+    .set('reticulumAutostart', enabled ? '1' : '0')
+    .catch((e: unknown) => {
+      console.warn(
+        '[appSettingsStorage] persist reticulumAutostart failed ' + errLikeToLogString(e),
+      );
+    });
 }
 
 /** Merge keys into existing app settings without dropping unrelated persisted fields. */

--- a/src/renderer/lib/flasher/rnode.test.ts
+++ b/src/renderer/lib/flasher/rnode.test.ts
@@ -89,9 +89,13 @@ describe('RNode.startBluetoothPairing', () => {
 
     // PIN arrives later — promise must still be pending until then.
     let settled = false;
-    void pairingPromise.then(() => {
-      settled = true;
-    });
+    void pairingPromise
+      .then(() => {
+        settled = true;
+      })
+      .catch(() => {
+        // catch-no-log-ok: pairing may reject on timeout; test awaits pairingPromise below
+      });
     await vi.advanceTimersByTimeAsync(50);
     expect(settled).toBe(false);
     expect(onPin).not.toHaveBeenCalled();

--- a/src/renderer/lib/networkDiscovery.ts
+++ b/src/renderer/lib/networkDiscovery.ts
@@ -54,16 +54,31 @@ export function startNetworkDiscovery(
     sweepTimeout = setTimeout(() => {
       void (async () => {
         if (stopped) return;
-        await runSweep();
+        try {
+          await runSweep();
+        } catch (e) {
+          console.warn(
+            '[networkDiscovery] sweep failed',
+            sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
+          );
+        }
         scheduleNext();
       })();
     }, intervalMs);
   }
 
   // Run an immediate sweep, then schedule recurring ones
-  void runSweep().then(() => {
-    if (!stopped) scheduleNext();
-  });
+  void runSweep()
+    .then(() => {
+      if (!stopped) scheduleNext();
+    })
+    .catch((e: unknown) => {
+      console.warn(
+        '[networkDiscovery] initial sweep failed',
+        sanitizeLogMessage(e instanceof Error ? e.message : String(e)),
+      );
+      if (!stopped) scheduleNext();
+    });
 
   return function stop() {
     stopped = true;

--- a/src/renderer/lib/reticulum/reticulumRmapDiscovery.ts
+++ b/src/renderer/lib/reticulum/reticulumRmapDiscovery.ts
@@ -335,13 +335,25 @@ export function persistRmapUiPrefs(prefs: {
       );
     }
   }
-  void window.electronAPI.appSettings.set(
-    RMAP_SETTINGS_KEYS.announceIntervalMin,
-    String(clampRmapAnnounceIntervalMin(prefs.announceIntervalMin)),
-  );
-  void window.electronAPI.appSettings.set(RMAP_SETTINGS_KEYS.reachableOn, prefs.reachableOn.trim());
+  void window.electronAPI.appSettings
+    .set(
+      RMAP_SETTINGS_KEYS.announceIntervalMin,
+      String(clampRmapAnnounceIntervalMin(prefs.announceIntervalMin)),
+    )
+    .catch((e: unknown) => {
+      console.warn('[reticulumRmapDiscovery] persist announceInterval ' + errLikeToLogString(e));
+    });
+  void window.electronAPI.appSettings
+    .set(RMAP_SETTINGS_KEYS.reachableOn, prefs.reachableOn.trim())
+    .catch((e: unknown) => {
+      console.warn('[reticulumRmapDiscovery] persist reachableOn ' + errLikeToLogString(e));
+    });
   if (height) {
-    void window.electronAPI.appSettings.set(RMAP_SETTINGS_KEYS.heightMeters, height);
+    void window.electronAPI.appSettings
+      .set(RMAP_SETTINGS_KEYS.heightMeters, height)
+      .catch((e: unknown) => {
+        console.warn('[reticulumRmapDiscovery] persist heightMeters ' + errLikeToLogString(e));
+      });
   }
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -32,11 +32,15 @@ function AppBootSplash() {
 }
 
 if (import.meta.env.DEV) {
-  void import('react').then((React) =>
-    import('react-dom').then((ReactDOM) =>
-      import('@axe-core/react').then((axe) => axe.default(React.default, ReactDOM.default, 1000)),
-    ),
-  );
+  void import('react')
+    .then((React) =>
+      import('react-dom').then((ReactDOM) =>
+        import('@axe-core/react').then((axe) => axe.default(React.default, ReactDOM.default, 1000)),
+      ),
+    )
+    .catch((e: unknown) => {
+      console.warn('[main] axe-core load failed:', e instanceof Error ? e.message : String(e));
+    });
 }
 
 installRendererUnhandledRejectionLogger();
@@ -51,7 +55,9 @@ void (async () => {
   runConnectionPanelStorageMigrations();
 
   // Kick App chunk download immediately after locale (parallel with splash paint).
-  void import('./App');
+  void import('./App').catch((e: unknown) => {
+    console.error('[main] App chunk prefetch failed:', e instanceof Error ? e.message : String(e));
+  });
 
   createRoot(document.getElementById('root')!).render(
     <I18nextProvider i18n={i18n}>
@@ -64,4 +70,9 @@ void (async () => {
       </ErrorBoundary>
     </I18nextProvider>,
   );
-})();
+})().catch((e: unknown) => {
+  console.error(
+    '[main] renderer boot failed:',
+    e instanceof Error ? (e.stack ?? e.message) : String(e),
+  );
+});

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -665,9 +665,15 @@ export function useMeshtasticRuntime() {
   }, []);
 
   useEffect(() => {
-    void hydrateLastRfSelfNodeIdFromAppSettings().then((nodeNum) => {
-      if (nodeNum > 0) lastRfSelfNodeIdRef.current = nodeNum;
-    });
+    void hydrateLastRfSelfNodeIdFromAppSettings()
+      .then((nodeNum) => {
+        if (nodeNum > 0) lastRfSelfNodeIdRef.current = nodeNum;
+      })
+      .catch((e: unknown) => {
+        console.debug(
+          '[useMeshtasticRuntime] hydrateLastRfSelfNodeId failed ' + errLikeToLogString(e),
+        );
+      });
   }, []);
 
   useEffect(() => {
@@ -1443,7 +1449,13 @@ export function useMeshtasticRuntime() {
           }
         }
         meshtasticIngestSessionRef.current?.markPacketSeen(msg.sender_id, packetId);
-        if (packetId !== 0) void window.electronAPI.db.updateMessageReceivedVia(packetId);
+        if (packetId !== 0) {
+          void window.electronAPI.db.updateMessageReceivedVia(packetId).catch((e: unknown) => {
+            console.debug(
+              '[useMeshtasticRuntime] updateMessageReceivedVia failed ' + errLikeToLogString(e),
+            );
+          });
+        }
         return;
       }
 
@@ -1492,7 +1504,11 @@ export function useMeshtasticRuntime() {
         if (pid !== undefined && pid !== 0) {
           isDuplicate(mqttWithPreviews.sender_id, pid); // registers as seen to suppress future duplicates
           meshtasticIngestSessionRef.current?.markPacketSeen(mqttWithPreviews.sender_id, pid);
-          void window.electronAPI.db.updateMessageReceivedVia(pid);
+          void window.electronAPI.db.updateMessageReceivedVia(pid).catch((e: unknown) => {
+            console.debug(
+              '[useMeshtasticRuntime] updateMessageReceivedVia failed ' + errLikeToLogString(e),
+            );
+          });
         }
         return;
       }
@@ -2760,7 +2776,13 @@ export function useMeshtasticRuntime() {
             clearMeshtasticOutboundTempId(tempId);
           }
           outboundSendByTempIdRef.current.delete(tempId);
-          void window.electronAPI.db.updateMessageStatus(tempId, 'failed', error);
+          void window.electronAPI.db
+            .updateMessageStatus(tempId, 'failed', error)
+            .catch((e: unknown) => {
+              console.warn(
+                '[useMeshtasticRuntime] updateMessageStatus failed ' + errLikeToLogString(e),
+              );
+            });
         }
       } else {
         // mqtt — read current device status from state so the DB update is consistent
@@ -2771,12 +2793,14 @@ export function useMeshtasticRuntime() {
           const existing = prev.find((m) => m.packetId === rowPacketId);
           if (status !== 'sending' && existing) {
             const deviceStatus = existing.status ?? 'acked';
-            void window.electronAPI.db.updateMessageStatus(
-              rowPacketId,
-              deviceStatus,
-              existing.error,
-              status,
-            );
+            void window.electronAPI.db
+              .updateMessageStatus(rowPacketId, deviceStatus, existing.error, status)
+              .catch((e: unknown) => {
+                console.warn(
+                  '[useMeshtasticRuntime] updateMessageStatus (mqtt) failed ' +
+                    errLikeToLogString(e),
+                );
+              });
           }
           return prev.map((m) => (m.packetId === rowPacketId ? { ...m, mqttStatus: status } : m));
         });


### PR DESCRIPTION
## Summary
- Attach `.catch` (or async IIFE + try/catch) on rejection-unsafe `void promise.then(...)` and bare `void` IPC fire-and-forget so rejections no longer surface only via global `unhandledrejection` handlers.
- Document intentional incomplete promises with `floating-ok` where the callee already swallows errors.
- Make `@typescript-eslint/no-floating-promises` explicit in ESLint config with `ignoreVoid: true` and `checkThenables: true` (floating-promise lint was already on via `strictTypeChecked`).

## Test plan
- [x] `pnpm exec eslint src --max-warnings 0`
- [x] Targeted Vitest (networkDiscovery, rnode, auth hooks, FirmwareDownloadLinks, LanguageSelector, appSettingsStorage, rmapDiscovery, withTimeout)
- [x] Pre-push `vitest run --changed` (152 files / 1581 tests)
- [ ] Smoke: boot app; confirm no new `[renderer] Unhandled rejection` / `[main] Unhandled rejection` noise from prune, locale reconcile, emoji panel, or BLE scan stop paths
- [ ] Confirm LanguageSelector still reconciles DB locale on mount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app and renderer startup reliability with clearer, user-facing failure handling.
  * Bluetooth pairing now completes even if “trust device” fails.
  * Network discovery scheduling now continues after sweep failures.
  * Settings, notes, language, firmware links, emoji panel actions, notifications, BLE scanning shutdown, sidecar sync, and message/database updates now handle async errors more safely.
* **Tests**
  * Updated tests and helpers to properly handle expected async rejections without unhandled rejection noise.
* **Chores / Tooling**
  * Tightened async promise linting to prevent missing error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->