### PR TITLE
fix(ble): don't throw from long-session health snapshot on Linux

### DIFF
--- a/src/main/noble-ble-manager.test.ts
+++ b/src/main/noble-ble-manager.test.ts
@@ -309,4 +309,41 @@ describe('NobleBleManager long-session maintenance (regression)', () => {
     expect(SOURCE).toContain('sessionAgeSec');
     expect(SOURCE).toContain('getLongSessionHealthSnapshot');
   });
+
+  /**
+   * On Linux, Noble is never initialized (Web Bluetooth is used in the renderer instead),
+   * so `sessions` stays empty for the app's whole lifetime. getLongSessionHealthSnapshot()
+   * used to call the throwing getSession() unconditionally, so once the hourly main-process
+   * health-log timer's 24h uptime gate opened, the very first tick threw an uncaught
+   * "Unknown noble session: meshtastic" in the main process — surfaced to the user as the
+   * "Mesh-Client — Unexpected Error" dialog on Linux after ~1 day of uptime.
+   */
+  it('reports a benign not-initialized snapshot on Linux instead of throwing from getSession()', () => {
+    expect(SOURCE).toMatch(
+      /getLongSessionHealthSnapshot\(\)[\s\S]*?const linuxNotInitialized = this\.isLinuxNotInitialized\(\);/,
+    );
+    // The guard must be checked inside sessionDetail() before the throwing getSession() call.
+    expect(SOURCE).toMatch(
+      /const sessionDetail = \(sessionId: 'meshtastic' \| 'meshcore'\) => \{\s*if \(linuxNotInitialized\) \{[\s\S]*?\};\s*\}\s*const session = this\.getSession\(sessionId\);/,
+    );
+    expect(SOURCE).toContain(
+      'getLongSessionHealthSnapshot: skipping session detail (not initialized on Linux)',
+    );
+  });
+
+  /**
+   * Follow-up cleanup (code review, PR self-review): the `sessions.size === 0` Linux check was
+   * duplicated across getLongSessionHealthSnapshot(), stopAllScanning(), and disconnectAll().
+   * Centralize it so all three call sites can't drift if the detection semantics ever change.
+   */
+  it('centralizes the Linux not-initialized check in a shared helper used by all call sites', () => {
+    expect(SOURCE).toMatch(
+      /private isLinuxNotInitialized\(\): boolean \{\s*return this\.sessions\.size === 0;\s*\}/,
+    );
+    expect(SOURCE).toContain('const linuxNotInitialized = this.isLinuxNotInitialized();');
+    expect(SOURCE).toContain('if (this.isLinuxNotInitialized()) return;');
+    expect(SOURCE).toContain('if (this.isLinuxNotInitialized()) {');
+    // No remaining inline `sessions.size === 0` checks — everything routes through the helper.
+    expect(SOURCE).not.toMatch(/(?<!return )this\.sessions\.size === 0/);
+  });
 });

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -435,6 +435,11 @@ export class NobleBleManager extends EventEmitter {
     return session;
   }
 
