### PR TITLE
test(meshcore): fix renderer-ui setup-abort reconnect contract

### DIFF
--- a/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
@@ -528,9 +528,13 @@ describe('useMeshcoreRuntime manual disconnect must not auto-reconnect', () => {
     expect(retryIdx).toBeGreaterThan(abortIdx);
     const abortBlock = reconnectBody.slice(abortIdx, retryIdx);
     expect(abortBlock).toContain('meshcoreDeferredReconnectRef.current = true');
-    expect(abortBlock).toContain("return 'defer'");
-    // Setup abort must clean up any transport this doomed attempt opened before deferring.
-    expect(abortBlock).toContain('lateTransport.cleanup(openedDriverIdentityId)');
+    // Setup abort must clean up any transport this doomed attempt opened *before* deferring,
+    // otherwise a late-opened driver leaks while the deferred restart brings up a fresh one.
+    const cleanupIdx = abortBlock.indexOf('lateTransport.cleanup(openedDriverIdentityId)');
+    const deferIdx = abortBlock.indexOf("return 'defer'");
+    expect(cleanupIdx).toBeGreaterThan(-1);
+    expect(deferIdx).toBeGreaterThan(-1);
+    expect(cleanupIdx).toBeLessThan(deferIdx);
     expect(abortBlock).not.toMatch(/meshcoreIsReconnectingRef\.current = false/);
   });
 

--- a/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
@@ -521,9 +521,16 @@ describe('useMeshcoreRuntime manual disconnect must not auto-reconnect', () => {
     // and left status=reconnecting with no further attempts (n7eal / #792 MeshCore TCP).
     const abortIdx = reconnectBody.indexOf('isMeshcoreSetupAbortError(err)');
     expect(abortIdx).toBeGreaterThan(-1);
-    const abortBlock = reconnectBody.slice(abortIdx, abortIdx + 900);
+    // Delimit the abort branch at the non-abort retry path rather than a fixed
+    // char window, so adding late-transport cleanup before the defer cannot push
+    // `return 'defer'` out of range.
+    const retryIdx = reconnectBody.indexOf("return 'retry'", abortIdx);
+    expect(retryIdx).toBeGreaterThan(abortIdx);
+    const abortBlock = reconnectBody.slice(abortIdx, retryIdx);
     expect(abortBlock).toContain('meshcoreDeferredReconnectRef.current = true');
     expect(abortBlock).toContain("return 'defer'");
+    // Setup abort must clean up any transport this doomed attempt opened before deferring.
+    expect(abortBlock).toContain('lateTransport.cleanup(openedDriverIdentityId)');
     expect(abortBlock).not.toMatch(/meshcoreIsReconnectingRef\.current = false/);
   });
 


### PR DESCRIPTION
## Summary

Fixes the `Coverage (renderer-ui)` CI failure from [run 31261707882](https://github.com/Colorado-Mesh/mesh-client/actions/runs/31261707882/job/93113438410) (PR #821). One source-contract test failed: `useMeshcoreRuntime.reconnect.test.ts › attemptMeshcoreReconnect treats setup AbortError as superseded reconnect`.

- The test sliced a **fixed 900-char window** after the `isMeshcoreSetupAbortError(err)` marker and asserted it contained `return 'defer'`.
- The merged PR-review fix added `await lateTransport.cleanup(openedDriverIdentityId)` (plus its explanatory comment) inside the setup-abort branch **before** the defer — correct behavior (a doomed attempt's late-opened transport must be cleaned up before deferring), but it pushed `return 'defer'` past the 900-char window, so the assertion failed.
- Reworked the contract to delimit the abort branch at the non-abort `return 'retry'` path instead of a char count, and additionally assert the branch performs the late-transport cleanup. This tracks intent without being length-brittle.

No production code changed — test-only.

## Test plan

- [x] `pnpm exec vitest run src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts` (64/64 pass)
- [x] Full `renderer-ui` project locally: 3126/3126 pass after the fix (was 1 failed)
- [x] Pre-commit (ESLint, typecheck, `check:i18n:branch`, staged Vitest incl. `sourcePolicy`) green
- [ ] CI `Coverage (renderer-ui)` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnection handling to ensure transport connections from superseded attempts are cleaned up before retrying.
  * Strengthened regression coverage for aborted reconnect attempts and deferred retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->