### PR TITLE
fix(e2e): run CI env check after pnpm is available

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,9 +32,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check environment (pre-pnpm)
-        run: node scripts/check-environment.mjs
-
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
 
@@ -42,6 +39,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      # After toolchain is on PATH; skip node_modules until install (still fatal on git/node/pnpm).
+      - name: Check environment (pre-install)
+        run: node scripts/check-environment.mjs --skip-node-modules
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -61,7 +61,7 @@ Test results are available as a downloadable artifact from the workflow run.
 
 Not a PR gate. Runs on a **daily schedule** (default branch only) and on **manual** `workflow_dispatch`:
 
-1. Checkout (`persist-credentials: false`), `node scripts/check-environment.mjs`, setup pnpm + Node 22, `pnpm install --frozen-lockfile`, then `pnpm run check:environment` (`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`)
+1. Checkout (`persist-credentials: false`), setup pnpm + Node 22, `node scripts/check-environment.mjs --skip-node-modules`, `pnpm install --frozen-lockfile`, then `pnpm run check:environment` (`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`)
 2. Linux (`ubuntu-24.04`): install Electron runtime libraries (`libatk-bridge2.0-0t64`, `libgtk-3-0t64`, `libasound2t64`, …) + `xvfb`
 3. `pnpm run build` (unpackaged `dist-electron` + renderer)
 4. `pnpm run test:e2e` (Linux under `xvfb-run -a`; macOS/Windows plain) — Playwright launches the local Electron binary via `resolveLocalElectronBin()` with an isolated `--user-data-dir`

--- a/scripts/check-environment.mjs
+++ b/scripts/check-environment.mjs
@@ -692,6 +692,16 @@ function checkLinuxDialout() {
 }
 
 /**
+ * @param {string[]} argv
+ * @returns {{ skipNodeModules: boolean }}
+ */
+export function parseCheckEnvironmentArgs(argv = process.argv.slice(2)) {
+  return {
+    skipNodeModules: argv.includes('--skip-node-modules'),
+  };
+}
+
+/**
  * @returns {CheckResult[]}
  */
 export function runChecks(options = {}) {
@@ -745,9 +755,13 @@ function printSummary(checks) {
 
 function main() {
   const platformLabel = PLATFORM_LABELS[process.platform] ?? process.platform;
+  const args = parseCheckEnvironmentArgs();
   console.log(`Mesh Client environment check (platform: ${platformLabel})\n`);
+  if (args.skipNodeModules) {
+    console.log('(skipping node_modules check — pre-install mode)\n');
+  }
 
-  const checks = runChecks();
+  const checks = runChecks({ skipNodeModules: args.skipNodeModules });
 
   for (const check of checks) {
     for (const line of formatCheckResult(check)) {

--- a/scripts/check-environment.test.mjs
+++ b/scripts/check-environment.test.mjs
@@ -6,10 +6,23 @@ import {
   formatLocalActDockerNote,
   evaluateContainerEngineCheck,
   evaluatePlaywrightCheck,
+  parseCheckEnvironmentArgs,
   parseVersion,
   resolveExitCode,
   versionGte,
 } from './check-environment.mjs';
+
+describe('check-environment parseCheckEnvironmentArgs', () => {
+  it('defaults skipNodeModules to false', () => {
+    expect(parseCheckEnvironmentArgs([])).toEqual({ skipNodeModules: false });
+  });
+
+  it('enables skipNodeModules for --skip-node-modules', () => {
+    expect(parseCheckEnvironmentArgs(['--skip-node-modules'])).toEqual({
+      skipNodeModules: true,
+    });
+  });
+});
 
 describe('check-environment parseVersion', () => {
   it('parses v-prefixed semver strings', () => {


### PR DESCRIPTION
## Summary
- E2E workflow run [30665649217](https://github.com/Colorado-Mesh/mesh-client/actions/runs/30665649217) failed on all OSes at **Check environment (pre-pnpm)** because required checks expect `pnpm` and `node_modules` before either exists.
- Move the pre-install env check to after pnpm/Node setup and add `--skip-node-modules` so git/node/pnpm are still fatal without requiring deps.
- Keep the full post-install `pnpm run check:environment` gate unchanged.

## Test plan
- [x] `pnpm exec vitest run scripts/check-environment.test.mjs`
- [x] `node scripts/check-environment.mjs --skip-node-modules` exits 0 locally
- [ ] Actions → E2E → Run workflow — green on ubuntu-24.04 / macos / windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment validation during Electron end-to-end workflow setup.
  * Initial checks can now run before dependencies are installed without incorrectly requiring the dependency directory.

* **Documentation**
  * Updated CI/CD guidance to configure pnpm and Node 22 before running the initial environment check.

* **Tests**
  * Added coverage for optional dependency-directory validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->