### PR TITLE
fix(reticulum): accept opportunistic LXMF from Sideband/Columba

### DIFF
--- a/reticulum-sidecar/patches/README.md
+++ b/reticulum-sidecar/patches/README.md
@@ -426,3 +426,24 @@ Ranked multi-path slots (up to 3 per destination) plus global / per-peer RF-vs-n
 ### Sunset
 
 When ratspeak/rsReticulum lands equivalent multi-slot ranking + medium preference, remove this patch and the apply step from `ensure-rsReticulum-patches.sh` / `clone-ratspeak-stack.sh` / `update.sh`.
+
+## rsReticulum-inbound-raw-saturation-log.patch
+
+Log when `LinkManager` opportunistic inbound-raw `try_send` fails because the bounded channel is full (tokio mpsc drops the **newest** packet; not drop-oldest).
+
+| Field | Value |
+| ----- | ----- |
+| **Base commit** | floated `origin/main` (regenerate; record short SHA in PR) |
+| **Upstream PR** | none yet (mesh-client-local) |
+
+**Touches:** `crates/rns-runtime/src/link_manager.rs`
+
+### Apply locally
+
+```bash
+./scripts/apply-rsReticulum-inbound-raw-saturation-log.sh
+```
+
+### Sunset
+
+When upstream logs (or otherwise surfaces) inbound-raw saturation the same way, remove this patch and the apply step.

