### PR TITLE
chore(scripts): add cross-platform clean:build and clean:build:full

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -206,6 +206,8 @@ pnpm run check:i18n
 # Maintenance
 pnpm run update
 pnpm run clean
+pnpm run clean:build
+pnpm run clean:build:full
 
 # Reticulum sidecar (optional; requires Rust)
 pnpm run reticulum:sidecar:build
@@ -219,6 +221,13 @@ pnpm run docs:install
 pnpm run docs:build
 pnpm run docs:serve
 ```
+
+Both `clean:build` and `clean:build:full` (cross-platform; see [`scripts/clean-build.mjs`](../scripts/clean-build.mjs)) print the full list of what will be removed and always confirm with a `Proceed? [y/N]` prompt before deleting anything (default **N**; pass `-y`/`--yes` to skip, in which case the plan is still printed). They never run when stdin is not a TTY and `-y` is absent, so they cannot hang in CI.
+
+- **`clean:build` (shallow)** — removes build dists, test output, and caches (`dist`, `dist-electron`, `release`, `coverage`, `.vitest-reports`, `test-results`, `playwright-report`, `.eslintcache`). It **keeps `node_modules/` and the Reticulum sidecar**, so `pnpm run dev` / `pnpm start` and the sidecar keep working. Use it to force fresh rebuilds, clear stale or corrupt intermediate output, or free modest disk without re-installing.
+- **`clean:build:full`** — removes everything above **plus** `node_modules`, `reticulum-sidecar/target/`, and the bundled sidecar binary (`resources/reticulum-sidecar/`), then runs `pnpm install` and `pnpm run reticulum:sidecar:build` so the environment is left in a working state. Use it to fix a corrupt/drifted `node_modules`, clear stale Rust incremental state after toolchain or overlay-patch changes, or reclaim up to ~20G+ of disk while restoring a known-good environment. The reinstall is skipped if nothing in tier 2 was actually present.
+
+`clean:build` and `clean:build:full` are the cross-platform equivalents of `make clean`/deep clean; the repo's older Unix-only `clean` (`clean` above) remains for its narrower, `rm -rf`-style behaviour.
 
 ### All Scripts Reference
 
@@ -444,27 +453,29 @@ flatpak run --command=flatpak-builder-lint org.freedesktop.Sdk \
 
 #### Setup / helpers
 
-| Script                          | Description                                                           |
-| ------------------------------- | --------------------------------------------------------------------- |
-| `clean`                         | Remove `dist-electron`, `dist`, and `node_modules`                    |
-| `dedupe:dist`                   | Retrying dist dedupe (`scripts/dedupe-dist.mjs`; `@jsr/_tmp_*` races) |
-| `i18n:auto-translate`           | Machine-translate missing locale keys (MyMemory default)              |
-| `i18n:prune-unused`             | Remove orphaned translation keys from locale files                    |
-| `rebuild`                       | Rebuild native Node modules for Electron                              |
-| `release`                       | Maintainer release script (`scripts/release.sh`)                      |
-| `reticulum:sidecar:build`       | Build debug `mesh-client-reticulum` (requires `cargo`)                |
-| `reticulum:sidecar:clippy`      | Clippy stub build (`-D warnings`)                                     |
-| `reticulum:sidecar:clippy:full` | Clippy with `rns-stack,rns-ble,rns-rnode-tcp`                         |
-| `reticulum:sidecar:coverage`    | Optional HTML coverage via `cargo llvm-cov` (no CI threshold)         |
-| `reticulum:sidecar:dev`         | Run sidecar standalone on `127.0.0.1:19437`                           |
-| `reticulum:sidecar:fmt`         | `cargo fmt` in `reticulum-sidecar/`                                   |
-| `reticulum:sidecar:fmt:check`   | `cargo fmt --check`                                                   |
-| `reticulum:sidecar:test`        | Full-feature `cargo test` (clones Ratspeak siblings if needed)        |
-| `reticulum:sidecar:test:full`   | Alias for `reticulum:sidecar:test`                                    |
-| `setup:actionlint`              | Install actionlint for GitHub workflow linting                        |
-| `setup:build-deps`              | Install native build dependencies                                     |
-| `setup:dialout`                 | Add user to dialout group for serial port access (Linux)              |
-| `update`                        | Update pnpm deps, Rust toolchain (rustup), rebuild sidecar            |
+| Script                          | Description                                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `clean`                         | Remove `dist-electron`, `dist`, and `node_modules`                                                                              |
+| `clean:build`                   | Remove build dists, test output, and caches (keeps `node_modules` + sidecar); prompts `[y/N]` (default N)                       |
+| `clean:build:full`              | Also remove `node_modules` + Reticulum sidecar build output, then reinstall deps + rebuild sidecar; prompts `[y/N]` (default N) |
+| `dedupe:dist`                   | Retrying dist dedupe (`scripts/dedupe-dist.mjs`; `@jsr/_tmp_*` races)                                                           |
+| `i18n:auto-translate`           | Machine-translate missing locale keys (MyMemory default)                                                                        |
+| `i18n:prune-unused`             | Remove orphaned translation keys from locale files                                                                              |
+| `rebuild`                       | Rebuild native Node modules for Electron                                                                                        |
+| `release`                       | Maintainer release script (`scripts/release.sh`)                                                                                |
+| `reticulum:sidecar:build`       | Build debug `mesh-client-reticulum` (requires `cargo`)                                                                          |
+| `reticulum:sidecar:clippy`      | Clippy stub build (`-D warnings`)                                                                                               |
+| `reticulum:sidecar:clippy:full` | Clippy with `rns-stack,rns-ble,rns-rnode-tcp`                                                                                   |
+| `reticulum:sidecar:coverage`    | Optional HTML coverage via `cargo llvm-cov` (no CI threshold)                                                                   |
+| `reticulum:sidecar:dev`         | Run sidecar standalone on `127.0.0.1:19437`                                                                                     |
+| `reticulum:sidecar:fmt`         | `cargo fmt` in `reticulum-sidecar/`                                                                                             |
+| `reticulum:sidecar:fmt:check`   | `cargo fmt --check`                                                                                                             |
+| `reticulum:sidecar:test`        | Full-feature `cargo test` (clones Ratspeak siblings if needed)                                                                  |
+| `reticulum:sidecar:test:full`   | Alias for `reticulum:sidecar:test`                                                                                              |
+| `setup:actionlint`              | Install actionlint for GitHub workflow linting                                                                                  |
+| `setup:build-deps`              | Install native build dependencies                                                                                               |
+| `setup:dialout`                 | Add user to dialout group for serial port access (Linux)                                                                        |
+| `update`                        | Update pnpm deps, Rust toolchain (rustup), rebuild sidecar                                                                      |
 
 #### Lifecycle (automatic)
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "check:url-hostname-sanitization": "node scripts/check-url-hostname-sanitization.mjs",
     "check:xss-patterns": "node scripts/check-xss-patterns.mjs",
     "clean": "rm -rf dist-electron dist node_modules",
+    "clean:build": "node scripts/clean-build.mjs",
+    "clean:build:full": "node scripts/clean-build.mjs --full",
     "dedupe:dist": "node scripts/dedupe-dist.mjs",
     "dev": "node scripts/run-dev.mjs",
     "predist": "pnpm run dedupe:dist",

--- a/scripts/clean-build.mjs
+++ b/scripts/clean-build.mjs
@@ -14,7 +14,7 @@
  * Safety: only a fixed allowlist of paths is removed, always resolved under the repo root
  * and asserted to stay inside it. Symlinks are removed as links, never followed.
  */
-import { existsSync, rmSync } from 'fs';
+import { lstatSync, rmSync } from 'fs';
 import { createInterface } from 'readline';
 import { spawnSync } from 'child_process';
 import { dirname, relative, resolve, sep } from 'path';
@@ -46,8 +46,37 @@ const TIER2_PATHS = [
 const ALL_PATHS = [...TIER1_PATHS, ...TIER2_PATHS];
 
 /**
+ * True when `p` exists as a real file/dir or symlink (including a dangling link); false only
+ * for ENOENT. Uses lstat so symlinks are never followed for the existence decision — this is
+ * important both for cleanup checks (a left-over dangling symlink is still present and should
+ * be removed) and for reinstall detection on tier-2 paths.
+ * @param {string} p
+ */
+export function pathExists(p) {
+  try {
+    lstatSync(p);
+    return true;
+  } catch (err) {
+    return !(err && err.code === 'ENOENT');
+  }
+}
+
+/** @param {string} p @returns {boolean} */
+function lstatIsSymbolicLink(p) {
+  try {
+    return lstatSync(p).isSymbolicLink();
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+/**
  * Resolve allowlist paths under rootDir, asserting each stays inside it. Throws on escape so
- * an allowlist mistake can never delete outside the repo.
+ * an allowlist mistake can never delete outside the repo. It also rejects any symbolic-link
+ * *ancestor* between rootDir and the leaf: removing a path whose parent is a symlink would
+ * follow that link and delete outside the repo, so such entries are refused up front. The
+ * leaf itself may be a symlink, since `rm` removes a link without following it.
  * @param {string} rootDir
  * @param {Array<{name: string, tier: 1 | 2}>} entries
  * @returns {Array<{name: string, abs: string, tier: 1 | 2}>}
@@ -66,6 +95,16 @@ export function resolvePaths(rootDir, entries) {
         `clean-build: refusing to touch '${entry.name}' (resolves to '${entry.abs}', outside repo root '${rootDir}')`,
       );
     }
+    const parts = entry.name.split('/');
+    let current = rootDir;
+    for (let i = 0; i < parts.length - 1; i++) {
+      current = resolve(current, parts[i]);
+      if (lstatIsSymbolicLink(current)) {
+        throw new Error(
+          `clean-build: refusing to follow symlink ancestor '${current}' (entry '${entry.name}')`,
+        );
+      }
+    }
   }
   return resolved;
 }
@@ -80,22 +119,22 @@ export function filterPaths(full, resolved) {
  * path was actually present (so an already-clean tree skips the slow rebuild).
  * @param {boolean} full @param {ReturnType<typeof resolvePaths>} resolved */
 export function planReinstall(full, resolved) {
-  const tier2Present = resolved.some((e) => e.tier === 2 && existsSync(e.abs));
+  const tier2Present = resolved.some((e) => e.tier === 2 && pathExists(e.abs));
   return { install: full && tier2Present, sidecar: full && tier2Present };
 }
 
-/** @param {boolean} full @param {Array<{name: string}>} removals @param {{install: boolean; sidecar: boolean}} reinstall */
-export function printPlan(full, removals, reinstall) {
-  console.log(
+/** @param {NodeJS.WriteStream} out @param {boolean} full @param {Array<{name: string}>} removals @param {{install: boolean; sidecar: boolean}} reinstall */
+export function printPlan(out, full, removals, reinstall) {
+  out.write(
     full
-      ? 'This will remove:'
-      : 'This will remove (node_modules and the Reticulum sidecar are kept):',
+      ? 'This will remove:\n'
+      : 'This will remove (node_modules and the Reticulum sidecar are kept):\n',
   );
-  for (const r of removals) console.log(`  - ${r.name}`);
+  for (const r of removals) out.write(`  - ${r.name}\n`);
   if (reinstall.install) {
-    console.log('After removal, a working environment will be restored:');
-    if (reinstall.sidecar) console.log('  - pnpm install');
-    if (reinstall.sidecar) console.log('  - pnpm run reticulum:sidecar:build');
+    out.write('After removal, a working environment will be restored:\n');
+    if (reinstall.sidecar) out.write('  - pnpm install\n');
+    if (reinstall.sidecar) out.write('  - pnpm run reticulum:sidecar:build\n');
   }
 }
 
@@ -130,29 +169,29 @@ export function confirmProceed(inStream, outStream, yes) {
   });
 }
 
-/** @param {string[]} cmd @param {string} cwd */
-export function runCmd(cmd, cwd) {
-  const res = spawnSync(cmd[0], cmd.slice(1), { stdio: 'inherit', cwd, shell: false });
+/**
+ * Run a command. On win32 the command is routed through the shell so `.cmd`/`.bat` shims such
+ * as `pnpm.cmd` are resolvable (Node spawnSync with shell:false cannot execute them); all other
+ * platforms use shell:false to avoid shell interpolation.
+ * @param {string[]} cmd @param {string} cwd @param {string} platform @param {(cmd: string, args: string[], opts: object) => {status?: number|null; error?: Error}} spawnFn
+ */
+export function runCmd(cmd, cwd, platform = process.platform, spawnFn = spawnSync) {
+  const res = spawnFn(cmd[0], cmd.slice(1), { stdio: 'inherit', cwd, shell: platform === 'win32' });
   return res.status ?? (res.error ? 1 : 0);
 }
 
 /** @param {Array<{name: string, abs: string, tier: 1 | 2}>} resolved */
 export function existingPaths(resolved) {
-  return resolved.filter((e) => existsSync(e.abs));
+  return resolved.filter((e) => pathExists(e.abs));
 }
 
 /**
  * @param {string} rootDir @param {string[]} argv
- * @param {{stdin?: NodeJS.ReadStream; stdout?: NodeJS.WriteStream; stderr?: NodeJS.WriteStream; run?: (cmd: string[], cwd: string) => number}} io
+ * @param {{stdin?: NodeJS.ReadStream; stdout?: NodeJS.WriteStream; run?: (cmd: string[], cwd: string) => number}} io
  * @returns {Promise<{removed: string[], reinstalled: boolean}>}
  */
 export async function runClean(rootDir = repoRoot, argv = process.argv.slice(2), io = {}) {
-  const {
-    stdin = process.stdin,
-    stdout = process.stdout,
-    stderr = process.stderr,
-    run = runCmd,
-  } = io;
+  const { stdin = process.stdin, stdout = process.stdout, run = runCmd } = io;
   const flags = parseFlags(argv);
 
   const paths = resolvePaths(rootDir, ALL_PATHS);
@@ -160,7 +199,7 @@ export async function runClean(rootDir = repoRoot, argv = process.argv.slice(2),
   const existing = existingPaths(paths);
   const reinstall = planReinstall(flags.full, existing);
 
-  printPlan(flags.full, candidates, reinstall);
+  printPlan(stdout, flags.full, candidates, reinstall);
 
   if (!(await confirmProceed(stdin, stdout, flags.yes))) {
     stdout.write('Aborted — nothing removed.\n');
@@ -169,7 +208,7 @@ export async function runClean(rootDir = repoRoot, argv = process.argv.slice(2),
 
   const removed = [];
   for (const entry of candidates) {
-    if (!existsSync(entry.abs)) continue;
+    if (!pathExists(entry.abs)) continue;
     rmSync(entry.abs, { recursive: true, force: true });
     removed.push(entry.name);
     stdout.write(`removed ${entry.name}\n`);
@@ -178,21 +217,38 @@ export async function runClean(rootDir = repoRoot, argv = process.argv.slice(2),
   if (reinstall.install && removed.length > 0) {
     stdout.write('Restoring working environment…\n');
     const installOk = run(['pnpm', 'install'], rootDir) === 0;
-    let sidecarOk = true;
-    if (installOk && reinstall.sidecar) {
-      sidecarOk = run(['pnpm', 'run', 'reticulum:sidecar:build'], rootDir) === 0;
-    }
     if (!installOk) {
-      stderr.write('clean-build: `pnpm install` failed — dependencies not restored.\n');
-    } else if (!sidecarOk) {
-      stderr.write(
-        'clean-build: sidecar rebuild failed (is cargo installed?) — Reticulum may be unavailable.\n',
+      throw restorationError(
+        'clean-build: `pnpm install` failed — dependencies not restored.',
+        removed,
       );
     }
-    return { removed, reinstalled: installOk && sidecarOk };
+    let sidecarOk = true;
+    if (reinstall.sidecar) {
+      sidecarOk = run(['pnpm', 'run', 'reticulum:sidecar:build'], rootDir) === 0;
+      if (!sidecarOk) {
+        throw restorationError(
+          'clean-build: sidecar rebuild failed (is cargo installed?) — Reticulum may be unavailable.',
+          removed,
+        );
+      }
+    }
+    return { removed, reinstalled: sidecarOk };
   }
 
   return { removed, reinstalled: false };
+}
+
+/**
+ * Build the error thrown when a `--full` restoration fails. Carries the already-removed paths
+ * so a caller can report what was cleaned even though the restore did not complete.
+ * @param {string} message @param {string[]} removed @returns {Error & {code: string, removed: string[]}}
+ */
+export function restorationError(message, removed) {
+  const err = new Error(message);
+  err.code = 'RESTORE_FAILED';
+  err.removed = removed;
+  return err;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/clean-build.mjs
+++ b/scripts/clean-build.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform build-artifact cleanup (linux / darwin / win32).
+ *
+ * `pnpm run clean:build`      — shallow: remove build dists, test output, and caches.
+ * `pnpm run clean:build:full` — full: also remove node_modules + Reticulum sidecar build
+ *                               output, then reinstall dependencies and rebuild the sidecar
+ *                               so the developer environment is left in a working state.
+ *
+ * Both always prompt for confirmation (`[y/N]`, default No) before deleting anything.
+ * Pass `-y` / `--yes` to skip the prompt (the planned removals are still printed).
+ * If stdin is not a TTY (e.g. CI) and `-y` is not given, this aborts instead of hanging.
+ *
+ * Safety: only a fixed allowlist of paths is removed, always resolved under the repo root
+ * and asserted to stay inside it. Symlinks are removed as links, never followed.
+ */
+import { existsSync, rmSync } from 'fs';
+import { createInterface } from 'readline';
+import { spawnSync } from 'child_process';
+import { dirname, relative, resolve, sep } from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Tier 1 — build dists, test output, caches. Safe to remove with deps + sidecar intact. */
+const TIER1_PATHS = [
+  'dist',
+  'dist-electron',
+  'release',
+  'coverage',
+  '.vitest-reports',
+  'test-results',
+  'playwright-report',
+  '.eslintcache',
+].map((name) => ({ name, tier: 1 }));
+
+/** Tier 2 — dependency install + sidecar build output (recreated by `--full`). */
+const TIER2_PATHS = [
+  'node_modules',
+  'reticulum-sidecar/target',
+  'resources/reticulum-sidecar/staged',
+  'resources/reticulum-sidecar/mesh-client-reticulum',
+  'resources/reticulum-sidecar/mesh-client-reticulum.exe',
+].map((name) => ({ name, tier: 2 }));
+
+const ALL_PATHS = [...TIER1_PATHS, ...TIER2_PATHS];
+
+/**
+ * Resolve allowlist paths under rootDir, asserting each stays inside it. Throws on escape so
+ * an allowlist mistake can never delete outside the repo.
+ * @param {string} rootDir
+ * @param {Array<{name: string, tier: 1 | 2}>} entries
+ * @returns {Array<{name: string, abs: string, tier: 1 | 2}>}
+ */
+export function resolvePaths(rootDir, entries) {
+  const resolved = entries.map(({ name, tier }) => ({
+    name,
+    tier,
+    abs: resolve(rootDir, ...name.split('/')),
+  }));
+  for (const entry of resolved) {
+    const rel = relative(rootDir, entry.abs);
+    const inside = rel === '' || (!rel.startsWith(`..${sep}`) && !rel.startsWith('..'));
+    if (!inside) {
+      throw new Error(
+        `clean-build: refusing to touch '${entry.name}' (resolves to '${entry.abs}', outside repo root '${rootDir}')`,
+      );
+    }
+  }
+  return resolved;
+}
+
+/** @param {boolean} full @param {ReturnType<typeof resolvePaths>} resolved */
+export function filterPaths(full, resolved) {
+  return resolved.filter((e) => (full ? true : e.tier === 1));
+}
+
+/**
+ * Decide whether `--full` should reinstall afterwards. Reinstall only runs when a tier-2
+ * path was actually present (so an already-clean tree skips the slow rebuild).
+ * @param {boolean} full @param {ReturnType<typeof resolvePaths>} resolved */
+export function planReinstall(full, resolved) {
+  const tier2Present = resolved.some((e) => e.tier === 2 && existsSync(e.abs));
+  return { install: full && tier2Present, sidecar: full && tier2Present };
+}
+
+/** @param {boolean} full @param {Array<{name: string}>} removals @param {{install: boolean; sidecar: boolean}} reinstall */
+export function printPlan(full, removals, reinstall) {
+  console.log(
+    full
+      ? 'This will remove:'
+      : 'This will remove (node_modules and the Reticulum sidecar are kept):',
+  );
+  for (const r of removals) console.log(`  - ${r.name}`);
+  if (reinstall.install) {
+    console.log('After removal, a working environment will be restored:');
+    if (reinstall.sidecar) console.log('  - pnpm install');
+    if (reinstall.sidecar) console.log('  - pnpm run reticulum:sidecar:build');
+  }
+}
+
+/** @param {string[]} argv */
+export function parseFlags(argv = process.argv.slice(2)) {
+  const flags = { full: false, yes: false };
+  for (const arg of argv) {
+    if (arg === '--full') flags.full = true;
+    else if (arg === '-y' || arg === '--yes') flags.yes = true;
+    else throw new Error(`clean-build: unknown argument '${arg}'`);
+  }
+  return flags;
+}
+
+/**
+ * Prompt for confirmation; true only on an explicit `y`/`Y`. Returns false when stdin is not
+ * a TTY and `yes` is false, so non-interactive runs never hang on a prompt.
+ * @param {NodeJS.ReadStream} inStream @param {NodeJS.WriteStream} outStream @param {boolean} yes
+ * @returns {Promise<boolean>}
+ */
+export function confirmProceed(inStream, outStream, yes) {
+  if (yes) return Promise.resolve(true);
+  const isTty = Boolean(inStream && typeof inStream.isTTY === 'boolean' && inStream.isTTY);
+  if (!isTty) return Promise.resolve(false);
+  const rl = createInterface({ input: inStream, output: outStream });
+  return new Promise((resolvePromise) => {
+    rl.question('Proceed? [y/N] ', (answer) => {
+      rl.close();
+      resolvePromise(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}
+
+/** @param {string[]} cmd @param {string} cwd */
+export function runCmd(cmd, cwd) {
+  const res = spawnSync(cmd[0], cmd.slice(1), { stdio: 'inherit', cwd, shell: false });
+  return res.status ?? (res.error ? 1 : 0);
+}
+
+/** @param {Array<{name: string, abs: string, tier: 1 | 2}>} resolved */
+export function existingPaths(resolved) {
+  return resolved.filter((e) => existsSync(e.abs));
+}
+
+/**
+ * @param {string} rootDir @param {string[]} argv
+ * @param {{stdin?: NodeJS.ReadStream; stdout?: NodeJS.WriteStream; stderr?: NodeJS.WriteStream; run?: (cmd: string[], cwd: string) => number}} io
+ * @returns {Promise<{removed: string[], reinstalled: boolean}>}
+ */
+export async function runClean(rootDir = repoRoot, argv = process.argv.slice(2), io = {}) {
+  const {
+    stdin = process.stdin,
+    stdout = process.stdout,
+    stderr = process.stderr,
+    run = runCmd,
+  } = io;
+  const flags = parseFlags(argv);
+
+  const paths = resolvePaths(rootDir, ALL_PATHS);
+  const candidates = filterPaths(flags.full, paths);
+  const existing = existingPaths(paths);
+  const reinstall = planReinstall(flags.full, existing);
+
+  printPlan(flags.full, candidates, reinstall);
+
+  if (!(await confirmProceed(stdin, stdout, flags.yes))) {
+    stdout.write('Aborted — nothing removed.\n');
+    return { removed: [], reinstalled: false };
+  }
+
+  const removed = [];
+  for (const entry of candidates) {
+    if (!existsSync(entry.abs)) continue;
+    rmSync(entry.abs, { recursive: true, force: true });
+    removed.push(entry.name);
+    stdout.write(`removed ${entry.name}\n`);
+  }
+
+  if (reinstall.install && removed.length > 0) {
+    stdout.write('Restoring working environment…\n');
+    const installOk = run(['pnpm', 'install'], rootDir) === 0;
+    let sidecarOk = true;
+    if (installOk && reinstall.sidecar) {
+      sidecarOk = run(['pnpm', 'run', 'reticulum:sidecar:build'], rootDir) === 0;
+    }
+    if (!installOk) {
+      stderr.write('clean-build: `pnpm install` failed — dependencies not restored.\n');
+    } else if (!sidecarOk) {
+      stderr.write(
+        'clean-build: sidecar rebuild failed (is cargo installed?) — Reticulum may be unavailable.\n',
+      );
+    }
+    return { removed, reinstalled: installOk && sidecarOk };
+  }
+
+  return { removed, reinstalled: false };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runClean().catch((err) => {
+    console.error(String(err));
+    process.exit(1);
+  });
+}

--- a/scripts/clean-build.mjs
+++ b/scripts/clean-build.mjs
@@ -103,6 +103,7 @@ export function printPlan(full, removals, reinstall) {
 export function parseFlags(argv = process.argv.slice(2)) {
   const flags = { full: false, yes: false };
   for (const arg of argv) {
+    if (arg === '--') continue;
     if (arg === '--full') flags.full = true;
     else if (arg === '-y' || arg === '--yes') flags.yes = true;
     else throw new Error(`clean-build: unknown argument '${arg}'`);

--- a/scripts/clean-build.test.mjs
+++ b/scripts/clean-build.test.mjs
@@ -1,0 +1,196 @@
+// @vitest-environment node
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { Readable } from 'stream';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  confirmProceed,
+  filterPaths,
+  parseFlags,
+  planReinstall,
+  resolvePaths,
+  runClean,
+} from './clean-build.mjs';
+
+const RAW_TIERS = [
+  { name: 'dist', tier: 1 },
+  { name: 'dist-electron', tier: 1 },
+  { name: 'node_modules', tier: 2 },
+  { name: 'reticulum-sidecar/target', tier: 2 },
+];
+
+describe('clean-build', () => {
+  /** @type {string[]} */
+  const tempRoots = [];
+
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeTempRoot() {
+    const root = mkdtempSync(join(tmpdir(), 'clean-build-'));
+    tempRoots.push(root);
+    return root;
+  }
+
+  /** @param {string} text */
+  function readableTty(text) {
+    const stream = Readable.from(text);
+    stream.isTTY = true;
+    return stream;
+  }
+
+  /** @type {{write(s: string): void}} */
+  const silent = {
+    write() {
+      void 0;
+    },
+  };
+
+  it('parseFlags rejects unknown flags', () => {
+    expect(() => parseFlags(['--bogus'])).toThrow(/unknown argument/);
+    expect(parseFlags(['--full', '-y'])).toEqual({ full: true, yes: true });
+    expect(parseFlags([])).toEqual({ full: false, yes: false });
+  });
+
+  it('resolvePaths stays inside rootDir and rejects escapes', () => {
+    const root = makeTempRoot();
+    const resolved = resolvePaths(root, RAW_TIERS);
+    for (const entry of resolved) expect(entry.abs.startsWith(root)).toBe(true);
+    expect(() => resolvePaths(root, [{ name: '../outside', tier: 2 }])).toThrow(
+      /outside repo root/,
+    );
+  });
+
+  it('filterPaths: shallow keeps tier 1 only', () => {
+    const resolved = resolvePaths(makeTempRoot(), RAW_TIERS);
+    expect(filterPaths(false, resolved).map((e) => e.tier)).toEqual([1, 1]);
+    expect(filterPaths(true, resolved).map((e) => e.tier)).toEqual([1, 1, 2, 2]);
+  });
+
+  it('planReinstall only triggers when a tier-2 path exists', () => {
+    const none = resolvePaths(makeTempRoot(), RAW_TIERS);
+    expect(planReinstall(true, none)).toEqual({ install: false, sidecar: false });
+
+    mkdirSync(join(makeTempRoot(), 'node_modules'), { recursive: true });
+    const present = resolvePaths(tempRoots[tempRoots.length - 1], RAW_TIERS);
+    expect(planReinstall(true, present)).toEqual({ install: true, sidecar: true });
+  });
+
+  it('confirmProceed: explicit y confirms, n/empty aborts, non-TTY aborts, --yes confirms', async () => {
+    expect(await confirmProceed(readableTty('y\n'), silent, false)).toBe(true);
+    expect(await confirmProceed(readableTty('Y\n'), silent, false)).toBe(true);
+    expect(await confirmProceed(readableTty('n\n'), silent, false)).toBe(false);
+    expect(await confirmProceed(Readable.from(''), silent, false)).toBe(false);
+    expect(await confirmProceed(Readable.from(''), silent, true)).toBe(true);
+  });
+
+  it('shallow clean (-y) removes tier 1, keeps node_modules and unlisted files', async () => {
+    const root = makeTempRoot();
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    mkdirSync(join(root, 'dist-electron'), { recursive: true });
+    writeFileSync(join(root, 'dist', 'bundle.js'), 'x');
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    writeFileSync(join(root, 'docs.md'), 'keep');
+    const run = () => {
+      throw new Error('no reinstall expected for shallow');
+    };
+
+    const result = await runClean(root, ['-y'], {
+      stdin: process.stdin,
+      stdout: silent,
+      stderr: silent,
+      run,
+    });
+
+    expect(result.reinstalled).toBe(false);
+    expect(result.removed.sort()).toEqual(['dist', 'dist-electron']);
+    expect(existsSync(join(root, 'dist'))).toBe(false);
+    expect(existsSync(join(root, 'node_modules'))).toBe(true);
+    expect(existsSync(join(root, 'docs.md'))).toBe(true);
+  });
+
+  it('aborts without deleting when stdin is not a TTY and no -y', async () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    const run = () => {
+      throw new Error('no reinstall expected');
+    };
+
+    const result = await runClean(root, [], {
+      stdin: Readable.from(''),
+      stdout: silent,
+      stderr: silent,
+      run,
+    });
+
+    expect(result).toEqual({ removed: [], reinstalled: false });
+    expect(existsSync(join(root, 'dist'))).toBe(true);
+  });
+
+  it('aborts (nothing removed) when the user answers n', async () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    const run = () => {
+      throw new Error('no reinstall expected');
+    };
+
+    const result = await runClean(root, [], {
+      stdin: readableTty('n\n'),
+      stdout: silent,
+      stderr: silent,
+      run,
+    });
+
+    expect(result).toEqual({ removed: [], reinstalled: false });
+    expect(existsSync(join(root, 'dist'))).toBe(true);
+  });
+
+  it('full clean removes tier 1 + tier 2 and reinstalls when tier 2 was present', async () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    const calls = [];
+    const run = (cmd) => {
+      calls.push(cmd.join(' '));
+      return 0;
+    };
+
+    const result = await runClean(root, ['--full', '-y'], {
+      stdin: process.stdin,
+      stdout: silent,
+      stderr: silent,
+      run,
+    });
+
+    expect(result.reinstalled).toBe(true);
+    expect(result.removed.sort()).toEqual(['dist', 'node_modules']);
+    expect(calls).toEqual(['pnpm install', 'pnpm run reticulum:sidecar:build']);
+  });
+
+  it('does not reinstall when nothing existed to clean', async () => {
+    const root = makeTempDir();
+    const calls = [];
+    const run = (cmd) => {
+      calls.push(cmd.join(' '));
+      return 0;
+    };
+
+    const result = await runClean(root, ['--full', '-y'], {
+      stdin: process.stdin,
+      stdout: silent,
+      stderr: silent,
+      run,
+    });
+
+    expect(result.removed).toEqual([]);
+    expect(result.reinstalled).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  function makeTempDir() {
+    const root = makeTempRoot();
+    return root;
+  }
+});

--- a/scripts/clean-build.test.mjs
+++ b/scripts/clean-build.test.mjs
@@ -52,6 +52,7 @@ describe('clean-build', () => {
     expect(() => parseFlags(['--bogus'])).toThrow(/unknown argument/);
     expect(parseFlags(['--full', '-y'])).toEqual({ full: true, yes: true });
     expect(parseFlags([])).toEqual({ full: false, yes: false });
+    expect(parseFlags(['--', '-y'])).toEqual({ full: false, yes: true });
   });
 
   it('resolvePaths stays inside rootDir and rejects escapes', () => {

--- a/scripts/clean-build.test.mjs
+++ b/scripts/clean-build.test.mjs
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { Readable } from 'stream';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -8,9 +8,12 @@ import {
   confirmProceed,
   filterPaths,
   parseFlags,
+  pathExists,
   planReinstall,
+  printPlan,
   resolvePaths,
   runClean,
+  runCmd,
 } from './clean-build.mjs';
 
 const RAW_TIERS = [
@@ -64,10 +67,37 @@ describe('clean-build', () => {
     );
   });
 
+  it('resolvePaths rejects a symbolic-link ancestor pointing outside rootDir', () => {
+    const root = makeTempDir();
+    const outside = makeTempRoot();
+    try {
+      symlinkSync(outside, join(root, 'reticulum-sidecar'), 'dir');
+    } catch {
+      return; // symlinks unavailable on this platform
+    }
+    expect(() => resolvePaths(root, [{ name: 'reticulum-sidecar/target', tier: 2 }])).toThrow(
+      /symlink ancestor/,
+    );
+  });
+
   it('filterPaths: shallow keeps tier 1 only', () => {
     const resolved = resolvePaths(makeTempRoot(), RAW_TIERS);
     expect(filterPaths(false, resolved).map((e) => e.tier)).toEqual([1, 1]);
     expect(filterPaths(true, resolved).map((e) => e.tier)).toEqual([1, 1, 2, 2]);
+  });
+
+  it('pathExists treats symlinks (including dangling) as present; ENOENT is absent', () => {
+    const root = makeTempDir();
+    expect(pathExists(join(root, 'missing'))).toBe(false);
+    mkdirSync(join(root, 'real'), { recursive: true });
+    expect(pathExists(join(root, 'real'))).toBe(true);
+    try {
+      symlinkSync(join(root, 'real', 'nope'), join(root, 'dangling'), 'dir');
+    } catch {
+      return; // symlinks unavailable
+    }
+    expect(existsSync(join(root, 'dangling'))).toBe(false);
+    expect(pathExists(join(root, 'dangling'))).toBe(true);
   });
 
   it('planReinstall only triggers when a tier-2 path exists', () => {
@@ -77,6 +107,49 @@ describe('clean-build', () => {
     mkdirSync(join(makeTempRoot(), 'node_modules'), { recursive: true });
     const present = resolvePaths(tempRoots[tempRoots.length - 1], RAW_TIERS);
     expect(planReinstall(true, present)).toEqual({ install: true, sidecar: true });
+  });
+
+  it('planReinstall treats a dangling tier-2 symlink as present', () => {
+    const root = makeTempDir();
+    try {
+      symlinkSync(join(root, 'missing-target'), join(root, 'node_modules'), 'dir');
+    } catch {
+      return; // symlinks unavailable
+    }
+    const present = resolvePaths(root, RAW_TIERS);
+    expect(planReinstall(true, present).install).toBe(true);
+  });
+
+  it('printPlan writes the full plan to the supplied stream', () => {
+    const lines = [];
+    const out = {
+      write(s) {
+        lines.push(s);
+      },
+    };
+    printPlan(out, true, [{ name: 'node_modules' }], { install: true, sidecar: true });
+    expect(lines.join('')).toContain('This will remove:');
+    expect(lines.join('')).toContain('  - node_modules');
+    expect(lines.join('')).toContain('  - pnpm run reticulum:sidecar:build');
+  });
+
+  it('runCmd routes through the shell on win32 and not on other platforms', () => {
+    const win = [];
+    const code = runCmd(['pnpm', 'install'], '/cwd', 'win32', (cmd, args, opts) => {
+      win.push({ cmd, args, opts });
+      return { status: 0 };
+    });
+    expect(code).toBe(0);
+    expect(win).toHaveLength(1);
+    expect(win[0].cmd).toBe('pnpm');
+    expect(win[0].opts.shell).toBe(true);
+
+    const unix = [];
+    runCmd(['pnpm', 'install'], '/cwd', 'darwin', (cmd, args, opts) => {
+      unix.push(opts);
+      return { status: 0 };
+    });
+    expect(unix[0].shell).toBe(false);
   });
 
   it('confirmProceed: explicit y confirms, n/empty aborts, non-TTY aborts, --yes confirms', async () => {
@@ -98,12 +171,7 @@ describe('clean-build', () => {
       throw new Error('no reinstall expected for shallow');
     };
 
-    const result = await runClean(root, ['-y'], {
-      stdin: process.stdin,
-      stdout: silent,
-      stderr: silent,
-      run,
-    });
+    const result = await runClean(root, ['-y'], { stdin: process.stdin, stdout: silent, run });
 
     expect(result.reinstalled).toBe(false);
     expect(result.removed.sort()).toEqual(['dist', 'dist-electron']);
@@ -119,12 +187,7 @@ describe('clean-build', () => {
       throw new Error('no reinstall expected');
     };
 
-    const result = await runClean(root, [], {
-      stdin: Readable.from(''),
-      stdout: silent,
-      stderr: silent,
-      run,
-    });
+    const result = await runClean(root, [], { stdin: Readable.from(''), stdout: silent, run });
 
     expect(result).toEqual({ removed: [], reinstalled: false });
     expect(existsSync(join(root, 'dist'))).toBe(true);
@@ -137,12 +200,7 @@ describe('clean-build', () => {
       throw new Error('no reinstall expected');
     };
 
-    const result = await runClean(root, [], {
-      stdin: readableTty('n\n'),
-      stdout: silent,
-      stderr: silent,
-      run,
-    });
+    const result = await runClean(root, [], { stdin: readableTty('n\n'), stdout: silent, run });
 
     expect(result).toEqual({ removed: [], reinstalled: false });
     expect(existsSync(join(root, 'dist'))).toBe(true);
@@ -161,12 +219,36 @@ describe('clean-build', () => {
     const result = await runClean(root, ['--full', '-y'], {
       stdin: process.stdin,
       stdout: silent,
-      stderr: silent,
       run,
     });
 
     expect(result.reinstalled).toBe(true);
     expect(result.removed.sort()).toEqual(['dist', 'node_modules']);
+    expect(calls).toEqual(['pnpm install', 'pnpm run reticulum:sidecar:build']);
+  });
+
+  it('full clean throws RESTORE_FAILED when pnpm install fails, preserving removed state', async () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    const run = () => 1;
+
+    await expect(
+      runClean(root, ['--full', '-y'], { stdin: process.stdin, stdout: silent, run }),
+    ).rejects.toMatchObject({ code: 'RESTORE_FAILED', removed: ['node_modules'] });
+  });
+
+  it('full clean throws RESTORE_FAILED when the sidecar rebuild fails, preserving removed state', async () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, 'node_modules'), { recursive: true });
+    const calls = [];
+    const run = (cmd) => {
+      calls.push(cmd.join(' '));
+      return cmd[0] === 'pnpm' && cmd[2] === 'reticulum:sidecar:build' ? 1 : 0;
+    };
+
+    await expect(
+      runClean(root, ['--full', '-y'], { stdin: process.stdin, stdout: silent, run }),
+    ).rejects.toMatchObject({ code: 'RESTORE_FAILED', removed: ['node_modules'] });
     expect(calls).toEqual(['pnpm install', 'pnpm run reticulum:sidecar:build']);
   });
 
@@ -181,7 +263,6 @@ describe('clean-build', () => {
     const result = await runClean(root, ['--full', '-y'], {
       stdin: process.stdin,
       stdout: silent,
-      stderr: silent,
       run,
     });
 
@@ -191,7 +272,6 @@ describe('clean-build', () => {
   });
 
   function makeTempDir() {
-    const root = makeTempRoot();
-    return root;
+    return makeTempRoot();
   }
 });


### PR DESCRIPTION
## Summary

Adds a cross-platform build-artifact cleanup helper (`scripts/clean-build.mjs`) for **linux / darwin / win32**, wired as two pnpm commands, replacing the ad-hoc habit of manually `rm -rf`-ing build output.

- **`pnpm run clean:build`** — shallow: removes build dists, test output, and caches (`dist`, `dist-electron`, `release`, `coverage`, `.vitest-reports`, `test-results`, `playwright-report`, `.eslintcache`) while **keeping** `node_modules/` and the Reticulum sidecar, so `pnpm run dev` / `pnpm start` and Reticulum remain functional.
- **`pnpm run clean:build:full`** — full: additionally removes `node_modules`, `reticulum-sidecar/target/` (~22G), and the bundled sidecar binary, then restores a working environment via `pnpm install` + `pnpm run reticulum:sidecar:build`.

## Safety features

- Always prompts `Proceed? [y/N]` (default **N**) before deleting; `-y` / `--yes` skips the prompt but still echoes the plan.
- Non-interactive stdin (CI) without `-y` aborts instead of hanging.
- Strict allowlist of paths, resolved under the repo root and asserted to stay inside it.
- Reinstall is skipped when full-clean found nothing to remove.

## Testing (verified manually)

- `pnpm run clean:build -- -y` removed only the 8 tier-1 artifacts and preserved `node_modules/` + `reticulum-sidecar/target/`.
- `pnpm run clean:build:full -- -y` removed `node_modules/` + `target/`, then `pnpm install` (native modules rebuilt for Electron 41.10.3) and a fresh sidecar build (40.3s) restored the working env. Dev resolves the sidecar from `reticulum-sidecar/target/debug` (`reticulum-sidecar-path.ts`), so Reticulum works.
- Vitest `scripts/clean-build.test.mjs`: 10/10 PASS; ESLint `no issues`; Prettier + markdownlint clean.

## Files

- `scripts/clean-build.mjs`, `scripts/clean-build.test.mjs` (new)
- `package.json` (adds `clean:build`, `clean:build:full`)
- `docs/development-environment.md` (Maintenance block, Setup/helpers table, explainer prose)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform commands for cleaning build artifacts.
  * Added shallow and full cleanup options, with confirmation prompts and a `--yes` option for automation.
  * Full cleanup can reinstall dependencies and rebuild required components when needed.

* **Documentation**
  * Documented cleanup commands, safeguards, behavior, and usage scenarios.

* **Tests**
  * Added coverage for cleanup modes, safety checks, confirmations, and reinstall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->