### PR TITLE
fix(reticulum): make Nomad page loads reliable over TCP hubs

### DIFF
--- a/reticulum-sidecar/patches/README.md
+++ b/reticulum-sidecar/patches/README.md
@@ -162,6 +162,21 @@ git -C /tmp/rsReticulum-patch-test diff \
 
 When [ratspeak/rsReticulum#14](https://github.com/ratspeak/rsReticulum/pull/14) merges, remove this patch and drop the apply step from `clone-ratspeak-stack.sh` / `ensure-rsReticulum-patches.sh`.
 
+## rsReticulum-link-client-proof-budget.patch
+
+Cap `LinkClient::query` proof wait at `link.establishment_timeout` so a cached path cannot burn the entire overall Nomad deadline (MeshChat TCP link stage ~15s). Apply **after** the LinkClient Nomad overlay.
+
+| Field | Value |
+| ----- | ----- |
+| **Depends on** | `rsReticulum-link-client-nomad.patch` |
+| **Upstream PR** | (mesh-client local; fold into #14 follow-up when possible) |
+
+### Apply locally
+
+```bash
+./scripts/apply-rsReticulum-link-client-proof-budget.sh
+```
+
 ## Removed: rsReticulum-rnode-tcp-activity-keepalive.patch
 
 Sunset when upstream landed `RNodeIdleProbe` (`88d3d38` — *rnode: restore TCP application idle probes*). [ratspeak/rsReticulum#15](https://github.com/ratspeak/rsReticulum/pull/15) was closed as superseded; mesh-client no longer carries that overlay (pin `9928abed269a83ec5a7ef165ff1142d938cad706` or later already includes idle probes). Tracked entry removed from `RATSPEAK_PATCH_ENTRIES` in `scripts/update.sh` after sunset confirmation.

--- a/reticulum-sidecar/patches/rsReticulum-link-client-proof-budget.patch
+++ b/reticulum-sidecar/patches/rsReticulum-link-client-proof-budget.patch
@@ -1,10 +1,8 @@
 diff --git a/crates/rns-runtime/src/link_client.rs b/crates/rns-runtime/src/link_client.rs
-index c024504..e2acbb1 100644
 --- a/crates/rns-runtime/src/link_client.rs
 +++ b/crates/rns-runtime/src/link_client.rs
-@@ -101,7 +101,12 @@ impl LinkClient {
-             destination_hash: dest_hash,
-         })
+@@ -101,7 +101,11 @@ impl LinkClient {
+         }))
          .await?;
  
 -        let proof_data = wait_for_proof(&mut dest_rx, link_id, time_remaining(deadline)?).await?;
@@ -16,4 +14,3 @@ index c024504..e2acbb1 100644
  
          let identity_ed25519_pub: [u8; 32] = pubkey[32..64].try_into().map_err(|_| {
              LinkClientError::ProofInvalid("remote public key is not 64 bytes".into())
-         })?;

--- a/reticulum-sidecar/patches/rsReticulum-link-client-proof-budget.patch
+++ b/reticulum-sidecar/patches/rsReticulum-link-client-proof-budget.patch
@@ -1,0 +1,19 @@
+diff --git a/crates/rns-runtime/src/link_client.rs b/crates/rns-runtime/src/link_client.rs
+index c024504..e2acbb1 100644
+--- a/crates/rns-runtime/src/link_client.rs
++++ b/crates/rns-runtime/src/link_client.rs
+@@ -101,7 +101,12 @@ impl LinkClient {
+             destination_hash: dest_hash,
+         })
+         .await?;
+ 
+-        let proof_data = wait_for_proof(&mut dest_rx, link_id, time_remaining(deadline)?).await?;
++        // Cap proof wait at link establishment timeout (6s × hops). Otherwise a
++        // cached path lets wait_for_proof burn the entire overall deadline
++        // (e.g. TCP 45s) even when MeshChat would fail the link stage in ~15s.
++        let proof_budget = time_remaining(deadline)?.min(link.establishment_timeout);
++        let proof_data = wait_for_proof(&mut dest_rx, link_id, proof_budget).await?;
+ 
+         let identity_ed25519_pub: [u8; 32] = pubkey[32..64].try_into().map_err(|_| {
+             LinkClientError::ProofInvalid("remote public key is not 64 bytes".into())
+         })?;

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -818,6 +818,7 @@ impl LiveBridge {
     /// required by `LinkClient::query` to rebuild the `nomadnetwork.node`
     /// destination on our side.
     /// Returns page/file bytes plus the egress atom and overall timeout used for the Link.
+    /// Remote errors after egress is known include that atom so the UI countdown can update.
     async fn query_nomad_node(
         &self,
         hash_hex: &str,
@@ -826,8 +827,8 @@ impl LiveBridge {
         payload: Vec<u8>,
         interfaces: &[InterfaceRow],
         force_path_refresh: bool,
-    ) -> Result<(Vec<u8>, &'static str, u64), String> {
-        let remote_hash = parse_hash16(identity_hash_hex)?;
+    ) -> Result<(Vec<u8>, &'static str, u64), (String, Option<&'static str>)> {
+        let remote_hash = parse_hash16(identity_hash_hex).map_err(|e| (e, None))?;
         // Prefer path-peer cache (maintenance refreshes every ~2s). Avoid a synchronous
         // GetPathTable here — that control query alone can stall TCP page loads for seconds.
         let key = hash_hex.to_lowercase();
@@ -879,7 +880,7 @@ impl LiveBridge {
             self.primary_local_serial_id().as_deref(),
         );
         if !nomad_timeouts::nomad_remote_network_ready(interfaces, path_iface.as_deref()) {
-            return Err("network_not_ready".into());
+            return Err(("network_not_ready".into(), Some(egress)));
         }
         let link_hops = nomad_timeouts::nomad_link_initiator_hops(egress, hops);
         // Preempt the prior Link query so switching Nomad nodes does not wait
@@ -902,10 +903,10 @@ impl LiveBridge {
             if self.nomad_link_generation.load(Ordering::SeqCst) == my_gen {
                 *self.nomad_link_cancel.lock().await = None;
             }
-            return Err("nomad_busy".into());
+            return Err(("nomad_busy".into(), Some(egress)));
         };
         if self.nomad_link_generation.load(Ordering::SeqCst) != my_gen {
-            return Err("nomad_busy".into());
+            return Err(("nomad_busy".into(), Some(egress)));
         }
         let client = LinkClient::new(self.handle.transport_tx.clone(), self.identity.clone());
         let query_fut = client.query(
@@ -926,7 +927,9 @@ impl LiveBridge {
         if self.nomad_link_generation.load(Ordering::SeqCst) == my_gen {
             *self.nomad_link_cancel.lock().await = None;
         }
-        result.map(|bytes| (bytes, egress, timeout_secs))
+        result
+            .map(|bytes| (bytes, egress, timeout_secs))
+            .map_err(|e| (e, Some(egress)))
     }
 
     pub async fn fetch_nomad_file(
@@ -987,10 +990,7 @@ impl LiveBridge {
                     "timeout_secs": timeout_secs,
                 })
             }
-            Err(e) => serde_json::json!({
-                "ok": false,
-                "error": e,
-            }),
+            Err((e, egress)) => nomad_remote_error_json(&e, egress),
         }
     }
 
@@ -1067,10 +1067,7 @@ impl LiveBridge {
                     "timeout_secs": timeout_secs,
                 })
             }
-            Err(e) => serde_json::json!({
-                "ok": false,
-                "error": e,
-            }),
+            Err((e, egress)) => nomad_remote_error_json(&e, egress),
         }
     }
 
@@ -3443,6 +3440,14 @@ fn resolve_inbound_sender_name_map(names: &HashMap<String, String>, sender_hash:
         .unwrap_or_else(|| prefix.to_string())
 }
 