--- a/reticulum-sidecar/patches/rsReticulum-inbound-raw-saturation-log.patch
+++ b/reticulum-sidecar/patches/rsReticulum-inbound-raw-saturation-log.patch
@@ -1,0 +1,19 @@
+diff --git a/crates/rns-runtime/src/link_manager.rs b/crates/rns-runtime/src/link_manager.rs
+index cd33492..6579213 100644
+--- a/crates/rns-runtime/src/link_manager.rs
++++ b/crates/rns-runtime/src/link_manager.rs
+@@ -1175,7 +1175,13 @@ impl LinkManager {
+         if !self.active_links.contains_key(&link_id) {
+             let processed = self.dispatch_destination_packet(raw, interface_id);
+             if let Some(ref tx) = self.inbound_raw_tx {
+-                let _ = tx.try_send(raw.to_vec());
++                if let Err(e) = tx.try_send(raw.to_vec()) {
++                    tracing::warn!(
++                        dest = %hex::encode(link_id),
++                        error = %e,
++                        "inbound raw channel full; dropping newest opportunistic packet"
++                    );
++                }
+             }
+             tracing::debug!(
+                 dest = hex::encode(link_id),

--- a/reticulum-sidecar/src/stack/lxmf_delivery.rs
+++ b/reticulum-sidecar/src/stack/lxmf_delivery.rs
@@ -36,18 +36,18 @@ pub const PROPAGATION_SYNC_ANNOUNCE_SETTLE: Duration = Duration::from_secs(2);
 const UNPACK_WARN_INTERVAL: Duration = Duration::from_secs(5);
 static LAST_UNPACK_WARN_MS: AtomicU64 = AtomicU64::new(0);
 
-fn rate_limited_unpack_warn(error: &str, len: usize) {
+fn rate_limited_unpack_warn(via: &str, error: &str, len: usize) {
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0);
     let prev = LAST_UNPACK_WARN_MS.load(Ordering::Relaxed);
     if now_ms.saturating_sub(prev) < UNPACK_WARN_INTERVAL.as_millis() as u64 {
-        tracing::debug!(error = %error, len, "link data not an LXMF message");
+        tracing::debug!(via, error = %error, len, "inbound data not an LXMF message");
         return;
     }
     LAST_UNPACK_WARN_MS.store(now_ms, Ordering::Relaxed);
-    tracing::warn!(error = %error, len, "link data not an LXMF message");
+    tracing::warn!(via, error = %error, len, "inbound data not an LXMF message");
 }
 
 fn mark_announce_sent(last_at: &Arc<Mutex<Option<Instant>>>) {
@@ -333,7 +333,7 @@ async fn handle_link_delivered_data(
     let msg = match LxMessage::unpack(&unpack_data) {
         Ok(msg) => msg,
         Err(e) => {
-            rate_limited_unpack_warn(&e.to_string(), unpack_data.len());
+            rate_limited_unpack_warn("link", &e.to_string(), unpack_data.len());
             return;
         }
     };
@@ -354,7 +354,7 @@ async fn handle_opportunistic_raw_packet(
     let msg = match LxMessage::unpack(&unpack_data) {
         Ok(msg) => msg,
         Err(e) => {
-            rate_limited_unpack_warn(&e.to_string(), unpack_data.len());
+            rate_limited_unpack_warn("opportunistic", &e.to_string(), unpack_data.len());
             return;
         }
     };
@@ -365,9 +365,51 @@ async fn handle_opportunistic_raw_packet(
 mod tests {
     use super::*;
     use lxmf_core::constants::DeliveryMethod;
+    use lxmf_core::router::RouterConfig;
     use rns_identity::destination::Destination;
     use rns_identity::identity::Identity;
     use rns_wire::flags::PacketType;
+
+    fn opportunistic_data_header(destination_hash: [u8; 16]) -> PacketHeader {
+        PacketHeader {
+            flags: PacketFlags {
+                header_type: HeaderType::Header1,
+                context_flag: false,
+                transport_type: TransportType::Broadcast,
+                destination_type: DestinationType::Single,
+                packet_type: PacketType::Data,
+            },
+            hops: 0,
+            transport_id: None,
+            destination_hash,
+            context: PacketContext::None,
+        }
+    }
+
+    /// Python-style opportunistic frame: encrypt stripped LXM body to recipient.
+    fn build_opportunistic_raw(
+        recipient: &Identity,
+        lxmf_hash: [u8; 16],
+        packed_with_dest: &[u8],
+    ) -> Vec<u8> {
+        assert!(packed_with_dest.len() > 16 && packed_with_dest[..16] == lxmf_hash);
+        let stripped = &packed_with_dest[16..];
+        let ciphertext = recipient.encrypt(stripped, None).unwrap();
+        let mut raw = opportunistic_data_header(lxmf_hash).pack();
+        raw.extend_from_slice(&ciphertext);
+        raw
+    }
+
+    async fn router_with_content_callback(
+        seen: Arc<Mutex<Option<String>>>,
+    ) -> Arc<TokioMutex<LxmRouter>> {
+        let router = Arc::new(TokioMutex::new(LxmRouter::new(RouterConfig::default())));
+        let seen_cb = seen.clone();
+        router.lock().await.register_delivery_callback(move |msg| {
+            *seen_cb.lock().expect("callback mutex") = Some(msg.content.clone());
+        });
+        router
+    }
 
     #[test]
     fn build_announce_packet_is_non_empty_announce() {
@@ -435,22 +477,7 @@ mod tests {
         assert!(packed.len() > 16 && packed[..16] == lxmf_hash);
         let stripped = &packed[16..];
 
-        let ciphertext = recipient.encrypt(stripped, None).unwrap();
-        let header = PacketHeader {
-            flags: PacketFlags {
-                header_type: HeaderType::Header1,
-                context_flag: false,
-                transport_type: TransportType::Broadcast,
-                destination_type: DestinationType::Single,
-                packet_type: PacketType::Data,
-            },
-            hops: 0,
-            transport_id: None,
-            destination_hash: lxmf_hash,
-            context: PacketContext::None,
-        };
-        let mut raw = header.pack();
-        raw.extend_from_slice(&ciphertext);
+        let raw = build_opportunistic_raw(&recipient, lxmf_hash, &packed);
 
         let plaintext = decrypt_opportunistic_payload(&recipient, &raw).expect("decrypt");
         assert_eq!(plaintext, stripped);
@@ -460,6 +487,111 @@ mod tests {
         assert_eq!(recovered.content, "hello from sideband");
         assert_eq!(recovered.source_hash, sender_lxmf);
         assert_eq!(recovered.destination_hash, lxmf_hash);
+    }
+
+    #[tokio::test]
+    async fn opportunistic_handler_delivers_to_callback() {
+        let recipient = Identity::new();
+        let sender = Identity::new();
+        let lxmf_hash = Destination::hash_from_name_and_identity(LXMF_APP, Some(&recipient.hash));
+        let sender_lxmf = Destination::hash_from_name_and_identity(LXMF_APP, Some(&sender.hash));
+
+        let mut msg = LxMessage::new(
+            lxmf_hash,
+            sender_lxmf,
+            "",
+            "hello from sideband",
+            DeliveryMethod::Opportunistic,
+        );
+        msg.sign(
+            sender
+                .get_signing_key()
+                .as_ref()
+                .expect("sender signing key"),
+        )
+        .unwrap();
+        let raw = build_opportunistic_raw(&recipient, lxmf_hash, &msg.pack().unwrap());
+
+        let seen = Arc::new(Mutex::new(None::<String>));
+        let router = router_with_content_callback(seen.clone()).await;
+        handle_opportunistic_raw_packet(&router, &recipient, lxmf_hash, &raw).await;
+        assert_eq!(
+            seen.lock().expect("seen").as_deref(),
+            Some("hello from sideband")
+        );
+    }
+
+    #[tokio::test]
+    async fn opportunistic_handler_delivers_self_send_to_callback() {
+        let identity = Identity::new();
+        let lxmf_hash = Destination::hash_from_name_and_identity(LXMF_APP, Some(&identity.hash));
+
+        let mut msg = LxMessage::new(
+            lxmf_hash,
+            lxmf_hash,
+            "",
+            "loopback self-send",
+            DeliveryMethod::Opportunistic,
+        );
+        msg.sign(
+            identity
+                .get_signing_key()
+                .as_ref()
+                .expect("identity signing key"),
+        )
+        .unwrap();
+        let raw = build_opportunistic_raw(&identity, lxmf_hash, &msg.pack().unwrap());
+
+        let seen = Arc::new(Mutex::new(None::<String>));
+        let router = router_with_content_callback(seen.clone()).await;
+        handle_opportunistic_raw_packet(&router, &identity, lxmf_hash, &raw).await;
+        assert_eq!(
+            seen.lock().expect("seen").as_deref(),
+            Some("loopback self-send")
+        );
+    }
+
+    #[tokio::test]
+    async fn link_handler_delivers_stripped_and_prefixed_bodies() {
+        let recipient = Identity::new();
+        let sender = Identity::new();
+        let lxmf_hash = Destination::hash_from_name_and_identity(LXMF_APP, Some(&recipient.hash));
+        let sender_lxmf = Destination::hash_from_name_and_identity(LXMF_APP, Some(&sender.hash));
+
+        let mut msg = LxMessage::new(
+            lxmf_hash,
+            sender_lxmf,
+            "",
+            "link delivered",
+            DeliveryMethod::Direct,
+        );
+        msg.sign(
+            sender
+                .get_signing_key()
+                .as_ref()
+                .expect("sender signing key"),
+        )
+        .unwrap();
+        let packed = msg.pack().unwrap();
+        let stripped = &packed[16..];
+
+        let seen = Arc::new(Mutex::new(None::<String>));
+        let router = router_with_content_callback(seen.clone()).await;
+
+        handle_link_delivered_data(&router, lxmf_hash, stripped).await;
+        assert_eq!(
+            seen.lock().expect("seen").as_deref(),
+            Some("link delivered"),
+            "stripped link body must prepend dest and deliver"
+        );
+
+        *seen.lock().expect("seen") = None;
+        handle_link_delivered_data(&router, lxmf_hash, &packed).await;
+        assert_eq!(
+            seen.lock().expect("seen").as_deref(),
+            Some("link delivered"),
+            "already-prefixed link body must deliver without double-prepend"
+        );
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/lxmf_delivery.rs
+++ b/reticulum-sidecar/src/stack/lxmf_delivery.rs
@@ -1,4 +1,10 @@
-//! LXMF delivery destination announce + inbound link receive (Ratspeak/lxmd parity).
+//! LXMF delivery destination announce + inbound receive (Ratspeak/lxmd parity).
+//!
+//! Inbound paths:
+//! - **Direct / resource** — decrypted link payloads via `set_link_packet_channel` /
+//!   `set_resource_completed_channel`
+//! - **Opportunistic** — destination-encrypted DATA packets via `set_inbound_raw_channel`
+//!   (Sideband / Columba short messages; lxmd wires the same channel)
 
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -173,7 +179,11 @@ fn read_announce_interval_sec(config_dir: &Path) -> u32 {
         .unwrap_or(config::DEFAULT_ANNOUNCE_INTERVAL_SEC)
 }
 
-/// Register `lxmf.delivery` + LinkManager and feed decrypted link/resource data into the router callback.
+/// Register `lxmf.delivery` + LinkManager and feed inbound LXMF into the router callback.
+///
+/// Wires Direct/resource channels **and** `set_inbound_raw_channel` (lxmd parity) so
+/// opportunistic packets from Python clients (Sideband, Columba) are not dropped after
+/// LinkManager decrypts/proves them.
 pub fn spawn_lxmf_inbound_receiver(
     transport_tx: mpsc::Sender<TransportMessage>,
     identity: &Identity,
@@ -185,7 +195,10 @@ pub fn spawn_lxmf_inbound_receiver(
     // Bound only if upstream grows a bounded setter; do not buffer-copy into a second queue.
     let (link_packet_tx, mut link_packet_rx) = mpsc::unbounded_channel::<(Vec<u8>, [u8; 16])>();
     let (resource_tx, mut resource_rx) = mpsc::channel::<(Vec<u8>, [u8; 16])>(256);
+    // Bounded: opportunistic bursts from hubs; drop-oldest via try_send on the LinkManager side.
+    let (inbound_raw_tx, mut inbound_raw_rx) = mpsc::channel::<Vec<u8>>(256);
 
+    let identity_for_raw = identity.clone();
     let mut link_mgr = LinkManager::with_destination(
         transport_tx,
         delivery_rx,
@@ -195,6 +208,7 @@ pub fn spawn_lxmf_inbound_receiver(
     );
     link_mgr.set_link_packet_channel(link_packet_tx);
     link_mgr.set_resource_completed_channel(resource_tx);
+    link_mgr.set_inbound_raw_channel(inbound_raw_tx);
 
     tokio::spawn(async move {
         link_mgr.run().await;
@@ -219,10 +233,55 @@ pub fn spawn_lxmf_inbound_receiver(
                     );
                     handle_link_delivered_data(&router, lxmf_dest_hash, &data).await;
                 }
+                Some(raw) = inbound_raw_rx.recv() => {
+                    tracing::debug!(len = raw.len(), "LXMF inbound opportunistic packet");
+                    handle_opportunistic_raw_packet(&router, &identity_for_raw, lxmf_dest_hash, &raw)
+                        .await;
+                }
                 else => break,
             }
         }
     });
+}
+
+/// Prepend `lxmf_dest_hash` when the sender omitted it (Python opportunistic strips dest hash).
+pub(crate) fn prepend_lxmf_dest_hash_if_needed(lxmf_dest_hash: [u8; 16], data: &[u8]) -> Vec<u8> {
+    if data.len() >= 16 && data[..16] == lxmf_dest_hash {
+        data.to_vec()
+    } else {
+        let mut full = lxmf_dest_hash.to_vec();
+        full.extend_from_slice(data);
+        full
+    }
+}
+
+/// Decrypt an opportunistic DATA packet payload (after RNS header) with the local identity.
+///
+/// LinkManager already decrypts once to emit an RNS proof; we decrypt again from the raw
+/// frame (same as lxmd `decrypt_inbound`) because the raw channel forwards ciphertext.
+pub(crate) fn decrypt_opportunistic_payload(identity: &Identity, raw: &[u8]) -> Option<Vec<u8>> {
+    let (header, data_offset) = PacketHeader::unpack(raw).ok()?;
+    if header.flags.packet_type != PacketType::Data {
+        return None;
+    }
+    let payload = raw.get(data_offset..)?;
+    if payload.is_empty() {
+        return None;
+    }
+    identity.decrypt(payload, None, false).ok()
+}
+
+async fn deliver_unpacked_lxmf(router: &Arc<TokioMutex<LxmRouter>>, msg: &LxMessage, via: &str) {
+    tracing::debug!(
+        from = %hex::encode(msg.source_hash),
+        len = msg.content.len(),
+        via,
+        "inbound LXMF message"
+    );
+    let router = router.lock().await;
+    if let Some(ref cb) = router.delivery_callback {
+        cb(msg);
+    }
 }
 
 async fn handle_link_delivered_data(
@@ -233,13 +292,7 @@ async fn handle_link_delivered_data(
     if data.is_empty() {
         return;
     }
-    let unpack_data = if data.len() >= 16 && data[..16] == lxmf_dest_hash {
-        data.to_vec()
-    } else {
-        let mut full = lxmf_dest_hash.to_vec();
-        full.extend_from_slice(data);
-        full
-    };
+    let unpack_data = prepend_lxmf_dest_hash_if_needed(lxmf_dest_hash, data);
     let msg = match LxMessage::unpack(&unpack_data) {
         Ok(msg) => msg,
         Err(e) => {
@@ -247,22 +300,37 @@ async fn handle_link_delivered_data(
             return;
         }
     };
-    tracing::debug!(
-        from = %hex::encode(msg.source_hash),
-        len = msg.content.len(),
-        "inbound LXMF message via link"
-    );
-    let router = router.lock().await;
-    if let Some(ref cb) = router.delivery_callback {
-        cb(&msg);
-    }
+    deliver_unpacked_lxmf(router, &msg, "link").await;
+}
+
+async fn handle_opportunistic_raw_packet(
+    router: &Arc<TokioMutex<LxmRouter>>,
+    identity: &Identity,
+    lxmf_dest_hash: [u8; 16],
+    raw: &[u8],
+) {
+    let Some(plaintext) = decrypt_opportunistic_payload(identity, raw) else {
+        tracing::debug!(len = raw.len(), "opportunistic LXMF decrypt failed");
+        return;
+    };
+    let unpack_data = prepend_lxmf_dest_hash_if_needed(lxmf_dest_hash, &plaintext);
+    let msg = match LxMessage::unpack(&unpack_data) {
+        Ok(msg) => msg,
+        Err(e) => {
+            rate_limited_unpack_warn(&e.to_string(), unpack_data.len());
+            return;
+        }
+    };
+    deliver_unpacked_lxmf(router, &msg, "opportunistic").await;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lxmf_core::constants::DeliveryMethod;
     use rns_identity::destination::Destination;
     use rns_identity::identity::Identity;
+    use rns_wire::flags::PacketType;
 
     #[test]
     fn build_announce_packet_is_non_empty_announce() {
@@ -284,5 +352,90 @@ mod tests {
     #[test]
     fn propagation_sync_announce_settle_is_two_seconds() {
         assert_eq!(PROPAGATION_SYNC_ANNOUNCE_SETTLE, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn prepend_lxmf_dest_hash_skips_when_already_present() {
+        let dest = [0x11; 16];
+        let mut body = dest.to_vec();
+        body.extend_from_slice(b"lxm-body");
+        let out = prepend_lxmf_dest_hash_if_needed(dest, &body);
+        assert_eq!(out, body);
+    }
+
+    #[test]
+    fn prepend_lxmf_dest_hash_adds_when_python_stripped() {
+        let dest = [0x22; 16];
+        let body = b"stripped-lxm-body";
+        let out = prepend_lxmf_dest_hash_if_needed(dest, body);
+        assert_eq!(&out[..16], &dest);
+        assert_eq!(&out[16..], body);
+    }
+
+    #[test]
+    fn opportunistic_raw_decrypts_and_unpacks_python_stripped_payload() {
+        let recipient = Identity::new();
+        let sender = Identity::new();
+        let lxmf_hash = Destination::hash_from_name_and_identity(LXMF_APP, Some(&recipient.hash));
+        let sender_lxmf = Destination::hash_from_name_and_identity(LXMF_APP, Some(&sender.hash));
+
+        let mut msg = LxMessage::new(
+            lxmf_hash,
+            sender_lxmf,
+            "",
+            "hello from sideband",
+            DeliveryMethod::Opportunistic,
+        );
+        msg.sign(
+            sender
+                .get_signing_key()
+                .as_ref()
+                .expect("sender signing key"),
+        )
+        .unwrap();
+        let packed = msg.pack().unwrap();
+        // Python opportunistic delivery encrypts the LXM body *without* leading dest hash.
+        assert!(packed.len() > 16 && packed[..16] == lxmf_hash);
+        let stripped = &packed[16..];
+
+        let ciphertext = recipient.encrypt(stripped, None).unwrap();
+        let header = PacketHeader {
+            flags: PacketFlags {
+                header_type: HeaderType::Header1,
+                context_flag: false,
+                transport_type: TransportType::Broadcast,
+                destination_type: DestinationType::Single,
+                packet_type: PacketType::Data,
+            },
+            hops: 0,
+            transport_id: None,
+            destination_hash: lxmf_hash,
+            context: PacketContext::None,
+        };
+        let mut raw = header.pack();
+        raw.extend_from_slice(&ciphertext);
+
+        let plaintext = decrypt_opportunistic_payload(&recipient, &raw).expect("decrypt");
+        assert_eq!(plaintext, stripped);
+
+        let unpack_data = prepend_lxmf_dest_hash_if_needed(lxmf_hash, &plaintext);
+        let recovered = LxMessage::unpack(&unpack_data).expect("unpack");
+        assert_eq!(recovered.content, "hello from sideband");
+        assert_eq!(recovered.source_hash, sender_lxmf);
+        assert_eq!(recovered.destination_hash, lxmf_hash);
+    }
+
+    #[test]
+    fn inbound_receiver_source_wires_opportunistic_raw_channel() {
+        // Guard against regressing to link-only inbound (drops Sideband/Columba opportunistic).
+        let src = include_str!("lxmf_delivery.rs");
+        assert!(
+            src.contains("set_inbound_raw_channel"),
+            "spawn_lxmf_inbound_receiver must wire set_inbound_raw_channel (lxmd parity)"
+        );
+        assert!(
+            src.contains("handle_opportunistic_raw_packet"),
+            "opportunistic raw packets must be delivered to the LXMF router"
+        );
     }
 }

--- a/reticulum-sidecar/src/stack/lxmf_delivery.rs
+++ b/reticulum-sidecar/src/stack/lxmf_delivery.rs
@@ -195,8 +195,10 @@ pub fn spawn_lxmf_inbound_receiver(
     // Bound only if upstream grows a bounded setter; do not buffer-copy into a second queue.
     let (link_packet_tx, mut link_packet_rx) = mpsc::unbounded_channel::<(Vec<u8>, [u8; 16])>();
     let (resource_tx, mut resource_rx) = mpsc::channel::<(Vec<u8>, [u8; 16])>(256);
-    // Bounded: opportunistic bursts from hubs; drop-oldest via try_send on the LinkManager side.
-    let (inbound_raw_tx, mut inbound_raw_rx) = mpsc::channel::<Vec<u8>>(256);
+    // Bounded: LinkManager `try_send`s here. When full, tokio mpsc drops the *new* packet
+    // (not oldest) — "dropping newest opportunistic packet" (LinkManager saturation log overlay).
+    let (inbound_raw_tx, mut inbound_raw_rx) =
+        mpsc::channel::<Vec<u8>>(INBOUND_RAW_CHANNEL_CAPACITY);
 
     let identity_for_raw = identity.clone();
     let mut link_mgr = LinkManager::with_destination(
@@ -244,14 +246,49 @@ pub fn spawn_lxmf_inbound_receiver(
     });
 }
 
+/// Capacity for opportunistic inbound raw frames (`LinkManager` `try_send`s into this queue).
+pub(crate) const INBOUND_RAW_CHANNEL_CAPACITY: usize = 256;
+
 /// Prepend `lxmf_dest_hash` when the sender omitted it (Python opportunistic strips dest hash).
+///
+/// Do **not** use this for opportunistic raw decrypt output — self-messages start with
+/// `source_hash == lxmf_dest_hash` after the dest is stripped, which would skip a needed prepend.
+/// Prefer [`prepend_lxmf_dest_hash`] on that path.
 pub(crate) fn prepend_lxmf_dest_hash_if_needed(lxmf_dest_hash: [u8; 16], data: &[u8]) -> Vec<u8> {
     if data.len() >= 16 && data[..16] == lxmf_dest_hash {
         data.to_vec()
     } else {
-        let mut full = lxmf_dest_hash.to_vec();
-        full.extend_from_slice(data);
-        full
+        prepend_lxmf_dest_hash(lxmf_dest_hash, data)
+    }
+}
+
+/// Always prepend `lxmf_dest_hash` (opportunistic Python strips it before encrypt).
+pub(crate) fn prepend_lxmf_dest_hash(lxmf_dest_hash: [u8; 16], data: &[u8]) -> Vec<u8> {
+    let mut full = lxmf_dest_hash.to_vec();
+    full.extend_from_slice(data);
+    full
+}
+
+/// Enqueue an opportunistic raw frame the same way `LinkManager` does (`try_send`).
+///
+/// When the queue is full, the **new** packet is dropped (tokio bounded mpsc) and a warning is
+/// logged. This is not drop-oldest. Production saturation logs live in the LinkManager overlay;
+/// this helper exists so unit tests can assert the same drop-newest policy.
+#[cfg(test)]
+pub(crate) fn try_enqueue_inbound_raw(
+    tx: &mpsc::Sender<Vec<u8>>,
+    raw: Vec<u8>,
+) -> Result<(), mpsc::error::TrySendError<Vec<u8>>> {
+    match tx.try_send(raw) {
+        Ok(()) => Ok(()),
+        Err(e @ mpsc::error::TrySendError::Full(_)) => {
+            tracing::warn!(
+                capacity = INBOUND_RAW_CHANNEL_CAPACITY,
+                "LXMF inbound raw channel full; dropping newest opportunistic packet"
+            );
+            Err(e)
+        }
+        Err(e) => Err(e),
     }
 }
 
@@ -313,7 +350,7 @@ async fn handle_opportunistic_raw_packet(
         tracing::debug!(len = raw.len(), "opportunistic LXMF decrypt failed");
         return;
     };
-    let unpack_data = prepend_lxmf_dest_hash_if_needed(lxmf_dest_hash, &plaintext);
+    let unpack_data = prepend_lxmf_dest_hash(lxmf_dest_hash, &plaintext);
     let msg = match LxMessage::unpack(&unpack_data) {
         Ok(msg) => msg,
         Err(e) => {
@@ -418,11 +455,72 @@ mod tests {
         let plaintext = decrypt_opportunistic_payload(&recipient, &raw).expect("decrypt");
         assert_eq!(plaintext, stripped);
 
-        let unpack_data = prepend_lxmf_dest_hash_if_needed(lxmf_hash, &plaintext);
+        let unpack_data = prepend_lxmf_dest_hash(lxmf_hash, &plaintext);
         let recovered = LxMessage::unpack(&unpack_data).expect("unpack");
         assert_eq!(recovered.content, "hello from sideband");
         assert_eq!(recovered.source_hash, sender_lxmf);
         assert_eq!(recovered.destination_hash, lxmf_hash);
+    }
+
+    #[test]
+    fn opportunistic_self_send_requires_always_prepend() {
+        // After Python strips dest, self-send plaintext starts with source_hash == lxmf_dest_hash.
+        // Conditional prepend would skip and corrupt unpack; always-prepend recovers.
+        let identity = Identity::new();
+        let lxmf_hash = Destination::hash_from_name_and_identity(LXMF_APP, Some(&identity.hash));
+
+        let mut msg = LxMessage::new(
+            lxmf_hash,
+            lxmf_hash,
+            "",
+            "loopback self-send",
+            DeliveryMethod::Opportunistic,
+        );
+        msg.sign(
+            identity
+                .get_signing_key()
+                .as_ref()
+                .expect("identity signing key"),
+        )
+        .unwrap();
+        let packed = msg.pack().unwrap();
+        assert!(packed.len() > 16 && packed[..16] == lxmf_hash);
+        let stripped = &packed[16..];
+        assert_eq!(
+            &stripped[..16],
+            &lxmf_hash,
+            "self-send stripped body must start with source == dest hash"
+        );
+
+        let wrongly_skipped = prepend_lxmf_dest_hash_if_needed(lxmf_hash, stripped);
+        assert_eq!(
+            wrongly_skipped, stripped,
+            "conditional helper skips when source_hash == dest (self-send)"
+        );
+        assert!(
+            LxMessage::unpack(&wrongly_skipped).is_err(),
+            "skipped prepend must not unpack as a valid self-send LXM"
+        );
+
+        let unpack_data = prepend_lxmf_dest_hash(lxmf_hash, stripped);
+        let recovered = LxMessage::unpack(&unpack_data).expect("always-prepend unpack");
+        assert_eq!(recovered.content, "loopback self-send");
+        assert_eq!(recovered.source_hash, lxmf_hash);
+        assert_eq!(recovered.destination_hash, lxmf_hash);
+    }
+
+    #[tokio::test]
+    async fn inbound_raw_try_send_drops_newest_when_full() {
+        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(2);
+        assert!(try_enqueue_inbound_raw(&tx, vec![1]).is_ok());
+        assert!(try_enqueue_inbound_raw(&tx, vec![2]).is_ok());
+        match try_enqueue_inbound_raw(&tx, vec![3]) {
+            Err(mpsc::error::TrySendError::Full(dropped)) => assert_eq!(dropped, vec![3]),
+            other => panic!("expected Full(newest), got {other:?}"),
+        }
+        assert_eq!(rx.recv().await.expect("first"), vec![1]);
+        assert_eq!(rx.recv().await.expect("second"), vec![2]);
+        assert!(rx.try_recv().is_err(), "newest must not be queued");
     }
 
     #[test]
@@ -436,6 +534,14 @@ mod tests {
         assert!(
             src.contains("handle_opportunistic_raw_packet"),
             "opportunistic raw packets must be delivered to the LXMF router"
+        );
+        assert!(
+            src.contains("prepend_lxmf_dest_hash(lxmf_dest_hash, &plaintext)"),
+            "opportunistic path must always prepend dest hash (self-send safe)"
+        );
+        assert!(
+            src.contains("dropping newest opportunistic packet"),
+            "full inbound_raw queue must log saturation (drop-newest policy)"
         );
     }
 }

--- a/scripts/apply-rsReticulum-inbound-raw-saturation-log.sh
+++ b/scripts/apply-rsReticulum-inbound-raw-saturation-log.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Apply mesh-client rsReticulum inbound-raw saturation log overlay.
+# LinkManager try_send drops the *newest* frame when the opportunistic raw channel
+# is full; log that instead of silently discarding.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=lib/apply-ratspeak-overlay.sh
+source "${SCRIPT_DIR}/lib/apply-ratspeak-overlay.sh"
+PATCH_FILE="${REPO_ROOT}/reticulum-sidecar/patches/rsReticulum-inbound-raw-saturation-log.patch"
+RNS_DIR="${RS_RETICULUM_DIR:-$(cd "${REPO_ROOT}/.." && pwd)/rsReticulum}"
+LINK_MANAGER_RS="${RNS_DIR}/crates/rns-runtime/src/link_manager.rs"
+
+if [[ ! -d "${RNS_DIR}/.git" ]]; then
+  echo "error: rsReticulum not found at ${RNS_DIR}" >&2
+  echo "Clone: git clone https://github.com/ratspeak/rsReticulum.git ${RNS_DIR}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${PATCH_FILE}" ]]; then
+  echo "error: patch not found at ${PATCH_FILE}" >&2
+  exit 1
+fi
+
+if [[ -f "${LINK_MANAGER_RS}" ]] \
+  && grep -q 'dropping newest opportunistic packet' "${LINK_MANAGER_RS}"; then
+  echo "inbound-raw saturation-log overlay already applied on rsReticulum @ $(git -C "${RNS_DIR}" rev-parse --short HEAD)"
+  exit 0
+fi
+
+if apply_ratspeak_overlay_or_die "${RNS_DIR}" "${PATCH_FILE}" "inbound-raw-saturation-log"; then
+  exit 0
+fi
+exit 1

--- a/scripts/lib/ratspeak-overlay-apply-list.sh
+++ b/scripts/lib/ratspeak-overlay-apply-list.sh
@@ -11,6 +11,7 @@ RS_RETICULUM_APPLY_SCRIPTS=(
   apply-rsReticulum-ble-rnode-pairing-transition-debounce.sh
   apply-rsReticulum-discovery-announce-egress.sh
   apply-rsReticulum-path-medium-slots.sh
+  apply-rsReticulum-inbound-raw-saturation-log.sh
 )
 
 RS_LXMF_APPLY_SCRIPTS=(

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -215,6 +215,7 @@ check_ratspeak_patches() {
     'rsReticulum-link-client-proof-budget.patch|ratspeak/rsReticulum||rsReticulum LinkClient proof-budget remaining-deadline|'
     'rsReticulum-ble-rnode-pairing-transition-debounce.patch|ratspeak/rsReticulum|20|rsReticulum BLE RNode pairing-transition debounce|https://github.com/ratspeak/rsReticulum/pull/20'
     'rsReticulum-discovery-announce-egress.patch|ratspeak/rsReticulum|19|rsReticulum discovery announce egress|https://github.com/ratspeak/rsReticulum/pull/19'
+    'rsReticulum-inbound-raw-saturation-log.patch|ratspeak/rsReticulum||rsReticulum inbound-raw saturation log|'
     'rsLXMF-propagation-sync-peering.patch|ratspeak/rsLXMF|4|rsLXMF propagation sync peering|https://github.com/ratspeak/rsLXMF/pull/4'
     'rsLXMF-propagation-node-policy-setters.patch|ratspeak/rsLXMF|6|rsLXMF PropagationNode policy setters|https://github.com/ratspeak/rsLXMF/pull/6'
     'rsLXMF-link-delivery-has-pending-to.patch|ratspeak/rsLXMF||rsLXMF LinkDeliveryManager has_pending_to|'


### PR DESCRIPTION
## Summary
- Wire `set_inbound_raw_channel` (lxmd parity) so opportunistic LXMF from Sideband/Columba is unpacked into Chat instead of being dropped after decrypt/proof.
- Fixes asymmetric interop reported by w0rmt: mesh-client → Python clients worked; reverse short messages did not (mesh-client ↔ mesh-client Direct still worked).

## Test plan
- [x] `cargo test --features rns-stack stack::lxmf_delivery::tests` (7/7)
- [ ] Restart stack on a build with this sidecar; **Announce now**
- [ ] From Sideband/Columba, send a short DM to the mesh-client LXMF hash and confirm it appears in Chat
- [ ] Confirm mesh-client ↔ mesh-client Direct DMs still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for receiving opportunistically encrypted LXMF messages.
  - Unified delivery of messages received through direct, resource-based, and raw packet channels.
  - Improved handling of destination information during message processing.

- **Bug Fixes**
  - Improved reliability when decrypting and unpacking incoming opportunistic messages.
  - Added controlled warnings for malformed or unsupported incoming packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->