+  /** True on Linux, where Noble is never initialized (Web Bluetooth is used in renderer instead). */
+  private isLinuxNotInitialized(): boolean {
+    return this.sessions.size === 0;
+  }
+
   private clearSessionState(session: NobleBleSession): void {
     const peri = session.connectedPeripheral;
     const mtuHandler = session.peripheralMtuHandler;
@@ -694,7 +699,27 @@ export class NobleBleManager extends EventEmitter {
       meshcore: ReturnType<typeof sessionDetail>;
     };
   } {
+    // On Linux, Noble is not initialized (Web Bluetooth is used in renderer instead), so
+    // getSession() below would throw. Report a benign "not initialized" snapshot instead.
+    const linuxNotInitialized = this.isLinuxNotInitialized();
+    if (linuxNotInitialized) {
+      console.debug(
+        '[NobleBleManager] getLongSessionHealthSnapshot: skipping session detail (not initialized on Linux)',
+      );
+    }
     const sessionDetail = (sessionId: 'meshtastic' | 'meshcore') => {
+      if (linuxNotInitialized) {
+        return {
+          connected: false,
+          peripheralId: null,
+          sessionAgeSec: null,
+          postWriteTimer: false,
+          notifyWatchdog: false,
+          gattInflight: false,
+          readPumpActive: false,
+          fromRadioPackets: 0,
+        };
+      }
       const session = this.getSession(sessionId);
       const established = session.sessionEstablishedAtMs;
       return {
@@ -783,7 +808,7 @@ export class NobleBleManager extends EventEmitter {
 
   /** Stop all scanning immediately — used for app quit and force-quit IPC. */
   async stopAllScanning(): Promise<void> {
-    if (this.sessions.size === 0) return;
+    if (this.isLinuxNotInitialized()) return;
     this.scanRequesters.clear();
     await this.doStopScanning();
     bleCoexistenceCoordinator.releaseScan('noble');
@@ -1715,8 +1740,7 @@ export class NobleBleManager extends EventEmitter {
   }
 
   async disconnectAll(): Promise<void> {
-    // On Linux, Noble is not initialized (Web Bluetooth is used in renderer instead)
-    if (this.sessions.size === 0) {
+    if (this.isLinuxNotInitialized()) {
       console.debug('[NobleBleManager] disconnectAll: skipping (not initialized on Linux)');
       return;
     }


### PR DESCRIPTION
## Problem

On Linux, after mesh-client had been running continuously for a bit over 24 hours, users could hit an "Mesh-Client — Unexpected Error" dialog:

```
Unknown noble session: meshtastic
  at Fu.getSession (.../dist-electron/main/index.js:825:57375)
  at Fu.getLongSessionHealthSnapshot (.../dist-electron/main/index.js:825:62421)
  at Timeout._onTimeout (.../dist-electron/main/index.js:988:18724)
```

Diagnosed from a user-supplied support bundle: the crash fired at exactly 24h 9s of main-process uptime, matching the hourly `long-session health` timer in `src/main/index.ts` that only executes its body once `process.uptime()` crosses the 24h threshold.

## Root cause

`NobleBleManager.getLongSessionHealthSnapshot()` called the throwing `getSession()` unconditionally for both the `meshtastic` and `meshcore` sessions. On Linux, Noble is never initialized (Web Bluetooth is used in the renderer instead) — the constructor returns early before populating the `sessions` map, so it stays empty for the app's entire lifetime. The first time the 24h-gated health-log timer actually ran its body, the lookup threw, and since it's an uncaught exception in the main process, the global `uncaughtException` handler surfaced it as a user-facing error dialog (the app itself did not crash/quit — traffic continued normally afterward).

## Fix

Guard the session lookup the same way `disconnectAll()` and `stopAllScanning()` already guard for Linux, returning a benign "not initialized" snapshot instead of throwing. Extracted the shared `sessions.size === 0` check (which was about to be triplicated) into one private `isLinuxNotInitialized()` helper used by all three call sites.

## Testing

- New regression tests in `noble-ble-manager.test.ts` (source-contract style, matching this file's established pattern for testing a class that wraps the native `@stoprocent/noble` module) verifying the guard is present and that no inline `sessions.size === 0` checks remain outside the shared helper.
- `pnpm run typecheck`, `pnpm exec eslint` on changed files, and the full `main` Vitest project (200 files / 2223 tests) all pass.
- Pre-commit hook ran clean (security scanners, i18n, license check, staged-related Vitest — including the adjacent `noble-ble-manager.behavior.test.ts`, 53 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bluetooth behavior on Linux when the Bluetooth subsystem is not initialized.
  - Health checks now report a safe disconnected state instead of failing.
  - Scanning and disconnect actions avoid unavailable cleanup operations in this state.

- **Tests**
  - Added regression coverage for Linux Bluetooth initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->