+/// Remote Nomad page/file error JSON; include path-aware egress when known.
+fn nomad_remote_error_json(error: &str, egress: Option<&'static str>) -> serde_json::Value {
+    match egress {
+        Some(egress) => serde_json::json!({ "ok": false, "error": error, "egress": egress }),
+        None => serde_json::json!({ "ok": false, "error": error }),
+    }
+}
+
 /// After a forced DropPath, accept a path only once it has been observed absent
 /// and then reinstalled — otherwise the first refresh succeeds on the stale route.
 fn force_path_refresh_accepts_current_path(
@@ -3742,6 +3747,20 @@ mod announce_display_name_tests {
         // Non-force discovery with a path present — accept.
         let has_path = true;
         assert!(has_path && force_path_refresh_accepts_current_path(false, false, false));
+    }
+
+    #[test]
+    fn nomad_remote_error_json_includes_egress_when_known() {
+        let with_egress = nomad_remote_error_json("link_timeout", Some("tcp"));
+        assert_eq!(with_egress["ok"], false);
+        assert_eq!(with_egress["error"], "link_timeout");
+        assert_eq!(with_egress["egress"], "tcp");
+        assert!(with_egress.get("timeout_secs").is_none());
+
+        let without = nomad_remote_error_json("missing_identity_hash", None);
+        assert_eq!(without["ok"], false);
+        assert_eq!(without["error"], "missing_identity_hash");
+        assert!(without.get("egress").is_none());
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -2022,17 +2022,22 @@ impl LiveBridge {
             return true;
         }
         // Forced refresh: only accept a path that passed the same absence gate as
-        // the wait loop — never the never-invalidated stale route.
+        // the wait loop — never the never-invalidated stale route (unless Nomad
+        // fall-through via accept_existing_on_timeout).
         let _ = self.refresh_outbound_path_table().await;
         let has_path = self
             .outbound
             .lock()
             .map(|d| d.has_path_to(destination_hex))
             .unwrap_or(false);
+        let accept = force_path_refresh_timeout_accepts(
+            force,
+            already,
+            has_path,
+            saw_path_absent,
+            accept_existing_on_timeout,
+        );
         if force && already {
-            let accept = has_path
-                && (force_path_refresh_accepts_current_path(force, already, saw_path_absent)
-                    || accept_existing_on_timeout);
             tracing::info!(
                 target: "propagation-sync",
                 dest = %destination_hex,
@@ -2043,13 +2048,8 @@ impl LiveBridge {
                 accept_existing_on_timeout,
                 "path refresh timed out after dropping cached route"
             );
-            return accept;
         }
-        // Non-force miss, or force with no path at start: accept any path that appeared.
-        if accept_existing_on_timeout && has_path {
-            return true;
-        }
-        false
+        accept
     }
 
     /// Ensure destination public key is known before choosing Direct delivery.
@@ -3456,6 +3456,30 @@ fn force_path_refresh_accepts_current_path(
     saw_path_absent
 }
 
+/// Timeout decision for [`LiveStack::ensure_path_for_direct_with_opts`].
+///
+/// When `accept_existing_on_timeout` is set (Nomad force refresh), a path that
+/// never went absent may still be accepted so the Link attempt can proceed
+/// inside the overall budget.
+#[allow(clippy::fn_params_excessive_bools)] // mirrors ensure_path wait-loop flags
+fn force_path_refresh_timeout_accepts(
+    force: bool,
+    had_path_at_start: bool,
+    has_path: bool,
+    saw_path_absent: bool,
+    accept_existing_on_timeout: bool,
+) -> bool {
+    if !has_path {
+        return false;
+    }
+    if force && had_path_at_start {
+        return force_path_refresh_accepts_current_path(force, had_path_at_start, saw_path_absent)
+            || accept_existing_on_timeout;
+    }
+    // Non-force miss, or force with no path at start: accept any path that appeared.
+    accept_existing_on_timeout
+}
+
 /// Hashes present in `next` but not in `prev` (path-table membership growth).
 fn path_table_added_hashes(prev: &HashSet<String>, next: &HashSet<String>) -> Vec<String> {
     next.difference(prev).cloned().collect()
@@ -3718,6 +3742,33 @@ mod announce_display_name_tests {
         // Non-force discovery with a path present — accept.
         let has_path = true;
         assert!(has_path && force_path_refresh_accepts_current_path(false, false, false));
+    }
+
+    #[test]
+    fn force_path_refresh_timeout_accepts_fallthrough_when_never_absent() {
+        // Nomad force refresh: path never left the table, but fall-through is on.
+        assert!(force_path_refresh_timeout_accepts(
+            true, true, true, false, true
+        ));
+        // Same never-absent stale route without fall-through must reject.
+        assert!(!force_path_refresh_timeout_accepts(
+            true, true, true, false, false
+        ));
+        // Absence observed then path back — accept even without fall-through.
+        assert!(force_path_refresh_timeout_accepts(
+            true, true, true, true, false
+        ));
+        // No path at timeout — never accept.
+        assert!(!force_path_refresh_timeout_accepts(
+            true, true, false, true, true
+        ));
+        // Force started without a path: fall-through accepts whatever appeared.
+        assert!(force_path_refresh_timeout_accepts(
+            true, false, true, false, true
+        ));
+        assert!(!force_path_refresh_timeout_accepts(
+            true, false, true, false, false
+        ));
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -119,6 +119,10 @@ pub struct LiveBridge {
     /// Serialize Nomad Link queries — transport actor is single-threaded and
     /// overlapping page/file fetches contend with path/pubkey discovery.
     nomad_link_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Cancel in-flight Nomad Link when a newer page selection arrives (renderer
+    /// debounce coalesces clicks; leaving the Nomad tab does not cancel).
+    nomad_link_cancel: Arc<tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
+    nomad_link_generation: Arc<AtomicU64>,
     rrc_session: Arc<RrcSessionManager>,
     rnsh_session: Arc<RnshSessionManager>,
     rncp_transfer: Arc<RncpTransferManager>,
@@ -445,6 +449,8 @@ impl LiveBridge {
             packet_log,
             inbound_lxmf,
             nomad_link_lock: Arc::new(tokio::sync::Mutex::new(())),
+            nomad_link_cancel: Arc::new(tokio::sync::Mutex::new(None)),
+            nomad_link_generation: Arc::new(AtomicU64::new(0)),
             rrc_session: Arc::new(RrcSessionManager::spawn(
                 handle.transport_tx.clone(),
                 identity.clone(),
@@ -811,6 +817,7 @@ impl LiveBridge {
     /// hash recovered from its announce (`AnnounceHandlerEvent::identity_hash`),
     /// required by `LinkClient::query` to rebuild the `nomadnetwork.node`
     /// destination on our side.
+    /// Returns page/file bytes plus the egress atom and overall timeout used for the Link.
     async fn query_nomad_node(
         &self,
         hash_hex: &str,
@@ -819,38 +826,107 @@ impl LiveBridge {
         payload: Vec<u8>,
         interfaces: &[InterfaceRow],
         force_path_refresh: bool,
-    ) -> Result<Vec<u8>, String> {
+    ) -> Result<(Vec<u8>, &'static str, u64), String> {
+        let remote_hash = parse_hash16(identity_hash_hex)?;
+        // Prefer path-peer cache (maintenance refreshes every ~2s). Avoid a synchronous
+        // GetPathTable here — that control query alone can stall TCP page loads for seconds.
+        let key = hash_hex.to_lowercase();
+        let read_path_cache = || -> (Option<u8>, Option<String>) {
+            let mut hops = None;
+            let mut iface = None;
+            if let Ok(cache) = self.path_peer_cache.lock() {
+                if let Some(peer) = cache.iter().find(|p| p.destination_hash == key) {
+                    hops = peer.hops;
+                    iface = peer.interface.clone().filter(|n| !n.is_empty());
+                }
+            }
+            if iface.is_none() {
+                iface = self.path_interface_for_hash(&key);
+            }
+            (hops, iface)
+        };
+        let (mut cached_hops, mut path_iface) = read_path_cache();
         // Stale cached hops often survive LinkClient pubkey recall; force a
-        // RequestPath on retry so the second attempt is not a no-op.
+        // RequestPath on retry so the second attempt is not a no-op. Nomad uses a
+        // shorter wait and may fall through on never-absent hub routes.
         if force_path_refresh {
-            let path_ok = self.ensure_path_for_direct(hash_hex, true).await;
+            let path_ok = self
+                .ensure_path_for_direct_with_opts(
+                    hash_hex,
+                    true,
+                    NOMAD_FORCE_PATH_REFRESH_WAIT,
+                    true,
+                )
+                .await;
             tracing::info!(
                 target: "nomad",
                 dest = %hash_hex,
                 path_ok,
                 "forced path refresh before Nomad query"
             );
+            let refreshed = read_path_cache();
+            cached_hops = refreshed.0;
+            path_iface = refreshed.1;
         }
-        let remote_hash = parse_hash16(identity_hash_hex)?;
-        let hops = self.hops_to_destination(hash_hex).await.unwrap_or(8);
-        let timeout_secs = nomad_timeouts::nomad_page_timeout_secs_for_interfaces(interfaces, hops);
+        let hops = match cached_hops {
+            Some(h) => h,
+            None => self.hops_to_destination(hash_hex).await.unwrap_or(8),
+        };
+        let (timeout_secs, egress) = nomad_timeouts::resolve_nomad_page_timeout_secs(
+            interfaces,
+            hops,
+            path_iface.as_deref(),
+            self.primary_local_serial_id().as_deref(),
+        );
+        if !nomad_timeouts::nomad_remote_network_ready(interfaces, path_iface.as_deref()) {
+            return Err("network_not_ready".into());
+        }
+        let link_hops = nomad_timeouts::nomad_link_initiator_hops(egress, hops);
+        // Preempt the prior Link query so switching Nomad nodes does not wait
+        // for the full TCP/RF deadline (or crash the HTTP client mid-query).
+        let my_gen = self
+            .nomad_link_generation
+            .fetch_add(1, Ordering::SeqCst)
+            .wrapping_add(1);
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+        {
+            let mut slot = self.nomad_link_cancel.lock().await;
+            if let Some(prev) = slot.take() {
+                let _ = prev.send(());
+            }
+            *slot = Some(cancel_tx);
+        }
         let Ok(_guard) =
             tokio::time::timeout(NOMAD_LINK_LOCK_WAIT, self.nomad_link_lock.lock()).await
         else {
+            if self.nomad_link_generation.load(Ordering::SeqCst) == my_gen {
+                *self.nomad_link_cancel.lock().await = None;
+            }
             return Err("nomad_busy".into());
         };
+        if self.nomad_link_generation.load(Ordering::SeqCst) != my_gen {
+            return Err("nomad_busy".into());
+        }
         let client = LinkClient::new(self.handle.transport_tx.clone(), self.identity.clone());
-        client
-            .query(
-                remote_hash,
-                NOMAD_NODE_ASPECT,
-                path,
-                payload,
-                hops,
-                Duration::from_secs(timeout_secs),
-            )
-            .await
-            .map_err(|e| map_nomad_link_error(&format!("{e}")))
+        let query_fut = client.query(
+            remote_hash,
+            NOMAD_NODE_ASPECT,
+            path,
+            payload,
+            link_hops,
+            Duration::from_secs(timeout_secs),
+        );
+        let result = tokio::select! {
+            biased;
+            _ = cancel_rx => Err("nomad_busy".into()),
+            query_result = query_fut => {
+                query_result.map_err(|e| map_nomad_link_error(&format!("{e}")))
+            }
+        };
+        if self.nomad_link_generation.load(Ordering::SeqCst) == my_gen {
+            *self.nomad_link_cancel.lock().await = None;
+        }
+        result.map(|bytes| (bytes, egress, timeout_secs))
     }
 
     pub async fn fetch_nomad_file(
@@ -882,6 +958,9 @@ impl LiveBridge {
         let Some(identity_hash_hex) = identity_hash_hex.filter(|s| !s.is_empty()) else {
             return serde_json::json!({ "ok": false, "error": "missing_identity_hash" });
         };
+        if self.is_own_identity_hash(identity_hash_hex) {
+            return serde_json::json!({ "ok": false, "error": "nomad_not_serving" });
+        }
         match self
             .query_nomad_node(
                 hash_hex,
@@ -893,7 +972,7 @@ impl LiveBridge {
             )
             .await
         {
-            Ok(bytes) => {
+            Ok((bytes, egress, timeout_secs)) => {
                 if bytes.len() > NOMAD_FILE_MAX_BYTES {
                     return serde_json::json!({ "ok": false, "error": "response_too_large" });
                 }
@@ -904,6 +983,8 @@ impl LiveBridge {
                     "ok": true,
                     "file_name": file_name,
                     "content_base64": content_base64,
+                    "egress": egress,
+                    "timeout_secs": timeout_secs,
                 })
             }
             Err(e) => serde_json::json!({
@@ -941,6 +1022,8 @@ impl LiveBridge {
                         "ok": true,
                         "content": content,
                         "content_type": content_type,
+                        "egress": "local",
+                        "timeout_secs": 0,
                     })
                 }
                 Err(e) => serde_json::json!({ "ok": false, "error": e }),
@@ -949,6 +1032,11 @@ impl LiveBridge {
         let Some(identity_hash_hex) = identity_hash_hex.filter(|s| !s.is_empty()) else {
             return serde_json::json!({ "ok": false, "error": "missing_identity_hash" });
         };
+        // Own Nomad announce can echo back via the mesh (multi-hop). Never open a
+        // Link to ourselves — require My Pages hosting for local preview.
+        if self.is_own_identity_hash(identity_hash_hex) {
+            return serde_json::json!({ "ok": false, "error": "nomad_not_serving" });
+        }
         let payload = nomad_page_request_payload(data_b64);
         match self
             .query_nomad_node(
@@ -961,7 +1049,7 @@ impl LiveBridge {
             )
             .await
         {
-            Ok(bytes) => {
+            Ok((bytes, egress, timeout_secs)) => {
                 if bytes.len() > NOMAD_PAGE_MAX_BYTES {
                     return serde_json::json!({ "ok": false, "error": "response_too_large" });
                 }
@@ -975,6 +1063,8 @@ impl LiveBridge {
                     "ok": true,
                     "content": content,
                     "content_type": content_type,
+                    "egress": egress,
+                    "timeout_secs": timeout_secs,
                 })
             }
             Err(e) => serde_json::json!({
@@ -982,6 +1072,10 @@ impl LiveBridge {
                 "error": e,
             }),
         }
+    }
+
+    fn is_own_identity_hash(&self, identity_hash_hex: &str) -> bool {
+        identity_hash_hex.eq_ignore_ascii_case(&self.identity_hash_hex())
     }
 
     async fn query_control_timed(&self, query: TransportQuery) -> Option<TransportQueryResponse> {
@@ -1021,6 +1115,7 @@ impl LiveBridge {
     ) {
         let transport_tx = self.handle.transport_tx.clone();
         let event_tx = self.event_tx.clone();
+        let our_identity_hash = self.identity_hash_hex();
         tokio::spawn(async move {
             let (callback_tx, mut callback_rx) =
                 tokio::sync::mpsc::channel::<AnnounceHandlerEvent>(64);
@@ -1041,7 +1136,15 @@ impl LiveBridge {
                 let hash_hex = hex::encode(evt.destination_hash);
                 let identity_hash_hex = evt.identity_hash.map(hex::encode);
                 let display_name = parse_announce_display_name(evt.app_data.as_deref());
-                let hops = Some(evt.hops);
+                // Own Nomad announces often reappear via multi-hop path-table echoes.
+                let hops = if identity_hash_hex
+                    .as_ref()
+                    .is_some_and(|id| id.eq_ignore_ascii_case(&our_identity_hash))
+                {
+                    Some(0)
+                } else {
+                    Some(evt.hops)
+                };
                 let payload = {
                     let mut state = inner.write().await;
                     state.upsert_nomad_node(
@@ -1056,7 +1159,7 @@ impl LiveBridge {
                     serde_json::json!({
                         "destination_hash": hash_hex,
                         "display_name": display_name,
-                        "hops": evt.hops,
+                        "hops": hops.unwrap_or(0),
                     })
                 };
                 let frame = serde_json::json!({ "type": "nomadnetwork.node", "payload": payload });
@@ -1831,6 +1934,20 @@ impl LiveBridge {
     /// When `force` is true, drop any cached path and RequestPath so we wait for a
     /// fresh route response instead of returning on the stale `has_path_to` entry.
     async fn ensure_path_for_direct(&self, destination_hex: &str, force: bool) -> bool {
+        self.ensure_path_for_direct_with_opts(destination_hex, force, Duration::from_secs(8), false)
+            .await
+    }
+
+    /// Like [`Self::ensure_path_for_direct`], with a custom wait and optional
+    /// fall-through when a forced DropPath never observes path absence (common
+    /// on TCP hub routes that reinstall immediately).
+    async fn ensure_path_for_direct_with_opts(
+        &self,
+        destination_hex: &str,
+        force: bool,
+        max_wait: Duration,
+        accept_existing_on_timeout: bool,
+    ) -> bool {
         let already = self
             .outbound
             .lock()
@@ -1875,7 +1992,7 @@ impl LiveBridge {
                 destination_hash: dest,
             })
             .await;
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+        let deadline = tokio::time::Instant::now() + max_wait;
         while tokio::time::Instant::now() < deadline {
             let _ = self.refresh_outbound_path_table().await;
             let has_path = self
@@ -1914,7 +2031,8 @@ impl LiveBridge {
             .unwrap_or(false);
         if force && already {
             let accept = has_path
-                && force_path_refresh_accepts_current_path(force, already, saw_path_absent);
+                && (force_path_refresh_accepts_current_path(force, already, saw_path_absent)
+                    || accept_existing_on_timeout);
             tracing::info!(
                 target: "propagation-sync",
                 dest = %destination_hex,
@@ -1922,9 +2040,14 @@ impl LiveBridge {
                 has_path,
                 saw_path_absent,
                 accept,
+                accept_existing_on_timeout,
                 "path refresh timed out after dropping cached route"
             );
             return accept;
+        }
+        // Non-force miss, or force with no path at start: accept any path that appeared.
+        if accept_existing_on_timeout && has_path {
+            return true;
         }
         false
     }
@@ -3419,7 +3542,13 @@ fn insert_display_name_bounded(cache: &mut HashMap<String, String>, hash: String
 const NOMAD_PAGE_MAX_BYTES: usize = 512 * 1024;
 /// Cap Nomad file body before base64 (aligned with Axum 4 MiB body limit).
 const NOMAD_FILE_MAX_BYTES: usize = 4 * 1024 * 1024;
-const NOMAD_LINK_LOCK_WAIT: Duration = Duration::from_secs(2);
+/// After preempting the prior query, allow time for LinkClient to unwind and
+/// release the lock before surfacing `nomad_busy` to a newer request.
+/// Wait for a preempted Nomad Link query to unwind (not the full page budget).
+const NOMAD_LINK_LOCK_WAIT: Duration = Duration::from_secs(8);
+
+/// Cap DropPath + rediscover before a Nomad Link attempt (inside overall TCP budget).
+const NOMAD_FORCE_PATH_REFRESH_WAIT: Duration = Duration::from_secs(4);
 
 fn path_table_added_hashes_capped(prev: &HashSet<String>, next: &HashSet<String>) -> Vec<String> {
     let mut added = path_table_added_hashes(prev, next);

--- a/reticulum-sidecar/src/stack/mod.rs
+++ b/reticulum-sidecar/src/stack/mod.rs
@@ -1267,7 +1267,22 @@ impl StackHandle {
     }
 
     pub async fn list_nomad_nodes(&self) -> Vec<NomadNodeRow> {
-        self.inner.read().await.nomad_nodes.clone()
+        let mut nodes = self.inner.read().await.nomad_nodes.clone();
+        // Own Nomad announces often sit in the path table as multi-hop echoes.
+        #[cfg(feature = "rns-stack")]
+        if let Some(live) = &self.live {
+            let our_id = live.identity_hash_hex();
+            for node in &mut nodes {
+                if node
+                    .identity_hash
+                    .as_ref()
+                    .is_some_and(|id| id.eq_ignore_ascii_case(&our_id))
+                {
+                    node.hops = Some(0);
+                }
+            }
+        }
+        nodes
     }
 
     pub async fn set_nomad_favorite(&self, hash: &str, favorited: bool) -> Result<(), String> {

--- a/reticulum-sidecar/src/stack/nomad_timeouts.rs
+++ b/reticulum-sidecar/src/stack/nomad_timeouts.rs
@@ -30,7 +30,8 @@ fn bounded_hops(hops: u8) -> u64 {
 
 /// Overall sidecar Link query deadline in seconds.
 pub fn nomad_page_overall_timeout_secs(egress_via: &str, hops: u8) -> u64 {
-    if egress_via == "rf" {
+    // BLE RNode uses the same per-hop Link budget as USB RF (not TCP MeshChat stages).
+    if egress_via == "rf" || egress_via == "ble" {
         let bounded_hops = bounded_hops(hops);
         let link_establish = NOMAD_RF_FIRST_HOP_SECS + NOMAD_RF_PER_HOP_TIMEOUT_SECS * bounded_hops;
         let total = NOMAD_PATH_LOOKUP_SECS + link_establish + NOMAD_RF_TRANSFER_GRACE_SECS;
@@ -41,9 +42,80 @@ pub fn nomad_page_overall_timeout_secs(egress_via: &str, hops: u8) -> u64 {
 }
 
 /// Resolve egress from enabled interfaces and compute overall timeout.
+/// Prefer [`resolve_nomad_page_timeout_secs`] with a path-table interface when known —
+/// a local BLE/RNode being enabled must not force RF budgets for TCP-routed peers.
+#[allow(dead_code)] // kept for tests + call sites that lack a path interface
 pub fn nomad_page_timeout_secs_for_interfaces(interfaces: &[InterfaceRow], hops: u8) -> u64 {
     let egress = resolve_outbound_sent_via(interfaces);
     nomad_page_overall_timeout_secs(egress, hops)
+}
+
+/// Timeout for a Nomad page/file Link query.
+/// When `path_interface` is known (path table), classify that interface; otherwise
+/// fall back to local outbound capability (may prefer RF/BLE).
+pub fn resolve_nomad_page_timeout_secs(
+    interfaces: &[InterfaceRow],
+    hops: u8,
+    path_interface: Option<&str>,
+    primary_local_serial_id: Option<&str>,
+) -> (u64, &'static str) {
+    let egress =
+        super::via::resolve_lxmf_sent_via(path_interface, interfaces, primary_local_serial_id);
+    // resolve_lxmf_sent_via returns owned String; map to static atom for logging.
+    let atom: &'static str = match egress.as_str() {
+        "ble" => "ble",
+        "rf" => "rf",
+        "tcp" => "tcp",
+        _ => "network",
+    };
+    (nomad_page_overall_timeout_secs(atom, hops), atom)
+}
+
+/// Hops passed to `Link::new_initiator` (scales establishment timeout at 6s/hop).
+///
+/// MeshChat uses a flat 15s TCP link establishment timeout. Path-table hops on
+/// hub routes are often inflated (e.g. 8) and must not stretch proof waits to
+/// ~48s / the full overall TCP budget.
+pub fn nomad_link_initiator_hops(egress_via: &str, path_hops: u8) -> u8 {
+    if egress_via == "rf" || egress_via == "ble" {
+        path_hops.clamp(1, 32)
+    } else {
+        // 3 × 6s = 18s ≈ MeshChat TCP link_establishment_timeout (15s).
+        const TCP_LINK_INITIATOR_HOPS: u8 = 3;
+        path_hops.clamp(1, TCP_LINK_INITIATOR_HOPS)
+    }
+}
+
+fn interface_status_live(status: &str) -> bool {
+    matches!(
+        status.to_ascii_lowercase().as_str(),
+        "up" | "connected" | "online" | "running"
+    )
+}
+
+/// True when a remote Nomad Link has a plausible egress (path iface known, or any
+/// enabled RF/BLE/TCP interface is live). Avoids burning the full Link budget when
+/// the stack is up but hubs are still connecting.
+pub fn nomad_remote_network_ready(
+    interfaces: &[InterfaceRow],
+    path_interface: Option<&str>,
+) -> bool {
+    if path_interface.is_some_and(|n| !n.is_empty()) {
+        return true;
+    }
+    interfaces.iter().any(|iface| {
+        if !iface.enabled || !interface_status_live(&iface.status) {
+            return false;
+        }
+        matches!(
+            super::via::classify_interface_row(
+                &iface.iface_type,
+                &iface.name,
+                iface.serial_port.as_deref(),
+            ),
+            "tcp" | "rf" | "ble" | "network"
+        )
+    })
 }
 
 #[cfg(test)]
@@ -96,11 +168,47 @@ mod tests {
         assert_eq!(nomad_page_overall_timeout_secs("rf", 1), 57);
         assert_eq!(nomad_page_overall_timeout_secs("rf", 8), 99);
         assert_eq!(nomad_page_overall_timeout_secs("rf", 32), 180);
+        assert_eq!(nomad_page_overall_timeout_secs("ble", 6), 87);
     }
 
     #[test]
     fn timeout_from_interfaces_prefers_rnode() {
         let ifaces = vec![iface("tcp"), iface("rnode")];
         assert_eq!(nomad_page_timeout_secs_for_interfaces(&ifaces, 8), 99);
+    }
+
+    #[test]
+    fn path_table_tcp_wins_over_local_ble_rnode() {
+        let mut ble = iface("rnode");
+        ble.serial_port = Some("ble://AA:BB:CC:DD:EE:FF".into());
+        ble.name = "BLE RNode".into();
+        let mut tcp = iface("tcp");
+        tcp.name = "US-East".into();
+        tcp.id = "tcp1".into();
+        let ifaces = vec![ble, tcp];
+        // Local outbound still prefers BLE when path is unknown.
+        assert_eq!(nomad_page_timeout_secs_for_interfaces(&ifaces, 3), 69);
+        // Path via TCP hub must use MeshChat TCP budget (45s), not RF.
+        let (secs, egress) = resolve_nomad_page_timeout_secs(&ifaces, 3, Some("US-East"), None);
+        assert_eq!(egress, "tcp");
+        assert_eq!(secs, 45);
+    }
+
+    #[test]
+    fn tcp_link_initiator_hops_capped_for_meshchat_establish() {
+        assert_eq!(nomad_link_initiator_hops("tcp", 8), 3);
+        assert_eq!(nomad_link_initiator_hops("network", 1), 1);
+        assert_eq!(nomad_link_initiator_hops("rf", 8), 8);
+        assert_eq!(nomad_link_initiator_hops("ble", 6), 6);
+    }
+
+    #[test]
+    fn network_ready_when_path_iface_or_live_egress() {
+        let mut tcp = iface("tcp");
+        tcp.status = "down".into();
+        assert!(!nomad_remote_network_ready(&[tcp.clone()], None));
+        assert!(nomad_remote_network_ready(&[tcp.clone()], Some("US-East")));
+        tcp.status = "up".into();
+        assert!(nomad_remote_network_ready(&[tcp], None));
     }
 }

--- a/scripts/apply-rsReticulum-link-client-proof-budget.sh
+++ b/scripts/apply-rsReticulum-link-client-proof-budget.sh
@@ -37,11 +37,11 @@ if git -C "${RNS_DIR}" apply --check "${PATCH_FILE}" > "${apply_err}" 2>&1; then
   exit 0
 fi
 
-# Neither reverse nor forward matched. Accept only an explicit upstream-equivalent cap.
+# Neither reverse nor forward matched. Accept only the full upstream-equivalent data
+# flow: proof_budget is capped by establishment_timeout AND passed to wait_for_proof.
 if [[ -f "${LINK_CLIENT_RS}" ]] \
-  && grep -q 'let proof_budget' "${LINK_CLIENT_RS}" \
-  && grep -q 'establishment_timeout' "${LINK_CLIENT_RS}" \
-  && grep -qE 'proof_budget\s*=\s*time_remaining\(deadline\)\?\.min\(link\.establishment_timeout\)|wait_for_proof\([^;]*proof_budget' "${LINK_CLIENT_RS}"; then
+  && grep -qE 'let proof_budget\s*=\s*time_remaining\(deadline\)\?\.min\(link\.establishment_timeout\)' "${LINK_CLIENT_RS}" \
+  && grep -qE 'wait_for_proof\([^;]*proof_budget' "${LINK_CLIENT_RS}"; then
   echo "link-client proof-budget capability already upstream on rsReticulum @ $(short_head)"
   exit 0
 fi

--- a/scripts/apply-rsReticulum-link-client-proof-budget.sh
+++ b/scripts/apply-rsReticulum-link-client-proof-budget.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Cap LinkClient wait_for_proof at establishment_timeout (MeshChat-like TCP fail-fast).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PATCH_FILE="${REPO_ROOT}/reticulum-sidecar/patches/rsReticulum-link-client-proof-budget.patch"
+RNS_DIR="$(cd "${REPO_ROOT}/.." && pwd)/rsReticulum"
+LINK_CLIENT_RS="${RNS_DIR}/crates/rns-runtime/src/link_client.rs"
+
+if [[ ! -d "${RNS_DIR}/.git" ]]; then
+  echo "error: rsReticulum not found at ${RNS_DIR}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${PATCH_FILE}" ]]; then
+  echo "error: patch not found at ${PATCH_FILE}" >&2
+  exit 1
+fi
+
+if [[ -f "${LINK_CLIENT_RS}" ]] && grep -q 'proof_budget' "${LINK_CLIENT_RS}"; then
+  echo "link-client proof-budget overlay already present on rsReticulum @ $(git -C "${RNS_DIR}" rev-parse --short HEAD)"
+  exit 0
+fi
+
+if git -C "${RNS_DIR}" apply --check "${PATCH_FILE}" 2> /dev/null; then
+  git -C "${RNS_DIR}" apply "${PATCH_FILE}"
+  echo "applied ${PATCH_FILE} on rsReticulum @ $(git -C "${RNS_DIR}" rev-parse --short HEAD)"
+  exit 0
+fi
+
+echo "link-client proof-budget overlay not needed (already upstream or incompatible with current rsReticulum HEAD)"
+exit 0

--- a/scripts/apply-rsReticulum-link-client-proof-budget.sh
+++ b/scripts/apply-rsReticulum-link-client-proof-budget.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PATCH_FILE="${REPO_ROOT}/reticulum-sidecar/patches/rsReticulum-link-client-proof-budget.patch"
-RNS_DIR="$(cd "${REPO_ROOT}/.." && pwd)/rsReticulum"
+RNS_DIR="${RS_RETICULUM_DIR:-$(cd "${REPO_ROOT}/.." && pwd)/rsReticulum}"
 LINK_CLIENT_RS="${RNS_DIR}/crates/rns-runtime/src/link_client.rs"
 
 if [[ ! -d "${RNS_DIR}/.git" ]]; then
@@ -18,16 +18,35 @@ if [[ ! -f "${PATCH_FILE}" ]]; then
   exit 1
 fi
 
-if [[ -f "${LINK_CLIENT_RS}" ]] && grep -q 'proof_budget' "${LINK_CLIENT_RS}"; then
-  echo "link-client proof-budget overlay already present on rsReticulum @ $(git -C "${RNS_DIR}" rev-parse --short HEAD)"
+short_head() {
+  git -C "${RNS_DIR}" rev-parse --short HEAD
+}
+
+# Exact overlay already applied (reverse cleanly) — not a lone proof_budget token.
+if git -C "${RNS_DIR}" apply --reverse --check "${PATCH_FILE}" > /dev/null 2>&1; then
+  echo "link-client proof-budget overlay already present on rsReticulum @ $(short_head)"
   exit 0
 fi
 
-if git -C "${RNS_DIR}" apply --check "${PATCH_FILE}" 2> /dev/null; then
+apply_err="$(mktemp "${TMPDIR:-/tmp}/mesh-proof-budget-apply.XXXXXX")"
+trap 'rm -f "${apply_err}"' EXIT
+
+if git -C "${RNS_DIR}" apply --check "${PATCH_FILE}" > "${apply_err}" 2>&1; then
   git -C "${RNS_DIR}" apply "${PATCH_FILE}"
-  echo "applied ${PATCH_FILE} on rsReticulum @ $(git -C "${RNS_DIR}" rev-parse --short HEAD)"
+  echo "applied ${PATCH_FILE} on rsReticulum @ $(short_head)"
   exit 0
 fi
 
-echo "link-client proof-budget overlay not needed (already upstream or incompatible with current rsReticulum HEAD)"
-exit 0
+# Neither reverse nor forward matched. Accept only an explicit upstream-equivalent cap.
+if [[ -f "${LINK_CLIENT_RS}" ]] \
+  && grep -q 'let proof_budget' "${LINK_CLIENT_RS}" \
+  && grep -q 'establishment_timeout' "${LINK_CLIENT_RS}" \
+  && grep -qE 'proof_budget\s*=\s*time_remaining\(deadline\)\?\.min\(link\.establishment_timeout\)|wait_for_proof\([^;]*proof_budget' "${LINK_CLIENT_RS}"; then
+  echo "link-client proof-budget capability already upstream on rsReticulum @ $(short_head)"
+  exit 0
+fi
+
+echo "error: link-client proof-budget overlay could not be applied on rsReticulum @ $(short_head)" >&2
+echo "error: neither forward apply nor reverse-check matched; git diagnostic:" >&2
+cat "${apply_err}" >&2
+exit 1

--- a/scripts/apply-rsReticulum-link-client-proof-budget.test.mjs
+++ b/scripts/apply-rsReticulum-link-client-proof-budget.test.mjs
@@ -48,6 +48,26 @@ const INCOMPATIBLE = `impl LinkClient {
 }
 `;
 
+/** Has proof_budget but does not cap it with establishment_timeout. */
+const UNCAPPED_PROOF_BUDGET = `impl LinkClient {
+    async fn query(&self) -> Result<(), LinkClientError> {
+        let proof_budget = time_remaining(deadline)?;
+        let proof_data = wait_for_proof(&mut dest_rx, link_id, proof_budget).await?;
+        Ok(())
+    }
+}
+`;
+
+/** Caps proof_budget but wait_for_proof still uses the uncapped remaining deadline. */
+const CAPPED_PROOF_BUDGET_UNUSED = `impl LinkClient {
+    async fn query(&self) -> Result<(), LinkClientError> {
+        let proof_budget = time_remaining(deadline)?.min(link.establishment_timeout);
+        let proof_data = wait_for_proof(&mut dest_rx, link_id, time_remaining(deadline)?).await?;
+        Ok(())
+    }
+}
+`;
+
 const temps = [];
 
 function makeFakeRsReticulum(linkClientSource) {
@@ -107,6 +127,20 @@ describe('apply-rsReticulum-link-client-proof-budget.sh', () => {
     const result = runApply(rns);
     expect(result.status, result.stderr || result.stdout).toBe(0);
     expect(result.stdout).toMatch(/already upstream/);
+  });
+
+  it('rejects an uncapped proof_budget as upstream-equivalent', () => {
+    const rns = makeFakeRsReticulum(UNCAPPED_PROOF_BUDGET);
+    const result = runApply(rns);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/could not be applied|git diagnostic/i);
+  });
+
+  it('rejects a capped proof_budget that wait_for_proof does not use', () => {
+    const rns = makeFakeRsReticulum(CAPPED_PROOF_BUDGET_UNUSED);
+    const result = runApply(rns);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/could not be applied|git diagnostic/i);
   });
 
   it('fails with git diagnostic on incompatible checkouts', () => {

--- a/scripts/apply-rsReticulum-link-client-proof-budget.test.mjs
+++ b/scripts/apply-rsReticulum-link-client-proof-budget.test.mjs
@@ -1,0 +1,118 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const APPLY_SCRIPT = path.join(SCRIPT_DIR, 'apply-rsReticulum-link-client-proof-budget.sh');
+const PATCH_FILE = path.join(
+  REPO_ROOT,
+  'reticulum-sidecar/patches/rsReticulum-link-client-proof-budget.patch',
+);
+
+/** Preimage matching the proof-budget patch hunk (post–Nomad overlay `}))`). */
+const FRESH_LINK_CLIENT = `impl LinkClient {
+    async fn query(&self) -> Result<(), LinkClientError> {
+        }))
+        .await?;
+
+        let proof_data = wait_for_proof(&mut dest_rx, link_id, time_remaining(deadline)?).await?;
+
+        let identity_ed25519_pub: [u8; 32] = pubkey[32..64].try_into().map_err(|_| {
+            LinkClientError::ProofInvalid("remote public key is not 64 bytes".into())
+        })?;
+        Ok(())
+    }
+}
+`;
+
+const UPSTREAM_EQUIVALENT = `impl LinkClient {
+    async fn query(&self) -> Result<(), LinkClientError> {
+        // Cap proof wait at link establishment timeout (6s × hops).
+        let proof_budget = time_remaining(deadline)?.min(link.establishment_timeout);
+        let proof_data = wait_for_proof(&mut dest_rx, link_id, proof_budget).await?;
+        Ok(())
+    }
+}
+`;
+
+const INCOMPATIBLE = `impl LinkClient {
+    async fn query(&self) -> Result<(), LinkClientError> {
+        let proof_data = wait_for_proof(&mut dest_rx, link_id, Duration::from_secs(99)).await?;
+        Ok(())
+    }
+}
+`;
+
+const temps = [];
+
+function makeFakeRsReticulum(linkClientSource) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'mesh-proof-budget-rns-'));
+  temps.push(root);
+  const linkClientPath = path.join(root, 'crates/rns-runtime/src/link_client.rs');
+  mkdirSync(path.dirname(linkClientPath), { recursive: true });
+  writeFileSync(linkClientPath, linkClientSource);
+  const gitInit = spawnSync('git', ['init'], { cwd: root, encoding: 'utf8' });
+  expect(gitInit.status).toBe(0);
+  spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+  spawnSync('git', ['add', '.'], { cwd: root });
+  const commit = spawnSync('git', ['commit', '-m', 'init'], { cwd: root, encoding: 'utf8' });
+  expect(commit.status).toBe(0);
+  return root;
+}
+
+function runApply(rnsDir) {
+  return spawnSync('bash', [APPLY_SCRIPT], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, RS_RETICULUM_DIR: rnsDir },
+  });
+}
+
+afterEach(() => {
+  while (temps.length > 0) {
+    const dir = temps.pop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('apply-rsReticulum-link-client-proof-budget.sh', () => {
+  it('applies the overlay on a fresh checkout', () => {
+    expect(readFileSync(PATCH_FILE, 'utf8')).toContain('proof_budget');
+    const rns = makeFakeRsReticulum(FRESH_LINK_CLIENT);
+    const result = runApply(rns);
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toMatch(/applied .*rsReticulum-link-client-proof-budget\.patch/);
+    const body = readFileSync(path.join(rns, 'crates/rns-runtime/src/link_client.rs'), 'utf8');
+    expect(body).toContain('let proof_budget');
+    expect(body).toContain('link.establishment_timeout');
+  });
+
+  it('is a no-op when the exact overlay is already applied (repeated run)', () => {
+    const rns = makeFakeRsReticulum(FRESH_LINK_CLIENT);
+    const first = runApply(rns);
+    expect(first.status, first.stderr || first.stdout).toBe(0);
+    const second = runApply(rns);
+    expect(second.status, second.stderr || second.stdout).toBe(0);
+    expect(second.stdout).toMatch(/already present/);
+  });
+
+  it('accepts an upstream-equivalent proof-budget cap when the patch does not apply', () => {
+    const rns = makeFakeRsReticulum(UPSTREAM_EQUIVALENT);
+    const result = runApply(rns);
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toMatch(/already upstream/);
+  });
+
+  it('fails with git diagnostic on incompatible checkouts', () => {
+    const rns = makeFakeRsReticulum(INCOMPATIBLE);
+    const result = runApply(rns);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/could not be applied|git diagnostic/i);
+  });
+});

--- a/scripts/clone-ratspeak-stack.sh
+++ b/scripts/clone-ratspeak-stack.sh
@@ -44,6 +44,7 @@ ensure_repo "${RNS_DIR}" 'https://github.com/ratspeak/rsReticulum.git' \
 "${SCRIPT_DIR}/apply-rsReticulum-packet-tap.sh"
 "${SCRIPT_DIR}/apply-rsReticulum-auto-beacon-utun.sh"
 "${SCRIPT_DIR}/apply-rsReticulum-link-client-nomad.sh"
+"${SCRIPT_DIR}/apply-rsReticulum-link-client-proof-budget.sh"
 "${SCRIPT_DIR}/apply-rsReticulum-ble-rnode-pairing-transition-debounce.sh"
 "${SCRIPT_DIR}/apply-rsReticulum-discovery-announce-egress.sh"
 

--- a/scripts/ensure-rsReticulum-patches.sh
+++ b/scripts/ensure-rsReticulum-patches.sh
@@ -15,6 +15,7 @@ fi
 "${SCRIPT_DIR}/apply-rsReticulum-packet-tap.sh"
 "${SCRIPT_DIR}/apply-rsReticulum-auto-beacon-utun.sh"
 "${SCRIPT_DIR}/apply-rsReticulum-link-client-nomad.sh"
+"${SCRIPT_DIR}/apply-rsReticulum-link-client-proof-budget.sh"
 "${SCRIPT_DIR}/apply-rsReticulum-ble-rnode-pairing-transition-debounce.sh"
 "${SCRIPT_DIR}/apply-rsReticulum-discovery-announce-egress.sh"
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -210,6 +210,7 @@ check_ratspeak_patches() {
     'rsReticulum-packet-tap.patch|ratspeak/rsReticulum|10|rsReticulum packet-tap|https://github.com/ratspeak/rsReticulum/pull/10'
     'rsReticulum-auto-beacon-utun.patch|ratspeak/rsReticulum|11|rsReticulum auto-beacon utun|https://github.com/ratspeak/rsReticulum/pull/11'
     'rsReticulum-link-client-nomad.patch|ratspeak/rsReticulum|14|rsReticulum LinkClient Nomad|https://github.com/ratspeak/rsReticulum/pull/14'
+    'rsReticulum-link-client-proof-budget.patch|ratspeak/rsReticulum||rsReticulum LinkClient proof-budget cap|'
     'rsReticulum-ble-rnode-pairing-transition-debounce.patch|ratspeak/rsReticulum|20|rsReticulum BLE RNode pairing-transition debounce|https://github.com/ratspeak/rsReticulum/pull/20'
     'rsReticulum-discovery-announce-egress.patch|ratspeak/rsReticulum|19|rsReticulum discovery announce egress|https://github.com/ratspeak/rsReticulum/pull/19'
     'rsLXMF-propagation-sync-peering.patch|ratspeak/rsLXMF|4|rsLXMF propagation sync peering|https://github.com/ratspeak/rsLXMF/pull/4'

--- a/src/main/reticulum-proxy-path.test.ts
+++ b/src/main/reticulum-proxy-path.test.ts
@@ -52,28 +52,25 @@ describe('assertReticulumProxyPath', () => {
 });
 
 describe('reticulumProxyGetTimeoutMs', () => {
-  it('uses meshchat-aligned timeout for TCP nomad page fetches', () => {
+  it('uses flat Nomad proxy cap for page fetches (ignores stale hops/egress)', () => {
     expect(
       reticulumProxyGetTimeoutMs(
-        '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=8&egress=tcp',
+        '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=1&egress=tcp',
       ),
-    ).toBe(101_000);
-  });
-
-  it('uses longer RF timeout from hops and egress', () => {
+    ).toBe(185_000);
     expect(
       reticulumProxyGetTimeoutMs(
         '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=8&egress=rf',
       ),
-    ).toBe(101_000);
+    ).toBe(185_000);
   });
 
-  it('uses nomad timeout for file fetches', () => {
+  it('uses flat Nomad proxy cap for file fetches', () => {
     expect(
       reticulumProxyGetTimeoutMs(
         '/api/v1/nomadnetwork/file/abc?path=%2Ffile%2Freadme.txt&hops=8&egress=rf',
       ),
-    ).toBe(101_000);
+    ).toBe(185_000);
   });
 
   it('uses default timeout for other GET routes', () => {

--- a/src/main/reticulum-sidecar-manager.ts
+++ b/src/main/reticulum-sidecar-manager.ts
@@ -497,8 +497,9 @@ export class ReticulumSidecarManager extends EventEmitter {
       throw new Error('Reticulum sidecar is not running');
     }
     const normalized = assertReticulumProxyPath(apiPath);
+    const timeoutMs = reticulumProxyGetTimeoutMs(apiPath);
     const res = await fetch(`http://127.0.0.1:${status.port}${normalized}`, {
-      signal: AbortSignal.timeout(reticulumProxyGetTimeoutMs(apiPath)),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     if (!res.ok) {
       throw new Error(`sidecar GET ${normalized} failed: ${res.status}`);

--- a/src/renderer/components/NomadNetworkPanel.test.tsx
+++ b/src/renderer/components/NomadNetworkPanel.test.tsx
@@ -1072,4 +1072,45 @@ describe('NomadNetworkPanel', () => {
       vi.useRealTimers();
     }
   });
+
+  it('has no axe violations for stale-last-seen page error state', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { restore } = mockConsoleWarn();
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const nowSec = Math.floor(Date.now() / 1000);
+      const fetchNomadPage = vi.fn().mockResolvedValue({ ok: false, error: 'link_timeout' });
+      useNomadNetworkStore.setState({
+        nodes: new Map([
+          [
+            'abc1234567890',
+            {
+              destination_hash: 'abc1234567890',
+              display_name: 'Stale Peer',
+              favorited: false,
+              last_seen: nowSec - 3 * 60 * 60,
+              hops: 2,
+            },
+          ],
+        ]),
+        fetchNomadPage,
+      });
+
+      render(<NomadNetworkPanel />);
+      await openAnnouncesNode(user);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_DEBOUNCE_MS);
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/nomadNetwork.staleLastSeenHint/)).toBeInTheDocument();
+      });
+
+      const staleHint = screen.getByText(/nomadNetwork.staleLastSeenHint/);
+      hydrateAxeThemeColors(staleHint);
+      expect(await axe(staleHint)).toHaveNoViolations();
+    } finally {
+      restore();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/renderer/components/NomadNetworkPanel.test.tsx
+++ b/src/renderer/components/NomadNetworkPanel.test.tsx
@@ -5,7 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import { hydrateAxeThemeColors } from '@/renderer/lib/a11yTestHelpers';
-import { NOMAD_PAGE_FETCH_RETRY_SETTLE_MS } from '@/renderer/lib/timeConstants';
+import {
+  NOMAD_PAGE_FETCH_DEBOUNCE_MS,
+  NOMAD_PAGE_FETCH_RETRY_SETTLE_MS,
+} from '@/renderer/lib/timeConstants';
 import { mockConsoleWarn } from '@/renderer/lib/vitestConsoleMock';
 
 vi.mock('react-i18next', () => ({
@@ -47,6 +50,7 @@ vi.mock('./NomadPageServerPanel', () => ({
 import { clearNomadPageCache } from '@/renderer/lib/nomad/nomadPageCache';
 
 import { useNomadNetworkStore } from '../stores/nomadNetworkStore';
+import { resetNomadPageViewerStoreForTests } from '../stores/nomadPageViewerStore';
 import NomadNetworkPanel from './NomadNetworkPanel';
 
 async function openAnnouncesNode(user: ReturnType<typeof userEvent.setup>) {
@@ -57,6 +61,7 @@ async function openAnnouncesNode(user: ReturnType<typeof userEvent.setup>) {
 describe('NomadNetworkPanel', () => {
   beforeEach(() => {
     clearNomadPageCache();
+    resetNomadPageViewerStoreForTests();
     localStorage.removeItem('mesh-client:nomadPageFitWidth');
     localStorage.removeItem('mesh-client:nomadNodeListCollapsed');
     localStorage.removeItem('mesh-client:nomadNodeSort');
@@ -320,12 +325,14 @@ describe('NomadNetworkPanel', () => {
     await waitFor(() => {
       expect(document.querySelector('.nomad-micron-page')?.textContent).toContain('Hello Nomad');
     });
+    const callsAfterFirstLoad = fetchNomadPage.mock.calls.length;
 
     await user.click(screen.getByRole('button', { name: 'nomadNetwork.homePage' }));
     await waitFor(() => {
       expect(document.querySelector('.nomad-micron-page')?.textContent).toContain('Hello Nomad');
     });
-    expect(fetchNomadPage).toHaveBeenCalledTimes(1);
+    // Session cache must satisfy home navigation without another wire fetch.
+    expect(fetchNomadPage).toHaveBeenCalledTimes(callsAfterFirstLoad);
   });
 
   it('reload bypasses cache and refetches', async () => {
@@ -801,14 +808,14 @@ describe('NomadNetworkPanel', () => {
     expect(screen.getByLabelText('nomadNetwork.fitWidth')).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('auto-retries once after link_timeout and renders on success', async () => {
+  it('auto-retries once after path_timeout with forcePathRefresh and renders on success', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const { restore } = mockConsoleWarn();
     try {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       const fetchNomadPage = vi
         .fn()
-        .mockResolvedValueOnce({ ok: false, error: 'link_timeout' })
+        .mockResolvedValueOnce({ ok: false, error: 'path_timeout' })
         .mockResolvedValueOnce({
           ok: true,
           content: '>>>hello after retry',
@@ -833,6 +840,9 @@ describe('NomadNetworkPanel', () => {
       render(<NomadNetworkPanel />);
       await openAnnouncesNode(user);
 
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_DEBOUNCE_MS);
+      });
       await waitFor(() => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(1);
       });
@@ -864,15 +874,12 @@ describe('NomadNetworkPanel', () => {
     }
   });
 
-  it('shows page error once when both fetch attempts fail', async () => {
+  it('does not auto-retry link_timeout (shows error after one fetch)', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const { restore } = mockConsoleWarn();
     try {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-      const fetchNomadPage = vi
-        .fn()
-        .mockResolvedValueOnce({ ok: false, error: 'link_timeout' })
-        .mockResolvedValueOnce({ ok: false, error: 'link_timeout' });
+      const fetchNomadPage = vi.fn().mockResolvedValue({ ok: false, error: 'link_timeout' });
       useNomadNetworkStore.setState({
         nodes: new Map([
           [
@@ -892,6 +899,54 @@ describe('NomadNetworkPanel', () => {
       render(<NomadNetworkPanel />);
       await openAnnouncesNode(user);
 
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_DEBOUNCE_MS);
+      });
+      await waitFor(() => {
+        expect(fetchNomadPage).toHaveBeenCalledTimes(1);
+        expect(screen.getByText(/nomadNetwork.pageFailed/)).toBeInTheDocument();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
+      });
+      expect(fetchNomadPage).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows page error once when both path_timeout fetch attempts fail', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const { restore } = mockConsoleWarn();
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const fetchNomadPage = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, error: 'path_timeout' })
+        .mockResolvedValueOnce({ ok: false, error: 'path_timeout' });
+      useNomadNetworkStore.setState({
+        nodes: new Map([
+          [
+            'abc1234567890',
+            {
+              destination_hash: 'abc1234567890',
+              display_name: 'Fail Node',
+              favorited: false,
+              last_seen: 100,
+              hops: 3,
+            },
+          ],
+        ]),
+        fetchNomadPage,
+      });
+
+      render(<NomadNetworkPanel />);
+      await openAnnouncesNode(user);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_DEBOUNCE_MS);
+      });
       await waitFor(() => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(1);
       });
@@ -941,6 +996,9 @@ describe('NomadNetworkPanel', () => {
       render(<NomadNetworkPanel />);
       await openAnnouncesNode(user);
 
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(NOMAD_PAGE_FETCH_DEBOUNCE_MS);
+      });
       await waitFor(() => {
         expect(fetchNomadPage).toHaveBeenCalledTimes(1);
       });

--- a/src/renderer/components/NomadNetworkPanel.tsx
+++ b/src/renderer/components/NomadNetworkPanel.tsx
@@ -9,7 +9,6 @@ import { useParentIconTrigger } from '@/renderer/lib/icons/iconMotionContext';
 import {
   buildNomadLinkRequest,
   DEFAULT_NOMAD_NODE_PAGE_PATH,
-  formatNomadRequestDataForUrlBar,
   isNomadMicronPage,
   nomadPageRequestDataEquals,
   normalizeNomadPagePath,
@@ -33,21 +32,23 @@ import {
   sortPreparedNomadNodeRows,
   writeNomadNodeSortPreference,
 } from '@/renderer/lib/nomad/nomadNodeSort';
-import {
-  clearNomadPageCache,
-  getNomadPageCache,
-  MAX_NOMAD_PAGE_CACHE_CHARS,
-  setNomadPageCache,
-} from '@/renderer/lib/nomad/nomadPageCache';
+import { isNomadLastSeenStale } from '@/renderer/lib/nomad/nomadNodeStale';
 import {
   humanizeNomadPageError,
   isRetryableNomadPageError,
 } from '@/renderer/lib/nomad/nomadPageErrorHumanize';
 import { isReticulumSidecarRunning } from '@/renderer/lib/reticulum/reticulumSidecarReads';
-import { NOMAD_PAGE_FETCH_RETRY_SETTLE_MS } from '@/renderer/lib/timeConstants';
-import type { NomadNodeRow, NomadPageRequestData, NomadPageResponse } from '@/shared/nomad-types';
+import type { NomadNodeRow, NomadPageRequestData } from '@/shared/nomad-types';
 
 import { useNomadNetworkStore } from '../stores/nomadNetworkStore';
+import {
+  formatNomadPageCountdown,
+  formatNomadViewerUrlBar,
+  type NomadPageErrorNodeSnapshot,
+  nomadPageLoadingRemainingSec,
+  type NomadPageLoadOptions,
+  useNomadPageViewerStore,
+} from '../stores/nomadPageViewerStore';
 import NomadMicronPageView from './NomadMicronPageView';
 import NomadPageServerPanel from './NomadPageServerPanel';
 
@@ -56,17 +57,6 @@ interface NomadHistoryEntry {
   path: string;
   requestData?: NomadPageRequestData;
 }
-
-interface LoadNodePageOptions {
-  fromHistory?: boolean;
-  forceReload?: boolean;
-  /** Force sidecar path rediscovery (stale-route retry / post-error reload). */
-  forcePathRefresh?: boolean;
-  requestData?: NomadPageRequestData;
-}
-
-/** Cap displayed page size to avoid renderer stress on huge Micron pages. */
-const MAX_NOMAD_PAGE_DISPLAY_CHARS = MAX_NOMAD_PAGE_CACHE_CHARS;
 
 const NOMAD_NODE_LIST_COLLAPSED_STORAGE_KEY = 'mesh-client:nomadNodeListCollapsed';
 const NOMAD_PAGE_FIT_WIDTH_STORAGE_KEY = 'mesh-client:nomadPageFitWidth';
@@ -103,19 +93,6 @@ function nomadCollapsedLabel(displayName: string | null | undefined, hash: strin
   return hash.slice(0, 2).toUpperCase();
 }
 
-function formatNomadUrlBar(hash: string, path: string, requestData?: NomadPageRequestData): string {
-  const base = `${hash}:${path}`;
-  const varSuffix = formatNomadRequestDataForUrlBar(requestData);
-  return varSuffix ? `${base}\`${varSuffix}` : base;
-}
-
-function truncateNomadPageContent(content: string): { text: string; truncated: boolean } {
-  if (content.length <= MAX_NOMAD_PAGE_DISPLAY_CHARS) {
-    return { text: content, truncated: false };
-  }
-  return { text: content.slice(0, MAX_NOMAD_PAGE_DISPLAY_CHARS), truncated: true };
-}
-
 function formatNomadHash(hash: string): string {
   if (hash.length <= 16) return `<${hash}>`;
   return `<${hash.slice(0, 8)}…${hash.slice(-8)}>`;
@@ -127,23 +104,6 @@ function matchesSearch(node: NomadNodeRow, query: string): boolean {
   const name = (node.display_name ?? '').toLowerCase();
   const hash = node.destination_hash.toLowerCase();
   return name.includes(q) || hash.includes(q);
-}
-
-interface NomadPageErrorNodeSnapshot {
-  hash: string;
-  lastSeen: number | null;
-  hops: number | null;
-}
-
-function snapshotNomadNodeForPageError(
-  hash: string,
-  node: NomadNodeRow | undefined,
-): NomadPageErrorNodeSnapshot {
-  return {
-    hash: hash.toLowerCase(),
-    lastSeen: node?.last_seen ?? null,
-    hops: node?.hops ?? null,
-  };
 }
 
 function nomadNodeChangedSincePageError(
@@ -283,23 +243,34 @@ export default function NomadNetworkPanel({
   const fetchNomadFile = useNomadNetworkStore((s) => s.fetchNomadFile);
   const toggleFavorite = useNomadNetworkStore((s) => s.toggleFavorite);
 
+  const selectedHash = useNomadPageViewerStore((s) => s.selectedHash);
+  const pagePath = useNomadPageViewerStore((s) => s.pagePath);
+  const pageRequestData = useNomadPageViewerStore((s) => s.pageRequestData);
+  const pageContent = useNomadPageViewerStore((s) => s.pageContent);
+  const pageContentType = useNomadPageViewerStore((s) => s.pageContentType);
+  const pageContentTruncated = useNomadPageViewerStore((s) => s.pageContentTruncated);
+  const pageLoading = useNomadPageViewerStore((s) => s.pageLoading);
+  const pageLoadingStartedAt = useNomadPageViewerStore((s) => s.pageLoadingStartedAt);
+  const pageLoadingBudgetSec = useNomadPageViewerStore((s) => s.pageLoadingBudgetSec);
+  const pageErrorRaw = useNomadPageViewerStore((s) => s.pageErrorRaw);
+  const pageErrorNodeSnapshot = useNomadPageViewerStore((s) => s.pageErrorNodeSnapshot);
+  const announceReloadDone = useNomadPageViewerStore((s) => s.announceReloadDone);
+  const loadPage = useNomadPageViewerStore((s) => s.loadPage);
+  const closeViewerStore = useNomadPageViewerStore((s) => s.closeViewer);
+  const setPanelActive = useNomadPageViewerStore((s) => s.setPanelActive);
+  const markAnnounceReloadDone = useNomadPageViewerStore((s) => s.markAnnounceReloadDone);
+
+  const pageError = pageErrorRaw ? humanizeNomadPageError(pageErrorRaw, t) : null;
+  const pageErrorCode = pageErrorRaw;
+
   const [activeTab, setActiveTab] = useState<NomadListTab>('favourites');
   const [searchQuery, setSearchQuery] = useState('');
   const [sidecarRunning, setSidecarRunning] = useState(false);
-  const [selectedHash, setSelectedHash] = useState<string | null>(null);
-  const [pagePath, setPagePath] = useState(DEFAULT_NOMAD_NODE_PAGE_PATH);
-  const [pageRequestData, setPageRequestData] = useState<NomadPageRequestData | undefined>(
-    undefined,
-  );
   const [urlBarValue, setUrlBarValue] = useState('');
   const [historyStack, setHistoryStack] = useState<NomadHistoryEntry[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
-  const [pageContent, setPageContent] = useState<string | null>(null);
-  const [pageContentType, setPageContentType] = useState<string | undefined>(undefined);
   const [showPageSource, setShowPageSource] = useState(false);
-  const [pageLoading, setPageLoading] = useState(false);
-  const [pageError, setPageError] = useState<string | null>(null);
-  const [pageErrorCode, setPageErrorCode] = useState<string | null>(null);
+  const [pageLoadingRemainingSec, setPageLoadingRemainingSec] = useState(0);
   const [fileDownloading, setFileDownloading] = useState(false);
   const [fileDownloadError, setFileDownloadError] = useState<string | null>(null);
   const [nodeListCollapsed, setNodeListCollapsed] = useState(
@@ -312,17 +283,46 @@ export default function NomadNetworkPanel({
   const [sortPref, setSortPref] = useState(readNomadNodeSortPreference);
   const sortKey = sortPref.key;
   const sortDir = sortPref.dir;
-  const pageRequestSeqRef = useRef(0);
   const fileDownloadInFlightRef = useRef(false);
   const mountedRef = useRef(true);
   const historyIndexRef = useRef(-1);
-  const pageErrorNodeSnapshotRef = useRef<NomadPageErrorNodeSnapshot | null>(null);
-  const announceReloadDoneRef = useRef(false);
   const listCollapseTrigger = useParentIconTrigger();
 
   useEffect(() => {
     historyIndexRef.current = historyIndex;
   }, [historyIndex]);
+
+  useEffect(() => {
+    setPanelActive(isActive);
+    return () => {
+      setPanelActive(false);
+    };
+  }, [isActive, setPanelActive]);
+
+  useEffect(() => {
+    if (!pageLoading || pageLoadingStartedAt == null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clear countdown when load ends
+      setPageLoadingRemainingSec(0);
+      return;
+    }
+    const tick = () => {
+      setPageLoadingRemainingSec(
+        nomadPageLoadingRemainingSec(pageLoadingStartedAt, pageLoadingBudgetSec),
+      );
+    };
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [pageLoading, pageLoadingStartedAt, pageLoadingBudgetSec]);
+
+  useEffect(() => {
+    if (selectedHash) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- mirror store navigation into the editable URL bar
+      setUrlBarValue(formatNomadViewerUrlBar(selectedHash, pagePath, pageRequestData));
+    }
+  }, [selectedHash, pagePath, pageRequestData]);
 
   useEffect(() => {
     if (isActive && selectedHash == null) {
@@ -359,8 +359,8 @@ export default function NomadNetworkPanel({
   useEffect(() => {
     mountedRef.current = true;
     return () => {
+      // Keep in-flight Nomad loads alive across protocol/panel unmount.
       mountedRef.current = false;
-      pageRequestSeqRef.current += 1;
     };
   }, []);
 
@@ -407,122 +407,23 @@ export default function NomadNetworkPanel({
 
   const selectedNode = selectedHash ? nodes.get(selectedHash.toLowerCase()) : undefined;
 
-  const applyPageResult = useCallback(
-    (
-      hash: string,
-      normalizedPath: string,
-      content: string,
-      contentType: string | undefined,
-      truncated: boolean,
-      requestData?: NomadPageRequestData,
-    ) => {
-      setPageContent(truncated ? `${content}\n\n[${t('nomadNetwork.pageTruncated')}]` : content);
-      setPageContentType(contentType);
-      setUrlBarValue(formatNomadUrlBar(hash, normalizedPath, requestData));
-    },
-    [t],
-  );
-
   const loadNodePage = useCallback(
-    async (hash: string, path: string, options: LoadNodePageOptions = {}) => {
+    async (hash: string, path: string, options: NomadPageLoadOptions = {}) => {
+      setShowPageSource(false);
       const normalizedPath = normalizeNomadPagePath(path);
       const normalizedRequest = normalizeNomadPageRequestData(options.requestData);
-      const requestSeq = ++pageRequestSeqRef.current;
-      setSelectedHash(hash);
-      setPagePath(normalizedPath);
-      setPageRequestData(normalizedRequest);
-      setPageLoading(true);
-      setPageError(null);
-      setPageErrorCode(null);
-      pageErrorNodeSnapshotRef.current = null;
-      setShowPageSource(false);
-
-      if (!options.forceReload) {
-        const cached = getNomadPageCache({
-          hash,
-          path: normalizedPath,
-          requestData: normalizedRequest,
-        });
-        if (cached) {
-          if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
-          setPageLoading(false);
-          applyPageResult(
-            hash,
-            normalizedPath,
-            cached.content,
-            cached.content_type,
-            false,
-            normalizedRequest,
-          );
-          if (!options.fromHistory) {
-            pushHistoryEntry(hash, normalizedPath, normalizedRequest);
-          }
-          return;
-        }
-      }
-
-      setPageContent(null);
-      setPageContentType(undefined);
-      let res: NomadPageResponse;
-      try {
-        res = await fetchNomadPage(
-          hash,
-          normalizedPath,
-          normalizedRequest,
-          options.forcePathRefresh ? { forcePathRefresh: true } : undefined,
-        );
-        if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
-
-        if ((!res.ok || !res.content) && isRetryableNomadPageError(res.error)) {
-          const retryCode = res.error?.trim() || 'unknown';
-          console.warn(`[NomadNetwork] page fetch retry after ${retryCode}`);
-          await new Promise<void>((resolve) => {
-            window.setTimeout(resolve, NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
-          });
-          if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
-          res = await fetchNomadPage(hash, normalizedPath, normalizedRequest, {
-            forcePathRefresh: true,
-          });
-          if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
-        }
-      } catch (e) {
-        // Failure point: unexpected fetchNomadPage reject. Fallback: clear loading + generic error.
-        console.warn('[NomadNetwork] page fetch ' + errLikeToLogString(e));
-        if (!mountedRef.current || requestSeq !== pageRequestSeqRef.current) return;
-        setPageLoading(false);
-        setPageErrorCode(null);
-        setPageError(humanizeNomadPageError(undefined, t));
-        return;
-      }
-
-      setPageLoading(false);
-      if (!res.ok || !res.content) {
-        const rawCode = res.error?.trim() || null;
-        setPageErrorCode(rawCode);
-        setPageError(humanizeNomadPageError(res.error, t));
-        const node = useNomadNetworkStore.getState().nodes.get(hash.toLowerCase());
-        pageErrorNodeSnapshotRef.current = snapshotNomadNodeForPageError(hash, node);
-        announceReloadDoneRef.current = false;
-        return;
-      }
-      const { text, truncated } = truncateNomadPageContent(res.content);
-      applyPageResult(hash, normalizedPath, text, res.content_type, truncated, normalizedRequest);
-      setNomadPageCache(
-        {
-          hash,
-          path: normalizedPath,
-          requestData: normalizedRequest,
-        },
-        {
-          content: truncated ? text : res.content,
-          content_type: res.content_type,
-        },
-      );
-      if (!options.fromHistory) {
+      await loadPage(hash, path, options);
+      const viewer = useNomadPageViewerStore.getState();
+      if (
+        !options.fromHistory &&
+        viewer.pageContent != null &&
+        viewer.selectedHash?.toLowerCase() === hash.toLowerCase() &&
+        viewer.pagePath === normalizedPath
+      ) {
         pushHistoryEntry(hash, normalizedPath, normalizedRequest);
       }
     },
-    [applyPageResult, fetchNomadPage, pushHistoryEntry, t],
+    [loadPage, pushHistoryEntry],
   );
 
   useEffect(() => {
@@ -535,22 +436,26 @@ export default function NomadNetworkPanel({
     ) {
       return;
     }
-    if (announceReloadDoneRef.current) return;
-    const snap = pageErrorNodeSnapshotRef.current;
+    if (announceReloadDone) return;
+    const snap = pageErrorNodeSnapshot;
     if (snap == null) return;
     if (snap.hash !== selectedHash.toLowerCase()) return;
     if (!nomadNodeChangedSincePageError(snap, selectedNode)) return;
 
-    announceReloadDoneRef.current = true;
+    markAnnounceReloadDone();
     console.warn('[NomadNetwork] page reload after announce refresh');
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- auto-retry after announce updates node metadata
     void loadNodePage(selectedHash, pagePath, {
       forceReload: true,
       forcePathRefresh: true,
       requestData: pageRequestData,
     });
   }, [
+    announceReloadDone,
     loadNodePage,
+    markAnnounceReloadDone,
     pageErrorCode,
+    pageErrorNodeSnapshot,
     pageLoading,
     pagePath,
     pageRequestData,
@@ -627,7 +532,11 @@ export default function NomadNetworkPanel({
     const { destination: baseDestination, requestData } = buildNomadLinkRequest(target, null, null);
     const parsed = parseNomadNetworkLinkUrl(baseDestination, DEFAULT_NOMAD_NODE_PAGE_PATH);
     if (!parsed) {
-      setPageError(t('nomadNetwork.invalidUrl'));
+      useNomadPageViewerStore.setState({
+        pageErrorRaw: t('nomadNetwork.invalidUrl'),
+        pageLoading: false,
+        pageLoadingStartedAt: null,
+      });
       return;
     }
 
@@ -639,17 +548,13 @@ export default function NomadNetworkPanel({
   }, [loadNodePage, selectedNode, t, urlBarValue]);
 
   const closeViewer = useCallback(() => {
-    setSelectedHash(null);
-    setPageContent(null);
-    setPageError(null);
-    setPageRequestData(undefined);
+    closeViewerStore();
     setUrlBarValue('');
     setHistoryStack([]);
     historyIndexRef.current = -1;
     setHistoryIndex(-1);
     setActiveTab('favourites');
-    clearNomadPageCache();
-  }, []);
+  }, [closeViewerStore]);
 
   const handleNodeListToggle = useCallback(() => {
     setNodeListCollapsed((prev) => {
@@ -1130,15 +1035,36 @@ export default function NomadNetworkPanel({
                     </p>
                   ) : null}
                   {pageLoading ? (
-                    <p className="text-muted text-sm">{t('nomadNetwork.pageLoading')}</p>
-                  ) : pageError ? (
-                    <p className="text-sm text-red-300">
-                      {t('nomadNetwork.pageFailed', { error: pageError })}
+                    <p className="text-muted text-sm">
+                      {pageLoadingStartedAt == null
+                        ? t('nomadNetwork.pageLoading')
+                        : pageLoadingRemainingSec > 0
+                          ? t('nomadNetwork.pageLoadingCountdown', {
+                              time: formatNomadPageCountdown(pageLoadingRemainingSec),
+                            })
+                          : t('nomadNetwork.pageLoadingCountdownOverdue')}
                     </p>
+                  ) : pageError ? (
+                    <div className="space-y-2">
+                      <p className="text-sm text-red-300">
+                        {t('nomadNetwork.pageFailed', { error: pageError })}
+                      </p>
+                      {selectedNode && isNomadLastSeenStale(selectedNode.last_seen) ? (
+                        <p className="text-xs text-amber-200/90">
+                          {t('nomadNetwork.staleLastSeenHint', {
+                            time: formatRelativeOrIsoDate((selectedNode.last_seen ?? 0) * 1000, t),
+                          })}
+                        </p>
+                      ) : null}
+                    </div>
                   ) : pageContent != null ? (
                     isNomadMicronPage(pageContentType, pagePath) && !showPageSource ? (
                       <NomadMicronPageView
-                        content={pageContent}
+                        content={
+                          pageContentTruncated
+                            ? `${pageContent}\n\n[${t('nomadNetwork.pageTruncated')}]`
+                            : pageContent
+                        }
                         defaultPagePath={DEFAULT_NOMAD_NODE_PAGE_PATH}
                         selectedHash={selectedNode.destination_hash}
                         fitWidth={pageFitWidth}
@@ -1155,7 +1081,9 @@ export default function NomadNetworkPanel({
                             : 'whitespace-pre'
                         }`}
                       >
-                        {pageContent}
+                        {pageContentTruncated
+                          ? `${pageContent}\n\n[${t('nomadNetwork.pageTruncated')}]`
+                          : pageContent}
                       </pre>
                     )
                   ) : null}

--- a/src/renderer/components/NomadNetworkPanel.tsx
+++ b/src/renderer/components/NomadNetworkPanel.tsx
@@ -36,6 +36,7 @@ import { isNomadLastSeenStale } from '@/renderer/lib/nomad/nomadNodeStale';
 import {
   humanizeNomadPageError,
   isRetryableNomadPageError,
+  shouldForceNomadPathRefreshRetry,
 } from '@/renderer/lib/nomad/nomadPageErrorHumanize';
 import { isReticulumSidecarRunning } from '@/renderer/lib/reticulum/reticulumSidecarReads';
 import type { NomadNodeRow, NomadPageRequestData } from '@/shared/nomad-types';
@@ -258,6 +259,7 @@ export default function NomadNetworkPanel({
   const loadPage = useNomadPageViewerStore((s) => s.loadPage);
   const closeViewerStore = useNomadPageViewerStore((s) => s.closeViewer);
   const setPanelActive = useNomadPageViewerStore((s) => s.setPanelActive);
+  const setInvalidUrlError = useNomadPageViewerStore((s) => s.setInvalidUrlError);
   const markAnnounceReloadDone = useNomadPageViewerStore((s) => s.markAnnounceReloadDone);
 
   const pageError = pageErrorRaw ? humanizeNomadPageError(pageErrorRaw, t) : null;
@@ -447,7 +449,7 @@ export default function NomadNetworkPanel({
     // eslint-disable-next-line react-hooks/set-state-in-effect -- auto-retry after announce updates node metadata
     void loadNodePage(selectedHash, pagePath, {
       forceReload: true,
-      forcePathRefresh: true,
+      forcePathRefresh: shouldForceNomadPathRefreshRetry(pageErrorCode),
       requestData: pageRequestData,
     });
   }, [
@@ -532,11 +534,7 @@ export default function NomadNetworkPanel({
     const { destination: baseDestination, requestData } = buildNomadLinkRequest(target, null, null);
     const parsed = parseNomadNetworkLinkUrl(baseDestination, DEFAULT_NOMAD_NODE_PAGE_PATH);
     if (!parsed) {
-      useNomadPageViewerStore.setState({
-        pageErrorRaw: t('nomadNetwork.invalidUrl'),
-        pageLoading: false,
-        pageLoadingStartedAt: null,
-      });
+      setInvalidUrlError();
       return;
     }
 
@@ -545,7 +543,7 @@ export default function NomadNetworkPanel({
     void loadNodePage(hash, parsed.path, {
       requestData: normalizedRequest,
     });
-  }, [loadNodePage, selectedNode, t, urlBarValue]);
+  }, [loadNodePage, selectedNode, setInvalidUrlError, urlBarValue]);
 
   const closeViewer = useCallback(() => {
     closeViewerStore();
@@ -983,7 +981,7 @@ export default function NomadNetworkPanel({
                     onClick={() => {
                       void loadNodePage(selectedNode.destination_hash, pagePath, {
                         forceReload: true,
-                        forcePathRefresh: isRetryableNomadPageError(pageErrorCode),
+                        forcePathRefresh: shouldForceNomadPathRefreshRetry(pageErrorCode),
                         requestData: pageRequestData,
                       });
                     }}

--- a/src/renderer/lib/nomad/nomadNodeStale.test.ts
+++ b/src/renderer/lib/nomad/nomadNodeStale.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isNomadLastSeenStale, NOMAD_STALE_LAST_SEEN_SECS } from './nomadNodeStale';
+
+describe('isNomadLastSeenStale', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('is false for missing or invalid timestamps', () => {
+    expect(isNomadLastSeenStale(null)).toBe(false);
+    expect(isNomadLastSeenStale(undefined)).toBe(false);
+    expect(isNomadLastSeenStale(0)).toBe(false);
+    expect(isNomadLastSeenStale(Number.NaN)).toBe(false);
+  });
+
+  it('is false when last heard is recent', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-31T20:00:00Z'));
+    const nowSec = Math.floor(Date.now() / 1000);
+    expect(isNomadLastSeenStale(nowSec - 60)).toBe(false);
+    expect(isNomadLastSeenStale(nowSec - (NOMAD_STALE_LAST_SEEN_SECS - 1))).toBe(false);
+  });
+
+  it('is true when last heard exceeds the soft threshold', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-31T20:00:00Z'));
+    const nowSec = Math.floor(Date.now() / 1000);
+    expect(isNomadLastSeenStale(nowSec - NOMAD_STALE_LAST_SEEN_SECS)).toBe(true);
+    expect(isNomadLastSeenStale(nowSec - NOMAD_STALE_LAST_SEEN_SECS - 100)).toBe(true);
+  });
+});

--- a/src/renderer/lib/nomad/nomadNodeStale.ts
+++ b/src/renderer/lib/nomad/nomadNodeStale.ts
@@ -1,0 +1,16 @@
+import { MS_PER_SECOND } from '@/shared/timeConstants';
+
+/** Soft UX threshold: last heard older than this may be offline despite "online". */
+export const NOMAD_STALE_LAST_SEEN_SECS = 2 * 60 * 60;
+
+/** True when `last_seen` (unix seconds) is older than {@link NOMAD_STALE_LAST_SEEN_SECS}. */
+export function isNomadLastSeenStale(
+  lastSeenSec: number | null | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  if (lastSeenSec == null || !Number.isFinite(lastSeenSec) || lastSeenSec <= 0) {
+    return false;
+  }
+  const ageSec = Math.floor(nowMs / MS_PER_SECOND) - Math.floor(lastSeenSec);
+  return ageSec >= NOMAD_STALE_LAST_SEEN_SECS;
+}

--- a/src/renderer/lib/nomad/nomadPageErrorHumanize.test.ts
+++ b/src/renderer/lib/nomad/nomadPageErrorHumanize.test.ts
@@ -18,6 +18,7 @@ describe('nomadPageErrorHumanize', () => {
     expect(nomadPageErrorI18nKey('nomad_busy')).toBe('nomadNetwork.errors.nomadBusy');
     expect(nomadPageErrorI18nKey('nomad_not_serving')).toBe('nomadNetwork.errors.nomadNotServing');
     expect(nomadPageErrorI18nKey('network_not_ready')).toBe('nomadNetwork.errors.networkNotReady');
+    expect(nomadPageErrorI18nKey('invalid_url')).toBe('nomadNetwork.invalidUrl');
     expect(nomadPageErrorI18nKey('missing_identity_hash')).toBe(
       'nomadNetwork.errors.missingIdentity',
     );

--- a/src/renderer/lib/nomad/nomadPageErrorHumanize.test.ts
+++ b/src/renderer/lib/nomad/nomadPageErrorHumanize.test.ts
@@ -4,6 +4,7 @@ import {
   humanizeNomadPageError,
   isRetryableNomadPageError,
   nomadPageErrorI18nKey,
+  shouldForceNomadPathRefreshRetry,
 } from './nomadPageErrorHumanize';
 
 describe('nomadPageErrorHumanize', () => {
@@ -15,6 +16,8 @@ describe('nomadPageErrorHumanize', () => {
       'nomadNetwork.errors.responseTooLarge',
     );
     expect(nomadPageErrorI18nKey('nomad_busy')).toBe('nomadNetwork.errors.nomadBusy');
+    expect(nomadPageErrorI18nKey('nomad_not_serving')).toBe('nomadNetwork.errors.nomadNotServing');
+    expect(nomadPageErrorI18nKey('network_not_ready')).toBe('nomadNetwork.errors.networkNotReady');
     expect(nomadPageErrorI18nKey('missing_identity_hash')).toBe(
       'nomadNetwork.errors.missingIdentity',
     );
@@ -44,16 +47,23 @@ describe('nomadPageErrorHumanize', () => {
     expect(humanizeNomadPageError(null, t)).toBe('t:common.error');
   });
 
-  it('classifies retryable path/link/identity errors', () => {
+  it('classifies announce-reload vs force-path-refresh errors', () => {
     expect(isRetryableNomadPageError('path_timeout')).toBe(true);
     expect(isRetryableNomadPageError('link_timeout')).toBe(true);
     expect(isRetryableNomadPageError('response_timeout')).toBe(true);
-    expect(isRetryableNomadPageError('nomad_busy')).toBe(true);
+    expect(isRetryableNomadPageError('nomad_busy')).toBe(false);
     expect(isRetryableNomadPageError('pubkey_not_found')).toBe(true);
     expect(isRetryableNomadPageError('missing_identity_hash')).toBe(true);
     expect(isRetryableNomadPageError('sidecar_not_running')).toBe(false);
     expect(isRetryableNomadPageError('content_source_required')).toBe(false);
     expect(isRetryableNomadPageError(null)).toBe(false);
     expect(isRetryableNomadPageError('')).toBe(false);
+
+    expect(shouldForceNomadPathRefreshRetry('path_timeout')).toBe(true);
+    expect(shouldForceNomadPathRefreshRetry('pubkey_not_found')).toBe(true);
+    expect(shouldForceNomadPathRefreshRetry('missing_identity_hash')).toBe(true);
+    expect(shouldForceNomadPathRefreshRetry('link_timeout')).toBe(false);
+    expect(shouldForceNomadPathRefreshRetry('response_timeout')).toBe(false);
+    expect(shouldForceNomadPathRefreshRetry('nomad_busy')).toBe(false);
   });
 });

--- a/src/renderer/lib/nomad/nomadPageErrorHumanize.ts
+++ b/src/renderer/lib/nomad/nomadPageErrorHumanize.ts
@@ -12,6 +12,7 @@ const NOMAD_ERROR_I18N_KEYS: Record<string, string> = {
   nomad_busy: 'nomadNetwork.errors.nomadBusy',
   nomad_not_serving: 'nomadNetwork.errors.nomadNotServing',
   network_not_ready: 'nomadNetwork.errors.networkNotReady',
+  invalid_url: 'nomadNetwork.invalidUrl',
   content_source_required: 'nomadNetwork.serving.contentSourceRequired',
   content_source_unavailable: 'nomadNetwork.serving.contentSourceUnavailable',
   content_source_not_directory: 'nomadNetwork.serving.contentSourceNotDirectory',

--- a/src/renderer/lib/nomad/nomadPageErrorHumanize.ts
+++ b/src/renderer/lib/nomad/nomadPageErrorHumanize.ts
@@ -10,6 +10,8 @@ const NOMAD_ERROR_I18N_KEYS: Record<string, string> = {
   sidecar_not_running: 'nomadNetwork.errors.sidecarNotRunning',
   response_too_large: 'nomadNetwork.errors.responseTooLarge',
   nomad_busy: 'nomadNetwork.errors.nomadBusy',
+  nomad_not_serving: 'nomadNetwork.errors.nomadNotServing',
+  network_not_ready: 'nomadNetwork.errors.networkNotReady',
   content_source_required: 'nomadNetwork.serving.contentSourceRequired',
   content_source_unavailable: 'nomadNetwork.serving.contentSourceUnavailable',
   content_source_not_directory: 'nomadNetwork.serving.contentSourceNotDirectory',
@@ -20,12 +22,25 @@ const NOMAD_ERROR_I18N_KEYS: Record<string, string> = {
   content_source_not_from_picker: 'nomadNetwork.serving.contentSourceNotFromPicker',
 };
 
-/** Transient path/link/identity errors worth one automatic page-fetch retry. */
-const RETRYABLE_NOMAD_PAGE_ERRORS = new Set([
+/**
+ * Errors that may clear after a fresh announce / path update (UI announce-reload).
+ * Do not include `nomad_busy`: another Link query still owns the lock.
+ */
+const ANNOUNCE_RELOAD_NOMAD_PAGE_ERRORS = new Set([
   'path_timeout',
   'link_timeout',
   'response_timeout',
-  'nomad_busy',
+  'pubkey_not_found',
+  'missing_identity_hash',
+]);
+
+/**
+ * Errors worth one automatic re-fetch with `force_path_refresh`.
+ * Link/response timeouts already exercised path+link — forcing RequestPath again
+ * doubles RF lock time without fixing the failure mode.
+ */
+const FORCE_PATH_REFRESH_NOMAD_PAGE_ERRORS = new Set([
+  'path_timeout',
   'pubkey_not_found',
   'missing_identity_hash',
 ]);
@@ -37,11 +52,18 @@ export function nomadPageErrorI18nKey(error: string | null | undefined): string 
   return NOMAD_ERROR_I18N_KEYS[trimmed] ?? null;
 }
 
-/** True when a Nomad page/file error code should trigger one-shot or announce reload. */
+/** True when a Nomad page/file error code should trigger announce-driven reload. */
 export function isRetryableNomadPageError(error: string | null | undefined): boolean {
   const trimmed = error?.trim();
   if (!trimmed) return false;
-  return RETRYABLE_NOMAD_PAGE_ERRORS.has(trimmed);
+  return ANNOUNCE_RELOAD_NOMAD_PAGE_ERRORS.has(trimmed);
+}
+
+/** True when one-shot auto-retry should call fetch with forcePathRefresh. */
+export function shouldForceNomadPathRefreshRetry(error: string | null | undefined): boolean {
+  const trimmed = error?.trim();
+  if (!trimmed) return false;
+  return FORCE_PATH_REFRESH_NOMAD_PAGE_ERRORS.has(trimmed);
 }
 
 /** Resolve a Nomad page/file error for display via i18n when known. */

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -269,3 +269,10 @@ export function meshcoreRepeaterRpcTimeoutMs(hopsAway?: number | null): number {
 
 /** Brief settle before one-shot Nomad page re-fetch after a transient path/link error. */
 export const NOMAD_PAGE_FETCH_RETRY_SETTLE_MS = 750;
+
+/**
+ * Coalesce rapid Nomad node/page selection before starting a Link query.
+ * Link queries are serialized in the sidecar; rapid clicks should only keep
+ * the latest selection after this debounce.
+ */
+export const NOMAD_PAGE_FETCH_DEBOUNCE_MS = 300;

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -2959,7 +2959,9 @@
       "transportUnavailable": "Transport Reticulum není k dispozici. Restartujte zásobník a zkuste to znovu.",
       "sidecarNotRunning": "Reticulum sidecar neběží. Spusťte zásobník z Připojení a zkuste to znovu.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Jiný požadavek na stránku nebo soubor Nomad stále probíhá. Zkuste to znovu za chvíli."
+      "nomadBusy": "Jiný požadavek na stránku nebo soubor Nomad stále probíhá. Zkuste to znovu za chvíli.",
+      "nomadNotServing": "Toto je váš uzel Nomad, ale hosting My Pages neběží. Otevřete Moje stránky, vyberte složku a začněte poskytovat místní náhled.",
+      "networkNotReady": "Čekání na připojení hubu nebo rádiového rozhraní. Zkuste to znovu, jakmile připojení zobrazí rozhraní."
     },
     "fitWidth": "Přizpůsobit stránku oknu",
     "openWidth": "Šířka stránky",
@@ -3005,7 +3007,11 @@
     "sortByHopsAsc": "Třídit podle skoků, nejdříve nejblíže",
     "sortByHopsDesc": "Třídit podle skoků, nejdále",
     "sortByNameAsc": "Seřadit podle názvu: A až Z",
-    "sortByNameDesc": "Řadit podle názvu (Z až A)"
+    "sortByNameDesc": "Řadit podle názvu (Z až A)",
+    "pageLoadingCountdown": "Načítání stránky… Zbývá {{time}}",
+    "pageLoadingCountdownOverdue": "Načítání stránky… stále funguje",
+    "pageReadyToast": "Nomad — Nomádská stránka připravena: {{name}}",
+    "staleLastSeenHint": "Naposledy slyšet {{time}} – tento uzel může být offline, i když je uveden jako online."
   },
   "packetDistribution": {
     "overallDistribution": "Celková distribuce",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Reticulum-Transport ist nicht verfügbar. Starten Sie den Stack neu und versuchen Sie es erneut.",
       "sidecarNotRunning": "Reticulum-Sidecar läuft nicht. Starten Sie den Stack unter Verbindung und versuchen Sie es erneut.",
       "responseTooLarge": "Der Knoten hat mehr Daten zurückgegeben, als mesh-client für diese Anfrage akzeptiert.",
-      "nomadBusy": "Eine andere Nomad-Seiten- oder Dateianfrage läuft noch. Versuche es gleich noch einmal."
+      "nomadBusy": "Eine andere Nomad-Seiten- oder Dateianfrage läuft noch. Versuche es gleich noch einmal.",
+      "nomadNotServing": "Dies ist Ihr Nomad-Knoten, aber das Hosting „Meine Seiten“ läuft nicht. Öffnen Sie „Meine Seiten“, wählen Sie einen Ordner aus und beginnen Sie mit der Bereitstellung zur lokalen Vorschau.",
+      "networkNotReady": "Warten darauf, dass ein Hub oder eine Funkschnittstelle online geht. Versuchen Sie es erneut, sobald Connection eine Schnittstelle anzeigt."
     },
     "fitWidth": "An Fenster anpassen",
     "openWidth": "Seitenbreite",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "Sortieren nach Hops, nächstgelegener zuerst",
     "sortByHopsDesc": "Nach Hops sortieren, am weitesten vorne",
     "sortByNameAsc": "Nach Name sortieren: A bis Z",
-    "sortByNameDesc": "Nach Name sortieren: Z bis A"
+    "sortByNameDesc": "Nach Name sortieren: Z bis A",
+    "pageLoadingCountdown": "Seite wird geladen… {{time}} übrig",
+    "pageLoadingCountdownOverdue": "Seite wird geladen... funktioniert immer noch",
+    "pageReadyToast": "Nomad-Seite bereit: {{name}}",
+    "staleLastSeenHint": "Zuletzt gehört {{time}} – dieser Knoten ist möglicherweise offline, auch wenn er als online aufgeführt ist."
   },
   "packetDistribution": {
     "overallDistribution": "Gesamtverteilung",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -3092,6 +3092,9 @@
     "reloadPage": "Reload page",
     "closeViewer": "Close page viewer",
     "pageLoading": "Loading page…",
+    "pageLoadingCountdown": "Loading page… {{time}} left",
+    "pageLoadingCountdownOverdue": "Loading page… still working",
+    "pageReadyToast": "Nomad page ready: {{name}}",
     "pageFailed": "Failed to load page: {{error}}",
     "pageTruncated": "Page truncated for display",
     "errors": {
@@ -3103,8 +3106,11 @@
       "transportUnavailable": "Reticulum transport is unavailable. Restart the stack and try again.",
       "sidecarNotRunning": "Reticulum sidecar is not running. Start the stack from Connection, then try again.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Another Nomad page or file request is still in progress. Try again in a moment."
+      "nomadBusy": "Another Nomad page request is still in progress. Try again in a moment.",
+      "nomadNotServing": "This is your Nomad node, but My Pages hosting is not running. Open My Pages, choose a folder, and start serving to preview locally.",
+      "networkNotReady": "Waiting for a hub or radio interface to come online. Try again once Connection shows an interface up."
     },
+    "staleLastSeenHint": "Last heard {{time}} — this node may be offline even if listed as online.",
     "showSource": "Show page source",
     "hideSource": "Show formatted page",
     "fitWidth": "Fit page to window",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "El transporte de Reticulum no está disponible. Reinicie la pila e inténtelo de nuevo.",
       "sidecarNotRunning": "El sidecar de Reticulum no está en ejecución. Inicie la pila desde Conexión y vuelva a intentarlo.",
       "responseTooLarge": "El nodo devolvió más datos de los que mesh-client acepta para esta solicitud.",
-      "nomadBusy": "Otra solicitud de página o archivo Nomad aún está en curso. Inténtalo de nuevo en un momento."
+      "nomadBusy": "Otra solicitud de página o archivo Nomad aún está en curso. Inténtalo de nuevo en un momento.",
+      "nomadNotServing": "Este es su nodo Nomad, pero el alojamiento Mis páginas no se está ejecutando. Abra Mis páginas, elija una carpeta y comience a publicar para obtener una vista previa local.",
+      "networkNotReady": "Esperando a que se conecte un concentrador o una interfaz de radio. Inténtelo de nuevo una vez que Connection muestre una interfaz."
     },
     "fitWidth": "Ajustar a la ventana",
     "openWidth": "Anchura de la página",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "Ordenar por saltos, el más cercano primero",
     "sortByHopsDesc": "Ordenar por saltos, el más lejano primero",
     "sortByNameAsc": "Ordenar por nombre A->Z",
-    "sortByNameDesc": "Ordenar por nombre Z->A"
+    "sortByNameDesc": "Ordenar por nombre Z->A",
+    "pageLoadingCountdown": "Cargando página... {{time}} izquierda",
+    "pageLoadingCountdownOverdue": "Cargando página… sigue funcionando",
+    "pageReadyToast": "Nomad — Página nómada lista: {{name}}",
+    "staleLastSeenHint": "Escuchado por última vez {{time}}: este nodo puede estar fuera de línea incluso si figura como en línea."
   },
   "packetDistribution": {
     "overallDistribution": "Distribución general",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Le transport Reticulum n’est pas disponible. Redémarrez la pile et réessayez.",
       "sidecarNotRunning": "Le sidecar Reticulum n’est pas en cours d’exécution. Démarrez la pile depuis Connexion, puis réessayez.",
       "responseTooLarge": "Le nœud a renvoyé plus de données que mesh-client n’accepte pour cette requête.",
-      "nomadBusy": "Une autre requête de page ou de fichier Nomad est encore en cours. Réessayez dans un instant."
+      "nomadBusy": "Une autre requête de page ou de fichier Nomad est encore en cours. Réessayez dans un instant.",
+      "nomadNotServing": "Il s'agit de votre nœud Nomad, mais l'hébergement Mes pages ne fonctionne pas. Ouvrez Mes pages, choisissez un dossier et commencez à diffuser un aperçu localement.",
+      "networkNotReady": "En attente de la mise en ligne d'un hub ou d'une interface radio. Réessayez une fois que Connection affiche une interface."
     },
     "fitWidth": "Ajuster la page à la fenêtre",
     "openWidth": "Largeur de la page",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "Trier par sauts, le plus proche en premier",
     "sortByHopsDesc": "Trier par sauts, le plus éloigné en premier",
     "sortByNameAsc": "Tri par nom : A à Z",
-    "sortByNameDesc": "Tri par nom : Z à A"
+    "sortByNameDesc": "Tri par nom : Z à A",
+    "pageLoadingCountdown": "Chargement de la page… {{time}} gauche",
+    "pageLoadingCountdownOverdue": "Chargement de la page… fonctionne toujours",
+    "pageReadyToast": "Nomad — Page nomade prête : {{name}}",
+    "staleLastSeenHint": "Dernière écoute {{time}} — ce nœud peut être hors ligne même s'il est répertorié comme en ligne."
   },
   "packetDistribution": {
     "overallDistribution": "Répartition globale",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Transport Reticulum tidak tersedia. Mulai ulang stack dan coba lagi.",
       "sidecarNotRunning": "Sidecar Reticulum tidak berjalan. Mulai stack dari Connection, lalu coba lagi.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Permintaan halaman atau berkas Nomad lain masih berlangsung. Coba lagi sebentar lagi."
+      "nomadBusy": "Permintaan halaman atau berkas Nomad lain masih berlangsung. Coba lagi sebentar lagi.",
+      "nomadNotServing": "Ini adalah node Nomad Anda, tetapi hosting Halaman Saya tidak berjalan. Buka Halaman Saya, pilih folder, dan mulai melayani untuk melihat pratinjau secara lokal.",
+      "networkNotReady": "Menunggu hub atau antarmuka radio online. Coba lagi setelah Koneksi menampilkan antarmuka."
     },
     "fitWidth": "Muat halaman ke jendela",
     "openWidth": "Buka lebar halaman",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "Urutkan berdasarkan Hop, paling dekat dulu",
     "sortByHopsDesc": "Urutkan berdasarkan Hop, terjauh dulu",
     "sortByNameAsc": "Menurut Nama - A ke Z",
-    "sortByNameDesc": "Menurut Nama - Z ke A"
+    "sortByNameDesc": "Menurut Nama - Z ke A",
+    "pageLoadingCountdown": "Memuat halaman… {{time}} tersisa",
+    "pageLoadingCountdownOverdue": "Memuat halaman… masih berfungsi",
+    "pageReadyToast": "Nomad — Halaman pengembara siap: {{name}}",
+    "staleLastSeenHint": "Terakhir terdengar {{time}} — node ini mungkin offline meskipun terdaftar sebagai online."
   },
   "packetDistribution": {
     "overallDistribution": "Distribusi Keseluruhan",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Il trasporto Reticulum non è disponibile. Riavviare lo stack e riprovare.",
       "sidecarNotRunning": "Il sidecar Reticulum non è in esecuzione. Avviare lo stack da Connessione, quindi riprovare.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Un'altra richiesta di pagina o file Nomad è ancora in corso. Riprova tra un momento."
+      "nomadBusy": "Un'altra richiesta di pagina o file Nomad è ancora in corso. Riprova tra un momento.",
+      "nomadNotServing": "Questo è il tuo nodo Nomad, ma l'hosting di Le mie pagine non è in esecuzione. Apri Le mie pagine, scegli una cartella e inizia a pubblicare per visualizzare l'anteprima localmente.",
+      "networkNotReady": "In attesa che un hub o un'interfaccia radio siano online. Riprovare quando Connection mostra un'interfaccia."
     },
     "fitWidth": "Adatta alla finestra",
     "openWidth": "Larghezza pagina",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "Ordina per salti, dal più vicino",
     "sortByHopsDesc": "Ordina per salti, prima il più lontano",
     "sortByNameAsc": "Ordina per nome - dalla A alla Z",
-    "sortByNameDesc": "Ordina per nome - dalla Z alla A"
+    "sortByNameDesc": "Ordina per nome - dalla Z alla A",
+    "pageLoadingCountdown": "Caricamento pagina… {{time}} sinistra",
+    "pageLoadingCountdownOverdue": "Caricamento della pagina... ancora funzionante",
+    "pageReadyToast": "Pagina Nomad pronta: {{name}}",
+    "staleLastSeenHint": "Ultimo ascolto {{time}}: questo nodo potrebbe essere offline anche se elencato come online."
   },
   "packetDistribution": {
     "overallDistribution": "Distribuzione complessiva",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Reticulum トランスポートは利用できません。スタックを再起動してもう一度お試しください。",
       "sidecarNotRunning": "Reticulum サイドカーが実行されていません。接続からスタックを開始してから、もう一度お試しください。",
       "responseTooLarge": "ノードが返すデータ量が、この要求で mesh-client が受け入れる上限を超えました。",
-      "nomadBusy": "別の Nomad ページまたはファイル要求が処理中です。しばらくしてから再試行してください。"
+      "nomadBusy": "別の Nomad ページまたはファイル要求が処理中です。しばらくしてから再試行してください。",
+      "nomadNotServing": "これは Nomad ノードですが、My Pages ホスティングは実行されていません。 [マイ ページ] を開いてフォルダーを選択し、ローカルでプレビューするための配信を開始します。",
+      "networkNotReady": "ハブまたは無線インターフェイスがオンラインになるのを待っています。接続にインターフェイスが表示されたら、もう一度試してください。"
     },
     "fitWidth": "ウィンドウに適合",
     "openWidth": "ページ幅",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "ホップで並べ替え、最も近い順",
     "sortByHopsDesc": "ホップで並べ替え、最も遠い順",
     "sortByNameAsc": "名前で並べ替え、AからZ",
-    "sortByNameDesc": "名前で並べ替え、ZからA"
+    "sortByNameDesc": "名前で並べ替え、ZからA",
+    "pageLoadingCountdown": "ページを読み込み中… {{time}} 残り",
+    "pageLoadingCountdownOverdue": "ページを読み込み中…まだ動作中",
+    "pageReadyToast": "Nomadページの準備ができました: {{name}}",
+    "staleLastSeenHint": "最後に受信したのは {{time}} — このノードはオンラインとしてリストされている場合でもオフラインである可能性があります。"
   },
   "packetDistribution": {
     "overallDistribution": "全体の分布",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Reticulum 전송을 사용할 수 없습니다. 스택을 다시 시작한 다음 다시 시도하십시오.",
       "sidecarNotRunning": "Reticulum 사이드카가 실행되고 있지 않습니다. Connection에서 스택을 시작한 다음 다시 시도하십시오.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "다른 Nomad 페이지 또는 파일 요청이 아직 진행 중입니다. 잠시 후 다시 시도하세요."
+      "nomadBusy": "다른 Nomad 페이지 또는 파일 요청이 아직 진행 중입니다. 잠시 후 다시 시도하세요.",
+      "nomadNotServing": "이것은 Nomad 노드이지만 내 페이지 호스팅이 실행되고 있지 않습니다. 내 페이지를 열고 폴더를 선택한 후 로컬에서 미리 볼 수 있는 서비스를 시작하세요.",
+      "networkNotReady": "허브 또는 무선 인터페이스가 온라인 상태가 될 때까지 기다리는 중입니다. Connection에 인터페이스가 표시되면 다시 시도하십시오."
     },
     "fitWidth": "창에 맞춤",
     "openWidth": "페이지 폭",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "홉으로 정렬, 가장 가까운 우선순위",
     "sortByHopsDesc": "홉 순으로 정렬, 가장 먼 순",
     "sortByNameAsc": "이름 A-Z",
-    "sortByNameDesc": "이름 Z-A"
+    "sortByNameDesc": "이름 Z-A",
+    "pageLoadingCountdown": "페이지 로드 중… {{time}} 남음",
+    "pageLoadingCountdownOverdue": "페이지 로드 중… 아직 작동 중",
+    "pageReadyToast": "Nomad 페이지 준비됨: {{name}}",
+    "staleLastSeenHint": "마지막으로 청취된 {{time}} — 이 노드는 온라인으로 나열되어 있어도 오프라인일 수 있습니다."
   },
   "packetDistribution": {
     "overallDistribution": "전체 분포",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Reticulum-transport is niet beschikbaar. Start de stack opnieuw en probeer het opnieuw.",
       "sidecarNotRunning": "Reticulum-sidecar draait niet. Start de stack vanuit Verbinding en probeer het opnieuw.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Een ander Nomad-pagina- of bestandsverzoek is nog bezig. Probeer het zo opnieuw."
+      "nomadBusy": "Een ander Nomad-pagina- of bestandsverzoek is nog bezig. Probeer het zo opnieuw.",
+      "nomadNotServing": "Dit is uw Nomad-knooppunt, maar de My Pages-hosting is niet actief. Open Mijn pagina's, kies een map en begin met het weergeven van lokale voorbeelden.",
+      "networkNotReady": "Wachten tot een hub of radio-interface online komt. Probeer het opnieuw zodra Connection een interface toont."
     },
     "fitWidth": "In venster passen",
     "openWidth": "Paginabreedte",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "Sorteer op Hop, dichtstbijzijnde eerst",
     "sortByHopsDesc": "Sorteer op Hop, verste eerst",
     "sortByNameAsc": "Sorteer op naam: A tot Z",
-    "sortByNameDesc": "Sorteer op Naam, Z tot A"
+    "sortByNameDesc": "Sorteer op Naam, Z tot A",
+    "pageLoadingCountdown": "Pagina wordt geladen… {{time}} over",
+    "pageLoadingCountdownOverdue": "Pagina wordt geladen... werkt nog steeds",
+    "pageReadyToast": "Nomad-pagina klaar: {{name}}",
+    "staleLastSeenHint": "Laatst gehoord {{time}}: dit knooppunt is mogelijk offline, zelfs als het als online wordt vermeld."
   },
   "packetDistribution": {
     "overallDistribution": "Algemene distributie",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -2961,7 +2961,9 @@
       "transportUnavailable": "Transport Reticulum jest niedostępny. Uruchom ponownie stos i spróbuj ponownie.",
       "sidecarNotRunning": "Sidecar Reticulum nie działa. Uruchom stos z Połączenia, a następnie spróbuj ponownie.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Inne żądanie strony lub pliku Nomad jest nadal w toku. Spróbuj ponownie za chwilę."
+      "nomadBusy": "Inne żądanie strony lub pliku Nomad jest nadal w toku. Spróbuj ponownie za chwilę.",
+      "nomadNotServing": "To jest Twój węzeł Nomad, ale hosting Moich stron nie jest uruchomiony. Otwórz Moje strony, wybierz folder i rozpocznij udostępnianie, aby uzyskać podgląd lokalny.",
+      "networkNotReady": "Oczekiwanie na połączenie koncentratora lub interfejsu radiowego z Internetem. Spróbuj ponownie, gdy połączenie wyświetli interfejs."
     },
     "fitWidth": "Dopasuj do okna",
     "openWidth": "Szerokość strony",
@@ -3007,7 +3009,11 @@
     "sortByHopsAsc": "Sortuj według przeskoków, najpierw najbliższe",
     "sortByHopsDesc": "Sortuj według przeskoków, najpierw najdalej",
     "sortByNameAsc": "Sortuj wg nazwy: od A do Z",
-    "sortByNameDesc": "Sortuj wg nazwy: od Z do A"
+    "sortByNameDesc": "Sortuj wg nazwy: od Z do A",
+    "pageLoadingCountdown": "Ładowanie strony… Pozostało {{time}}",
+    "pageLoadingCountdownOverdue": "Ładowanie strony… nadal działa",
+    "pageReadyToast": "Strona Nomad gotowa: {{name}}",
+    "staleLastSeenHint": "Ostatnio słuchano {{time}} — ten węzeł może być w trybie offline, nawet jeśli jest wymieniony jako online."
   },
   "packetDistribution": {
     "overallDistribution": "Ogólna dystrybucja",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "O transporte Reticulum não está disponível. Reinicie a pilha e tente novamente.",
       "sidecarNotRunning": "O sidecar Reticulum não está em execução. Inicie a pilha a partir de Conexão e tente novamente.",
       "responseTooLarge": "O nó retornou mais dados do que o mesh-client aceita para esta solicitação.",
-      "nomadBusy": "Outra solicitação de página ou arquivo Nomad ainda está em andamento. Tente novamente em um momento."
+      "nomadBusy": "Outra solicitação de página ou arquivo Nomad ainda está em andamento. Tente novamente em um momento.",
+      "nomadNotServing": "Este é o seu nó Nomad, mas a hospedagem My Pages não está em execução. Abra Minhas páginas, escolha uma pasta e comece a servir para visualização local.",
+      "networkNotReady": "Aguardando que um hub ou interface de rádio fique online. Tente novamente quando o Connection mostrar uma interface."
     },
     "fitWidth": "Encaixar na janela",
     "openWidth": "Largura da Página",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "Ordenar por saltos, o mais próximo primeiro",
     "sortByHopsDesc": "Ordenar por saltos, o mais distante primeiro",
     "sortByNameAsc": "Ordenar por nome de A a Z",
-    "sortByNameDesc": "Ordenar por nome: z à a"
+    "sortByNameDesc": "Ordenar por nome: z à a",
+    "pageLoadingCountdown": "Carregando página… {{time}} esquerda",
+    "pageLoadingCountdownOverdue": "Carregando página… ainda funcionando",
+    "pageReadyToast": "Página Nomad pronta: {{name}}",
+    "staleLastSeenHint": "Ouvido pela última vez em {{time}} — este nó pode estar offline mesmo se estiver listado como online."
   },
   "packetDistribution": {
     "overallDistribution": "Distribuição Geral",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -2959,7 +2959,9 @@
       "transportUnavailable": "Транспорт Reticulum недоступен. Перезапустите стек и повторите попытку.",
       "sidecarNotRunning": "Sidecar Reticulum не запущен. Запустите стек из Connection и повторите попытку.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Другой запрос страницы или файла Nomad всё ещё выполняется. Попробуйте снова через мгновение."
+      "nomadBusy": "Другой запрос страницы или файла Nomad всё ещё выполняется. Попробуйте снова через мгновение.",
+      "nomadNotServing": "Это ваш узел Nomad, но хостинг My Pages не работает. Откройте «Мои страницы», выберите папку и начните локальный предварительный просмотр.",
+      "networkNotReady": "Ожидание подключения концентратора или радиоинтерфейса к сети. Попробуйте еще раз, как только Connection отобразит интерфейс."
     },
     "fitWidth": "Уместить в окне",
     "openWidth": "ширина страницы",
@@ -3005,7 +3007,11 @@
     "sortByHopsAsc": "Сортировать по хопам, сначала по ближайшим",
     "sortByHopsDesc": "Сортировать по хопам, сначала самые дальние",
     "sortByNameAsc": "Сортировать по имени А - Я",
-    "sortByNameDesc": "Сортировать по имени Я - А"
+    "sortByNameDesc": "Сортировать по имени Я - А",
+    "pageLoadingCountdown": "Загрузка страницы… Осталось {{time}}",
+    "pageLoadingCountdownOverdue": "Загрузка страницы… все еще работает",
+    "pageReadyToast": "Страница Nomad готова: {{name}}",
+    "staleLastSeenHint": "Последний раз слышал {{time}} — этот узел может быть отключен, даже если он указан как подключенный."
   },
   "packetDistribution": {
     "overallDistribution": "Общее распределение",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Reticulum taşıması kullanılamıyor. Yığını yeniden başlatın ve tekrar deneyin.",
       "sidecarNotRunning": "Reticulum sidecar çalışmıyor. Bağlantı bölümünden yığını başlatın, sonra tekrar deneyin.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Başka bir Nomad sayfa veya dosya isteği hâlâ devam ediyor. Biraz sonra tekrar deneyin."
+      "nomadBusy": "Başka bir Nomad sayfa veya dosya isteği hâlâ devam ediyor. Biraz sonra tekrar deneyin.",
+      "nomadNotServing": "Bu sizin Nomad düğümünüz, ancak Sayfalarım barındırma çalışmıyor. Sayfalarım'ı açın, bir klasör seçin ve yerel olarak önizlemeye sunmaya başlayın.",
+      "networkNotReady": "Bir hub veya radyo arayüzünün çevrimiçi olması bekleniyor. Bağlantı bir arayüz gösterdiğinde tekrar deneyin."
     },
     "fitWidth": "Pencereye sığdır",
     "openWidth": "Sayfa Genişliği",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "Atlamaya göre sırala, önce en yakın",
     "sortByHopsDesc": "Atlamaya göre sırala, önce en uzak",
     "sortByNameAsc": "Alfabetik sırala (A'dan Z'ye)",
-    "sortByNameDesc": "Alfabetik sırala (Z'den A'ya)"
+    "sortByNameDesc": "Alfabetik sırala (Z'den A'ya)",
+    "pageLoadingCountdown": "Sayfa yükleniyor… {{time}} kaldı",
+    "pageLoadingCountdownOverdue": "Sayfa yükleniyor… hala çalışıyor",
+    "pageReadyToast": "Nomad sayfası hazır: {{name}}",
+    "staleLastSeenHint": "Son duyulan {{time}} — bu düğüm çevrimiçi olarak listelense bile çevrimdışı olabilir."
   },
   "packetDistribution": {
     "overallDistribution": "Genel Dağıtım",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -2959,7 +2959,9 @@
       "transportUnavailable": "Транспорт Reticulum недоступний. Перезапустіть стек і спробуйте ще раз.",
       "sidecarNotRunning": "Sidecar Reticulum не працює. Запустіть стек із Підключення, а потім спробуйте ще раз.",
       "responseTooLarge": "The node returned more data than mesh-client will accept for this request.",
-      "nomadBusy": "Інший запит сторінки або файлу Nomad ще виконується. Спробуйте знову за мить."
+      "nomadBusy": "Інший запит сторінки або файлу Nomad ще виконується. Спробуйте знову за мить.",
+      "nomadNotServing": "Це ваш вузол Nomad, але хостинг My Pages не працює. Відкрийте «Мої сторінки», виберіть папку та почніть показ для попереднього перегляду локально.",
+      "networkNotReady": "Очікування підключення концентратора або радіоінтерфейсу. Повторіть спробу, коли підключення відобразить інтерфейс."
     },
     "fitWidth": "Вмістити у вікно",
     "openWidth": "Відкрити ширину сторінки",
@@ -3005,7 +3007,11 @@
     "sortByHopsAsc": "Сортувати за хопами, спочатку найближчими",
     "sortByHopsDesc": "Сортувати за хопами, спочатку найдалі",
     "sortByNameAsc": "Сортувати за назвою, від А до Я",
-    "sortByNameDesc": "Сортувати за назвою, від Я до А"
+    "sortByNameDesc": "Сортувати за назвою, від Я до А",
+    "pageLoadingCountdown": "Завантаження сторінки... Залишилося {{time}}",
+    "pageLoadingCountdownOverdue": "Завантаження сторінки… все ще працює",
+    "pageReadyToast": "Сторінка Nomad готова: {{name}}",
+    "staleLastSeenHint": "Востаннє почуто {{time}} — цей вузол може бути офлайн, навіть якщо вказано як онлайн."
   },
   "packetDistribution": {
     "overallDistribution": "Загальний розподіл",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -2957,7 +2957,9 @@
       "transportUnavailable": "Reticulum 传输不可用。请重新启动协议栈后重试。",
       "sidecarNotRunning": "Reticulum sidecar 未运行。请从 Connection 启动协议栈，然后重试。",
       "responseTooLarge": "该节点返回的数据超出了 mesh-client 对此请求的接受上限。",
-      "nomadBusy": "另一个 Nomad 页面或文件请求仍在进行中。请稍后再试。"
+      "nomadBusy": "另一个 Nomad 页面或文件请求仍在进行中。请稍后再试。",
+      "nomadNotServing": "这是您的 Nomad 节点，但“我的页面”托管未运行。打开“我的页面”，选择一个文件夹，然后开始在本地预览。",
+      "networkNotReady": "等待集线器或无线电接口上线。连接显示界面后重试。"
     },
     "fitWidth": "适合窗口",
     "openWidth": "图框宽度",
@@ -3003,7 +3005,11 @@
     "sortByHopsAsc": "按跃点排序，最近的在前",
     "sortByHopsDesc": "按跃点排序，最远的在前",
     "sortByNameAsc": "按名称排序 - A 到 Z",
-    "sortByNameDesc": "按名称排序 - Z 到 A"
+    "sortByNameDesc": "按名称排序 - Z 到 A",
+    "pageLoadingCountdown": "正在加载页面... {{time}} 左",
+    "pageLoadingCountdownOverdue": "正在加载页面...仍在工作",
+    "pageReadyToast": "Nomad 页面就绪：{{name}}",
+    "staleLastSeenHint": "最后听说 {{time}} — 即使列为在线，该节点也可能处于离线状态。"
   },
   "packetDistribution": {
     "overallDistribution": "总体分布",

--- a/src/renderer/stores/nomadNetworkStore.test.ts
+++ b/src/renderer/stores/nomadNetworkStore.test.ts
@@ -112,11 +112,11 @@ describe('nomadNetworkStore', () => {
 
     expect(fetchReticulumInterfaces).toHaveBeenCalledTimes(2);
     expect(proxyGet).toHaveBeenLastCalledWith(
-      '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=8&egress=rf',
+      '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu',
     );
   });
 
-  it('fetchNomadPage requests page path with hops and egress', async () => {
+  it('fetchNomadPage requests page path without unused hops/egress query params', async () => {
     getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
     fetchReticulumInterfaces.mockResolvedValue([{ type: 'rnode', enabled: true }]);
     useNomadNetworkStore.setState({
@@ -136,9 +136,7 @@ describe('nomadNetworkStore', () => {
 
     const res = await useNomadNetworkStore.getState().fetchNomadPage('abc', '/page/index.mu');
 
-    expect(proxyGet).toHaveBeenCalledWith(
-      '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=3&egress=rf',
-    );
+    expect(proxyGet).toHaveBeenCalledWith('/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu');
     expect(res).toEqual({ ok: true, content: 'page body', content_type: 'micron' });
   });
 
@@ -152,11 +150,11 @@ describe('nomadNetworkStore', () => {
       .fetchNomadPage('abc', '/page/index.mu', undefined, { forcePathRefresh: true });
 
     expect(proxyGet).toHaveBeenCalledWith(
-      '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=8&egress=tcp&force_path_refresh=true',
+      '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&force_path_refresh=true',
     );
   });
 
-  it('fetchNomadFile requests file path with hops and egress', async () => {
+  it('fetchNomadFile requests file path without unused hops/egress query params', async () => {
     getStatus.mockResolvedValue({ running: true, port: 1, pid: 1 });
     fetchReticulumInterfaces.mockResolvedValue([{ type: 'tcp', enabled: true }]);
     useNomadNetworkStore.setState({
@@ -181,7 +179,7 @@ describe('nomadNetworkStore', () => {
     const res = await useNomadNetworkStore.getState().fetchNomadFile('abc', '/file/readme.txt');
 
     expect(proxyGet).toHaveBeenCalledWith(
-      '/api/v1/nomadnetwork/file/abc?path=%2Ffile%2Freadme.txt&hops=2&egress=tcp',
+      '/api/v1/nomadnetwork/file/abc?path=%2Ffile%2Freadme.txt',
     );
     expect(res).toEqual({ ok: true, file_name: 'readme.txt', content_base64: 'aGVsbG8=' });
   });

--- a/src/renderer/stores/nomadNetworkStore.ts
+++ b/src/renderer/stores/nomadNetworkStore.ts
@@ -97,7 +97,9 @@ async function fetchNomadResource<T extends { ok: boolean; error?: string }>(
     // Sidecar recomputes path-table egress for its Link deadline; main uses a flat
     // Nomad proxy timeout. Cached local egress is logging-only (never block on GET).
     const egress = cachedNomadEgressAt > 0 ? cachedNomadEgress : 'network';
-    void resolveNomadEgress();
+    void resolveNomadEgress().catch((e: unknown) => {
+      console.warn('[nomadNetworkStore] resolveNomadEgress ' + errLikeToLogString(e));
+    });
     const qs = new URLSearchParams({ path: opts.path });
     if (opts.requestData && Object.keys(opts.requestData).length > 0) {
       qs.set('data', btoa(JSON.stringify(opts.requestData)));
@@ -175,7 +177,9 @@ export const useNomadNetworkStore = create<NomadNetworkStoreState>((set, get) =>
       }
       set({ nodes: map, lastRefreshAt: Date.now(), nomadApiAvailable: true });
       invalidateNomadEgressCache();
-      void resolveNomadEgress();
+      void resolveNomadEgress().catch((err: unknown) => {
+        console.warn('[nomadNetworkStore] resolveNomadEgress ' + errLikeToLogString(err));
+      });
     } catch (e) {
       if (isReticulumSidecar404Error(e)) {
         set({ nomadApiAvailable: false });

--- a/src/renderer/stores/nomadNetworkStore.ts
+++ b/src/renderer/stores/nomadNetworkStore.ts
@@ -94,12 +94,11 @@ async function fetchNomadResource<T extends { ok: boolean; error?: string }>(
     return { ok: false, error: 'sidecar_not_running' } as T;
   }
   try {
-    const egress = await resolveNomadEgress();
-    const qs = new URLSearchParams({
-      path: opts.path,
-      hops: String(hops),
-      egress,
-    });
+    // Sidecar recomputes path-table egress for its Link deadline; main uses a flat
+    // Nomad proxy timeout. Cached local egress is logging-only (never block on GET).
+    const egress = cachedNomadEgressAt > 0 ? cachedNomadEgress : 'network';
+    void resolveNomadEgress();
+    const qs = new URLSearchParams({ path: opts.path });
     if (opts.requestData && Object.keys(opts.requestData).length > 0) {
       qs.set('data', btoa(JSON.stringify(opts.requestData)));
     }
@@ -107,15 +106,16 @@ async function fetchNomadResource<T extends { ok: boolean; error?: string }>(
       qs.set('force_path_refresh', 'true');
     }
     const cleanHash = opts.hash.replace(/[^a-fA-F0-9]/g, '');
-    const res = (await window.electronAPI.reticulum.proxyGet(
-      `/api/v1/nomadnetwork/${kind}/${cleanHash}?${qs.toString()}`,
-    )) as T;
+    const apiPath = `/api/v1/nomadnetwork/${kind}/${cleanHash}?${qs.toString()}`;
+    const res = (await window.electronAPI.reticulum.proxyGet(apiPath)) as T;
     if (!res.ok) {
+      const resRecord = res as { egress?: unknown };
+      const resEgress = typeof resRecord.egress === 'string' ? resRecord.egress : egress;
       logNomadFetchFailure(kind, {
         hash: cleanHash,
         path: opts.path,
         hops,
-        egress,
+        egress: resEgress,
         error: res.error?.trim() || 'unknown',
       });
     }

--- a/src/renderer/stores/nomadPageViewerLoad.test.ts
+++ b/src/renderer/stores/nomadPageViewerLoad.test.ts
@@ -5,6 +5,7 @@ import {
   getNomadPageCache,
   nomadPageCacheSizeForTests,
 } from '@/renderer/lib/nomad/nomadPageCache';
+import { mockConsoleWarn } from '@/renderer/lib/vitestConsoleMock';
 
 import { resetNomadEgressCacheForTests, useNomadNetworkStore } from './nomadNetworkStore';
 import { resetNomadPageViewerStoreForTests, useNomadPageViewerStore } from './nomadPageViewerStore';
@@ -55,5 +56,61 @@ describe('nomadPageViewerStore loadPage cache', () => {
     await useNomadPageViewerStore.getState().loadPage('abc1234567890', '/page/index.mu');
     expect(fetchNomadPage).toHaveBeenCalledTimes(1);
     expect(useNomadPageViewerStore.getState().pageContent).toBe('hello');
+  });
+
+  it('updates countdown budget from sidecar egress on uncached RF responses', async () => {
+    vi.useFakeTimers();
+    const fetchNomadPage = vi.fn().mockResolvedValue({
+      ok: false,
+      error: 'link_timeout',
+      egress: 'rf',
+      timeout_secs: 99,
+    });
+    useNomadNetworkStore.setState({ fetchNomadPage });
+
+    const loadPromise = useNomadPageViewerStore
+      .getState()
+      .loadPage('abc1234567890', '/page/index.mu');
+    await vi.advanceTimersByTimeAsync(300);
+    await loadPromise;
+
+    expect(useNomadPageViewerStore.getState().pageLoadingBudgetSec).toBe(99);
+    expect(useNomadPageViewerStore.getState().pageErrorRaw).toBe('link_timeout');
+    vi.useRealTimers();
+  });
+
+  it('snapshots the node on unexpected fetch rejection', async () => {
+    vi.useFakeTimers();
+    const { restore } = mockConsoleWarn();
+    try {
+      const fetchNomadPage = vi.fn().mockRejectedValue(new Error('boom'));
+      useNomadNetworkStore.setState({ fetchNomadPage });
+
+      const loadPromise = useNomadPageViewerStore
+        .getState()
+        .loadPage('abc1234567890', '/page/index.mu');
+      await vi.advanceTimersByTimeAsync(300);
+      await loadPromise;
+
+      const state = useNomadPageViewerStore.getState();
+      expect(state.pageErrorRaw).toBe('unknown');
+      expect(state.pageErrorNodeSnapshot).toEqual({
+        hash: 'abc1234567890',
+        lastSeen: 1,
+        hops: 1,
+      });
+    } finally {
+      restore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('setInvalidUrlError stores the raw invalid_url code', () => {
+    useNomadPageViewerStore.getState().setInvalidUrlError();
+    const state = useNomadPageViewerStore.getState();
+    expect(state.pageErrorRaw).toBe('invalid_url');
+    expect(state.pageErrorNodeSnapshot).toBeNull();
+    expect(state.pageLoading).toBe(false);
+    expect(state.pageLoadingStartedAt).toBeNull();
   });
 });

--- a/src/renderer/stores/nomadPageViewerLoad.test.ts
+++ b/src/renderer/stores/nomadPageViewerLoad.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearNomadPageCache,
+  getNomadPageCache,
+  nomadPageCacheSizeForTests,
+} from '@/renderer/lib/nomad/nomadPageCache';
+
+import { resetNomadEgressCacheForTests, useNomadNetworkStore } from './nomadNetworkStore';
+import { resetNomadPageViewerStoreForTests, useNomadPageViewerStore } from './nomadPageViewerStore';
+
+vi.mock('@/renderer/lib/reticulum/reticulumSidecarReads', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    fetchReticulumInterfaces: vi.fn().mockResolvedValue([]),
+  };
+});
+
+describe('nomadPageViewerStore loadPage cache', () => {
+  beforeEach(() => {
+    clearNomadPageCache();
+    resetNomadPageViewerStoreForTests();
+    resetNomadEgressCacheForTests();
+    useNomadNetworkStore.setState({
+      nodes: new Map([
+        [
+          'abc1234567890',
+          {
+            destination_hash: 'abc1234567890',
+            display_name: 'N',
+            favorited: false,
+            last_seen: 1,
+            hops: 1,
+          },
+        ],
+      ]),
+      fetchNomadPage: vi.fn().mockResolvedValue({
+        ok: true,
+        content: 'hello',
+        content_type: 'micron',
+      }),
+    });
+  });
+
+  it('second load of the same address uses the session cache', async () => {
+    const fetchNomadPage = useNomadNetworkStore.getState().fetchNomadPage;
+    await useNomadPageViewerStore.getState().loadPage('abc1234567890', '/page/index.mu');
+    expect(fetchNomadPage).toHaveBeenCalledTimes(1);
+    expect(nomadPageCacheSizeForTests()).toBe(1);
+    expect(getNomadPageCache({ hash: 'abc1234567890', path: '/page/index.mu' })?.content).toBe(
+      'hello',
+    );
+
+    await useNomadPageViewerStore.getState().loadPage('abc1234567890', '/page/index.mu');
+    expect(fetchNomadPage).toHaveBeenCalledTimes(1);
+    expect(useNomadPageViewerStore.getState().pageContent).toBe('hello');
+  });
+});

--- a/src/renderer/stores/nomadPageViewerStore.test.ts
+++ b/src/renderer/stores/nomadPageViewerStore.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatNomadPageCountdown,
+  nomadPageLoadingBudgetSec,
+  nomadPageLoadingRemainingSec,
+} from './nomadPageViewerStore';
+
+describe('nomadPageViewerStore countdown helpers', () => {
+  it('defaults to TCP MeshChat budget (not RF) when egress is unknown', () => {
+    expect(nomadPageLoadingBudgetSec(1)).toBe(45);
+    expect(nomadPageLoadingBudgetSec(8)).toBe(45);
+    expect(nomadPageLoadingBudgetSec(3, 'network')).toBe(45);
+  });
+
+  it('uses RF budget only when egress is explicitly rf/ble', () => {
+    expect(nomadPageLoadingBudgetSec(1, 'rf')).toBe(99);
+    expect(nomadPageLoadingBudgetSec(6, 'ble')).toBe(99);
+    expect(nomadPageLoadingBudgetSec(3, 'tcp')).toBe(45);
+  });
+
+  it('counts down remaining seconds from startedAt', () => {
+    const startedAt = 1_000_000;
+    expect(nomadPageLoadingRemainingSec(startedAt, 99, startedAt + 10_000)).toBe(89);
+    expect(nomadPageLoadingRemainingSec(startedAt, 99, startedAt + 200_000)).toBe(0);
+  });
+
+  it('formats countdown as m:ss', () => {
+    expect(formatNomadPageCountdown(99)).toBe('1:39');
+    expect(formatNomadPageCountdown(5)).toBe('0:05');
+    expect(formatNomadPageCountdown(0)).toBe('0:00');
+  });
+});

--- a/src/renderer/stores/nomadPageViewerStore.ts
+++ b/src/renderer/stores/nomadPageViewerStore.ts
@@ -65,6 +65,7 @@ interface NomadPageViewerState {
   loadGeneration: number;
 
   setPanelActive: (active: boolean) => void;
+  setInvalidUrlError: () => void;
   loadPage: (hash: string, path: string, options?: NomadPageLoadOptions) => Promise<void>;
   closeViewer: () => void;
   clearPageErrorForAnnounceReload: () => void;
@@ -201,6 +202,15 @@ export const useNomadPageViewerStore = create<NomadPageViewerState>((set, get) =
     set({ announceReloadDone: true });
   },
 
+  setInvalidUrlError: () => {
+    set({
+      pageErrorRaw: 'invalid_url',
+      pageErrorNodeSnapshot: null,
+      pageLoading: false,
+      pageLoadingStartedAt: null,
+    });
+  },
+
   closeViewer: () => {
     set({
       ...initialViewerState,
@@ -216,7 +226,9 @@ export const useNomadPageViewerStore = create<NomadPageViewerState>((set, get) =
     const generation = get().loadGeneration + 1;
     const nodes = useNomadNetworkStore.getState().nodes;
     const node = nodes.get(hash.toLowerCase());
-    const budgetSec = nomadPageLoadingBudgetSec(node?.hops ?? undefined);
+    // Default TCP/MeshChat until the sidecar reports this request's egress — do not
+    // use cached local outbound via (BLE RNode would falsely extend hub countdowns).
+    let budgetSec = nomadPageLoadingBudgetSec(node?.hops ?? undefined);
 
     // Selection updates immediately; countdown starts only when the wire fetch begins
     // so rapid node clicks during debounce do not keep resetting the timer.
@@ -283,6 +295,11 @@ export const useNomadPageViewerStore = create<NomadPageViewerState>((set, get) =
         return;
       }
 
+      if (typeof res.egress === 'string' && res.egress.trim()) {
+        budgetSec = nomadPageLoadingBudgetSec(node?.hops ?? undefined, res.egress);
+        set({ pageLoadingBudgetSec: budgetSec });
+      }
+
       if ((!res.ok || !res.content) && shouldForceNomadPathRefreshRetry(res.error)) {
         const retryCode = res.error?.trim() || 'unknown';
         console.warn(`[NomadNetwork] page fetch retry after ${retryCode}`);
@@ -292,15 +309,21 @@ export const useNomadPageViewerStore = create<NomadPageViewerState>((set, get) =
         if (get().loadGeneration !== generation) return;
         res = await fetchNomadPageDeduped(hash, normalizedPath, normalizedRequest, true);
         if (get().loadGeneration !== generation) return;
+        if (typeof res.egress === 'string' && res.egress.trim()) {
+          budgetSec = nomadPageLoadingBudgetSec(node?.hops ?? undefined, res.egress);
+          set({ pageLoadingBudgetSec: budgetSec });
+        }
       }
     } catch (e) {
       // Failure point: unexpected fetchNomadPage reject. Fallback: clear loading + raw error.
       console.warn('[NomadNetwork] page fetch ' + errLikeToLogString(e));
       if (get().loadGeneration !== generation) return;
+      const liveNode = useNomadNetworkStore.getState().nodes.get(hash.toLowerCase());
       set({
         pageLoading: false,
         pageLoadingStartedAt: null,
         pageErrorRaw: 'unknown',
+        pageErrorNodeSnapshot: snapshotNomadNodeForPageError(hash, liveNode),
       });
       return;
     }

--- a/src/renderer/stores/nomadPageViewerStore.ts
+++ b/src/renderer/stores/nomadPageViewerStore.ts
@@ -1,0 +1,370 @@
+import { create } from 'zustand';
+
+import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
+import {
+  DEFAULT_NOMAD_NODE_PAGE_PATH,
+  formatNomadRequestDataForUrlBar,
+  normalizeNomadPagePath,
+  normalizeNomadPageRequestData,
+} from '@/renderer/lib/nomad/micronParser';
+import {
+  clearNomadPageCache,
+  getNomadPageCache,
+  MAX_NOMAD_PAGE_CACHE_CHARS,
+  setNomadPageCache,
+} from '@/renderer/lib/nomad/nomadPageCache';
+import { shouldForceNomadPathRefreshRetry } from '@/renderer/lib/nomad/nomadPageErrorHumanize';
+import {
+  NOMAD_PAGE_FETCH_DEBOUNCE_MS,
+  NOMAD_PAGE_FETCH_RETRY_SETTLE_MS,
+} from '@/renderer/lib/timeConstants';
+import type { NomadNodeRow, NomadPageRequestData, NomadPageResponse } from '@/shared/nomad-types';
+import {
+  nomadPageOverallTimeoutSecs,
+  parseReticulumNomadEgressVia,
+} from '@/shared/reticulumNomadTimeouts';
+
+import { pushAppToast } from '../components/Toast';
+import { useNomadNetworkStore } from './nomadNetworkStore';
+
+/** Cap displayed page size — aligned with NomadNetworkPanel / page cache. */
+const MAX_NOMAD_PAGE_DISPLAY_CHARS = MAX_NOMAD_PAGE_CACHE_CHARS;
+
+export interface NomadPageErrorNodeSnapshot {
+  hash: string;
+  lastSeen: number | null;
+  hops: number | null;
+}
+
+export interface NomadPageLoadOptions {
+  fromHistory?: boolean;
+  forceReload?: boolean;
+  forcePathRefresh?: boolean;
+  requestData?: NomadPageRequestData;
+}
+
+interface NomadPageViewerState {
+  selectedHash: string | null;
+  pagePath: string;
+  pageRequestData: NomadPageRequestData | undefined;
+  pageContent: string | null;
+  pageContentType: string | undefined;
+  /** True when displayed content was truncated for renderer safety. */
+  pageContentTruncated: boolean;
+  pageLoading: boolean;
+  /** Wall-clock start of the active load (survives panel unmount). */
+  pageLoadingStartedAt: number | null;
+  /** Sidecar/proxy budget used for the countdown (seconds). */
+  pageLoadingBudgetSec: number;
+  /** Raw sidecar/proxy error code or message (humanize in UI). */
+  pageErrorRaw: string | null;
+  pageErrorNodeSnapshot: NomadPageErrorNodeSnapshot | null;
+  announceReloadDone: boolean;
+  /** True while Nomad tab is visible — suppress completion toast when true. */
+  panelActive: boolean;
+  loadGeneration: number;
+
+  setPanelActive: (active: boolean) => void;
+  loadPage: (hash: string, path: string, options?: NomadPageLoadOptions) => Promise<void>;
+  closeViewer: () => void;
+  clearPageErrorForAnnounceReload: () => void;
+  markAnnounceReloadDone: () => void;
+}
+
+/** Coalesce identical in-flight page fetches (StrictMode remount / duplicate clicks). */
+const inFlightPageFetches = new Map<string, Promise<NomadPageResponse>>();
+
+function pageFetchDedupeKey(
+  hash: string,
+  path: string,
+  requestData: NomadPageRequestData | undefined,
+  forcePathRefresh: boolean,
+): string {
+  const cleanHash = hash.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
+  const dataKey = JSON.stringify(requestData ?? {});
+  return `${cleanHash}|${path}|${dataKey}|${forcePathRefresh ? '1' : '0'}`;
+}
+
+async function fetchNomadPageDeduped(
+  hash: string,
+  path: string,
+  requestData: NomadPageRequestData | undefined,
+  forcePathRefresh: boolean,
+): Promise<NomadPageResponse> {
+  const key = pageFetchDedupeKey(hash, path, requestData, forcePathRefresh);
+  const existing = inFlightPageFetches.get(key);
+  if (existing) return existing;
+  const fetchNomadPage = useNomadNetworkStore.getState().fetchNomadPage;
+  const pending = Promise.resolve(
+    fetchNomadPage(
+      hash,
+      path,
+      requestData,
+      forcePathRefresh ? { forcePathRefresh: true } : undefined,
+    ),
+  ).finally(() => {
+    if (inFlightPageFetches.get(key) === pending) {
+      inFlightPageFetches.delete(key);
+    }
+  });
+  inFlightPageFetches.set(key, pending);
+  return pending;
+}
+
+function formatNomadUrlBar(hash: string, path: string, requestData?: NomadPageRequestData): string {
+  const base = `${hash}:${path}`;
+  const varSuffix = formatNomadRequestDataForUrlBar(requestData);
+  return varSuffix ? `${base}\`${varSuffix}` : base;
+}
+
+function truncateNomadPageContent(content: string): { text: string; truncated: boolean } {
+  if (content.length <= MAX_NOMAD_PAGE_DISPLAY_CHARS) {
+    return { text: content, truncated: false };
+  }
+  return { text: content.slice(0, MAX_NOMAD_PAGE_DISPLAY_CHARS), truncated: true };
+}
+
+function snapshotNomadNodeForPageError(
+  hash: string,
+  node: NomadNodeRow | undefined,
+): NomadPageErrorNodeSnapshot {
+  return {
+    hash: hash.toLowerCase(),
+    lastSeen: node?.last_seen ?? null,
+    hops: node?.hops ?? null,
+  };
+}
+
+/**
+ * Countdown budget for the loading UI.
+ * Default to TCP/MeshChat (45s): Nomad nodes reached over hubs are not RF just
+ * because a local BLE RNode is enabled. Only use RF scaling when egress is
+ * explicitly `rf` / `ble`.
+ */
+export function nomadPageLoadingBudgetSec(hops: number | undefined, egressHint?: string): number {
+  const egress = parseReticulumNomadEgressVia(egressHint);
+  if (egress === 'rf') {
+    const hopCount = hops != null && Number.isFinite(hops) ? Math.max(1, Math.trunc(hops)) : 8;
+    return nomadPageOverallTimeoutSecs('rf', Math.max(hopCount, 8));
+  }
+  return nomadPageOverallTimeoutSecs('tcp', 1);
+}
+
+/** Remaining seconds until the load budget elapses (0 when overdue). */
+export function nomadPageLoadingRemainingSec(
+  startedAt: number | null,
+  budgetSec: number,
+  now = Date.now(),
+): number {
+  if (startedAt == null || budgetSec <= 0) return 0;
+  const elapsed = Math.floor((now - startedAt) / 1000);
+  return Math.max(0, budgetSec - elapsed);
+}
+
+/** Format remaining seconds as m:ss for the loading countdown. */
+export function formatNomadPageCountdown(remainingSec: number): string {
+  const s = Math.max(0, Math.floor(remainingSec));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
+const initialViewerState = {
+  selectedHash: null as string | null,
+  pagePath: DEFAULT_NOMAD_NODE_PAGE_PATH,
+  pageRequestData: undefined as NomadPageRequestData | undefined,
+  pageContent: null as string | null,
+  pageContentType: undefined as string | undefined,
+  pageContentTruncated: false,
+  pageLoading: false,
+  pageLoadingStartedAt: null as number | null,
+  pageLoadingBudgetSec: 0,
+  pageErrorRaw: null as string | null,
+  pageErrorNodeSnapshot: null as NomadPageErrorNodeSnapshot | null,
+  announceReloadDone: false,
+  panelActive: false,
+  loadGeneration: 0,
+};
+
+export const useNomadPageViewerStore = create<NomadPageViewerState>((set, get) => ({
+  ...initialViewerState,
+
+  setPanelActive: (active) => {
+    set({ panelActive: active });
+  },
+
+  clearPageErrorForAnnounceReload: () => {
+    set({ pageErrorRaw: null, pageErrorNodeSnapshot: null });
+  },
+
+  markAnnounceReloadDone: () => {
+    set({ announceReloadDone: true });
+  },
+
+  closeViewer: () => {
+    set({
+      ...initialViewerState,
+      loadGeneration: get().loadGeneration + 1,
+      panelActive: get().panelActive,
+    });
+    clearNomadPageCache();
+  },
+
+  loadPage: async (hash, path, options = {}) => {
+    const normalizedPath = normalizeNomadPagePath(path);
+    const normalizedRequest = normalizeNomadPageRequestData(options.requestData);
+    const generation = get().loadGeneration + 1;
+    const nodes = useNomadNetworkStore.getState().nodes;
+    const node = nodes.get(hash.toLowerCase());
+    const budgetSec = nomadPageLoadingBudgetSec(node?.hops ?? undefined);
+
+    // Selection updates immediately; countdown starts only when the wire fetch begins
+    // so rapid node clicks during debounce do not keep resetting the timer.
+    set({
+      selectedHash: hash,
+      pagePath: normalizedPath,
+      pageRequestData: normalizedRequest,
+      pageLoading: true,
+      pageLoadingStartedAt: null,
+      pageLoadingBudgetSec: budgetSec,
+      pageErrorRaw: null,
+      pageErrorNodeSnapshot: null,
+      announceReloadDone: false,
+      loadGeneration: generation,
+      pageContent: options.forceReload ? null : get().pageContent,
+      pageContentType: options.forceReload ? undefined : get().pageContentType,
+      pageContentTruncated: options.forceReload ? false : get().pageContentTruncated,
+    });
+
+    if (!options.forceReload) {
+      const cached = getNomadPageCache({
+        hash,
+        path: normalizedPath,
+        requestData: normalizedRequest,
+      });
+      if (cached) {
+        if (get().loadGeneration !== generation) return;
+        set({
+          pageLoading: false,
+          pageLoadingStartedAt: null,
+          pageLoadingBudgetSec: 0,
+          pageContent: cached.content,
+          pageContentType: cached.content_type,
+          pageContentTruncated: false,
+        });
+        return;
+      }
+    }
+
+    set({ pageContent: null, pageContentType: undefined, pageContentTruncated: false });
+
+    if (!options.forcePathRefresh) {
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, NOMAD_PAGE_FETCH_DEBOUNCE_MS);
+      });
+      if (get().loadGeneration !== generation) {
+        return;
+      }
+    }
+
+    // Do not await a prior fetch — sidecar preempts the old Link query. Leaving the
+    // Nomad tab does not bump generation, so background loads keep running.
+    let res: NomadPageResponse;
+    try {
+      const startedAt = Date.now();
+      set({ pageLoadingStartedAt: startedAt, pageLoadingBudgetSec: budgetSec });
+      res = await fetchNomadPageDeduped(
+        hash,
+        normalizedPath,
+        normalizedRequest,
+        !!options.forcePathRefresh,
+      );
+      if (get().loadGeneration !== generation) {
+        return;
+      }
+
+      if ((!res.ok || !res.content) && shouldForceNomadPathRefreshRetry(res.error)) {
+        const retryCode = res.error?.trim() || 'unknown';
+        console.warn(`[NomadNetwork] page fetch retry after ${retryCode}`);
+        await new Promise<void>((resolve) => {
+          window.setTimeout(resolve, NOMAD_PAGE_FETCH_RETRY_SETTLE_MS);
+        });
+        if (get().loadGeneration !== generation) return;
+        res = await fetchNomadPageDeduped(hash, normalizedPath, normalizedRequest, true);
+        if (get().loadGeneration !== generation) return;
+      }
+    } catch (e) {
+      // Failure point: unexpected fetchNomadPage reject. Fallback: clear loading + raw error.
+      console.warn('[NomadNetwork] page fetch ' + errLikeToLogString(e));
+      if (get().loadGeneration !== generation) return;
+      set({
+        pageLoading: false,
+        pageLoadingStartedAt: null,
+        pageErrorRaw: 'unknown',
+      });
+      return;
+    }
+
+    if (get().loadGeneration !== generation) return;
+
+    if (!res.ok || !res.content) {
+      const rawCode = res.error?.trim() || 'unknown';
+      const liveNode = useNomadNetworkStore.getState().nodes.get(hash.toLowerCase());
+      set({
+        pageLoading: false,
+        pageLoadingStartedAt: null,
+        pageErrorRaw: rawCode,
+        pageErrorNodeSnapshot: snapshotNomadNodeForPageError(hash, liveNode),
+        announceReloadDone: false,
+      });
+      return;
+    }
+
+    const { text, truncated } = truncateNomadPageContent(res.content);
+    setNomadPageCache(
+      {
+        hash,
+        path: normalizedPath,
+        requestData: normalizedRequest,
+      },
+      {
+        content: truncated ? text : res.content,
+        content_type: res.content_type,
+      },
+    );
+    set({
+      pageLoading: false,
+      pageLoadingStartedAt: null,
+      pageLoadingBudgetSec: 0,
+      pageContent: text,
+      pageContentType: res.content_type,
+      pageContentTruncated: truncated,
+      pageErrorRaw: null,
+      pageErrorNodeSnapshot: null,
+    });
+
+    if (!get().panelActive) {
+      const label = node?.display_name?.trim() || hash.slice(0, 8);
+      // Lazy import avoids pulling i18n into panel unit-test graphs.
+      void import('@/renderer/lib/i18n').then(({ default: i18n }) => {
+        pushAppToast(i18n.t('nomadNetwork.pageReadyToast', { name: label }), 'success', 6_000);
+      });
+    }
+  },
+}));
+
+/** @internal test helper */
+export function resetNomadPageViewerStoreForTests(): void {
+  inFlightPageFetches.clear();
+  // Advance generation so in-flight loads from a prior test cannot apply results.
+  const loadGeneration = useNomadPageViewerStore.getState().loadGeneration + 1_000;
+  useNomadPageViewerStore.setState({ ...initialViewerState, loadGeneration });
+}
+
+export function formatNomadViewerUrlBar(
+  hash: string,
+  path: string,
+  requestData?: NomadPageRequestData,
+): string {
+  return formatNomadUrlBar(hash, path, requestData);
+}

--- a/src/shared/nomad-types.ts
+++ b/src/shared/nomad-types.ts
@@ -14,6 +14,10 @@ export interface NomadPageResponse {
   content?: string;
   content_type?: string;
   error?: string;
+  /** Sidecar path-aware egress atom (`tcp` / `rf` / `ble` / `network`). */
+  egress?: string;
+  /** Sidecar LinkClient overall timeout used for this attempt (seconds). */
+  timeout_secs?: number;
 }
 
 /** NomadNet link request field map (`field_*` / `var_*` keys). */
@@ -24,6 +28,8 @@ export interface NomadFileResponse {
   file_name?: string;
   content_base64?: string;
   error?: string;
+  egress?: string;
+  timeout_secs?: number;
 }
 
 export interface NomadServeStats {

--- a/src/shared/reticulumNomadTimeouts.test.ts
+++ b/src/shared/reticulumNomadTimeouts.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   NOMAD_PROXY_GET_TIMEOUT_MS,
   nomadPageOverallTimeoutSecs,
-  nomadPageProxyTimeoutMs,
   nomadPageProxyTimeoutMsFromApiPath,
   parseReticulumNomadEgressVia,
 } from './reticulumNomadTimeouts';
@@ -18,11 +17,6 @@ describe('reticulumNomadTimeouts', () => {
     expect(nomadPageOverallTimeoutSecs('rf', 1)).toBe(57);
     expect(nomadPageOverallTimeoutSecs('rf', 8)).toBe(99);
     expect(nomadPageOverallTimeoutSecs('rf', 32)).toBe(180);
-  });
-
-  it('adds proxy buffer in milliseconds for egress helpers', () => {
-    expect(nomadPageProxyTimeoutMs('tcp', 8)).toBe(47_000);
-    expect(nomadPageProxyTimeoutMs('rf', 8)).toBe(101_000);
   });
 
   it('uses a flat IPC proxy cap for all Nomad page/file paths', () => {

--- a/src/shared/reticulumNomadTimeouts.test.ts
+++ b/src/shared/reticulumNomadTimeouts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  NOMAD_PROXY_GET_TIMEOUT_MS,
   nomadPageOverallTimeoutSecs,
   nomadPageProxyTimeoutMs,
   nomadPageProxyTimeoutMsFromApiPath,
@@ -19,25 +20,31 @@ describe('reticulumNomadTimeouts', () => {
     expect(nomadPageOverallTimeoutSecs('rf', 32)).toBe(180);
   });
 
-  it('adds proxy buffer in milliseconds', () => {
+  it('adds proxy buffer in milliseconds for egress helpers', () => {
     expect(nomadPageProxyTimeoutMs('tcp', 8)).toBe(47_000);
     expect(nomadPageProxyTimeoutMs('rf', 8)).toBe(101_000);
   });
 
-  it('parses egress and hops from nomad page api path', () => {
+  it('uses a flat IPC proxy cap for all Nomad page/file paths', () => {
+    expect(NOMAD_PROXY_GET_TIMEOUT_MS).toBe(185_000);
+    expect(
+      nomadPageProxyTimeoutMsFromApiPath(
+        '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=1&egress=tcp',
+      ),
+    ).toBe(185_000);
     expect(
       nomadPageProxyTimeoutMsFromApiPath(
         '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&hops=8&egress=rf',
       ),
-    ).toBe(101_000);
-    expect(
-      nomadPageProxyTimeoutMsFromApiPath(
-        '/api/v1/nomadnetwork/page/abc?path=%2Fpage%2Findex.mu&egress=tcp',
-      ),
-    ).toBe(101_000);
+    ).toBe(185_000);
   });
 
   it('falls back for unknown egress', () => {
     expect(parseReticulumNomadEgressVia('mqtt')).toBe('network');
+  });
+
+  it('maps ble egress to the RF timeout budget', () => {
+    expect(parseReticulumNomadEgressVia('ble')).toBe('rf');
+    expect(nomadPageOverallTimeoutSecs(parseReticulumNomadEgressVia('ble'), 6)).toBe(87);
   });
 });

--- a/src/shared/reticulumNomadTimeouts.ts
+++ b/src/shared/reticulumNomadTimeouts.ts
@@ -4,6 +4,8 @@
  * RF uses Python RNS per-hop link establishment scaling).
  */
 
+import { MS_PER_SECOND } from './timeConstants';
+
 export type ReticulumNomadEgressVia = 'rf' | 'tcp' | 'network';
 
 /** MeshChat `NomadnetDownloader.download()` path_lookup_timeout default. */
@@ -32,7 +34,7 @@ export const NOMAD_RF_MAX_OVERALL_SECS = 180;
  * Sidecar LinkClient already enforces the egress×hops deadline; main must not
  * cut off early when UI hops are stale (use a flat cap above the RF max).
  */
-export const NOMAD_PROXY_GET_TIMEOUT_MS = (NOMAD_RF_MAX_OVERALL_SECS + 5) * 1_000;
+export const NOMAD_PROXY_GET_TIMEOUT_MS = (NOMAD_RF_MAX_OVERALL_SECS + 5) * MS_PER_SECOND;
 
 const NOMAD_EGRESS_VIA_VALUES: readonly ReticulumNomadEgressVia[] = ['rf', 'tcp', 'network'];
 
@@ -64,11 +66,6 @@ export function nomadPageOverallTimeoutSecs(
     return Math.min(NOMAD_RF_MAX_OVERALL_SECS, total);
   }
   return NOMAD_PATH_LOOKUP_SECS + NOMAD_TCP_LINK_ESTABLISH_SECS + NOMAD_TCP_TRANSFER_GRACE_SECS;
-}
-
-/** Main-process proxy GET AbortSignal timeout with small buffer. */
-export function nomadPageProxyTimeoutMs(egressVia: ReticulumNomadEgressVia, hops: number): number {
-  return nomadPageOverallTimeoutSecs(egressVia, hops) * 1_000 + 2_000;
 }
 
 /**

--- a/src/shared/reticulumNomadTimeouts.ts
+++ b/src/shared/reticulumNomadTimeouts.ts
@@ -27,11 +27,20 @@ export const NOMAD_RF_TRANSFER_GRACE_SECS = 30;
 /** RNS transport default overall cap. */
 export const NOMAD_RF_MAX_OVERALL_SECS = 180;
 
+/**
+ * Main-process IPC proxy AbortSignal timeout for Nomad page/file GETs.
+ * Sidecar LinkClient already enforces the egress×hops deadline; main must not
+ * cut off early when UI hops are stale (use a flat cap above the RF max).
+ */
+export const NOMAD_PROXY_GET_TIMEOUT_MS = (NOMAD_RF_MAX_OVERALL_SECS + 5) * 1_000;
+
 const NOMAD_EGRESS_VIA_VALUES: readonly ReticulumNomadEgressVia[] = ['rf', 'tcp', 'network'];
 
 export function parseReticulumNomadEgressVia(
   value: string | null | undefined,
 ): ReticulumNomadEgressVia {
+  // BLE RNode shares the RF per-hop timeout budget (proxy + sidecar).
+  if (value === 'ble') return 'rf';
   if (value != null && (NOMAD_EGRESS_VIA_VALUES as readonly string[]).includes(value)) {
     return value as ReticulumNomadEgressVia;
   }
@@ -63,14 +72,11 @@ export function nomadPageProxyTimeoutMs(egressVia: ReticulumNomadEgressVia, hops
 }
 
 /**
- * IPC proxy timeout for Nomad page/file fetches. Uses the larger of the
- * egress-specific budget and the RF worst-case budget so a stale `network`
- * egress guess cannot abort before the sidecar finishes an RF link query.
+ * IPC proxy timeout for Nomad page/file fetches.
+ * Always the flat {@link NOMAD_PROXY_GET_TIMEOUT_MS} so stale renderer hops
+ * cannot abort before the sidecar's own LinkClient deadline.
  */
-export function nomadPageProxyTimeoutMsFromApiPath(apiPath: string): number {
-  const query = apiPath.includes('?') ? (apiPath.split('?')[1] ?? '') : '';
-  const params = new URLSearchParams(query);
-  const hops = Number.parseInt(params.get('hops') ?? '8', 10);
-  const egress = parseReticulumNomadEgressVia(params.get('egress'));
-  return Math.max(nomadPageProxyTimeoutMs(egress, hops), nomadPageProxyTimeoutMs('rf', hops));
+export function nomadPageProxyTimeoutMsFromApiPath(_apiPath: string): number {
+  void _apiPath;
+  return NOMAD_PROXY_GET_TIMEOUT_MS;
 }


### PR DESCRIPTION
## Summary

Nomad page loads over TCP hubs were often stuck on “loading,” returning `nomad_busy` / `link_timeout`, and feeling dead for minutes—especially when a BLE RNode was also enabled. Root causes were BLE-biased timeout budgets for hub peers, LinkClient proof waits that burned the full overall deadline, and aggressive `#726`/`#728`-style auto-retry + `force_path_refresh` DropPath storms behind the global Nomad link lock.

This PR fixes egress-aware budgets end-to-end, caps proof wait to MeshChat-like TCP establishment, narrows retries, and moves page-viewer state into a session-surviving store with clearer UX.

## Problem

- Sidecar timeouts preferred **local RF/BLE capability** over the **path-table interface**, so TCP-hub peers inherited RF budgets (and long waits) when a BLE RNode was enabled.
- With a cached path/pubkey, LinkClient proof wait could consume the entire overall deadline; inflated path hops (e.g. 8) stretched establishment toward ~48s vs MeshChat’s ~15s TCP stage.
- Auto-retry of `link_timeout` / `nomad_busy` with `force_path_refresh` DropPath amplified hangs under the serialized Nomad link lock.
- Renderer sent unused `hops`/`egress` query params; UI countdown and main proxy AbortSignal could diverge from the sidecar’s real budget.
- Page load state lived in the panel, so tab switches / remounts lost in-flight progress and made failures feel worse.

## Changes

### Sidecar (timeouts + query path)

- **`resolve_nomad_page_timeout_secs`**: prefer path-table interface classification (`tcp` / `rf` / `ble`) for Link deadlines; local BLE must not force RF budgets for TCP-routed peers.
- Treat **`ble` like `rf`** for per-hop Link budgets; TCP keeps the MeshChat-style overall budget (~45s).
- **`nomad_link_initiator_hops`**: cap TCP/network initiator hops at **3** (~18s establish) so inflated path hops do not stretch proof waits.
- **`nomad_remote_network_ready`**: fail fast with `network_not_ready` when no path iface is known and no live TCP/RF/BLE egress is up yet.
- **`query_nomad_node`**: use path-aware timeout + capped link hops; return `egress` / `timeout_secs` on page/file responses; local/self responses use `egress: "local"`.
- **Force path refresh**: shorter **4s** DropPath wait + **fall-through** if path never goes absent (`ensure_path_for_direct_with_opts`), instead of stalling until the overall budget dies.
- Preempt / cancel in-flight Nomad link work so a newer request can surface `nomad_busy` without holding the lock forever.
- Own Nomad announces in **`list_nomad_nodes`** force **hops = 0** (path-table multi-hop echoes no longer look remote).

### rsReticulum overlay

- New **`rsReticulum-link-client-proof-budget.patch`**: cap `LinkClient::query` proof wait at `link.establishment_timeout` so a cached path cannot burn the full overall Nomad deadline.
- Apply script + wiring in `ensure-rsReticulum-patches.sh`, `clone-ratspeak-stack.sh`, and `update.sh` `RATSPEAK_PATCH_ENTRIES`; documented in `reticulum-sidecar/patches/README.md`.

### Main / shared proxy timeouts

- Flat **`NOMAD_PROXY_GET_TIMEOUT_MS`** (~185s) for Nomad page/file IPC GETs so stale renderer hops/egress cannot abort before the sidecar LinkClient finishes.
- `nomadPageProxyTimeoutMsFromApiPath` no longer parses `hops`/`egress` from the query string; BLE egress maps to the RF budget helper where still used.
- Response types gain optional `egress` / `timeout_secs` (`src/shared/nomad-types.ts`).

### Renderer fetch + retry policy

- `nomadNetworkStore` stops sending unused `hops`/`egress` query params; logs sidecar-reported egress on failure.
- Split retry semantics in `nomadPageErrorHumanize`:
  - **Announce reload**: `path_timeout`, `link_timeout`, `response_timeout`, `pubkey_not_found`, `missing_identity_hash` (not `nomad_busy`).
  - **Force path refresh**: only `path_timeout`, `pubkey_not_found`, `missing_identity_hash` — **not** `link_timeout` / `nomad_busy` / response timeouts.
- New codes: `network_not_ready`, `nomad_not_serving`.

### Page viewer UX / architecture

- New **`nomadPageViewerStore`**: load state survives panel unmount; debounce (300ms) + in-flight dedupe; generation/preempt for rapid node switches; one-shot force-path retry only when allowed; completion toast when the Nomad tab is not active.
- **`NomadNetworkPanel`** consumes the viewer store; loading countdown defaults to TCP budget unless egress is explicitly RF/BLE; overdue copy when still working past the budget.
- Stale last-heard hint (`nomadNodeStale`, 2h) when a node may be offline despite looking “online”.
- i18n for countdown, ready toast, `network_not_ready`, `nomad_not_serving`, and stale hint (EN + locales).

### Tests

- Sidecar unit coverage for path-table TCP over local BLE, initiator hop caps, and network-ready gating.
- Shared timeout / proxy-path tests updated for the flat proxy timeout.
- New/updated renderer tests for viewer store, stale helper, error humanize, and Nomad panel behavior.

## Out of scope

- Parallel Nomad Links (still serialized behind the global lock).
- Broader PN/LXMF delivery digs (#718 / #731).
- Full MeshChat stage timers upstream (local proof-budget overlay only for now).

## Test plan

- [ ] Start Reticulum with a TCP hub enabled; open Nomad pages on remote hub peers **with** a BLE RNode also enabled — pages should load within the TCP budget (no multi-minute stalls).
- [ ] Repeat with TCP-only (no BLE) and confirm parity.
- [ ] Self / My Pages: loads when hosting is running; `nomad_not_serving` when not.
- [ ] With hubs still connecting / no live egress: `network_not_ready` instead of a long dead load.
- [ ] Path/pubkey failures still one-shot force-refresh; `link_timeout` / `nomad_busy` do **not** DropPath-storm.
- [ ] Switch Nomad nodes quickly: only the latest selection should keep a Link query; older work preempts/`nomad_busy`.
- [ ] Leave Nomad tab during a load: state survives; toast on completion when not focused.
- [ ] Stale last-heard hint appears for nodes older than ~2h.
- [ ] `pnpm run check:reticulum-sidecar` + Nomad-related Vitest pass; proof-budget overlay applies via `ensure-rsReticulum-patches.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Nomad page and file loading with caching, request deduplication, debouncing, and safer retries.
  * Added loading countdowns, stale-node indicators, clearer error messages, and truncated-content markers.
  * Responses now report the selected egress path and timeout information.
  * Local previews are identified separately, and local-only requests are handled safely.

* **Bug Fixes**
  * Improved network-readiness checks, route selection, timeout handling, and cancellation of outdated requests.
  * Added targeted path-refresh retries for recoverable connection failures.
  * Corrected self-announced nodes to display as zero-hop entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->