### PR TITLE
fix: retry dist dedupe on @jsr temp-dir rename races

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -258,7 +258,7 @@ Complete reference of all pnpm scripts in [`package.json`](../package.json), org
 | `dist:win`           | Build Windows .exe installer (hoisted install workaround) + verify packaging |
 | `dist:win:publish`   | Build Windows and upload to release server                                   |
 
-`dist:mac`, `dist:linux`, and `predist` run `dedupe:dist` before packaging. `dist:win` uses `scripts/dist-win-hoisted-install.mjs` and restores `node_modules` afterward.
+`dist:mac`, `dist:linux`, and `predist` run `dedupe:dist` (`scripts/dedupe-dist.mjs`) before packaging; that helper retries on transient `@jsr/_tmp_*` rename races. `dist:win` uses `scripts/dist-win-hoisted-install.mjs` and restores `node_modules` afterward.
 
 #### Building a Flatpak (Linux)
 
@@ -444,27 +444,27 @@ flatpak run --command=flatpak-builder-lint org.freedesktop.Sdk \
 
 #### Setup / helpers
 
-| Script                          | Description                                                    |
-| ------------------------------- | -------------------------------------------------------------- |
-| `clean`                         | Remove `dist-electron`, `dist`, and `node_modules`             |
-| `dedupe:dist`                   | Dedupe dependency tree before packaging (`predist` hook)       |
-| `i18n:auto-translate`           | Machine-translate missing locale keys (MyMemory default)       |
-| `i18n:prune-unused`             | Remove orphaned translation keys from locale files             |
-| `rebuild`                       | Rebuild native Node modules for Electron                       |
-| `release`                       | Maintainer release script (`scripts/release.sh`)               |
-| `reticulum:sidecar:build`       | Build debug `mesh-client-reticulum` (requires `cargo`)         |
-| `reticulum:sidecar:clippy`      | Clippy stub build (`-D warnings`)                              |
-| `reticulum:sidecar:clippy:full` | Clippy with `rns-stack,rns-ble,rns-rnode-tcp`                  |
-| `reticulum:sidecar:coverage`    | Optional HTML coverage via `cargo llvm-cov` (no CI threshold)  |
-| `reticulum:sidecar:dev`         | Run sidecar standalone on `127.0.0.1:19437`                    |
-| `reticulum:sidecar:fmt`         | `cargo fmt` in `reticulum-sidecar/`                            |
-| `reticulum:sidecar:fmt:check`   | `cargo fmt --check`                                            |
-| `reticulum:sidecar:test`        | Full-feature `cargo test` (clones Ratspeak siblings if needed) |
-| `reticulum:sidecar:test:full`   | Alias for `reticulum:sidecar:test`                             |
-| `setup:actionlint`              | Install actionlint for GitHub workflow linting                 |
-| `setup:build-deps`              | Install native build dependencies                              |
-| `setup:dialout`                 | Add user to dialout group for serial port access (Linux)       |
-| `update`                        | Update pnpm deps, Rust toolchain (rustup), rebuild sidecar     |
+| Script                          | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `clean`                         | Remove `dist-electron`, `dist`, and `node_modules`                    |
+| `dedupe:dist`                   | Retrying dist dedupe (`scripts/dedupe-dist.mjs`; `@jsr/_tmp_*` races) |
+| `i18n:auto-translate`           | Machine-translate missing locale keys (MyMemory default)              |
+| `i18n:prune-unused`             | Remove orphaned translation keys from locale files                    |
+| `rebuild`                       | Rebuild native Node modules for Electron                              |
+| `release`                       | Maintainer release script (`scripts/release.sh`)                      |
+| `reticulum:sidecar:build`       | Build debug `mesh-client-reticulum` (requires `cargo`)                |
+| `reticulum:sidecar:clippy`      | Clippy stub build (`-D warnings`)                                     |
+| `reticulum:sidecar:clippy:full` | Clippy with `rns-stack,rns-ble,rns-rnode-tcp`                         |
+| `reticulum:sidecar:coverage`    | Optional HTML coverage via `cargo llvm-cov` (no CI threshold)         |
+| `reticulum:sidecar:dev`         | Run sidecar standalone on `127.0.0.1:19437`                           |
+| `reticulum:sidecar:fmt`         | `cargo fmt` in `reticulum-sidecar/`                                   |
+| `reticulum:sidecar:fmt:check`   | `cargo fmt --check`                                                   |
+| `reticulum:sidecar:test`        | Full-feature `cargo test` (clones Ratspeak siblings if needed)        |
+| `reticulum:sidecar:test:full`   | Alias for `reticulum:sidecar:test`                                    |
+| `setup:actionlint`              | Install actionlint for GitHub workflow linting                        |
+| `setup:build-deps`              | Install native build dependencies                                     |
+| `setup:dialout`                 | Add user to dialout group for serial port access (Linux)              |
+| `update`                        | Update pnpm deps, Rust toolchain (rustup), rebuild sidecar            |
 
 #### Lifecycle (automatic)
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "check:url-hostname-sanitization": "node scripts/check-url-hostname-sanitization.mjs",
     "check:xss-patterns": "node scripts/check-xss-patterns.mjs",
     "clean": "rm -rf dist-electron dist node_modules",
