### PR TITLE
fix(connection): disable Meshtastic TCP host-link RTT probe (device RST hazard)

### DIFF
--- a/src/renderer/components/ConnectionPanel.hostLinkMeter.test.tsx
+++ b/src/renderer/components/ConnectionPanel.hostLinkMeter.test.tsx
@@ -141,7 +141,10 @@ describe('ConnectionPanel host link meter', () => {
     });
   });
 
-  it('shows Link quality for Meshtastic TCP', async () => {
+  it('shows Link quality with no data for Meshtastic TCP and never probes (device RST hazard)', () => {
+    // Meshtastic raw-TCP RTT probing opens a second connection to the same host:port as
+    // the live session — confirmed via live packet capture to get the device to RST the
+    // real session. See useHostLinkMeter.ts's meshtasticTcpProbeUnsafe comment.
     vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
     vi.mocked(window.electronAPI.hostLink.probeTcpRtt).mockResolvedValue(120);
     render(
@@ -161,8 +164,7 @@ describe('ConnectionPanel host link meter', () => {
       />,
     );
     expect(screen.getByText('Link quality')).toBeInTheDocument();
-    await waitFor(() => {
-      expect(window.electronAPI.hostLink.probeTcpRtt).toHaveBeenCalled();
-    });
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(window.electronAPI.hostLink.probeTcpRtt).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/components/ConnectionPanel.hostLinkMeter.test.tsx
+++ b/src/renderer/components/ConnectionPanel.hostLinkMeter.test.tsx
@@ -141,30 +141,34 @@ describe('ConnectionPanel host link meter', () => {
     });
   });
 
-  it('shows Link quality with no data for Meshtastic TCP and never probes (device RST hazard)', () => {
-    // Meshtastic raw-TCP RTT probing opens a second connection to the same host:port as
-    // the live session — confirmed via live packet capture to get the device to RST the
-    // real session. See useHostLinkMeter.ts's meshtasticTcpProbeUnsafe comment.
-    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
-    vi.mocked(window.electronAPI.hostLink.probeTcpRtt).mockResolvedValue(120);
-    render(
-      <ConnectionPanel
-        state={{
-          status: 'configured',
-          myNodeNum: 1,
-          connectionType: 'tcp',
-          firmwareVersion: '2.5.3',
-        }}
-        onConnect={vi.fn().mockResolvedValue(undefined)}
-        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
-        onDisconnect={vi.fn().mockResolvedValue(undefined)}
-        mqttStatus="disconnected"
-        protocol="meshtastic"
-        suppressMountAutoConnect
-      />,
-    );
-    expect(screen.getByText('Link quality')).toBeInTheDocument();
-    expect(screen.getByText('—')).toBeInTheDocument();
-    expect(window.electronAPI.hostLink.probeTcpRtt).not.toHaveBeenCalled();
-  });
+  it.each(['linux', 'darwin', 'win32'] as const)(
+    'shows Link quality with no data for Meshtastic TCP and never probes on %s (device RST hazard)',
+    (platform) => {
+      // Meshtastic raw-TCP RTT probing opens a second connection to the same host:port as
+      // the live session — confirmed via live packet capture to get the device to RST the
+      // real session. See useHostLinkMeter.ts's meshtasticTcpProbeUnsafe comment.
+      // Platform-independent behavior, so covered on all three platforms per convention.
+      vi.mocked(window.electronAPI.getPlatform).mockReturnValue(platform);
+      vi.mocked(window.electronAPI.hostLink.probeTcpRtt).mockResolvedValue(120);
+      render(
+        <ConnectionPanel
+          state={{
+            status: 'configured',
+            myNodeNum: 1,
+            connectionType: 'tcp',
+            firmwareVersion: '2.5.3',
+          }}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+          suppressMountAutoConnect
+        />,
+      );
+      expect(screen.getByText('Link quality')).toBeInTheDocument();
+      expect(screen.getByText('—')).toBeInTheDocument();
+      expect(window.electronAPI.hostLink.probeTcpRtt).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/renderer/hooks/useHostLinkMeter.test.ts
+++ b/src/renderer/hooks/useHostLinkMeter.test.ts
@@ -77,7 +77,19 @@ describe('useHostLinkMeter', () => {
     },
   );
 
-  it('returns ip-rtt for Meshtastic TCP via probeTcpRtt', async () => {
+  it('returns ip-rtt with no data for Meshtastic raw TCP and never opens a competing probe connection', async () => {
+    // Meshtastic raw-TCP RTT probing used to open a second, separate connection to the
+    // exact same host:port as the live session every poll tick — confirmed via live
+    // packet capture to intermittently get the *real* session RST'd by the device
+    // (5/5 reproduced samples; unaffected by upstream PR #808's setNoDelay/setKeepAlive,
+    // which only touches the main session's socket). Do not re-enable this probe for
+    // 'meshtastic' + 'tcp' without deriving RTT from the already-open session instead.
+    //
+    // kind stays 'ip-rtt' (not 'unavailable') with null rttMs/level — same rendering as
+    // an HTTP probe failure ("—" + no-data bars). A dedicated 'unavailable' kind would
+    // incorrectly show ConnectionLinkMeter's Web-Bluetooth-specific copy on this
+    // WiFi/TCP-only transport.
+    vi.useFakeTimers();
     const { result } = renderHook(() =>
       useHostLinkMeter({
         protocol: 'meshtastic',
@@ -88,11 +100,14 @@ describe('useHostLinkMeter', () => {
       }),
     );
     expect(result.current.kind).toBe('ip-rtt');
-    await waitFor(() => {
-      expect(result.current.rttMs).toBe(80);
-      expect(result.current.level).toBe(3);
+    expect(result.current.rttMs).toBeNull();
+    expect(result.current.level).toBeNull();
+
+    // Advance well past several poll intervals to confirm no deferred/interval probe fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
     });
-    expect(window.electronAPI.hostLink.probeTcpRtt).toHaveBeenCalledWith('10.0.0.5', 4403);
+    expect(window.electronAPI.hostLink.probeTcpRtt).not.toHaveBeenCalled();
   });
 
   it('returns ip-rtt for MeshCore TCP/IP (http transport) via probeTcpRtt', async () => {

--- a/src/renderer/hooks/useHostLinkMeter.test.ts
+++ b/src/renderer/hooks/useHostLinkMeter.test.ts
@@ -77,37 +77,74 @@ describe('useHostLinkMeter', () => {
     },
   );
 
-  it('returns ip-rtt with no data for Meshtastic raw TCP and never opens a competing probe connection', async () => {
-    // Meshtastic raw-TCP RTT probing used to open a second, separate connection to the
-    // exact same host:port as the live session every poll tick — confirmed via live
-    // packet capture to intermittently get the *real* session RST'd by the device
-    // (5/5 reproduced samples; unaffected by upstream PR #808's setNoDelay/setKeepAlive,
-    // which only touches the main session's socket). Do not re-enable this probe for
-    // 'meshtastic' + 'tcp' without deriving RTT from the already-open session instead.
-    //
-    // kind stays 'ip-rtt' (not 'unavailable') with null rttMs/level — same rendering as
-    // an HTTP probe failure ("—" + no-data bars). A dedicated 'unavailable' kind would
-    // incorrectly show ConnectionLinkMeter's Web-Bluetooth-specific copy on this
-    // WiFi/TCP-only transport.
-    vi.useFakeTimers();
-    const { result } = renderHook(() =>
-      useHostLinkMeter({
-        protocol: 'meshtastic',
-        connectionType: 'tcp',
-        status: 'configured',
-        hostAddress: '10.0.0.5:4403',
-        platform: 'darwin',
-      }),
+  it.each(['linux', 'darwin', 'win32'] as const)(
+    'returns ip-rtt with no data for Meshtastic raw TCP and never opens a competing probe connection on %s',
+    async (platform) => {
+      // Meshtastic raw-TCP RTT probing used to open a second, separate connection to the
+      // exact same host:port as the live session every poll tick — confirmed via live
+      // packet capture to intermittently get the *real* session RST'd by the device
+      // (5/5 reproduced samples; unaffected by upstream PR #808's setNoDelay/setKeepAlive,
+      // which only touches the main session's socket). Do not re-enable this probe for
+      // 'meshtastic' + 'tcp' without deriving RTT from the already-open session instead.
+      // Platform-independent behavior (no OS-specific mechanism involved), so covered on
+      // all three platforms per project convention rather than a single-platform case.
+      //
+      // kind stays 'ip-rtt' (not 'unavailable') with null rttMs/level — same rendering as
+      // an HTTP probe failure ("—" + no-data bars). A dedicated 'unavailable' kind would
+      // incorrectly show ConnectionLinkMeter's Web-Bluetooth-specific copy on this
+      // WiFi/TCP-only transport.
+      vi.useFakeTimers();
+      const { result } = renderHook(() =>
+        useHostLinkMeter({
+          protocol: 'meshtastic',
+          connectionType: 'tcp',
+          status: 'configured',
+          hostAddress: '10.0.0.5:4403',
+          platform,
+        }),
+      );
+      expect(result.current.kind).toBe('ip-rtt');
+      expect(result.current.rttMs).toBeNull();
+      expect(result.current.level).toBeNull();
+
+      // Advance well past several poll intervals to confirm no deferred/interval probe fires.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      expect(window.electronAPI.hostLink.probeTcpRtt).not.toHaveBeenCalled();
+    },
+  );
+
+  it('clears stale HTTP RTT when Meshtastic switches from HTTP to TCP', async () => {
+    // Render logic derives the displayed RTT from meshtasticTcpProbeUnsafe directly
+    // rather than trusting rttMs state, so a prior HTTP probe result can never render
+    // as if it were the (disabled) TCP link quality, without depending on the probe
+    // effect's cleanup (setRttMs(null)) having committed first. Verifies the settled
+    // end state; RTL's act()-wrapped rerender flushes that cleanup synchronously in
+    // this environment, so this does not exercise the specific single-render flash
+    // the derivation also guards against in a real browser (passive effects commit
+    // after paint there) — the render-time guard is defense in depth regardless.
+    const { result, rerender } = renderHook(
+      (props: { connectionType: 'http' | 'tcp' }) =>
+        useHostLinkMeter({
+          protocol: 'meshtastic',
+          connectionType: props.connectionType,
+          status: 'configured',
+          hostAddress: 'meshtastic.local',
+          platform: 'darwin',
+        }),
+      { initialProps: { connectionType: 'http' } },
     );
+
+    await waitFor(() => {
+      expect(result.current.rttMs).toBe(40);
+    });
+
+    rerender({ connectionType: 'tcp' });
+
     expect(result.current.kind).toBe('ip-rtt');
     expect(result.current.rttMs).toBeNull();
     expect(result.current.level).toBeNull();
-
-    // Advance well past several poll intervals to confirm no deferred/interval probe fires.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(20_000);
-    });
-    expect(window.electronAPI.hostLink.probeTcpRtt).not.toHaveBeenCalled();
   });
 
   it('returns ip-rtt for MeshCore TCP/IP (http transport) via probeTcpRtt', async () => {

--- a/src/renderer/hooks/useHostLinkMeter.ts
+++ b/src/renderer/hooks/useHostLinkMeter.ts
@@ -148,12 +148,17 @@ export function useHostLinkMeter(opts: {
   }
 
   if (connectionType === 'http' || connectionType === 'tcp') {
-    // meshtasticTcpProbeUnsafe: rttMs never gets set (probe effect above skips this
-    // combo entirely), so this naturally renders the same "—" / no-data state as an
-    // HTTP probe failure — not a separate 'unavailable' kind, which would incorrectly
-    // show ConnectionLinkMeter's Web-Bluetooth-specific copy for a WiFi/TCP transport.
-    const level = rttMs != null ? rttToSignalLevel(rttMs) : null;
-    return { kind: 'ip-rtt', rssi: null, rttMs, level };
+    // meshtasticTcpProbeUnsafe: force the displayed RTT to null rather than trusting
+    // rttMs state directly — on the render right after switching from Meshtastic HTTP
+    // to TCP, this branch runs before the probe effect's cleanup has cleared rttMs
+    // (effects commit after render), so a stale HTTP RTT value could otherwise flash
+    // as if it were the (disabled) TCP link quality. Same "—" / no-data rendering as
+    // an HTTP probe failure — not a separate 'unavailable' kind, which would
+    // incorrectly show ConnectionLinkMeter's Web-Bluetooth-specific copy on a
+    // WiFi/TCP-only transport.
+    const displayedRttMs = meshtasticTcpProbeUnsafe ? null : rttMs;
+    const level = displayedRttMs != null ? rttToSignalLevel(displayedRttMs) : null;
+    return { kind: 'ip-rtt', rssi: null, rttMs: displayedRttMs, level };
   }
 
   return IDLE;

--- a/src/renderer/hooks/useHostLinkMeter.ts
+++ b/src/renderer/hooks/useHostLinkMeter.ts
@@ -55,6 +55,23 @@ export function useHostLinkMeter(opts: {
     isConnectedStatus(status) &&
     (connectionType === 'ble' || connectionType === 'http' || connectionType === 'tcp');
 
+  // Meshtastic raw-TCP RTT probing opens a second, separate socket to the exact same
+  // host:port as the live protocol session every poll tick. Captured via live packet
+  // capture: the device intermittently RSTs the *real* session within ~15-210ms of a
+  // probe cycle overlapping a real outbound write (5/5 reproduced samples, both before
+  // and after PR #808's setNoDelay/setKeepAlive change — unaffected, since that only
+  // touches the main session's socket). Meshtastic WiFi/TCP firmware likely tracks very
+  // few concurrent API connections; a second churn-y connection to the same port
+  // destabilizes it. Do not reintroduce a competing connect for this transport without
+  // deriving RTT from the already-open session instead.
+  //
+  // Deliberate blunt/interim tradeoff: this disables the probe (and the signal-bars UI)
+  // for *every* Meshtastic TCP session, not only ones that hit the collision, because
+  // there is no cheap signal here for "is a competing probe currently unsafe" short of
+  // the real fix above. A previously-working, cosmetic-only feature regressing is an
+  // acceptable cost against dropping the live connection.
+  const meshtasticTcpProbeUnsafe = protocol === 'meshtastic' && connectionType === 'tcp';
+
   // BLE RSSI via Noble (macOS / Windows)
   useEffect(() => {
     if (!active || connectionType !== 'ble') {
@@ -78,7 +95,11 @@ export function useHostLinkMeter(opts: {
 
   // HTTP / TCP RTT probe
   useEffect(() => {
-    if (!active || (connectionType !== 'http' && connectionType !== 'tcp')) {
+    if (
+      !active ||
+      (connectionType !== 'http' && connectionType !== 'tcp') ||
+      meshtasticTcpProbeUnsafe
+    ) {
       setRttMs(null);
       return;
     }
@@ -98,8 +119,6 @@ export function useHostLinkMeter(opts: {
       let next: number | null = null;
       if (protocol === 'meshtastic' && connectionType === 'http') {
         next = await probeHttpLinkRttMs(address);
-      } else if (protocol === 'meshtastic' && connectionType === 'tcp') {
-        next = await probeTcpLinkRttMs(address, 'meshtastic');
       } else if (protocol === 'meshcore' && connectionType === 'http') {
         // MeshCore "http" transport is TCP/IP host:port
         next = await probeTcpLinkRttMs(address, 'meshcore');
@@ -117,7 +136,7 @@ export function useHostLinkMeter(opts: {
       if (timer) clearInterval(timer);
       setRttMs(null);
     };
-  }, [active, connectionType, hostAddress, protocol]);
+  }, [active, connectionType, hostAddress, protocol, meshtasticTcpProbeUnsafe]);
 
   if (!active || !connectionType) return IDLE;
 
@@ -129,6 +148,10 @@ export function useHostLinkMeter(opts: {
   }
 
   if (connectionType === 'http' || connectionType === 'tcp') {
+    // meshtasticTcpProbeUnsafe: rttMs never gets set (probe effect above skips this
+    // combo entirely), so this naturally renders the same "—" / no-data state as an
+    // HTTP probe failure — not a separate 'unavailable' kind, which would incorrectly
+    // show ConnectionLinkMeter's Web-Bluetooth-specific copy for a WiFi/TCP transport.
     const level = rttMs != null ? rttToSignalLevel(rttMs) : null;
     return { kind: 'ip-rtt', rssi: null, rttMs, level };
   }

--- a/src/renderer/lib/hostLinkQuality.ts
+++ b/src/renderer/lib/hostLinkQuality.ts
@@ -94,7 +94,12 @@ export async function probeHttpLinkRttMs(httpAddress: string): Promise<number | 
   }
 }
 
-/** Probe TCP connect RTT via main process (connect then destroy). */
+/**
+ * Probe TCP connect RTT via main process (connect then destroy).
+ *
+ * Never call this with `protocol: 'meshtastic'` (or omit `protocol`, whose
+ * default is `'meshtastic'`) — see `parseTcpProbeTarget`'s docstring for why.
+ */
 export async function probeTcpLinkRttMs(
   address: string,
   protocol: 'meshtastic' | 'meshcore' = 'meshtastic',

--- a/src/renderer/lib/hostLinkQuality.ts
+++ b/src/renderer/lib/hostLinkQuality.ts
@@ -53,6 +53,12 @@ export interface ParsedTcpProbeTarget {
  * Parse a TCP probe target.
  * - `meshtastic`: default port 4403 (`parseMeshtasticTcpAddress`)
  * - `meshcore`: default port 5000 (`parseTcpAddress`)
+ *
+ * The `'meshtastic'` branch is currently unreachable from any production call site —
+ * `useHostLinkMeter.ts` deliberately never probes Meshtastic raw TCP (opening a second
+ * connection to the same host:port as the live session has been confirmed to get the
+ * device to RST the real connection). Do not wire a new call site for it without reading
+ * that hook's `meshtasticTcpProbeUnsafe` comment first.
  */
 export function parseTcpProbeTarget(
   address: string,


### PR DESCRIPTION
## Summary

Meshtastic WiFi/TCP sessions intermittently drop with `ECONNRESET` — every
1-2 minutes in bad stretches, occasionally with a stable 20+ minute run in
between. Root-caused via live `tshark` packet capture on a real LAN node:
not the node (a stable Android-app connection to the same node holds for
hours), not the network (only one client active).

**Cause:** the Connection panel's WiFi/TCP signal-bars meter
(`useHostLinkMeter` → `probeTcpLinkRttMs` → `host-link-rtt.ts`) opens a
**second, separate TCP connection to the exact same `host:port` as the live
protocol session, every 4 seconds, for the entire life of the session**,
purely to time the connect for a link-quality indicator.

**Evidence:** 5/5 reproduced resets across two separate builds (before and
after #808) show the identical packet-level signature — a real outbound
write lands, a host-link probe cycle is running/just-closed in the same
~50-210ms window, and the device sends a genuine `RST+ACK` on the *real*
session shortly after. #808's `setNoDelay`/`setKeepAlive` don't affect
this at all (confirmed via a second live capture) since they're applied to
the main session's socket, not the probe's separate one. Likely mechanism:
Meshtastic WiFi/TCP firmware (ESP32/lwIP-class) probably tracks very few
concurrent API connections; churning a second one every 4s on top of the
real session destabilizes it.

## Fix

Disable the RTT probe for Meshtastic raw TCP specifically
(`meshtasticTcpProbeUnsafe` guard in `useHostLinkMeter.ts`). `rttMs` stays
`null` (the probe effect now skips this combo entirely), so the UI falls
through to the existing `ip-rtt` no-data rendering (`"—"`) rather than a
new `'unavailable'` kind — which would incorrectly show
`ConnectionLinkMeter`'s Web-Bluetooth-specific copy on a WiFi/TCP-only
transport. HTTP RTT probing and MeshCore's TCP-over-`http`-transport
probing are untouched — unproven, though MeshCore's probe uses the
identical pattern against its own live session and may warrant the same
scrutiny separately.

**Deliberate interim tradeoff:** this drops the signal-bars feature for
*every* Meshtastic TCP session, not only ones that would hit the
collision — there's no cheap signal for "is a competing probe currently
unsafe" short of deriving RTT from the already-open session instead of a
second connection. Flagged in code as the real fix for a follow-up;
happy to attempt that instead/as well if preferred.

## Verification

- **Diagnosis:** 3 live `tshark` captures (baseline pre-#808, baseline
  post-#808, and this fix) on a real Meshtastic WiFi/TCP node — see PR
  discussion / can attach pcaps on request.
- **This fix, local before/after on the same node:** 20-minute `pnpm run
  dev` session with a parallel capture, live traffic exercised (chat,
  traceroutes, position requests) — **zero RST packets, zero resets,
  exactly one continuous TCP conversation for the full session, zero
  competing probe connections observed on the wire.** Direct contrast with
  3 resets/~15min and 2 resets/~19.6min on the unfixed code in the two
  prior captures.
- `pnpm run test:staged` / related suite: 234 tests pass (pre-commit).
- `vitest run --changed`: 228 tests pass (pre-push).
- Lint + typecheck clean on all touched files.

## Test plan

- [x] Reproduce on unfixed `main`: connect Meshtastic WiFi/TCP to a real
      node, confirm intermittent `ECONNRESET` under normal use
- [x] Apply fix, same node, 20-min live capture: confirm zero resets, zero
      competing probe connections on the wire
- [x] Confirm Connection panel shows "Link quality: —" (no data) instead
      of a broken/misleading state for Meshtastic TCP
- [x] Confirm HTTP-connected Meshtastic and MeshCore (any transport)
      signal meters are unaffected
- [x] `pnpm run check:pr` — lint + typecheck + test:run (see CI)

## Notes

Independent finding, not addressing anything specific requested by #808 —
found while diagnosing the original TCP reset reports and confirmed #808
doesn't touch this code path. Full evidence trail (capture methodology,
per-reset packet timing) available if useful for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled TCP link-quality probing for Meshtastic connections to prevent interference with active sessions.
  * TCP connection meters now show no RTT data when probing is unavailable.
  * Improved connection stability by avoiding competing socket connections.

* **Tests**
  * Updated connection and link-quality checks to verify probing is not invoked and empty RTT values are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->