### PR TITLE
chore: gitignore local reticulum sidecar config/storage dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ reticulum-sidecar/target/
 resources/reticulum-sidecar/staged/
 resources/reticulum-sidecar/mesh-client-reticulum
 resources/reticulum-sidecar/mesh-client-reticulum.exe
+
+# Local runtime state (identities, path tables, caches) from running the sidecar
+# directly (e.g. `pnpm run reticulum:sidecar:dev`) with no --reticulum-config-dir override
+reticulum-sidecar/reticulum-config/


### PR DESCRIPTION
## Summary
- \`pnpm run reticulum:sidecar:dev\` (the documented standalone dev command for the Reticulum sidecar, see `docs/development-environment.md`) has no `--reticulum-config-dir` override, so it falls back to the binary's own default of `./reticulum-config` relative to cwd.
- That leaves local identity/key material and runtime caches (`storage/transport_identity`, `storage/identities`, `storage/path_table.msgpack`, etc.) sitting **untracked** in the repo tree for anyone following the documented command, with no matching `.gitignore` entry — same category as the existing `reticulum-sidecar/target/` entry for cargo's own build output.
- The packaged/normal Electron app is unaffected: `src/main/reticulum-sidecar-manager.ts` always passes an explicit `--reticulum-config-dir` under `app.getPath('userData')`.

## Test plan
- N/A — `.gitignore`-only change, no source files touched.