-    "dedupe:dist": "pnpm dedupe --config.ignore-scripts=true",
+    "dedupe:dist": "node scripts/dedupe-dist.mjs",
     "dev": "node scripts/run-dev.mjs",
     "predist": "pnpm run dedupe:dist",
     "dist": "pnpm run build && electron-builder --publish never",

--- a/scripts/dedupe-dist.mjs
+++ b/scripts/dedupe-dist.mjs
@@ -30,6 +30,7 @@ export const DEDUPE_DIST_MAX_ATTEMPTS = 3;
  *   cleanTemps?: (root: string) => void;
  * }} [opts]
  * @returns {number} process exit status
+ * @throws {Error} when pnpm fails to launch (`spawnSync` `result.error`)
  */
 export function runDedupeDist(opts = {}) {
   const cwd = opts.cwd ?? projectRoot;
@@ -48,6 +49,10 @@ export function runDedupeDist(opts = {}) {
       stdio: 'inherit',
       shell: process.platform === 'win32',
     });
+    if (result.error) {
+      console.error('[dedupe-dist] failed to spawn pnpm:', result.error);
+      throw result.error;
+    }
     lastStatus = result.status ?? 1;
     if (lastStatus === 0) {
       return 0;

--- a/scripts/dedupe-dist.mjs
+++ b/scripts/dedupe-dist.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Dist packaging dedupe with retry on @jsr temp-dir rename races.
+ *
+ * Failure point: `pnpm dedupe` can hit ERR_PNPM_ENOENT renaming
+ * `node_modules/@jsr/_tmp_*` → `@jsr/meshtastic__core` (and similar) even when
+ * the lockfile is already fully deduped. Same root cause as Windows hoisted
+ * install and Flatpak offline install.
+ *
+ * Fallback: clean stale `@jsr/_tmp_*` dirs and retry.
+ */
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { cleanJsrTempDirs } from './clean-jsr-temp-dirs.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+/** Args passed to `pnpm` for dist dedupe (exported for contract tests). */
+export const DEDUPE_DIST_ARGS = ['dedupe', '--config.ignore-scripts=true'];
+
+export const DEDUPE_DIST_MAX_ATTEMPTS = 3;
+
+/**
+ * @param {{
+ *   cwd?: string;
+ *   maxAttempts?: number;
+ *   spawnPnpm?: typeof spawnSync;
+ *   cleanTemps?: (root: string) => void;
+ * }} [opts]
+ * @returns {number} process exit status
+ */
+export function runDedupeDist(opts = {}) {
+  const cwd = opts.cwd ?? projectRoot;
+  const maxAttempts = opts.maxAttempts ?? DEDUPE_DIST_MAX_ATTEMPTS;
+  const spawnPnpm = opts.spawnPnpm ?? spawnSync;
+  const cleanTemps = opts.cleanTemps ?? cleanJsrTempDirs;
+  let lastStatus = 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (attempt > 1) {
+      cleanTemps(path.join(cwd, 'node_modules'));
+    }
+
+    const result = spawnPnpm('pnpm', DEDUPE_DIST_ARGS, {
+      cwd,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    lastStatus = result.status ?? 1;
+    if (lastStatus === 0) {
+      return 0;
+    }
+    if (attempt < maxAttempts) {
+      console.warn(
+        `[dedupe-dist] pnpm dedupe failed (attempt ${attempt}/${maxAttempts}), retrying…`,
+      );
+    }
+  }
+
+  return lastStatus;
+}
+
+const isDirectRun =
+  process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  process.exit(runDedupeDist());
+}

--- a/scripts/dedupe-dist.test.mjs
+++ b/scripts/dedupe-dist.test.mjs
@@ -43,4 +43,23 @@ describe('dedupe-dist.mjs', () => {
     expect(status).toBe(1);
     expect(spawnPnpm).toHaveBeenCalledTimes(3);
   });
+
+  it('logs and throws when spawn fails to launch with null status', () => {
+    const err = Object.assign(new Error('spawn pnpm ENOENT'), { code: 'ENOENT' });
+    const spawnPnpm = vi.fn().mockReturnValue({ status: null, error: err });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() =>
+        runDedupeDist({
+          cwd: '/tmp/mesh-dedupe-fixture',
+          spawnPnpm,
+          cleanTemps: () => {},
+        }),
+      ).toThrow(err);
+      expect(errorSpy).toHaveBeenCalledWith('[dedupe-dist] failed to spawn pnpm:', err);
+      expect(spawnPnpm).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/scripts/dedupe-dist.test.mjs
+++ b/scripts/dedupe-dist.test.mjs
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it, vi } from 'vitest';
+import { DEDUPE_DIST_ARGS, DEDUPE_DIST_MAX_ATTEMPTS, runDedupeDist } from './dedupe-dist.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('dedupe-dist.mjs', () => {
+  it('skips install scripts during dist dedupe', () => {
+    expect(DEDUPE_DIST_ARGS).toEqual(['dedupe', '--config.ignore-scripts=true']);
+    expect(DEDUPE_DIST_MAX_ATTEMPTS).toBeGreaterThanOrEqual(3);
+  });
+
+  it('wires package.json dedupe:dist to the retry helper', () => {
+    const packageJson = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
+    expect(packageJson.scripts?.['dedupe:dist']).toBe('node scripts/dedupe-dist.mjs');
+  });
+
+  it('retries after cleaning @jsr temp dirs when pnpm dedupe fails', () => {
+    const cleaned = [];
+    const spawnPnpm = vi.fn().mockReturnValueOnce({ status: 1 }).mockReturnValueOnce({ status: 0 });
+    const status = runDedupeDist({
+      cwd: '/tmp/mesh-dedupe-fixture',
+      spawnPnpm,
+      cleanTemps: (root) => cleaned.push(root),
+    });
+    expect(status).toBe(0);
+    expect(spawnPnpm).toHaveBeenCalledTimes(2);
+    expect(cleaned).toEqual([path.join('/tmp/mesh-dedupe-fixture', 'node_modules')]);
+    expect(spawnPnpm.mock.calls[0]?.[1]).toEqual(DEDUPE_DIST_ARGS);
+  });
+
+  it('returns last failure status after exhausting retries', () => {
+    const spawnPnpm = vi.fn().mockReturnValue({ status: 1 });
+    const status = runDedupeDist({
+      cwd: '/tmp/mesh-dedupe-fixture',
+      maxAttempts: 3,
+      spawnPnpm,
+      cleanTemps: () => {},
+    });
+    expect(status).toBe(1);
+    expect(spawnPnpm).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap `dedupe:dist` in `scripts/dedupe-dist.mjs` that retries `pnpm dedupe --config.ignore-scripts=true` after cleaning stale `@jsr/_tmp_*` dirs (same race as Flatpak offline install / Windows hoisted install).
- Fixes [Build Binaries Linux failure](https://github.com/Colorado-Mesh/mesh-client/actions/runs/30602394942/job/91067690373) where packaging died on `ERR_PNPM_ENOENT` renaming a JSR temp dir to `@jsr/meshtastic__core`.

## Test plan
- [x] `pnpm exec vitest run scripts/dedupe-dist.test.mjs`
- [ ] Re-run **Build Binaries (no release)** and confirm `build (ubuntu-latest, pnpm run dist:linux)` passes `dedupe:dist`
- [ ] Confirm macOS `dist:mac` still completes packaging after dedupe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved distribution deduplication by retrying transient packaging failures.
  * Stale temporary directories are cleaned up between attempts, with clear final success or failure status.
  * Packaging commands now behave consistently across supported environments, including Windows.

* **Documentation**
  * Updated development setup documentation with cleanup, sidecar, setup, and retry details.

* **Tests**
  * Added automated coverage for retry handling, cleanup behavior, command configuration, and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->