### PR TITLE
docs: note GitHub releases and gitworkshop source mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 **For everyone, everywhere.** We welcome community participation and collaboration in the development of this project!
 
+Releases and build artifacts are published on [GitHub](https://github.com/Colorado-Mesh/mesh-client); source is also manually mirrored to [gitworkshop](https://gitworkshop.dev/npub1wwaq5gyk7yljly3cwl3wleuk79nz63ukpp2a6lq5x4q9s9r4nrgqjk3dlv/relay.ngit.dev/mesh-client).
+
 ---
 
 ## Why


### PR DESCRIPTION
## Summary
- Call out in README that releases/build artifacts live on GitHub
- Note that source is manually mirrored to gitworkshop for Nostr readers

## Test plan
- [ ] Confirm the new sentence appears above the Why section in README.md
- [ ] Confirm both links open correctly (GitHub repo + gitworkshop mirror)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about where to find releases, build artifacts, and a manual source mirror.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->