### PR TITLE
fix: quiet noisy logs, stop false heartbeat errors, and auto-recover PKI DM key failures

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3247,7 +3247,6 @@ ipcMain.handle('mqtt:publishMeshcore', (event, args) => {
 ipcMain.handle('mqtt:publishMeshcorePacketLog', (event, args) => {
   assertIpcSender(event, 'mqtt:publishMeshcorePacketLog');
   try {
-    console.debug('[IPC] mqtt:publishMeshcorePacketLog');
     validateMqttPublishMeshcorePacketLogArgs(args);
     const a = args as {
       origin: string;

--- a/src/main/log-service.test.ts
+++ b/src/main/log-service.test.ts
@@ -352,6 +352,68 @@ describe('stripConsoleStyles (via appendLine + getRecentLines)', () => {
   });
 });
 
+describe('isDroppableMeshtasticSdkLogLine', () => {
+  it('drops routine SDK TRACE [iMeshDevice] chatter', async () => {
+    const { isDroppableMeshtasticSdkLogLine } = await import('./log-service');
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        '03:39:57:239 TRACE [iMeshDevice] HandleMeshPacket Received STORE_FORWARD_APP packet',
+      ),
+    ).toBe(true);
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        '01:25:29:719 TRACE [iMeshDevice] HandleFromRadio Received Queue Status',
+      ),
+    ).toBe(true);
+  });
+
+  it('drops periodic DEBUG [iMeshDevice] Ping heartbeats', async () => {
+    const { isDroppableMeshtasticSdkLogLine } = await import('./log-service');
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        '01:25:29:561 DEBUG [iMeshDevice] Ping Send heartbeat ping to radio',
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps INFO / WARN / ERROR SDK lines', async () => {
+    const { isDroppableMeshtasticSdkLogLine } = await import('./log-service');
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        '00:56:01:200 WARN [iMeshDevice] HandleFromRadio Unhandled payload variant: deviceuiConfig',
+      ),
+    ).toBe(false);
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        '00:56:01:185 INFO [iMeshDevice] HandleFromRadio Received Node info for this device',
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps non-Ping DEBUG lines', async () => {
+    const { isDroppableMeshtasticSdkLogLine } = await import('./log-service');
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        '00:56:01:222 DEBUG [iMeshDevice] GetMetadata Received metadata packet',
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps TRACE decode-failure lines needed by Foreign LoRa detection', async () => {
+    const { isDroppableMeshtasticSdkLogLine } = await import('./log-service');
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        'TRACE [iMeshDevice] HandleMeshPacket decode failed rssi -120 snr -8 3c 01 02',
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps unrelated renderer/main lines', async () => {
+    const { isDroppableMeshtasticSdkLogLine } = await import('./log-service');
+    expect(isDroppableMeshtasticSdkLogLine('[main] [MeshCore MQTT] PINGREQ sent')).toBe(false);
+  });
+});
+
 describe('formatRuntimeLogTag', () => {
   it('includes platform, arch, electron, node, packaged, and buildChannel fields', async () => {
     const { formatRuntimeLogTag } = await import('./log-service');

--- a/src/main/log-service.ts
+++ b/src/main/log-service.ts
@@ -385,6 +385,27 @@ export function patchMainConsole(): void {
 }
 
 /**
+ * Failure-context markers used by Foreign LoRa detection (see
+ * `src/renderer/lib/foreignLoraDetection.ts`). A TRACE line containing any of these
+ * is preserved so overheard decode-failure frames still reach the renderer.
+ */
+const SDK_FAILURE_CONTEXT_REGEX =
+  /packet.?dropped|crc.?err|crc.?fail|crc.?bad|bad.?crc|decode.?fail|decode.?error|corrupt.?packet|bad.?packet|invalid.?packet|preamble|rx.?error|lora.?err/i;
+
+/**
+ * True for high-volume `@meshtastic/core` console noise with no triage value:
+ * routine `TRACE [iMeshDevice]` chatter and periodic `DEBUG [iMeshDevice] Ping`
+ * heartbeats. INFO/WARN/ERROR and decode-failure TRACE lines are kept.
+ */
+export function isDroppableMeshtasticSdkLogLine(message: string): boolean {
+  if (/\bDEBUG \[iMeshDevice\] Ping\b/.test(message)) return true;
+  if (/\bTRACE \[iMeshDevice\]/.test(message) && !SDK_FAILURE_CONTEXT_REGEX.test(message)) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Renderer console-message (Electron 40+): single event object with message, level, lineNumber, sourceId.
  * level is 'info' | 'warning' | 'error' | 'debug'.
  */
@@ -406,5 +427,6 @@ export function forwardRendererConsoleMessage(details: {
     ? sanitizeLogMessage(`renderer:${path.basename(details.sourceId)}:${line}`)
     : 'renderer';
   const msg = sanitizeLogMessage(stripConsoleStyles(details.message));
+  if (isDroppableMeshtasticSdkLogLine(msg)) return;
   appendLine(mapped, src, msg);
 }

--- a/src/main/meshcore-mqtt-adapter.test.ts
+++ b/src/main/meshcore-mqtt-adapter.test.ts
@@ -73,6 +73,74 @@ describe('MeshcoreMqttAdapter — topicPrefix wildcards', () => {
   );
 });
 
+describe('MeshcoreMqttAdapter — PING logging', () => {
+  let adapter: MeshcoreMqttAdapter;
+
+  beforeEach(async () => {
+    const mqtt = await import('mqtt');
+    vi.mocked(mqtt.connect).mockClear();
+    adapter = new MeshcoreMqttAdapter();
+    adapter.on('error', () => {});
+  });
+
+  afterEach(() => {
+    adapter.disconnect();
+    vi.restoreAllMocks();
+  });
+
+  const lastHandler = (
+    client: { on: ReturnType<typeof vi.fn> },
+    name: string,
+  ): ((packet: { cmd: string }) => void) => {
+    const hits = client.on.mock.calls.filter((c: unknown[]) => c[0] === name);
+    return hits[hits.length - 1]?.[1] as (packet: { cmd: string }) => void;
+  };
+
+  it('logs PINGREQ and PINGRESP only once per connection', async () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const mqttMod = await import('mqtt');
+    adapter.connect({ ...BASE_SETTINGS });
+    const client = vi.mocked(mqttMod.connect).mock.results.at(-1)!.value as {
+      on: ReturnType<typeof vi.fn>;
+    };
+    const onSend = lastHandler(client, 'packetsend');
+    const onReceive = lastHandler(client, 'packetreceive');
+
+    onSend({ cmd: 'pingreq' });
+    onSend({ cmd: 'pingreq' });
+    onSend({ cmd: 'pingreq' });
+    onReceive({ cmd: 'pingresp' });
+    onReceive({ cmd: 'pingresp' });
+
+    const reqLogs = debugSpy.mock.calls.filter((c) => String(c[0]).includes('PINGREQ'));
+    const respLogs = debugSpy.mock.calls.filter((c) => String(c[0]).includes('PINGRESP'));
+    expect(reqLogs).toHaveLength(1);
+    expect(respLogs).toHaveLength(1);
+  });
+
+  it('re-logs PINGREQ once after a reconnect (flags reset)', async () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const mqttMod = await import('mqtt');
+
+    adapter.connect({ ...BASE_SETTINGS });
+    let client = vi.mocked(mqttMod.connect).mock.results.at(-1)!.value as {
+      on: ReturnType<typeof vi.fn>;
+    };
+    lastHandler(client, 'packetsend')({ cmd: 'pingreq' });
+    lastHandler(client, 'packetsend')({ cmd: 'pingreq' });
+
+    adapter.disconnect();
+    adapter.connect({ ...BASE_SETTINGS });
+    client = vi.mocked(mqttMod.connect).mock.results.at(-1)!.value as {
+      on: ReturnType<typeof vi.fn>;
+    };
+    lastHandler(client, 'packetsend')({ cmd: 'pingreq' });
+
+    const reqLogs = debugSpy.mock.calls.filter((c) => String(c[0]).includes('PINGREQ'));
+    expect(reqLogs).toHaveLength(2);
+  });
+});
+
 describe('MeshcoreMqttAdapter — clientId', () => {
   let adapter: MeshcoreMqttAdapter;
 

--- a/src/main/meshcore-mqtt-adapter.ts
+++ b/src/main/meshcore-mqtt-adapter.ts
@@ -311,6 +311,8 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       settings.tlsInsecure === true,
     );
     this.firstMessageLogged = false;
+    this.pingReqLogged = false;
+    this.pingRespLogged = false;
     this.setStatus('connecting');
     this.connectAbortByWatchdog = false;
     this.client = mqtt.connect(connectOpts);
@@ -405,16 +407,22 @@ export class MeshcoreMqttAdapter extends EventEmitter {
       this.scheduleTokenRefresh();
     });
     this.client.on('packetsend', (packet) => {
-      if (packet.cmd === 'pingreq') {
-        this.pingReqLogged = false;
-        console.debug('[MeshCore MQTT] PINGREQ sent', new Date().toISOString());
+      if (packet.cmd === 'pingreq' && !this.pingReqLogged) {
+        this.pingReqLogged = true;
+        console.debug(
+          '[MeshCore MQTT] PINGREQ sent (first this session)',
+          new Date().toISOString(),
+        );
       }
     });
     this.client.on('packetreceive', (packet) => {
       this.lastPacketReceivedAt = Date.now();
-      if (packet.cmd === 'pingresp') {
-        this.pingRespLogged = false;
-        console.debug('[MeshCore MQTT] PINGRESP received', new Date().toISOString());
+      if (packet.cmd === 'pingresp' && !this.pingRespLogged) {
+        this.pingRespLogged = true;
+        console.debug(
+          '[MeshCore MQTT] PINGRESP received (first this session)',
+          new Date().toISOString(),
+        );
       }
     });
     this.client.on('message', (topic, payload) => {

--- a/src/renderer/hooks/meshcore/meshcoreConnSideEffects.ts
+++ b/src/renderer/hooks/meshcore/meshcoreConnSideEffects.ts
@@ -243,18 +243,8 @@ async function drainWaitingMessagesManual(
     deps.setWaitingMessagesCount(total);
     deps.setWaitingMessagesSyncProgress({ processed: 0, total });
   } else if (total === 0) {
-    console.debug('[meshcoreConnSideEffects] processWaitingMessages empty queue (manual sync)');
     return;
   }
-  console.debug(
-    '[meshcoreConnSideEffects] processWaitingMessages start ' +
-      JSON.stringify({
-        count: total,
-        showSyncBanner: true,
-        connectionType: deps.connectionType,
-        mode: 'manual',
-      }),
-  );
   for (const m of arr) {
     if (!deps.meshcoreHookMountedRef.current) break;
     await ingestMeshcoreWaitingMessageItem(m, state, deps);
@@ -317,14 +307,6 @@ async function drainWaitingMessagesSilent(
   deps: MeshcoreWaitingMessagesDrainDeps,
 ): Promise<void> {
   const attemptId = beginMeshcoreSilentBulkAttempt();
-  console.debug(
-    '[meshcoreConnSideEffects] processWaitingMessages start ' +
-      JSON.stringify({
-        showSyncBanner: false,
-        connectionType: deps.connectionType,
-        mode: 'silent-bulk',
-      }),
-  );
 
   try {
     const msgs = await withTimeout(
@@ -339,7 +321,6 @@ async function drainWaitingMessagesSilent(
     if (!deps.meshcoreHookMountedRef.current) return;
     const arr = normalizeMeshcoreWaitingMessageBatch(msgs);
     if (arr.length === 0) {
-      console.debug('[meshcoreConnSideEffects] processWaitingMessages empty queue (silent bulk)');
       return;
     }
     state.syncTotal = arr.length;
@@ -382,14 +363,6 @@ async function drainWaitingMessagesSilent(
       state.syncTotal = 0;
       state.progressActive = true;
       deps.setWaitingMessagesSyncProgress({ processed: 0, total: 0 });
-      console.debug(
-        '[meshcoreConnSideEffects] processWaitingMessages start ' +
-          JSON.stringify({
-            showSyncBanner: false,
-            connectionType: deps.connectionType,
-            mode: 'silent-fallback',
-          }),
-      );
       if (!deps.meshcoreHookMountedRef.current) return;
       await drainWaitingMessagesIncremental(conn, state, deps);
       return;
@@ -408,7 +381,6 @@ async function runMeshcoreWaitingMessagesDrain(
   options: { showSyncBanner: boolean },
   deps: MeshcoreWaitingMessagesDrainDeps,
 ): Promise<void> {
-  const startedAt = Date.now();
   const state: MeshcoreWaitingMessagesDrainState = {
     processed: 0,
     bannerActive: false,
@@ -429,22 +401,6 @@ async function runMeshcoreWaitingMessagesDrain(
     } else {
       await drainWaitingMessagesSilent(conn, state, deps);
     }
-    console.debug(
-      '[meshcoreConnSideEffects] processWaitingMessages done ' +
-        JSON.stringify({
-          count: state.processed,
-          durationMs: Date.now() - startedAt,
-          showSyncBanner: options.showSyncBanner,
-          connectionType: deps.connectionType,
-          mode: options.showSyncBanner
-            ? 'manual'
-            : state.syncTotal > 0
-              ? 'silent-bulk'
-              : state.processed > 0 || state.progressActive
-                ? 'silent-fallback'
-                : 'silent',
-        }),
-    );
   } finally {
     if (silentDrainUiActive) {
       deps.setWaitingMessagesSilentDrainActive(false);
@@ -646,7 +602,6 @@ export function attachMeshcoreConnSideEffects(
       } else {
         requestMeshcoreWaitingMessagesFollowUp();
       }
-      console.debug('[meshcoreConnSideEffects] processWaitingMessages skipped (in flight)');
       return getMeshcoreProcessWaitingMessagesInFlight()!;
     }
     const showSyncBanner = options?.showSyncBanner !== false;

--- a/src/renderer/lib/meshtastic/meshtasticConfigureRetry.ts
+++ b/src/renderer/lib/meshtastic/meshtasticConfigureRetry.ts
@@ -11,6 +11,32 @@ const CONFIGURE_RETRYABLE_PATTERN = /packet does not exist/i;
 
 let lateConfigureRetryableSwallowUntilMs = 0;
 
+/**
+ * Ref-count of installed Meshtastic session unhandled-rejection swallow handlers. While > 0, the
+ * capture-phase handler owns `Packet does not exist` teardown-race rejects, so the app-lifetime
+ * renderer logger must defer instead of logging them as errors (both listeners are at_target on
+ * `window`, so registration order — not the capture flag — decides who runs first).
+ */
+let sessionRejectionSwallowDepth = 0;
+
+export function beginMeshtasticSessionRejectionSwallow(): void {
+  sessionRejectionSwallowDepth++;
+}
+
+export function endMeshtasticSessionRejectionSwallow(): void {
+  sessionRejectionSwallowDepth = Math.max(0, sessionRejectionSwallowDepth - 1);
+}
+
+/** True while a Meshtastic session rejection-swallow handler is installed. */
+export function isMeshtasticSessionRejectionSwallowActive(): boolean {
+  return sessionRejectionSwallowDepth > 0;
+}
+
+/** Test-only: reset the session swallow ref-count. */
+export function resetMeshtasticSessionRejectionSwallowForTests(): void {
+  sessionRejectionSwallowDepth = 0;
+}
+
 export function isMeshtasticConfigureRetryableError(err: unknown): boolean {
   return CONFIGURE_RETRYABLE_PATTERN.test(errLikeToLogString(err));
 }

--- a/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.ts
+++ b/src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.ts
@@ -834,6 +834,7 @@ export function attachMeshtasticRuntimeWireEffects(
       myNodeNum: myNodeNumRef.current,
       identityId: meshtasticIdentityIdRef.current,
       tempIdToWirePacketId: ackMeshPacketIdByTempIdRef.current,
+      onMissingRecipientKey: maybeRequestNodeInfoForNode,
     });
   };
 
@@ -842,6 +843,7 @@ export function attachMeshtasticRuntimeWireEffects(
       myNodeNum: myNodeNumRef.current,
       identityId: meshtasticIdentityIdRef.current,
       tempIdToWirePacketId: ackMeshPacketIdByTempIdRef.current,
+      onMissingRecipientKey: maybeRequestNodeInfoForNode,
     });
     if (!uiApplied) {
       const parsed = reason as { id?: number; packetId?: number; error?: number };

--- a/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorConsoleHook.ts
+++ b/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorConsoleHook.ts
@@ -1,6 +1,8 @@
 import { errLikeToLogString } from '../errLikeToLogString';
 import {
   armMeshtasticLateConfigureRetryableSwallow,
+  beginMeshtasticSessionRejectionSwallow,
+  endMeshtasticSessionRejectionSwallow,
   isMeshtasticConfigureRetryableError,
 } from './meshtasticConfigureRetry';
 import {
@@ -79,8 +81,12 @@ export function installMeshtasticSdkRoutingErrorUnhandledRejectionHandler(
   };
   // Capture phase so preventDefault runs before the bubble-phase renderer logger.
   window.addEventListener('unhandledrejection', handler, { capture: true });
+  // Mark a session swallow active so the app-lifetime renderer logger defers to this handler
+  // even though at_target listeners fire in registration order (renderer logger is installed first).
+  beginMeshtasticSessionRejectionSwallow();
   return () => {
     window.removeEventListener('unhandledrejection', handler, { capture: true });
+    endMeshtasticSessionRejectionSwallow();
     // Late SDK queue rejects can settle after wire-effects teardown removes this handler.
     armMeshtasticLateConfigureRetryableSwallow();
   };

--- a/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.test.ts
@@ -34,6 +34,7 @@ import {
   applyMeshtasticOutboundRoutingErrorFromRejection,
   chatRoutingErrorKeyForSdkErrorName,
   humanizeMeshtasticSdkQueueRejectionError,
+  isMeshtasticMissingRecipientKeyError,
   parseMeshtasticSdkQueueRejection,
   parseMeshtasticSdkRoutingErrorLog,
 } from './meshtasticSdkRoutingErrorLog';
@@ -48,6 +49,7 @@ interface SeedRow {
   channelIndex?: number;
   timestamp?: number;
   from?: number;
+  to?: number;
 }
 
 function clearStoreMessages(): void {
@@ -66,7 +68,7 @@ function seedOutbound(rows: SeedRow[]): void {
         id: String(row.packetId),
         from: row.from ?? 42,
         senderName: 'Me',
-        to: 0xffffffff,
+        to: row.to ?? 0xffffffff,
         payload: row.payload ?? 'hello',
         channelIndex: row.channelIndex ?? 0,
         timestamp: row.timestamp ?? Date.now(),
@@ -270,6 +272,67 @@ describe('meshtasticSdkRoutingErrorLog', () => {
       humanizeMeshtasticSdkQueueRejectionError({ id: 1, error: ROUTING_TIMEOUT }),
     ).toBeTruthy();
     expect(humanizeMeshtasticSdkQueueRejectionError('x')).toBeNull();
+  });
+
+  it('requests recipient NODEINFO on PKI_SEND_FAIL_PUBLIC_KEY for a DM row', () => {
+    seedOutbound([{ packetId: 669520633, to: 0x1234 }]);
+    const onMissingRecipientKey = vi.fn();
+    const applied = applyMeshtasticOutboundRoutingErrorFromLog(
+      'Error received for packet 669520633: PKI_SEND_FAIL_PUBLIC_KEY',
+      { myNodeNum: 42, identityId: IDENTITY, onMissingRecipientKey },
+    );
+    expect(applied).toBe(true);
+    expect(onMissingRecipientKey).toHaveBeenCalledWith(0x1234);
+  });
+
+  it('requests recipient NODEINFO on PKI_UNKNOWN_PUBKEY for a DM row', () => {
+    seedOutbound([{ packetId: 669520633, to: 0xabcd }]);
+    const onMissingRecipientKey = vi.fn();
+    applyMeshtasticOutboundRoutingErrorFromLog(
+      'Error received for packet 669520633: PKI_UNKNOWN_PUBKEY',
+      { myNodeNum: 42, identityId: IDENTITY, onMissingRecipientKey },
+    );
+    expect(onMissingRecipientKey).toHaveBeenCalledWith(0xabcd);
+  });
+
+  it('does not request NODEINFO for non-key routing errors', () => {
+    seedOutbound([{ packetId: 711859058, to: 0x1234 }]);
+    const onMissingRecipientKey = vi.fn();
+    applyMeshtasticOutboundRoutingErrorFromLog('Packet 711859058 of type packet timed out', {
+      myNodeNum: 42,
+      identityId: IDENTITY,
+      onMissingRecipientKey,
+    });
+    expect(onMissingRecipientKey).not.toHaveBeenCalled();
+  });
+
+  it('does not request NODEINFO for a broadcast row (no recipient)', () => {
+    seedOutbound([{ packetId: 669520633 }]);
+    const onMissingRecipientKey = vi.fn();
+    const applied = applyMeshtasticOutboundRoutingErrorFromLog(
+      'Error received for packet 669520633: PKI_SEND_FAIL_PUBLIC_KEY',
+      { myNodeNum: 42, identityId: IDENTITY, onMissingRecipientKey },
+    );
+    expect(applied).toBe(true);
+    expect(onMissingRecipientKey).not.toHaveBeenCalled();
+  });
+
+  it('does not request NODEINFO when no outbound row matches', () => {
+    seedOutbound([]);
+    const onMissingRecipientKey = vi.fn();
+    const applied = applyMeshtasticOutboundRoutingErrorFromLog(
+      'Error received for packet 669520633: PKI_SEND_FAIL_PUBLIC_KEY',
+      { myNodeNum: 42, identityId: IDENTITY, onMissingRecipientKey },
+    );
+    expect(applied).toBe(false);
+    expect(onMissingRecipientKey).not.toHaveBeenCalled();
+  });
+
+  it('classifies missing recipient key errors', () => {
+    expect(isMeshtasticMissingRecipientKeyError('PKI_SEND_FAIL_PUBLIC_KEY')).toBe(true);
+    expect(isMeshtasticMissingRecipientKeyError('PKI_UNKNOWN_PUBKEY')).toBe(true);
+    expect(isMeshtasticMissingRecipientKeyError('MAX_RETRANSMIT')).toBe(false);
+    expect(isMeshtasticMissingRecipientKeyError('TIMEOUT')).toBe(false);
   });
 });
 

--- a/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.ts
+++ b/src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.ts
@@ -69,6 +69,14 @@ export function humanizeMeshtasticSdkQueueRejectionError(reason: unknown): strin
   return i18nKey ? i18n.t(i18nKey) : parsed.errorName;
 }
 
+/**
+ * True for routing errors that mean we lack a usable public key for the DM recipient.
+ * Requesting the recipient's NODEINFO can recover the key so a retry succeeds.
+ */
+export function isMeshtasticMissingRecipientKeyError(errorName: string): boolean {
+  return errorName === 'PKI_SEND_FAIL_PUBLIC_KEY' || errorName === 'PKI_UNKNOWN_PUBKEY';
+}
+
 export function chatRoutingErrorKeyForSdkErrorName(errorName: string): string | null {
   switch (errorName) {
     case 'PKI_SEND_FAIL_PUBLIC_KEY':
@@ -98,6 +106,8 @@ export interface ApplyMeshtasticOutboundRoutingErrorContext {
   identityId: string | null;
   /** tempId → wire packet id assigned by the SDK (may differ from optimistic id). */
   tempIdToWirePacketId?: ReadonlyMap<number, number>;
+  /** Invoked with the recipient node num when a DM fails for lack of that node's public key. */
+  onMissingRecipientKey?: (recipientNodeNum: number) => void;
 }
 
 function outboundMatchesWirePacketId(
@@ -191,6 +201,10 @@ export function applyMeshtasticOutboundRoutingError(
   }
   const storeMessageId = resolveStoreMessageId(target, parsed.packetId);
   updateMessageStatus(identityId, storeMessageId, 'failed', errorText);
+  // Missing recipient public key: fetch the recipient's NODEINFO so a retry can succeed.
+  if (isMeshtasticMissingRecipientKeyError(parsed.errorName) && target.to != null) {
+    ctx.onMissingRecipientKey?.(target.to);
+  }
   // The DB row may still hold the optimistic temp packet id (device never acked,
   // so updateMessagePacketId never ran) — key the update on the row's own id,
   // not the wire id from the radio NAK, or the UPDATE matches zero rows.

--- a/src/renderer/lib/rendererUnhandledRejection.test.ts
+++ b/src/renderer/lib/rendererUnhandledRejection.test.ts
@@ -3,7 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   armMeshtasticLateConfigureRetryableSwallow,
+  beginMeshtasticSessionRejectionSwallow,
+  endMeshtasticSessionRejectionSwallow,
   resetMeshtasticLateConfigureRetryableSwallowForTests,
+  resetMeshtasticSessionRejectionSwallowForTests,
 } from './meshtastic/meshtasticConfigureRetry';
 import {
   installRendererUnhandledRejectionLogger,
@@ -50,6 +53,7 @@ function dispatchUnhandledRejection(
 describe('installRendererUnhandledRejectionLogger', () => {
   afterEach(() => {
     resetMeshtasticLateConfigureRetryableSwallowForTests();
+    resetMeshtasticSessionRejectionSwallowForTests();
     vi.restoreAllMocks();
   });
 
@@ -95,6 +99,39 @@ describe('installRendererUnhandledRejectionLogger', () => {
       '[renderer] Unhandled rejection:',
       expect.stringContaining('Packet does not exist'),
     );
+  });
+
+  it('defers Packet does not exist to the active session swallow handler (no error log)', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const uninstall = installRendererUnhandledRejectionLogger();
+    beginMeshtasticSessionRejectionSwallow();
+
+    const event = dispatchUnhandledRejection(new Error('Packet does not exist'));
+    uninstall();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(errorSpy).not.toHaveBeenCalled();
+    // The bubble logger defers silently; the capture-phase session handler owns the debug line.
+    expect(debugSpy).not.toHaveBeenCalled();
+
+    endMeshtasticSessionRejectionSwallow();
+  });
+
+  it('still logs unrelated rejections while a session swallow handler is active', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const uninstall = installRendererUnhandledRejectionLogger();
+    beginMeshtasticSessionRejectionSwallow();
+
+    dispatchUnhandledRejection(new Error('genuine failure'));
+    uninstall();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[renderer] Unhandled rejection:',
+      expect.stringContaining('genuine failure'),
+    );
+
+    endMeshtasticSessionRejectionSwallow();
   });
 
   it('does not log Packet does not exist during armed late-swallow window', () => {

--- a/src/renderer/lib/rendererUnhandledRejection.ts
+++ b/src/renderer/lib/rendererUnhandledRejection.ts
@@ -1,4 +1,8 @@
-import { shouldSwallowLateMeshtasticConfigureRetryableRejection } from './meshtastic/meshtasticConfigureRetry';
+import {
+  isMeshtasticConfigureRetryableError,
+  isMeshtasticSessionRejectionSwallowActive,
+  shouldSwallowLateMeshtasticConfigureRetryableRejection,
+} from './meshtastic/meshtasticConfigureRetry';
 
 /** Log renderer-wide unhandled promise rejections without throwing a second error. */
 export function logRendererUnhandledRejection(reason: unknown): void {
@@ -13,6 +17,16 @@ export function installRendererUnhandledRejectionLogger(target: Window = window)
   const handler = (event: PromiseRejectionEvent) => {
     // Capture-phase Meshtastic handler may have already preventDefault'd queue rejections.
     if (event.defaultPrevented) return;
+    // While a Meshtastic session swallow handler is installed, it owns the mid-send
+    // `Packet does not exist` teardown race. This bubble handler is registered first, so it runs
+    // before the capture handler at_target — defer (no error log) and let it log + preventDefault.
+    if (
+      isMeshtasticSessionRejectionSwallowActive() &&
+      isMeshtasticConfigureRetryableError(event.reason)
+    ) {
+      event.preventDefault();
+      return;
+    }
     // Only during a short post-teardown window (armed when Meshtastic session handler unsubscribes).
     if (shouldSwallowLateMeshtasticConfigureRetryableRejection(event.reason)) {
       console.debug(

--- a/src/renderer/stores/diagnosticsStore.ts
+++ b/src/renderer/stores/diagnosticsStore.ts
@@ -1584,7 +1584,6 @@ export const useDiagnosticsStore = create<DiagnosticsState>((set, get) => ({
 
   clearDiagnostics(options) {
     const preserveForeignLora = options?.preserveForeignLora === true;
-    console.debug(`[diagnosticsStore] clearDiagnostics preserveForeignLora=${preserveForeignLora}`);
     if (diagnosticsDebounce.incrementalAnalysisTimer)
       clearTimeout(diagnosticsDebounce.incrementalAnalysisTimer);
     diagnosticsDebounce.incrementalAnalysisTimer = null;

--- a/src/renderer/stores/reticulumPeerStore.ts
+++ b/src/renderer/stores/reticulumPeerStore.ts
@@ -1261,7 +1261,7 @@ async function refreshReticulumPeersFromSidecarOnce(
   }
 
   const elapsed = (typeof performance !== 'undefined' ? performance.now() : Date.now()) - started;
-  if (elapsed > 2000 || peers.size > 2000) {
+  if (elapsed > 2000) {
     console.debug(
       `[reticulumPeerStore] full refresh ${Math.round(elapsed)}ms peers=${peers.size} force=${Boolean(opts.forceRefresh)}`,
     );


### PR DESCRIPTION
## Summary

This branch reduces log/support-bundle noise from Meshtastic/MeshCore/Reticulum hot paths, fixes a false-positive error log on the Meshtastic heartbeat, and adds automated recovery for direct messages that fail because the recipient's public key is missing from the NodeDB.

Two commits:

1. `fix(logging): drop low-value noisy logs and false heartbeat errors`
2. `fix(meshtastic): auto-request recipient key on PKI DM send failure`

Motivation came from reviewing a ~2.8h session log where ~90% of lines were timer/keepalive/SDK-TRACE chatter, and a recurring `[error] Unhandled rejection: Packet does not exist` was firing on every few heartbeats despite already being handled.

## 1. Log noise reduction

Rule applied: if a line fires on a timer or on every successful IPC while healthy, it should not be emitted at that volume. Lifecycle events and real failures are kept.

- **MeshCore MQTT PING** (`src/main/meshcore-mqtt-adapter.ts`): `PINGREQ`/`PINGRESP` were logged on every keepalive (~656 lines/session) because the `pingReqLogged`/`pingRespLogged` gates were set to `false` and then always logged. Now they log once per connection and reset on each new connect.
- **Meshtastic SDK flood** (`src/main/log-service.ts`): added `isDroppableMeshtasticSdkLogLine()` and gate it in `forwardRendererConsoleMessage`. Drops routine `TRACE [iMeshDevice]` chatter and periodic `DEBUG [iMeshDevice] Ping` heartbeats (~1400 lines/session). Keeps INFO/WARN/ERROR and preserves decode-failure TRACE lines that Foreign LoRa detection depends on.
- **Reticulum peer refresh** (`src/renderer/stores/reticulumPeerStore.ts`): dropped the `peers.size > 2000` clause so the full-refresh line is emitted only when a refresh is actually slow (`elapsed > 2000ms`). With 6k+ peers it previously logged every refresh forever.
- **Routine chatter removed**: MeshCore waiting-message `start`/`done`/`skipped`/empty-queue debug (`src/renderer/hooks/meshcore/meshcoreConnSideEffects.ts`), per-success IPC `mqtt:publishMeshcorePacketLog` debug (`src/main/index.ts`), and `clearDiagnostics` debug (`src/renderer/stores/diagnosticsStore.ts`). Timeouts and real failures are retained.

## 2. False-positive heartbeat error fix

`[renderer] Unhandled rejection: Packet does not exist` was logged as an error on Meshtastic heartbeat even though a per-session capture handler already swallowed it (the same timestamp also logged `[Meshtastic] Ignoring disconnect mid-send rejection`).

Root cause: both `unhandledrejection` listeners are attached to `window`, so at the `at_target` phase they fire in registration order, not capture-first. The app-lifetime renderer logger (`src/renderer/main.tsx`) is registered before the per-session Meshtastic capture handler, so it logged the error before the capture handler could `preventDefault`.

Fix: add a session-swallow ref-count (`src/renderer/lib/meshtastic/meshtasticConfigureRetry.ts`), set it around the capture handler (`src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorConsoleHook.ts`), and make the renderer logger (`src/renderer/lib/rendererUnhandledRejection.ts`) defer silently to the session handler when it is active.

## 3. Auto-recover missing recipient key on PKI DM failures

DMs that failed with `PKI_SEND_FAIL_PUBLIC_KEY` / `PKI_UNKNOWN_PUBKEY` were surfaced as chat failures ("recipient public key is missing from NodeDB") but nothing fetched the key, so a manual retry failed identically.

- `src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.ts`: added `isMeshtasticMissingRecipientKeyError()` and an optional `onMissingRecipientKey(recipientNodeNum)` callback on the apply context; it fires for DM rows (broadcast rows carry no recipient) after the row is marked failed.
- `src/renderer/lib/meshtastic/meshtasticRuntimeWireEffects.ts`: wired the existing rate-limited `maybeRequestNodeInfoForNode` (`NODEINFO_APP`, 120s/node) into both the console-log and queue-rejection apply paths, so the recipient's key is requested and a subsequent retry can succeed.

`MAX_RETRANSMIT` is intentionally unchanged: it already marks the row failed and the outbox UI already offers manual retry.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm exec eslint` clean on all changed files; Prettier applied
- [x] New/updated tests pass:
  - `src/main/meshcore-mqtt-adapter.test.ts` — PING once-per-connection + reconnect reset
  - `src/main/log-service.test.ts` — SDK line-filter predicate (drops TRACE/Ping, keeps INFO/WARN/ERROR and decode-failure TRACE)
  - `src/renderer/lib/rendererUnhandledRejection.test.ts` — session-swallow deferral; unrelated rejections still logged
  - `src/renderer/lib/meshtastic/meshtasticSdkRoutingErrorLog.test.ts` — NODEINFO requested for PKI missing-key DM rows; not for non-key errors, broadcast rows, or unmatched packets
- [x] Regression sweeps green: MeshCore side-effects/stores, Meshtastic lib + runtime (683 tests), App suite
- [ ] Manual: confirm reduced log volume in `~/Library/Application Support/mesh-client/mesh-client.log` during a live session
- [ ] Manual: DM a node whose key is not yet in the NodeDB, confirm a NODEINFO request is sent and a retry then succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repetitive Meshtastic SDK, MQTT heartbeat, and diagnostic log noise.
  * MQTT connection logs now record initial ping activity once per connection.
  * Improved recovery when direct messages are missing recipient keys by requesting updated node information.
  * Suppressed expected transient session errors while maintaining visibility for unrelated failures.
* **Improvements**
  * Improved handling and reporting of routing and connection errors.
  * Removed unnecessary debug messages from MeshCore operations and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->