### PR TITLE
fix(meshtastic): harden BLE teardown and reconnect against stream races

### DIFF
--- a/src/renderer/lib/meshtastic/meshtasticConfigureRetry.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticConfigureRetry.test.ts
@@ -2,8 +2,11 @@ import type { MeshDevice } from '@meshtastic/core';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  armMeshtasticLateConfigureRetryableSwallow,
   configureMeshtasticDeviceWithRetry,
   isMeshtasticConfigureRetryableError,
+  resetMeshtasticLateConfigureRetryableSwallowForTests,
+  shouldSwallowLateMeshtasticConfigureRetryableRejection,
 } from './meshtasticConfigureRetry';
 
 describe('configureMeshtasticDeviceWithRetry', () => {
@@ -36,5 +39,16 @@ describe('configureMeshtasticDeviceWithRetry', () => {
   it('isMeshtasticConfigureRetryableError matches SDK message', () => {
     expect(isMeshtasticConfigureRetryableError(new Error('Packet does not exist'))).toBe(true);
     expect(isMeshtasticConfigureRetryableError(new Error('other'))).toBe(false);
+  });
+
+  it('late-swallow window is off by default and active only after arm', () => {
+    resetMeshtasticLateConfigureRetryableSwallowForTests();
+    const err = new Error('Packet does not exist');
+    expect(shouldSwallowLateMeshtasticConfigureRetryableRejection(err)).toBe(false);
+    armMeshtasticLateConfigureRetryableSwallow(60_000);
+    expect(shouldSwallowLateMeshtasticConfigureRetryableRejection(err)).toBe(true);
+    expect(shouldSwallowLateMeshtasticConfigureRetryableRejection(new Error('other'))).toBe(false);
+    resetMeshtasticLateConfigureRetryableSwallowForTests();
+    expect(shouldSwallowLateMeshtasticConfigureRetryableRejection(err)).toBe(false);
   });
 });

--- a/src/renderer/lib/meshtastic/meshtasticConfigureRetry.ts
+++ b/src/renderer/lib/meshtastic/meshtasticConfigureRetry.ts
@@ -4,10 +4,34 @@ import { errLikeToLogString } from '../errLikeToLogString';
 
 export const MESHTASTIC_CONFIGURE_RETRY_MAX_ATTEMPTS = 6;
 
+/** Window for late SDK "Packet does not exist" rejects after the session handler is removed. */
+export const MESHTASTIC_LATE_CONFIGURE_RETRYABLE_SWALLOW_MS = 5_000;
+
 const CONFIGURE_RETRYABLE_PATTERN = /packet does not exist/i;
+
+let lateConfigureRetryableSwallowUntilMs = 0;
 
 export function isMeshtasticConfigureRetryableError(err: unknown): boolean {
   return CONFIGURE_RETRYABLE_PATTERN.test(errLikeToLogString(err));
+}
+
+/** Arm a short post-teardown window so the global logger can swallow late SDK rejects. */
+export function armMeshtasticLateConfigureRetryableSwallow(
+  durationMs: number = MESHTASTIC_LATE_CONFIGURE_RETRYABLE_SWALLOW_MS,
+): void {
+  lateConfigureRetryableSwallowUntilMs = Date.now() + Math.max(0, durationMs);
+}
+
+/** True only while a post-teardown swallow window is active (not app-lifetime). */
+export function shouldSwallowLateMeshtasticConfigureRetryableRejection(err: unknown): boolean {
+  return (
+    Date.now() < lateConfigureRetryableSwallowUntilMs && isMeshtasticConfigureRetryableError(err)
+  );
+}
+
+/** Test-only: clear the late-swallow window. */
+export function resetMeshtasticLateConfigureRetryableSwallowForTests(): void {
+  lateConfigureRetryableSwallowUntilMs = 0;
 }
 
 /** Retry configure when the radio is still booting after a settings commit reboot. */

--- a/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.post-reboot.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.post-reboot.test.ts
@@ -1,6 +1,7 @@
 import type { MeshDevice } from '@meshtastic/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MESHTASTIC_BLE_CONFIGURE_TIMEOUT_MS } from '../timeConstants';
 import type { ConnectionType, DeviceState } from '../types';
 import { attachMeshtasticRuntimeWireEffects } from './meshtasticRuntimeWireEffects';
 
@@ -15,7 +16,6 @@ function makeDeps(opts?: { isBleReconnectAttemptActive?: () => boolean }) {
   const stopWatchdog = vi.fn();
   const stopGpsInterval = vi.fn();
   const cleanupSubscriptions = vi.fn();
-  const clearConfigureTimeout = vi.fn();
   const startWatchdog = vi.fn();
   const startGpsInterval = vi.fn();
   const refreshOurPosition = vi.fn().mockResolvedValue(null);
@@ -27,6 +27,12 @@ function makeDeps(opts?: { isBleReconnectAttemptActive?: () => boolean }) {
     current: { type: 'ble' as ConnectionType, blePeripheralId: 'p1' },
   };
   const configureTimeoutRef = { current: null as ReturnType<typeof setTimeout> | null };
+  const clearConfigureTimeout = vi.fn(() => {
+    if (configureTimeoutRef.current != null) {
+      clearTimeout(configureTimeoutRef.current);
+      configureTimeoutRef.current = null;
+    }
+  });
   const meshtasticIngestSessionRef = {
     current: {
       setConfiguring: vi.fn(),
@@ -272,6 +278,22 @@ describe('meshtasticRuntimeWireEffects BLE configure timeout arming', () => {
 
     for (const cb of statusSubscribers) cb(DEVICE_CONFIGURING);
 
+    expect(configureTimeoutRef.current).toBeNull();
+  });
+
+  it('fires handleConnectionLost after BLE configure timeout when armed', () => {
+    const { deps, configureTimeoutRef } = makeDeps({
+      isBleReconnectAttemptActive: () => false,
+    });
+    const onLost = vi.mocked(deps.handleConnectionLostRef.current);
+    const statusSubscribers = attachBleWithStatusSubscribers(deps);
+
+    for (const cb of statusSubscribers) cb(DEVICE_CONFIGURING);
+    expect(configureTimeoutRef.current).not.toBeNull();
+
+    vi.advanceTimersByTime(MESHTASTIC_BLE_CONFIGURE_TIMEOUT_MS);
+
+    expect(onLost).toHaveBeenCalledTimes(1);
     expect(configureTimeoutRef.current).toBeNull();
   });
 });

--- a/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.post-reboot.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.post-reboot.test.ts
@@ -1,10 +1,13 @@
 import type { MeshDevice } from '@meshtastic/core';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ConnectionType, DeviceState } from '../types';
 import { attachMeshtasticRuntimeWireEffects } from './meshtasticRuntimeWireEffects';
 
-function makeDeps() {
+/** DeviceConfiguring — see Types.DeviceStatusEnum */
+const DEVICE_CONFIGURING = 6;
+
+function makeDeps(opts?: { isBleReconnectAttemptActive?: () => boolean }) {
   const touchLastData = vi.fn();
   const schedulePostCommitRebootRecovery = vi.fn();
   const clearPostCommitRebootRecovery = vi.fn();
@@ -88,7 +91,7 @@ function makeDeps() {
     isDuplicate: vi.fn().mockReturnValue(false),
     ensureNodeExists: vi.fn(),
     clearConfigureTimeout,
-    isBleReconnectAttemptActive: () => false,
+    isBleReconnectAttemptActive: opts?.isBleReconnectAttemptActive ?? (() => false),
     applyMeshtasticForeignLoraFromLog: vi.fn(),
     emptyNode: vi.fn(),
     setMeshtasticIdentityId: noopSet,
@@ -132,6 +135,7 @@ function makeDeps() {
 
   return {
     deps,
+    configureTimeoutRef,
     touchLastData,
     schedulePostCommitRebootRecovery,
     clearPostCommitRebootRecovery,
@@ -139,6 +143,31 @@ function makeDeps() {
     isConfiguringRef,
     setState,
   };
+}
+
+function attachBleWithStatusSubscribers(
+  deps: ReturnType<typeof makeDeps>['deps'],
+): Set<(status: number) => void> {
+  const statusSubscribers = new Set<(status: number) => void>();
+  const noopSub = { subscribe: () => () => {} };
+  const device = {
+    events: new Proxy({} as MeshDevice['events'], {
+      get: (_target, prop) => {
+        if (prop === 'onDeviceStatus') {
+          return {
+            subscribe: (cb: (status: number) => void) => {
+              statusSubscribers.add(cb);
+              return () => statusSubscribers.delete(cb);
+            },
+          };
+        }
+        return noopSub;
+      },
+    }),
+    setHeartbeatInterval: vi.fn(),
+  } as unknown as MeshDevice;
+  attachMeshtasticRuntimeWireEffects(device, 'ble', { driverIdentityId: 'id-1' }, deps);
+  return statusSubscribers;
 }
 
 describe('meshtasticRuntimeWireEffects DeviceRestarting', () => {
@@ -213,5 +242,36 @@ describe('meshtasticRuntimeWireEffects DeviceRestarting', () => {
     for (const cb of statusSubscribers) cb(7);
 
     expect(clearPostCommitRebootRecovery).toHaveBeenCalled();
+  });
+});
+
+describe('meshtasticRuntimeWireEffects BLE configure timeout arming', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('arms 30s timeout on DeviceConfiguring when reconnect is inactive', () => {
+    const { deps, configureTimeoutRef } = makeDeps({
+      isBleReconnectAttemptActive: () => false,
+    });
+    const statusSubscribers = attachBleWithStatusSubscribers(deps);
+
+    for (const cb of statusSubscribers) cb(DEVICE_CONFIGURING);
+
+    expect(configureTimeoutRef.current).not.toBeNull();
+  });
+
+  it('does not arm timeout on DeviceConfiguring when reconnect owns the attempt', () => {
+    const { deps, configureTimeoutRef } = makeDeps({
+      isBleReconnectAttemptActive: () => true,
+    });
+    const statusSubscribers = attachBleWithStatusSubscribers(deps);
+
+    for (const cb of statusSubscribers) cb(DEVICE_CONFIGURING);
+
+    expect(configureTimeoutRef.current).toBeNull();
   });
 });

--- a/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.post-reboot.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.post-reboot.test.ts
@@ -88,6 +88,7 @@ function makeDeps() {
     isDuplicate: vi.fn().mockReturnValue(false),
     ensureNodeExists: vi.fn(),
     clearConfigureTimeout,
+    isBleReconnectAttemptActive: () => false,
     applyMeshtasticForeignLoraFromLog: vi.fn(),
     emptyNode: vi.fn(),
     setMeshtasticIdentityId: noopSet,

--- a/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.telemetry-nodeinfo.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.telemetry-nodeinfo.test.ts
@@ -109,6 +109,7 @@ function makeDeps() {
       isDuplicate: vi.fn().mockReturnValue(false),
       ensureNodeExists,
       clearConfigureTimeout: vi.fn(),
+      isBleReconnectAttemptActive: () => false,
       applyMeshtasticForeignLoraFromLog: vi.fn(),
       emptyNode: vi.fn(),
       setMeshtasticIdentityId: vi.fn(),

--- a/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.ts
+++ b/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.ts
@@ -173,6 +173,8 @@ export interface MeshtasticRuntimeWireEffectsDeps {
   isDuplicate: (senderId: number, packetId: number) => boolean;
   ensureNodeExists: (nodeNum: number, source: 'rf' | 'mqtt') => void;
   clearConfigureTimeout: () => void;
+  /** True while reconnect owns the BLE open+configure attempt (90s budget is the stall ceiling). */
+  isBleReconnectAttemptActive: () => boolean;
   applyMeshtasticForeignLoraFromLog: (message: string) => void;
   emptyNode: (nodeId: number) => MeshNode;
   setMeshtasticIdentityId: Dispatch<SetStateAction<string | null>>;
@@ -319,6 +321,7 @@ export function attachMeshtasticRuntimeWireEffects(
     isDuplicate,
     ensureNodeExists,
     clearConfigureTimeout,
+    isBleReconnectAttemptActive,
     applyMeshtasticForeignLoraFromLog,
     emptyNode,
     setMeshtasticIdentityId,
@@ -420,10 +423,12 @@ export function attachMeshtasticRuntimeWireEffects(
     ) {
       isConfiguringRef.current = true;
       meshtasticIngestSessionRef.current?.setConfiguring(true);
+      // Initial BLE connect only — during reconnect the 90s attempt budget owns stall detection.
       if (
         status === DeviceStatusEnum.DeviceConfiguring &&
         type === 'ble' &&
-        !configureTimeoutRef.current
+        !configureTimeoutRef.current &&
+        !isBleReconnectAttemptActive()
       ) {
         configureTimeoutRef.current = setTimeout(() => {
           console.warn('[useMeshtasticRuntime] configure timeout (BLE 30s) — forcing disconnect');

--- a/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorConsoleHook.ts
+++ b/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorConsoleHook.ts
@@ -1,5 +1,8 @@
 import { errLikeToLogString } from '../errLikeToLogString';
-import { isMeshtasticConfigureRetryableError } from './meshtasticConfigureRetry';
+import {
+  armMeshtasticLateConfigureRetryableSwallow,
+  isMeshtasticConfigureRetryableError,
+} from './meshtasticConfigureRetry';
 import {
   parseMeshtasticSdkQueueRejection,
   parseMeshtasticSdkRoutingErrorLog,
@@ -78,5 +81,7 @@ export function installMeshtasticSdkRoutingErrorUnhandledRejectionHandler(
   window.addEventListener('unhandledrejection', handler, { capture: true });
   return () => {
     window.removeEventListener('unhandledrejection', handler, { capture: true });
+    // Late SDK queue rejects can settle after wire-effects teardown removes this handler.
+    armMeshtasticLateConfigureRetryableSwallow();
   };
 }

--- a/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorConsoleHook.ts
+++ b/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorConsoleHook.ts
@@ -74,8 +74,9 @@ export function installMeshtasticSdkRoutingErrorUnhandledRejectionHandler(
       event.preventDefault();
     }
   };
-  window.addEventListener('unhandledrejection', handler);
+  // Capture phase so preventDefault runs before the bubble-phase renderer logger.
+  window.addEventListener('unhandledrejection', handler, { capture: true });
   return () => {
-    window.removeEventListener('unhandledrejection', handler);
+    window.removeEventListener('unhandledrejection', handler, { capture: true });
   };
 }

--- a/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.test.ts
@@ -16,6 +16,10 @@ vi.mock('@/renderer/stores/messageStore', () => ({
 import { updateMessageStatus } from '@/renderer/stores/messageStore';
 
 import {
+  resetMeshtasticLateConfigureRetryableSwallowForTests,
+  shouldSwallowLateMeshtasticConfigureRetryableRejection,
+} from './meshtasticConfigureRetry';
+import {
   beginMeshtasticNonChatOutbound,
   endMeshtasticNonChatOutbound,
   registerMeshtasticNonChatWirePacketId,
@@ -434,5 +438,18 @@ describe('installMeshtasticSdkRoutingErrorUnhandledRejectionHandler', () => {
       expect.any(Function),
       { capture: true },
     );
+  });
+
+  it('arms late-swallow window when the capture handler is removed', () => {
+    resetMeshtasticLateConfigureRetryableSwallowForTests();
+    const restore = installMeshtasticSdkRoutingErrorUnhandledRejectionHandler(vi.fn());
+    expect(
+      shouldSwallowLateMeshtasticConfigureRetryableRejection(new Error('Packet does not exist')),
+    ).toBe(false);
+    restore();
+    expect(
+      shouldSwallowLateMeshtasticConfigureRetryableRejection(new Error('Packet does not exist')),
+    ).toBe(true);
+    resetMeshtasticLateConfigureRetryableSwallowForTests();
   });
 });

--- a/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.test.ts
@@ -371,7 +371,9 @@ describe('installMeshtasticSdkRoutingErrorUnhandledRejectionHandler', () => {
     expect(onQueueRejection).toHaveBeenCalledWith(reason);
     expect(preventDefault).toHaveBeenCalled();
     restore();
-    expect(window.removeEventListener).toHaveBeenCalledWith('unhandledrejection', handler);
+    expect(window.removeEventListener).toHaveBeenCalledWith('unhandledrejection', handler, {
+      capture: true,
+    });
   });
 
   it('does not preventDefault when handler returns false', () => {
@@ -417,5 +419,20 @@ describe('installMeshtasticSdkRoutingErrorUnhandledRejectionHandler', () => {
     expect(onQueueRejection).not.toHaveBeenCalled();
     expect(preventDefault).toHaveBeenCalled();
     restore();
+  });
+
+  it('registers unhandledrejection listener in capture phase', () => {
+    const restore = installMeshtasticSdkRoutingErrorUnhandledRejectionHandler(vi.fn());
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'unhandledrejection',
+      expect.any(Function),
+      { capture: true },
+    );
+    restore();
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'unhandledrejection',
+      expect.any(Function),
+      { capture: true },
+    );
   });
 });

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
@@ -156,4 +156,33 @@ describe('meshtasticTransportLossDetection', () => {
 
     expect(device.transport.toDevice).toBe(inner);
   });
+
+  it('restores toDevice on cleanup instead of deleting (getWriter race regression)', async () => {
+    const inner = new WritableStream<Uint8Array>({
+      write: vi.fn(),
+    });
+    const device = {
+      transport: { toDevice: inner },
+    } as unknown as MeshDevice;
+
+    const detach = attachMeshtasticTransportLossWatch(device, 'ble', vi.fn());
+    expect(device.transport.toDevice).not.toBe(inner);
+
+    detach();
+
+    // Must remain defined so in-flight SDK processQueue/getWriter does not throw.
+    expect(device.transport.toDevice).toBeDefined();
+    expect(typeof device.transport.toDevice.getWriter).toBe('function');
+    const writer = device.transport.toDevice.getWriter();
+    // Original stream may still accept writes after restore; close must not throw.
+    await expect(writer.close()).resolves.toBeUndefined();
+  });
+
+  it('createSerializedWritableStream close soft-fails when inner is already closed', async () => {
+    const inner = new WritableStream<Uint8Array>({ write: vi.fn() });
+    await inner.close();
+    const serialized = createSerializedWritableStream(inner);
+    const writer = serialized.getWriter();
+    await expect(writer.close()).resolves.toBeUndefined();
+  });
 });

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
@@ -185,4 +185,30 @@ describe('meshtasticTransportLossDetection', () => {
     const writer = serialized.getWriter();
     await expect(writer.close()).resolves.toBeUndefined();
   });
+
+  it('createSerializedWritableStream abort soft-fails when inner.abort rejects asynchronously', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      const inner = new WritableStream<Uint8Array>({
+        write: vi.fn(),
+        abort() {
+          return Promise.reject(new DOMException('already closed', 'InvalidStateError'));
+        },
+      });
+      const serialized = createSerializedWritableStream(inner);
+      const writer = serialized.getWriter();
+      await expect(writer.abort('teardown')).resolves.toBeUndefined();
+      // Allow any stray rejection to surface before asserting.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
 });

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
@@ -100,9 +100,11 @@ export function createSerializedWritableStream(
 
   const abortInner = (reason?: unknown): Promise<void> => {
     try {
-      return inner.abort(reason);
+      return Promise.resolve(inner.abort(reason)).catch(() => {
+        // catch-no-log-ok async abort rejection during teardown
+      });
     } catch {
-      // catch-no-log-ok abort on closed/errored stream during teardown
+      // catch-no-log-ok sync abort throw on closed/errored stream during teardown
       return Promise.resolve();
     }
   };

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
@@ -53,7 +53,15 @@ export function createSerializedWritableStream(
 
   const writeInner = async (chunk: Uint8Array): Promise<void> => {
     await runExclusive(async () => {
-      const writer = inner.getWriter();
+      let writer: WritableStreamDefaultWriter<Uint8Array>;
+      try {
+        writer = inner.getWriter();
+      } catch (err) {
+        if (onWriteError && isMeshtasticTransportLostError(err)) {
+          onWriteError(err);
+        }
+        throw err;
+      }
       try {
         await writer.write(chunk);
       } catch (err) {
@@ -62,26 +70,47 @@ export function createSerializedWritableStream(
         }
         throw err;
       } finally {
-        writer.releaseLock();
+        try {
+          writer.releaseLock();
+        } catch {
+          // catch-no-log-ok stream already closed/errored during teardown
+        }
       }
     });
   };
 
   const closeInner = async (): Promise<void> => {
     await runExclusive(async () => {
-      const writer = inner.getWriter();
       try {
-        await writer.close();
-      } finally {
-        writer.releaseLock();
+        const writer = inner.getWriter();
+        try {
+          await writer.close();
+        } finally {
+          try {
+            writer.releaseLock();
+          } catch {
+            // catch-no-log-ok stream already closed/errored during teardown
+          }
+        }
+      } catch {
+        // catch-no-log-ok closed/errored inner stream during teardown (Illegal invocation)
       }
     });
+  };
+
+  const abortInner = (reason?: unknown): Promise<void> => {
+    try {
+      return inner.abort(reason);
+    } catch {
+      // catch-no-log-ok abort on closed/errored stream during teardown
+      return Promise.resolve();
+    }
   };
 
   const body = new WritableStream<Uint8Array>({
     write: writeInner,
     close: closeInner,
-    abort: (reason) => inner.abort(reason),
+    abort: abortInner,
   });
 
   return new Proxy(body, {
@@ -104,7 +133,7 @@ export function createSerializedWritableStream(
             return closeInner();
           },
           abort(reason?: unknown): Promise<void> {
-            return inner.abort(reason);
+            return abortInner(reason);
           },
         });
       }
@@ -166,20 +195,41 @@ export function attachMeshtasticTransportLossWatch(
 
   const transport = device.transport as { toDevice?: WritableStream<Uint8Array> } | undefined;
   if (transport?.toDevice) {
-    const wrapped = createLossAwareWritableStream(transport.toDevice, (err) => {
+    const transportObj = device.transport as object;
+    const originalDesc = Object.getOwnPropertyDescriptor(transportObj, 'toDevice');
+    const originalToDevice = transport.toDevice;
+    const wrapped = createLossAwareWritableStream(originalToDevice, (err) => {
       notify('write-failure', err);
     });
-    Object.defineProperty(device.transport, 'toDevice', {
+    Object.defineProperty(transportObj, 'toDevice', {
       configurable: true,
+      enumerable: true,
       get() {
         return wrapped;
       },
     });
     cleanups.push(() => {
+      // Never delete toDevice — in-flight SDK processQueue/getWriter needs a defined stream.
       try {
-        delete (device.transport as { toDevice?: WritableStream<Uint8Array> }).toDevice;
+        if (originalDesc) {
+          Object.defineProperty(transportObj, 'toDevice', originalDesc);
+        } else {
+          Object.defineProperty(transportObj, 'toDevice', {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: originalToDevice,
+          });
+        }
       } catch {
-        // catch-no-log-ok restore original getter after teardown
+        // catch-no-log-ok leave a soft-fail stub if restore fails
+        Object.defineProperty(transportObj, 'toDevice', {
+          configurable: true,
+          enumerable: true,
+          get() {
+            return createSerializedWritableStream(null);
+          },
+        });
       }
     });
   }

--- a/src/renderer/lib/rendererUnhandledRejection.test.ts
+++ b/src/renderer/lib/rendererUnhandledRejection.test.ts
@@ -30,9 +30,15 @@ describe('logRendererUnhandledRejection', () => {
   });
 });
 
-function dispatchUnhandledRejection(reason: unknown): void {
-  const event = new Event('unhandledrejection');
+function dispatchUnhandledRejection(
+  reason: unknown,
+  opts?: { preventDefaultFirst?: boolean },
+): void {
+  const event = new Event('unhandledrejection', { cancelable: true });
   Object.assign(event, { reason });
+  if (opts?.preventDefaultFirst) {
+    event.preventDefault();
+  }
   window.dispatchEvent(event);
 }
 
@@ -59,5 +65,30 @@ describe('installRendererUnhandledRejectionLogger', () => {
     dispatchUnhandledRejection('boom');
 
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('skips console.error when defaultPrevented (capture-phase Meshtastic handler)', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const uninstall = installRendererUnhandledRejectionLogger();
+
+    dispatchUnhandledRejection(new Error('queue rejected'), { preventDefaultFirst: true });
+    uninstall();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not log Packet does not exist as Unhandled rejection', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const uninstall = installRendererUnhandledRejectionLogger();
+
+    dispatchUnhandledRejection(new Error('Packet does not exist'));
+    uninstall();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[renderer] Ignoring Meshtastic disconnect mid-send rejection:',
+      'Packet does not exist',
+    );
   });
 });

--- a/src/renderer/lib/rendererUnhandledRejection.test.ts
+++ b/src/renderer/lib/rendererUnhandledRejection.test.ts
@@ -2,6 +2,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  armMeshtasticLateConfigureRetryableSwallow,
+  resetMeshtasticLateConfigureRetryableSwallowForTests,
+} from './meshtastic/meshtasticConfigureRetry';
+import {
   installRendererUnhandledRejectionLogger,
   logRendererUnhandledRejection,
 } from './rendererUnhandledRejection';
@@ -45,6 +49,7 @@ function dispatchUnhandledRejection(
 
 describe('installRendererUnhandledRejectionLogger', () => {
   afterEach(() => {
+    resetMeshtasticLateConfigureRetryableSwallowForTests();
     vi.restoreAllMocks();
   });
 
@@ -78,10 +83,25 @@ describe('installRendererUnhandledRejectionLogger', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('does not log Packet does not exist as Unhandled rejection', () => {
+  it('logs Packet does not exist when late-swallow window is not armed', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const uninstall = installRendererUnhandledRejectionLogger();
+
+    const event = dispatchUnhandledRejection(new Error('Packet does not exist'));
+    uninstall();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[renderer] Unhandled rejection:',
+      expect.stringContaining('Packet does not exist'),
+    );
+  });
+
+  it('does not log Packet does not exist during armed late-swallow window', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     const uninstall = installRendererUnhandledRejectionLogger();
+    armMeshtasticLateConfigureRetryableSwallow();
 
     const event = dispatchUnhandledRejection(new Error('Packet does not exist'));
     uninstall();

--- a/src/renderer/lib/rendererUnhandledRejection.test.ts
+++ b/src/renderer/lib/rendererUnhandledRejection.test.ts
@@ -33,13 +33,14 @@ describe('logRendererUnhandledRejection', () => {
 function dispatchUnhandledRejection(
   reason: unknown,
   opts?: { preventDefaultFirst?: boolean },
-): void {
+): Event {
   const event = new Event('unhandledrejection', { cancelable: true });
   Object.assign(event, { reason });
   if (opts?.preventDefaultFirst) {
     event.preventDefault();
   }
   window.dispatchEvent(event);
+  return event;
 }
 
 describe('installRendererUnhandledRejectionLogger', () => {
@@ -82,9 +83,10 @@ describe('installRendererUnhandledRejectionLogger', () => {
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     const uninstall = installRendererUnhandledRejectionLogger();
 
-    dispatchUnhandledRejection(new Error('Packet does not exist'));
+    const event = dispatchUnhandledRejection(new Error('Packet does not exist'));
     uninstall();
 
+    expect(event.defaultPrevented).toBe(true);
     expect(errorSpy).not.toHaveBeenCalled();
     expect(debugSpy).toHaveBeenCalledWith(
       '[renderer] Ignoring Meshtastic disconnect mid-send rejection:',

--- a/src/renderer/lib/rendererUnhandledRejection.ts
+++ b/src/renderer/lib/rendererUnhandledRejection.ts
@@ -1,4 +1,4 @@
-import { isMeshtasticConfigureRetryableError } from './meshtastic/meshtasticConfigureRetry';
+import { shouldSwallowLateMeshtasticConfigureRetryableRejection } from './meshtastic/meshtasticConfigureRetry';
 
 /** Log renderer-wide unhandled promise rejections without throwing a second error. */
 export function logRendererUnhandledRejection(reason: unknown): void {
@@ -13,8 +13,8 @@ export function installRendererUnhandledRejectionLogger(target: Window = window)
   const handler = (event: PromiseRejectionEvent) => {
     // Capture-phase Meshtastic handler may have already preventDefault'd queue rejections.
     if (event.defaultPrevented) return;
-    // Durable swallow: session teardown removes the Meshtastic handler before late SDK rejects.
-    if (isMeshtasticConfigureRetryableError(event.reason)) {
+    // Only during a short post-teardown window (armed when Meshtastic session handler unsubscribes).
+    if (shouldSwallowLateMeshtasticConfigureRetryableRejection(event.reason)) {
       console.debug(
         '[renderer] Ignoring Meshtastic disconnect mid-send rejection:',
         event.reason instanceof Error ? event.reason.message : String(event.reason),

--- a/src/renderer/lib/rendererUnhandledRejection.ts
+++ b/src/renderer/lib/rendererUnhandledRejection.ts
@@ -1,3 +1,5 @@
+import { isMeshtasticConfigureRetryableError } from './meshtastic/meshtasticConfigureRetry';
+
 /** Log renderer-wide unhandled promise rejections without throwing a second error. */
 export function logRendererUnhandledRejection(reason: unknown): void {
   console.error(
@@ -9,6 +11,17 @@ export function logRendererUnhandledRejection(reason: unknown): void {
 /** Route every renderer-wide unhandled rejection into the log. Returns an unsubscribe callback. */
 export function installRendererUnhandledRejectionLogger(target: Window = window): () => void {
   const handler = (event: PromiseRejectionEvent) => {
+    // Capture-phase Meshtastic handler may have already preventDefault'd queue rejections.
+    if (event.defaultPrevented) return;
+    // Durable swallow: session teardown removes the Meshtastic handler before late SDK rejects.
+    if (isMeshtasticConfigureRetryableError(event.reason)) {
+      console.debug(
+        '[renderer] Ignoring Meshtastic disconnect mid-send rejection:',
+        event.reason instanceof Error ? event.reason.message : String(event.reason),
+      );
+      event.preventDefault();
+      return;
+    }
     logRendererUnhandledRejection(event.reason);
   };
   target.addEventListener('unhandledrejection', handler);

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -158,6 +158,8 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     expect(lostBody).toContain('defer reconnect until in-flight open settles');
   });
 
+  // Source contract (not full runtime lifecycle): useMeshtasticRuntime reconnect wiring is
+  // covered by source contracts per AGENTS.md; full renderHook + BLE/driver mocks are out of scope.
   it('disconnects before cleanupSubscriptions so toDevice stays defined during safeDisconnect', () => {
     const lostBody = extractUseCallbackBody(SOURCE, 'handleConnectionLost');
     const driverIdentityIdx = lostBody.indexOf(
@@ -189,17 +191,18 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     expect(reconnectBody).toContain('Reconnect superseded during configure');
   });
 
-  it('BLE configure timeout routes through handleConnectionLost on initial connect only', () => {
+  it('wires isBleReconnectAttemptActive from reconnect refs (behavioral arming in wire-effects tests)', () => {
+    // DeviceConfiguring arm/skip is asserted in meshtasticRuntimeWireEffects.post-reboot.test.ts
+    expect(SOURCE).toMatch(
+      /isBleReconnectAttemptActive:\s*\(\)\s*=>\s*isReconnectingRef\.current \|\| reconnectConnectInFlightRef\.current/,
+    );
     const wireSource = readFileSync(
       join(TEST_DIR, '../lib/meshtastic/meshtasticRuntimeWireEffects.ts'),
       'utf-8',
     );
+    expect(wireSource).toContain('!isBleReconnectAttemptActive()');
     expect(wireSource).toMatch(
       /configure timeout \(BLE 30s\)[\s\S]*?handleConnectionLostRef\.current\(\)/,
-    );
-    expect(wireSource).toContain('!isBleReconnectAttemptActive()');
-    expect(SOURCE).toMatch(
-      /isBleReconnectAttemptActive:\s*\(\)\s*=>\s*isReconnectingRef\.current \|\| reconnectConnectInFlightRef\.current/,
     );
   });
 

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -158,6 +158,18 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     expect(lostBody).toContain('defer reconnect until in-flight open settles');
   });
 
+  it('disconnects before cleanupSubscriptions so toDevice stays defined during safeDisconnect', () => {
+    const lostBody = extractUseCallbackBody(SOURCE, 'handleConnectionLost');
+    const driverIdentityIdx = lostBody.indexOf(
+      'meshtasticIdentityIdRef.current ?? meshtasticPendingDriverIdentityRef.current',
+    );
+    const safeDisconnectIdx = lostBody.indexOf('safeDisconnect(staleDevice)');
+    const cleanupIdx = lostBody.indexOf('cleanupSubscriptions()');
+    expect(driverIdentityIdx).toBeGreaterThanOrEqual(0);
+    expect(safeDisconnectIdx).toBeGreaterThan(driverIdentityIdx);
+    expect(cleanupIdx).toBeGreaterThan(safeDisconnectIdx);
+  });
+
   it('flushes deferred reconnects after non-BLE reconnect attempts settle', () => {
     const reconnectBody = extractUseCallbackBody(SOURCE, 'attemptReconnect');
     const finallyBody = reconnectBody.slice(reconnectBody.indexOf('finally {'));
@@ -177,13 +189,17 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     expect(reconnectBody).toContain('Reconnect superseded during configure');
   });
 
-  it('BLE configure timeout routes through handleConnectionLost (reconnect)', () => {
+  it('BLE configure timeout routes through handleConnectionLost on initial connect only', () => {
     const wireSource = readFileSync(
       join(TEST_DIR, '../lib/meshtastic/meshtasticRuntimeWireEffects.ts'),
       'utf-8',
     );
     expect(wireSource).toMatch(
       /configure timeout \(BLE 30s\)[\s\S]*?handleConnectionLostRef\.current\(\)/,
+    );
+    expect(wireSource).toContain('!isBleReconnectAttemptActive()');
+    expect(SOURCE).toMatch(
+      /isBleReconnectAttemptActive:\s*\(\)\s*=>\s*isReconnectingRef\.current \|\| reconnectConnectInFlightRef\.current/,
     );
   });
 

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -191,11 +191,15 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     expect(reconnectBody).toContain('Reconnect superseded during configure');
   });
 
-  it('wires isBleReconnectAttemptActive from reconnect refs (behavioral arming in wire-effects tests)', () => {
+  it('wires isBleReconnectAttemptActive from isReconnectingRef only (not in-flight alone)', () => {
     // DeviceConfiguring arm/skip is asserted in meshtasticRuntimeWireEffects.post-reboot.test.ts
-    expect(SOURCE).toMatch(
-      /isBleReconnectAttemptActive:\s*\(\)\s*=>\s*isReconnectingRef\.current \|\| reconnectConnectInFlightRef\.current/,
+    expect(SOURCE).toMatch(/isBleReconnectAttemptActive:\s*\(\)\s*=>\s*isReconnectingRef\.current/);
+    expect(SOURCE).not.toMatch(
+      /isBleReconnectAttemptActive:\s*\(\)\s*=>\s*isReconnectingRef\.current \|\| reconnectConnectInFlightRef/,
     );
+    expect(SOURCE).toContain('reconnectConnectInFlightRef.current = false');
+    const prepareBody = extractUseCallbackBody(SOURCE, 'prepareRfConnect');
+    expect(prepareBody).toContain('reconnectConnectInFlightRef.current = false');
     const wireSource = readFileSync(
       join(TEST_DIR, '../lib/meshtastic/meshtasticRuntimeWireEffects.ts'),
       'utf-8',
@@ -229,13 +233,16 @@ describe('useMeshtasticRuntime manual disconnect must not auto-reconnect', () =>
     expect(finalizeBody).toContain('meshtasticExplicitDisconnectRef.current = true');
     expect(finalizeBody).toContain('connectionParamsRef.current = null');
     expect(finalizeBody).toContain('isReconnectingRef.current = false');
+    expect(finalizeBody).toContain('reconnectConnectInFlightRef.current = false');
     expect(finalizeBody).toContain('reconnectAttemptRef.current = 0');
     expect(finalizeBody).toContain('reconnectGenerationRef.current++');
     const driverIndex = finalizeBody.indexOf('connectionDriver.disconnect');
     const explicitIndex = finalizeBody.indexOf('meshtasticExplicitDisconnectRef.current = true');
+    const cleanupIdx = finalizeBody.lastIndexOf('cleanupSubscriptions()');
     expect(explicitIndex).toBeGreaterThanOrEqual(0);
     if (driverIndex >= 0) {
       expect(driverIndex).toBeGreaterThan(explicitIndex);
+      expect(cleanupIdx).toBeGreaterThan(driverIndex);
     }
   });
 

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -1608,22 +1608,28 @@ export function useMeshtasticRuntime() {
     pushMqttChannelKeys,
   ]);
 
-  // Cleanup on unmount — stop all intervals and subscriptions
+  // Cleanup on unmount — disconnect before unsubscribing so toDevice stays defined for SDK close.
   useEffect(() => {
     return () => {
       serialRediscoveryStopRef.current?.();
       serialRediscoveryStopRef.current = null;
-      cleanupSubscriptions();
       clearConfigureTimeout();
       stopWatchdog();
       stopGpsInterval();
       isReconnectingRef.current = false;
+      reconnectConnectInFlightRef.current = false;
       const device = deviceRef.current;
       deviceRef.current = null;
       if (device) {
-        safeDisconnect(device).catch((e: unknown) => {
-          console.debug('[useMeshtasticRuntime] unmount safeDisconnect ' + errLikeToLogString(e));
-        });
+        void safeDisconnect(device)
+          .catch((e: unknown) => {
+            console.debug('[useMeshtasticRuntime] unmount safeDisconnect ' + errLikeToLogString(e));
+          })
+          .finally(() => {
+            cleanupSubscriptions();
+          });
+      } else {
+        cleanupSubscriptions();
       }
     };
   }, [cleanupSubscriptions, clearConfigureTimeout, stopWatchdog, stopGpsInterval]);
@@ -1887,8 +1893,10 @@ export function useMeshtasticRuntime() {
       isDuplicate,
       ensureNodeExists,
       clearConfigureTimeout,
-      isBleReconnectAttemptActive: () =>
-        isReconnectingRef.current || reconnectConnectInFlightRef.current,
+      // isReconnectingRef only — not reconnectConnectInFlightRef. Manual prepareRfConnect clears
+      // reconnecting while a superseded attempt may still hold in-flight; OR-ing would skip the
+      // 30s configure watchdog on the new connect (which has no 90s reconnect budget).
+      isBleReconnectAttemptActive: () => isReconnectingRef.current,
       applyMeshtasticForeignLoraFromLog,
       emptyNode,
       setMeshtasticIdentityId,
@@ -2419,6 +2427,8 @@ export function useMeshtasticRuntime() {
       meshtasticExplicitDisconnectRef.current = false;
       reconnectAttemptRef.current = 0;
       isReconnectingRef.current = false;
+      // Supersede any in-flight reconnect open so configure-timeout gating does not stick.
+      reconnectConnectInFlightRef.current = false;
       reconnectGenerationRef.current++;
       if (type === 'ble') {
         bleConnectInProgressRef.current = true;
@@ -2561,11 +2571,11 @@ export function useMeshtasticRuntime() {
         (meshtasticIdentityIdRef.current ?? meshtasticPendingDriverIdentityRef.current)
           ? (meshtasticIdentityIdRef.current ?? meshtasticPendingDriverIdentityRef.current)
           : null;
-      cleanupSubscriptions();
       stopWatchdog();
       stopGpsInterval();
       meshtasticExplicitDisconnectRef.current = true;
       isReconnectingRef.current = false;
+      reconnectConnectInFlightRef.current = false;
       reconnectAttemptRef.current = 0;
       reconnectGenerationRef.current++;
       connectionParamsRef.current = null;
@@ -2583,6 +2593,8 @@ export function useMeshtasticRuntime() {
       } else if (disconnectDriver && device && !driverIdentity) {
         await safeDisconnect(device);
       }
+      // After disconnect: detach wire effects / loss-watch (restores toDevice; never deletes).
+      cleanupSubscriptions();
       meshtasticDriverConnectedRef.current = false;
       meshtasticPendingDriverIdentityRef.current = null;
       setState({

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -1887,6 +1887,8 @@ export function useMeshtasticRuntime() {
       isDuplicate,
       ensureNodeExists,
       clearConfigureTimeout,
+      isBleReconnectAttemptActive: () =>
+        isReconnectingRef.current || reconnectConnectInFlightRef.current,
       applyMeshtasticForeignLoraFromLog,
       emptyNode,
       setMeshtasticIdentityId,
@@ -1982,14 +1984,13 @@ export function useMeshtasticRuntime() {
       deviceConfiguredRef.current = false;
       isConfiguringRef.current = false;
       meshtasticIngestSessionRef.current?.setConfiguring(false);
-      // Clean up existing connection before reconnect (BlueZ needs GATT fully torn down).
+      // Tear down GATT/SDK before unsubscribing so toDevice stays defined for disconnect.
       clearConfigureTimeout();
       const staleDevice = deviceRef.current;
-      cleanupSubscriptions();
-      stopWatchdog();
-      stopGpsInterval();
       const driverIdentity =
         meshtasticIdentityIdRef.current ?? meshtasticPendingDriverIdentityRef.current;
+      stopWatchdog();
+      stopGpsInterval();
       deviceRef.current = null;
       meshtasticDriverConnectedRef.current = false;
       meshtasticPendingDriverIdentityRef.current = null;
@@ -2008,6 +2009,8 @@ export function useMeshtasticRuntime() {
           );
         });
       }
+      // After disconnect: detach wire effects / loss-watch (restores toDevice; never deletes).
+      cleanupSubscriptions();
       // Single-flight: if open+configure is still running, generation bump invalidates it;
       // that attempt's failure path (or finally deferred flush) schedules the next cycle.
       if (reconnectConnectInFlightRef.current) {


### PR DESCRIPTION
## Summary
- Restore (never delete) `transport.toDevice` on loss-watch cleanup and disconnect before `cleanupSubscriptions`, so in-flight SDK `getWriter`/`close` do not hit `undefined` during BLE teardown.
- Skip the 30s BLE configure watchdog while a reconnect attempt owns the link; stall detection stays on the 90s reconnect budget.
- Teach the global unhandled-rejection logger to respect `defaultPrevented` and swallow configure-retryable `Packet does not exist` noise; register the Meshtastic handler in capture phase.

## Test plan
- [ ] `pnpm exec vitest run src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts src/renderer/lib/rendererUnhandledRejection.test.ts src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.test.ts src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts`
- [ ] On macOS, connect Meshtastic over BLE, force a mid-configure drop (range/sleep), confirm reconnect no longer logs `reading 'getWriter'` or `[renderer] Unhandled rejection: Packet does not exist`
- [ ] Confirm initial BLE connect still arms the 30s configure timeout; reconnect attempts are not cut by that timer before the 90s budget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Meshtastic reconnection handling during BLE connection loss and configuration timeouts.
  * Preserved transport availability during disconnect cleanup and improved recovery from closed or failed streams.
  * Reduced noisy error reporting for expected retry and packet-related connection failures.
  * Improved cleanup of unhandled-rejection listeners and prevented duplicate error logging.
* **Tests**
  * Added regression coverage for reconnection, transport restoration, stream cleanup, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->