### PR TITLE
fix(reticulum): align RMAP toggles on stack restart and persist prefs

### DIFF
--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -413,7 +413,31 @@ describe('app_settings table + message retention defaults (schema sync)', () => 
     expect(INDEX_SOURCE).toContain('meshcoreRoomSync:');
     expect(INDEX_SOURCE).toContain('meshcoreRoomLastPost:');
     expect(INDEX_SOURCE).toContain('meshcoreRoomCredential:');
+    expect(INDEX_SOURCE).toContain('reticulumRmapAnnounceIntervalMin');
+    expect(INDEX_SOURCE).toContain('reticulumRmapReachableOn');
+    expect(INDEX_SOURCE).toContain('reticulumRmapHeightMeters');
+    expect(INDEX_SOURCE).not.toContain('reticulumRmapNotAllowed');
+    expect(INDEX_SOURCE).toMatch(/key not allowed/);
     expect(INDEX_SOURCE).toMatch(/INSERT OR REPLACE INTO app_settings\(key, value\) VALUES/);
+  });
+
+  it('appSettings:set allowlists RMAP prefs for SQLite persistence', () => {
+    // Source-level: Electron-bound IPC cannot be exercised here; assert write path + allowlist.
+    const allowListBlock = INDEX_SOURCE.slice(
+      INDEX_SOURCE.indexOf('APP_SETTINGS_ALLOWED_KEYS'),
+      INDEX_SOURCE.indexOf('APP_SETTINGS_MAX_VALUE_LENGTH'),
+    );
+    expect(allowListBlock).toContain("'reticulumRmapAnnounceIntervalMin'");
+    expect(allowListBlock).toContain("'reticulumRmapReachableOn'");
+    expect(allowListBlock).toContain("'reticulumRmapHeightMeters'");
+    expect(allowListBlock).not.toContain("'reticulumRmapNotAllowed'");
+    expect(INDEX_SOURCE).toMatch(
+      /isAppSettingsKeyAllowed\(key\)[\s\S]*?throw new Error\('appSettings:set: key not allowed'\)/,
+    );
+    expect(INDEX_SOURCE).toMatch(
+      /\.prepareOnce\('INSERT OR REPLACE INTO app_settings\(key, value\) VALUES \(\?, \?\)'\)/,
+    );
+    expect(INDEX_SOURCE).toMatch(/SELECT key, value FROM app_settings/);
   });
 
   it('appSettings:set rejects oversized values to bound DB writes', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3455,6 +3455,9 @@ const APP_SETTINGS_ALLOWED_KEYS: ReadonlySet<string> = new Set([
   'reduceMotion',
   'alwaysShowMessageActions',
   'reticulumAutostart',
+  'reticulumRmapAnnounceIntervalMin',
+  'reticulumRmapReachableOn',
+  'reticulumRmapHeightMeters',
   /** Legacy blob; prefer meshtasticRemoteAdminKey:<nodeNum> per-node keys. */
   'meshtasticRemoteAdminKeyByNode',
 ]);

--- a/src/renderer/components/reticulum/ReticulumInterfacesPanel.test.tsx
+++ b/src/renderer/components/reticulum/ReticulumInterfacesPanel.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import { hydrateAxeThemeColors } from '@/renderer/lib/a11yTestHelpers';
+import { GPS_SETTINGS_STORAGE_KEY } from '@/renderer/lib/gpsSource';
 import {
   buildDefaultHubAddRequest,
   RETICULUM_DEFAULT_HUB_PRESETS,
@@ -20,13 +21,18 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+const { addToastMock, restartStackMock } = vi.hoisted(() => ({
+  addToastMock: vi.fn(),
+  restartStackMock: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/renderer/components/Toast', () => ({
-  useToast: () => ({ addToast: vi.fn() }),
+  useToast: () => ({ addToast: addToastMock }),
 }));
 
 vi.mock('@/renderer/lib/sessions/reticulumSession', () => ({
   tryGetReticulumSession: () => ({
-    restartStack: vi.fn().mockResolvedValue(undefined),
+    restartStack: restartStackMock,
   }),
 }));
 
@@ -43,8 +49,31 @@ const defaultProps = {
   onBeginBleConnectGrace: vi.fn(),
 };
 
+const rmapCapableRnode: ReticulumInterfaceRow = {
+  id: 'rnode-41f4',
+  name: 'RNode 41F4',
+  type: 'rnode',
+  enabled: true,
+  status: 'up',
+  serial_port: 'ble://eccf2847-e1fd-3f5f-0811-064db1639a3d',
+  discoverable: false,
+};
+
+const rmapWorldHub: ReticulumInterfaceRow = {
+  id: 'rmap-world',
+  name: 'RMAP World',
+  type: 'tcp',
+  enabled: true,
+  status: 'up',
+  host: 'rmap.world',
+  port: 4242,
+};
+
 describe('ReticulumInterfacesPanel', () => {
   beforeEach(() => {
+    addToastMock.mockClear();
+    restartStackMock.mockClear();
+    localStorage.removeItem(GPS_SETTINGS_STORAGE_KEY);
     useConnectionStore.setState({ connections: {} });
     useIdentityStore.setState({ identities: {}, activeIdentityId: null });
     window.electronAPI.reticulum.proxyPost = vi.fn().mockResolvedValue({ ok: true });
@@ -63,6 +92,16 @@ describe('ReticulumInterfacesPanel', () => {
       }
       if (path === '/api/v1/config/audit') {
         return Promise.resolve({ issues: [] });
+      }
+      if (path === '/api/v1/stack/settings') {
+        return Promise.resolve({
+          enable_transport: true,
+          share_instance: false,
+          loglevel: 4,
+        });
+      }
+      if (path === '/api/v1/interfaces') {
+        return Promise.resolve({ interfaces: [rmapCapableRnode, rmapWorldHub] });
       }
       return Promise.resolve({});
     });
@@ -1109,5 +1148,108 @@ describe('ReticulumInterfacesPanel', () => {
       await screen.findByText('connectionPanel.reticulumInterfaces.identityNotConfigured'),
     ).toBeInTheDocument();
     expect(screen.queryByText('identity not configured')).not.toBeInTheDocument();
+  });
+
+  describe('RMAP discoverable toggle restart confirm', () => {
+    beforeEach(() => {
+      localStorage.setItem(
+        GPS_SETTINGS_STORAGE_KEY,
+        JSON.stringify({ staticLat: 40.19444, staticLon: -105.06722 }),
+      );
+    });
+
+    it('refreshes then shows restart confirm; confirm restarts the stack', async () => {
+      const user = userEvent.setup();
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <ReticulumInterfacesPanel
+          {...defaultProps}
+          onRefresh={onRefresh}
+          interfaces={[rmapCapableRnode, rmapWorldHub]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole('checkbox', {
+          name: 'connectionPanel.reticulumInterfaces.rmapDiscoverableAria',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(onRefresh).toHaveBeenCalled();
+      });
+      expect(await screen.findByText('reticulumRmapDiscovery.restartTitle')).toBeInTheDocument();
+      expect(restartStackMock).not.toHaveBeenCalled();
+
+      const dialog = screen.getByRole('alertdialog');
+      await user.click(
+        within(dialog).getByRole('button', { name: 'reticulumRmapDiscovery.restartConfirm' }),
+      );
+
+      await waitFor(() => {
+        expect(restartStackMock).toHaveBeenCalled();
+      });
+      expect(screen.queryByText('reticulumRmapDiscovery.restartTitle')).not.toBeInTheDocument();
+    });
+
+    it('cancel closes restart confirm and shows the restart hint', async () => {
+      const user = userEvent.setup();
+      const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <ReticulumInterfacesPanel
+          {...defaultProps}
+          onRefresh={onRefresh}
+          interfaces={[rmapCapableRnode, rmapWorldHub]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole('checkbox', {
+          name: 'connectionPanel.reticulumInterfaces.rmapDiscoverableAria',
+        }),
+      );
+
+      expect(await screen.findByText('reticulumRmapDiscovery.restartTitle')).toBeInTheDocument();
+
+      const dialog = screen.getByRole('alertdialog');
+      await user.click(within(dialog).getByRole('button', { name: 'common.cancel' }));
+
+      expect(screen.queryByText('reticulumRmapDiscovery.restartTitle')).not.toBeInTheDocument();
+      expect(
+        screen.getByText('connectionPanel.reticulumInterfaces.restartStackHint'),
+      ).toBeInTheDocument();
+      expect(restartStackMock).not.toHaveBeenCalled();
+    });
+
+    it('still shows restart confirm when onRefresh rejects after a successful toggle', async () => {
+      const user = userEvent.setup();
+      const onRefresh = vi.fn().mockRejectedValue(new Error('refresh failed'));
+
+      render(
+        <ReticulumInterfacesPanel
+          {...defaultProps}
+          onRefresh={onRefresh}
+          interfaces={[rmapCapableRnode, rmapWorldHub]}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole('checkbox', {
+          name: 'connectionPanel.reticulumInterfaces.rmapDiscoverableAria',
+        }),
+      );
+
+      expect(await screen.findByText('reticulumRmapDiscovery.restartTitle')).toBeInTheDocument();
+      expect(addToastMock).toHaveBeenCalledWith(
+        'connectionPanel.reticulumInterfaces.rmapEnableSuccess',
+        'success',
+      );
+      expect(addToastMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('rmapToggleFailed'),
+        'error',
+      );
+    });
   });
 });

--- a/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
+++ b/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
@@ -209,6 +209,7 @@ export function ReticulumInterfacesPanel({
   } | null>(null);
   const [editingInterface, setEditingInterface] = useState<ReticulumInterfaceRow | null>(null);
   const [restartStackHint, setRestartStackHint] = useState(false);
+  const [showRmapRestartConfirm, setShowRmapRestartConfirm] = useState(false);
   const [addingDefaultHubs, setAddingDefaultHubs] = useState(false);
   const [rmapToggleBusyId, setRmapToggleBusyId] = useState<string | null>(null);
 
@@ -701,8 +702,8 @@ export function ReticulumInterfacesPanel({
         });
         if (synced) {
           addToast(t('connectionPanel.reticulumRmap.syncSuccess'), 'success');
-          setRestartStackHint(true);
           await onRefresh();
+          setShowRmapRestartConfirm(true);
         }
       } catch (e) {
         addToast(t('connectionPanel.reticulumRmap.syncFailed'), 'error');
@@ -736,8 +737,8 @@ export function ReticulumInterfacesPanel({
             : t('connectionPanel.reticulumInterfaces.rmapDisableSuccess', { name: iface.name }),
           'success',
         );
-        setRestartStackHint(true);
         await onRefresh();
+        setShowRmapRestartConfirm(true);
       } catch (e) {
         if (e instanceof ReticulumRmapGpsRequiredError) {
           addToast(t('reticulumRmapDiscovery.gpsMissingWarning'), 'error');
@@ -882,6 +883,21 @@ export function ReticulumInterfacesPanel({
           }}
           onCancel={() => {
             setPendingDeleteInterface(null);
+          }}
+        />
+      ) : null}
+      {showRmapRestartConfirm ? (
+        <ConfirmModal
+          title={t('reticulumRmapDiscovery.restartTitle')}
+          message={t('reticulumRmapDiscovery.restartBody')}
+          confirmLabel={t('reticulumRmapDiscovery.restartConfirm')}
+          onConfirm={() => {
+            setShowRmapRestartConfirm(false);
+            void restartStackForInterfaceChange();
+          }}
+          onCancel={() => {
+            setShowRmapRestartConfirm(false);
+            setRestartStackHint(true);
           }}
         />
       ) : null}

--- a/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
+++ b/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
@@ -702,7 +702,12 @@ export function ReticulumInterfacesPanel({
         });
         if (synced) {
           addToast(t('connectionPanel.reticulumRmap.syncSuccess'), 'success');
-          await onRefresh();
+          try {
+            await onRefresh();
+          } catch (e) {
+            // catch-no-log-ok refresh failure must not mask successful RMAP sync
+            console.debug('[ReticulumInterfacesPanel] rmap sync refresh ' + errLikeToLogString(e));
+          }
           setShowRmapRestartConfirm(true);
         }
       } catch (e) {
@@ -737,7 +742,12 @@ export function ReticulumInterfacesPanel({
             : t('connectionPanel.reticulumInterfaces.rmapDisableSuccess', { name: iface.name }),
           'success',
         );
-        await onRefresh();
+        try {
+          await onRefresh();
+        } catch (e) {
+          // catch-no-log-ok refresh failure must not mask successful RMAP toggle
+          console.debug('[ReticulumInterfacesPanel] rmap toggle refresh ' + errLikeToLogString(e));
+        }
         setShowRmapRestartConfirm(true);
       } catch (e) {
         if (e instanceof ReticulumRmapGpsRequiredError) {


### PR DESCRIPTION
## Summary
- Interfaces per-row RMAP checkbox now shows the same restart confirm dialog as Network publish (cancel falls back to the amber restart hint).
- Allowlist `reticulumRmapAnnounceIntervalMin` / `reticulumRmapReachableOn` / `reticulumRmapHeightMeters` for `appSettings:set` so RMAP prefs persist to SQLite.

## Test plan
- [ ] Quit/restart app, set App static GPS
- [ ] Connection → Interfaces: toggle RNode RMAP → confirm restart → stack restarts; Connection shows Publishing
- [ ] Network → RMAP: toggle publish → confirm restart (same flow)
- [ ] Confirm no `appSettings:set: key not allowed` warnings for RMAP prefs in the app log
- [ ] Cancel restart on Interfaces → amber restart hint remains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reticulum RMap settings now persist between application sessions, including announce interval, reachable status, and height.
  - After RMap synchronization or discoverability changes, the app refreshes interfaces and prompts you to restart the Reticulum stack.

- **Usability Improvements**
  - Confirm the restart immediately or cancel and follow the existing restart guidance later.
  - Successful changes remain acknowledged even if interface refresh encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->