### PR TITLE
fix(ble): backfill Linux reconnect peripheral id and widen loss detection

### DIFF
--- a/src/renderer/lib/connection.getBlePeripheralIdFromMeshTransport.test.ts
+++ b/src/renderer/lib/connection.getBlePeripheralIdFromMeshTransport.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBlePeripheralIdFromMeshTransport } from './connection';
+
+describe('getBlePeripheralIdFromMeshTransport', () => {
+  it('returns the id from a transport exposing getConnectedDeviceId()', () => {
+    const transport = { getConnectedDeviceId: () => 'AA:BB:CC:DD:EE:FF' };
+    expect(getBlePeripheralIdFromMeshTransport(transport)).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('returns null when getConnectedDeviceId() itself resolves nothing yet', () => {
+    const transport = { getConnectedDeviceId: () => null };
+    expect(getBlePeripheralIdFromMeshTransport(transport)).toBeNull();
+  });
+
+  it('returns null for transports without getConnectedDeviceId (Noble, serial, http, tcp)', () => {
+    expect(getBlePeripheralIdFromMeshTransport({})).toBeNull();
+    expect(getBlePeripheralIdFromMeshTransport(null)).toBeNull();
+    expect(getBlePeripheralIdFromMeshTransport(undefined)).toBeNull();
+  });
+});

--- a/src/renderer/lib/connection.ts
+++ b/src/renderer/lib/connection.ts
@@ -425,6 +425,21 @@ export function getSerialPortFromMeshTransport(transport: unknown): SerialPort |
   return null;
 }
 
+/**
+ * Resolve the Linux Web Bluetooth device id a gesture-based connect actually landed on.
+ * `createBleConnection`'s Linux picker flow may run without a caller-supplied peripheralId
+ * (e.g. ConnectionPanel's Reconnect button), so this backfills reconnect state afterward —
+ * otherwise a later automatic reconnect has no id and falls back to `requestDevice()`, which
+ * Chromium refuses to run without a live user gesture.
+ */
+export function getBlePeripheralIdFromMeshTransport(transport: unknown): string | null {
+  const candidate = transport as { getConnectedDeviceId?: () => string | null } | null | undefined;
+  if (typeof candidate?.getConnectedDeviceId === 'function') {
+    return candidate.getConnectedDeviceId();
+  }
+  return null;
+}
+
 /** Best-effort close of an open Web Serial port before reconnect. */
 export async function closeSerialPortIfOpen(port: SerialPort): Promise<void> {
   if (!port.readable && !port.writable) return;

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
@@ -18,6 +18,18 @@ describe('meshtasticTransportLossDetection', () => {
     expect(isMeshtasticTransportLostError(new Error('Packet does not exist'))).toBe(false);
   });
 
+  it('detects Linux Web Bluetooth "Not connected" write failure', () => {
+    expect(isMeshtasticTransportLostError(new Error('Not connected'))).toBe(true);
+  });
+
+  it('detects native Chromium GATT server disconnected NetworkError', () => {
+    const err = new DOMException(
+      "GATT Server is disconnected. Cannot perform GATT operations. (Re)connect first with 'device.gatt.connect'.",
+      'NetworkError',
+    );
+    expect(isMeshtasticTransportLostError(err)).toBe(true);
+  });
+
   it('notifies on serial disconnect event', () => {
     const onLost = vi.fn();
     const handlers = new Map<string, EventListener>();

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts
@@ -22,6 +22,10 @@ describe('meshtasticTransportLossDetection', () => {
     expect(isMeshtasticTransportLostError(new Error('Not connected'))).toBe(true);
   });
 
+  it('does not treat an already-open port as transport loss', () => {
+    expect(isMeshtasticTransportLostError(new Error('Port is open'))).toBe(false);
+  });
+
   it('detects native Chromium GATT server disconnected NetworkError', () => {
     const err = new DOMException(
       "GATT Server is disconnected. Cannot perform GATT operations. (Re)connect first with 'device.gatt.connect'.",

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
@@ -5,7 +5,7 @@ import { errLikeToLogString } from '../errLikeToLogString';
 import type { ConnectionType } from '../types';
 
 const TRANSPORT_LOST_MESSAGE =
-  /device has been lost|device was lost|port is (?:not )?open|stream is closed|broken pipe|connection.*lost/i;
+  /device has been lost|device was lost|port is (?:not )?open|stream is closed|broken pipe|connection.*lost|not connected|gatt server is disconnected/i;
 
 /** True when a serial/BLE transport write or read failed because the link is gone. */
 export function isMeshtasticTransportLostError(err: unknown): boolean {

--- a/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
+++ b/src/renderer/lib/meshtastic/meshtasticTransportLossDetection.ts
@@ -5,7 +5,7 @@ import { errLikeToLogString } from '../errLikeToLogString';
 import type { ConnectionType } from '../types';
 
 const TRANSPORT_LOST_MESSAGE =
-  /device has been lost|device was lost|port is (?:not )?open|stream is closed|broken pipe|connection.*lost|not connected|gatt server is disconnected/i;
+  /device has been lost|device was lost|port is not open|stream is closed|broken pipe|connection.*lost|not connected|gatt server is disconnected/i;
 
 /** True when a serial/BLE transport write or read failed because the link is gone. */
 export function isMeshtasticTransportLostError(err: unknown): boolean {

--- a/src/renderer/lib/transportWebBluetoothIpc.test.ts
+++ b/src/renderer/lib/transportWebBluetoothIpc.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockRequestDevice, mockAcquireGrantedDeviceById } = vi.hoisted(() => ({
+  mockRequestDevice: vi.fn(),
+  mockAcquireGrantedDeviceById: vi.fn(),
+}));
+
+vi.mock('./webbluetooth-ble-manager', () => ({
+  WebBluetoothManager: vi.fn().mockImplementation(function WebBluetoothManager() {
+    return {
+      requestDevice: mockRequestDevice,
+      acquireGrantedDeviceById: mockAcquireGrantedDeviceById,
+    };
+  }),
+}));
+
+import { TransportWebBluetoothIpc } from './transportWebBluetoothIpc';
+
+describe('TransportWebBluetoothIpc.getConnectedDeviceId', () => {
+  it('is null before a device is resolved', () => {
+    const transport = new TransportWebBluetoothIpc('meshtastic');
+    expect(transport.getConnectedDeviceId()).toBeNull();
+  });
+
+  it('returns the device id resolved by requestDevice() (gesture-based picker flow)', async () => {
+    mockRequestDevice.mockResolvedValue({ id: 'AA:BB:CC:DD:EE:FF', name: 'Radio' });
+    const transport = new TransportWebBluetoothIpc('meshtastic');
+
+    await transport.requestDevice();
+
+    expect(transport.getConnectedDeviceId()).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('returns the device id resolved by requestGrantedDevice() (no-gesture reconnect flow)', async () => {
+    mockAcquireGrantedDeviceById.mockResolvedValue({ id: 'AA:BB:CC:DD:EE:FF', name: 'Radio' });
+    const transport = new TransportWebBluetoothIpc('meshtastic');
+
+    await transport.requestGrantedDevice('AA:BB:CC:DD:EE:FF');
+
+    expect(transport.getConnectedDeviceId()).toBe('AA:BB:CC:DD:EE:FF');
+  });
+});

--- a/src/renderer/lib/transportWebBluetoothIpc.ts
+++ b/src/renderer/lib/transportWebBluetoothIpc.ts
@@ -70,6 +70,11 @@ export class TransportWebBluetoothIpc implements Types.Transport {
     };
   }
 
+  /** Device id resolved by `requestDevice()`/`requestGrantedDevice()` (Linux reconnect state backfill). */
+  getConnectedDeviceId(): string | null {
+    return this._lastGrantedDeviceId;
+  }
+
   static getManager(sessionId: NobleBleSessionId): WebBluetoothManager | undefined {
     return webBluetoothManagerBySession.get(sessionId);
   }

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -261,3 +261,25 @@ describe('useMeshtasticRuntime manual disconnect must not auto-reconnect', () =>
     assertPowerResumeSkipsOnExplicitDisconnect(SOURCE, 'meshtasticExplicitDisconnectRef.current');
   });
 });
+
+describe('useMeshtasticRuntime Linux BLE reconnect peripheral id backfill', () => {
+  it('attachRfSession backfills blePeripheralId after a gesture-based Linux connect', () => {
+    const attachBody = extractUseCallbackBody(SOURCE, 'attachRfSession');
+    expect(attachBody.length).toBeGreaterThan(0);
+    // Guarded by `!connectionParamsRef.current.blePeripheralId` so an already-known
+    // peripheralId (picker flow, Noble) is never clobbered.
+    expect(attachBody).toMatch(
+      /type === 'ble' &&\s*connectionParamsRef\.current &&\s*!connectionParamsRef\.current\.blePeripheralId/,
+    );
+    expect(attachBody).toContain('getBlePeripheralIdFromMeshTransport(activeDevice.transport)');
+    expect(attachBody).toContain(
+      'connectionParamsRef.current.blePeripheralId = resolvedPeripheralId',
+    );
+  });
+
+  it('imports the backfill helper from lib/connection', () => {
+    expect(SOURCE).toMatch(
+      /import \{[\s\S]*?getBlePeripheralIdFromMeshTransport[\s\S]*?\} from '\.\.\/lib\/connection'/,
+    );
+  });
+});

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -269,12 +269,29 @@ describe('useMeshtasticRuntime Linux BLE reconnect peripheral id backfill', () =
     // Guarded by `!connectionParamsRef.current.blePeripheralId` so an already-known
     // peripheralId (picker flow, Noble) is never clobbered.
     expect(attachBody).toMatch(
-      /type === 'ble' &&\s*connectionParamsRef\.current &&\s*!connectionParamsRef\.current\.blePeripheralId/,
+      /type === 'ble' &&\s*reconnectGenerationRef\.current === generation &&\s*connectionParamsRef\.current &&\s*!connectionParamsRef\.current\.blePeripheralId/,
     );
     expect(attachBody).toContain('getBlePeripheralIdFromMeshTransport(activeDevice.transport)');
     expect(attachBody).toContain(
       'connectionParamsRef.current.blePeripheralId = resolvedPeripheralId',
     );
+  });
+
+  it('gates the backfill on the generation captured at attachRfSession start (no cross-session stamping)', () => {
+    // A superseded attachRfSession (newer prepareRfConnect already bumped
+    // reconnectGenerationRef and replaced connectionParamsRef.current) must not write
+    // its resolved device id onto a different, newer session's connectionParamsRef.
+    const attachBody = extractUseCallbackBody(SOURCE, 'attachRfSession');
+    const generationCaptureIdx = attachBody.indexOf(
+      'const generation = reconnectGenerationRef.current',
+    );
+    const guardIdx = attachBody.indexOf('reconnectGenerationRef.current === generation');
+    const backfillIdx = attachBody.indexOf(
+      'connectionParamsRef.current.blePeripheralId = resolvedPeripheralId',
+    );
+    expect(generationCaptureIdx).toBeGreaterThanOrEqual(0);
+    expect(guardIdx).toBeGreaterThan(generationCaptureIdx);
+    expect(backfillIdx).toBeGreaterThan(guardIdx);
   });
 
   it('imports the backfill helper from lib/connection', () => {

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -78,7 +78,11 @@ import {
 import { raceWithDeadline, verifyNobleBleRfLink } from '../lib/bleReconnectHelper';
 import { createBleReconnectTransportCleanup } from '../lib/bleReconnectLateTransport';
 import { MAX_IN_MEMORY_CHAT_MESSAGES, trimChatMessagesToMax } from '../lib/chatInMemoryBuffer';
-import { getSerialPortFromMeshTransport, safeDisconnect } from '../lib/connection';
+import {
+  getBlePeripheralIdFromMeshTransport,
+  getSerialPortFromMeshTransport,
+  safeDisconnect,
+} from '../lib/connection';
 import { validateCoords } from '../lib/coordUtils';
 import {
   getMergedNodesForForeignLoraDiagnostics,
@@ -2474,6 +2478,19 @@ export function useMeshtasticRuntime() {
         connectionParamsRef.current.serialPort = getSerialPortFromMeshTransport(
           activeDevice.transport,
         );
+      }
+      // Gesture-based Linux connects (e.g. ConnectionPanel's Reconnect button) may call
+      // prepareRfConnect without a peripheralId; backfill it here so a later automatic
+      // reconnect does not fall back to a gesture-requiring requestDevice() call.
+      if (
+        type === 'ble' &&
+        connectionParamsRef.current &&
+        !connectionParamsRef.current.blePeripheralId
+      ) {
+        const resolvedPeripheralId = getBlePeripheralIdFromMeshTransport(activeDevice.transport);
+        if (resolvedPeripheralId) {
+          connectionParamsRef.current.blePeripheralId = resolvedPeripheralId;
+        }
       }
       wireSubscriptions(activeDevice, type, { driverIdentityId });
 

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -2482,8 +2482,12 @@ export function useMeshtasticRuntime() {
       // Gesture-based Linux connects (e.g. ConnectionPanel's Reconnect button) may call
       // prepareRfConnect without a peripheralId; backfill it here so a later automatic
       // reconnect does not fall back to a gesture-requiring requestDevice() call.
+      // Generation-gated: a superseded attempt (newer prepareRfConnect already bumped
+      // reconnectGenerationRef and replaced connectionParamsRef.current) must not stamp
+      // its resolved device id onto a different, newer session's params.
       if (
         type === 'ble' &&
+        reconnectGenerationRef.current === generation &&
         connectionParamsRef.current &&
         !connectionParamsRef.current.blePeripheralId
       ) {


### PR DESCRIPTION
## Summary
- Backfill `connectionParamsRef.current.blePeripheralId` in `useMeshtasticRuntime`'s `attachRfSession` after a successful Linux BLE connect, when it wasn't already known. ConnectionPanel's Linux **Reconnect** button connects via a gesture-based Web Bluetooth picker without a caller-supplied peripheral id, so the runtime's reconnect state never learned the device id even though the connection succeeded. On a later mid-session drop, the internal auto-reconnect loop had no id to reuse and fell back to `requestDevice()`, which Chromium refuses to run without a live user gesture — so automatic reconnect could never succeed on its own and required a manual click every time.
- Widen `TRANSPORT_LOST_MESSAGE` in `meshtasticTransportLossDetection.ts` to also recognize Linux Web Bluetooth's own disconnect wording (`Not connected`, `GATT Server is disconnected`), so the write-failure watcher fires promptly instead of the app taking ~70s of repeated write-failure spam before anything reacts.
- Add `TransportWebBluetoothIpc.getConnectedDeviceId()` and `getBlePeripheralIdFromMeshTransport()` (mirrors the existing `getSerialPortFromMeshTransport()` pattern) to read the resolved device id back out of the transport.

Found while manually testing #775's BLE reconnect fixes on Linux — that PR's teardown/watchdog fixes are working correctly, but this is a separate, Linux-specific gap upstream of them (loss detection + reconnect state), diagnosed from a saved renderer debug log.

## Test plan
- [x] `pnpm exec vitest run src/renderer/lib/meshtastic/meshtasticTransportLossDetection.test.ts src/renderer/lib/transportWebBluetoothIpc.test.ts src/renderer/lib/connection.getBlePeripheralIdFromMeshTransport.test.ts src/renderer/lib/connection.ble-retry.test.ts src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts`
- [x] Full `pnpm run test:run` (804 files / 7189 tests passing)
- [x] `pnpm run typecheck`, `pnpm exec eslint` on changed files
- [x] Manual: connected Meshtastic over BLE on Linux via the Reconnect button, powered off the radio mid-session — confirmed detection is fast and automatic reconnect now succeeds without needing a manual click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Bluetooth reconnection by retaining the active device ID when it was not previously recorded.
  * Added support for retrieving connected Bluetooth device identifiers across connection flows.

* **Bug Fixes**
  * Improved detection of Bluetooth transport disconnections, including “not connected,” GATT, port, and stream errors.

* **Tests**
  * Added coverage for device ID retrieval, reconnection behavior, and expanded disconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->