### PR TITLE
fix: hide leftover auto-reconnect banner on configured radios

### DIFF
--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -13,6 +13,10 @@ import type { SerialPort } from '@/shared/electron-api.types';
 import { hydrateAxeThemeColors } from '../lib/a11yTestHelpers';
 import type { FirmwareCheckResult } from '../lib/firmwareCheck';
 import { MESHCORE_IDENTITY_STORAGE_KEY } from '../lib/letsMeshJwt';
+import {
+  initNobleBleDualRadioStartup,
+  resetNobleBleConnectMutexForTests,
+} from '../lib/meshcoreDualNobleBleInit';
 import type { DeviceState } from '../lib/types';
 import { mockConsoleWarn, withMockedConsoleWarn } from '../lib/vitestConsoleMock';
 import ConnectionPanel from './ConnectionPanel';
@@ -1283,6 +1287,26 @@ describe('ConnectionPanel exit actions', () => {
     expect(screen.getByRole('button', { name: /Disconnect & Quit/i })).toBeInTheDocument();
   });
 
+  it('shows auto-reconnect banner while status is reconnecting', () => {
+    render(
+      <ConnectionPanel
+        state={{
+          ...disconnectedState,
+          status: 'reconnecting',
+          connectionType: 'ble',
+          connectionLoss: true,
+          reconnectAttempt: 2,
+        }}
+        onConnect={vi.fn().mockResolvedValue(undefined)}
+        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+        onDisconnect={vi.fn().mockResolvedValue(undefined)}
+        mqttStatus="disconnected"
+        protocol="meshcore"
+      />,
+    );
+    expect(screen.getByText(/Auto-reconnect in progress/i)).toBeInTheDocument();
+  });
+
   it('shows Disconnect & Quit while RF connect is in progress', async () => {
     const user = userEvent.setup();
     let resolveConnect!: () => void;
@@ -1458,6 +1482,70 @@ describe('ConnectionPanel exit actions', () => {
       });
     } finally {
       localStorage.removeItem(lastConnKey);
+    }
+  });
+});
+
+describe('ConnectionPanel auto-reconnect banner leftover', () => {
+  afterEach(() => {
+    localStorage.removeItem('mesh-client:lastBleDevice:meshtastic');
+    localStorage.removeItem('mesh-client:lastBleDevice:meshcore');
+    localStorage.removeItem('mesh-client:protocol');
+    resetNobleBleConnectMutexForTests();
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('linux');
+  });
+
+  function seedDualRadioPrimaryMeshtastic(): ReturnType<typeof mockMacNoblePlatform> {
+    const platform = mockMacNoblePlatform();
+    localStorage.setItem('mesh-client:lastBleDevice:meshtastic', 'mt-peripheral');
+    localStorage.setItem('mesh-client:lastBleDevice:meshcore', 'mc-peripheral');
+    localStorage.setItem('mesh-client:protocol', 'meshtastic');
+    initNobleBleDualRadioStartup();
+    return platform;
+  }
+
+  it.each(['meshcore', 'meshtastic'] as const)(
+    'does not show leftover auto-reconnect banner on configured %s radio',
+    (protocol) => {
+      const { restore } = seedDualRadioPrimaryMeshtastic();
+      try {
+        render(
+          <ConnectionPanel
+            state={{
+              ...configuredState,
+              connectionType: 'ble',
+            }}
+            onConnect={vi.fn().mockResolvedValue(undefined)}
+            onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+            onDisconnect={vi.fn().mockResolvedValue(undefined)}
+            mqttStatus="connected"
+            protocol={protocol}
+          />,
+        );
+        expect(screen.queryByText(/Auto-reconnect in progress/i)).not.toBeInTheDocument();
+        expect(screen.getByText('Radio Connection')).toBeInTheDocument();
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  it('shows auto-reconnect banner on disconnected secondary while primary auto-connect is in flight', () => {
+    const { restore } = seedDualRadioPrimaryMeshtastic();
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshcore"
+        />,
+      );
+      expect(screen.getAllByText(/Auto-reconnect in progress/i).length).toBeGreaterThan(0);
+    } finally {
+      restore();
     }
   });
 });

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -1726,11 +1726,12 @@ export default function ConnectionPanel({
   const showNobleBleWaitNotice =
     nobleBleMutexWait.waitingOnNobleBlePeer && rfSessionPending && isRendererNobleBlePlatform();
 
+  const radioUp =
+    state.status === 'configured' || state.status === 'connected' || state.status === 'stale';
   const showAutoReconnectBanner =
-    isAutoConnecting ||
     state.status === 'reconnecting' ||
-    connecting ||
-    nobleBleMutexWait.waitingForPrimaryAutoConnect;
+    (!radioUp &&
+      (isAutoConnecting || connecting || nobleBleMutexWait.waitingForPrimaryAutoConnect));
 
   const renderAutoReconnectBanner = (): ReactNode =>
     showAutoReconnectBanner ? (

--- a/src/renderer/hooks/useProtocolRfAutoConnect.test.tsx
+++ b/src/renderer/hooks/useProtocolRfAutoConnect.test.tsx
@@ -265,6 +265,31 @@ describe('useProtocolRfAutoConnect cold-start TCP/HTTP', () => {
     },
   );
 
+  it('settles dual-radio primary gate after TCP auto-connect succeeds', async () => {
+    mocks.loadLastConnection.mockReturnValue({
+      type: 'tcp',
+      httpAddress: '192.168.1.50:4403',
+    });
+    mocks.dualNobleBleBothRadiosConfigured.mockReturnValue(true);
+    mocks.getNobleBleDualRadioPrimaryProtocol.mockReturnValue('meshtastic');
+    const connectAutomatic = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => {
+      useProtocolRfAutoConnect({
+        protocol: 'meshtastic',
+        state: disconnected,
+        connectAutomatic,
+      });
+    });
+
+    await waitFor(() => {
+      expect(connectAutomatic).toHaveBeenCalledWith('tcp', '192.168.1.50:4403');
+    });
+    await waitFor(() => {
+      expect(mocks.notifyNobleBlePrimaryAutoConnectSettled).toHaveBeenCalled();
+    });
+  });
+
   it.each(['linux', 'darwin', 'win32'] as const)(
     'auto-connects meshcore HTTP (TCP/IP) with stored address and skips Reticulum gate (%s)',
     async (platform) => {
@@ -289,6 +314,31 @@ describe('useProtocolRfAutoConnect cold-start TCP/HTTP', () => {
       expect(mocks.awaitReticulumBleCoexistenceClear).not.toHaveBeenCalled();
     },
   );
+
+  it('settles dual-radio primary gate after HTTP auto-connect succeeds', async () => {
+    mocks.loadLastConnection.mockReturnValue({
+      type: 'http',
+      httpAddress: '10.0.0.1:5000',
+    });
+    mocks.dualNobleBleBothRadiosConfigured.mockReturnValue(true);
+    mocks.getNobleBleDualRadioPrimaryProtocol.mockReturnValue('meshcore');
+    const connectAutomatic = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => {
+      useProtocolRfAutoConnect({
+        protocol: 'meshcore',
+        state: disconnected,
+        connectAutomatic,
+      });
+    });
+
+    await waitFor(() => {
+      expect(connectAutomatic).toHaveBeenCalledWith('http', '10.0.0.1:5000');
+    });
+    await waitFor(() => {
+      expect(mocks.notifyNobleBlePrimaryAutoConnectSettled).toHaveBeenCalled();
+    });
+  });
 
   it.each(['linux', 'darwin', 'win32'] as const)(
     'skips TCP auto-connect when httpAddress is blank and settles primary gate if needed (%s)',
@@ -385,6 +435,28 @@ describe('useProtocolRfAutoConnect cold-start serial + BLE', () => {
     expect(mocks.awaitReticulumBleCoexistenceClear).not.toHaveBeenCalled();
   });
 
+  it('settles dual-radio primary gate after serial auto-connect succeeds', async () => {
+    mocks.loadLastConnection.mockReturnValue({ type: 'serial', serialPortId: 'port-1' });
+    mocks.dualNobleBleBothRadiosConfigured.mockReturnValue(true);
+    mocks.getNobleBleDualRadioPrimaryProtocol.mockReturnValue('meshtastic');
+    const connectAutomatic = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => {
+      useProtocolRfAutoConnect({
+        protocol: 'meshtastic',
+        state: disconnected,
+        connectAutomatic,
+      });
+    });
+
+    await waitFor(() => {
+      expect(connectAutomatic).toHaveBeenCalledWith('serial', undefined, 'port-1');
+    });
+    await waitFor(() => {
+      expect(mocks.notifyNobleBlePrimaryAutoConnectSettled).toHaveBeenCalled();
+    });
+  });
+
   it('falls back to Noble BLE when serial auto-connect fails and lastBleDevice exists', async () => {
     mocks.loadLastConnection.mockReturnValue({
       type: 'serial',
@@ -438,6 +510,32 @@ describe('useProtocolRfAutoConnect cold-start serial + BLE', () => {
       });
       expect(mocks.awaitReticulumBleCoexistenceClear).toHaveBeenCalled();
       expect(mocks.awaitNobleBlePrimaryAutoConnectSettled).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['darwin', 'win32'] as const)(
+    'settles dual-radio primary gate after Noble BLE auto-connect succeeds (%s)',
+    async (platform) => {
+      vi.spyOn(window.electronAPI, 'getPlatform').mockReturnValue(platform);
+      mocks.loadLastConnection.mockReturnValue({ type: 'ble', bleDeviceId: 'primary-ble' });
+      mocks.dualNobleBleBothRadiosConfigured.mockReturnValue(true);
+      mocks.getNobleBleDualRadioPrimaryProtocol.mockReturnValue('meshtastic');
+      const connectAutomatic = vi.fn().mockResolvedValue(undefined);
+
+      renderHook(() => {
+        useProtocolRfAutoConnect({
+          protocol: 'meshtastic',
+          state: disconnected,
+          connectAutomatic,
+        });
+      });
+
+      await waitFor(() => {
+        expect(connectAutomatic).toHaveBeenCalledWith('ble', undefined, undefined, 'primary-ble');
+      });
+      await waitFor(() => {
+        expect(mocks.notifyNobleBlePrimaryAutoConnectSettled).toHaveBeenCalled();
+      });
     },
   );
 

--- a/src/renderer/hooks/useProtocolRfAutoConnect.ts
+++ b/src/renderer/hooks/useProtocolRfAutoConnect.ts
@@ -147,6 +147,7 @@ export function useProtocolRfAutoConnect({
       console.warn(
         `[useProtocolRfAutoConnect] ${protocol} ${transport} auto-connect failed: ${errLikeToLogString(error)}`,
       );
+      notifyPrimaryAutoConnectSettledIfNeeded(protocol);
     };
     const isAutoConnectAbortError = (error: unknown): boolean =>
       error instanceof DOMException && error.name === 'AbortError';
@@ -233,17 +234,21 @@ export function useProtocolRfAutoConnect({
           bleDeviceName: lastConnection.bleDeviceName,
         };
         saveLastConnection(protocol, bleLast);
-        runBleAutoConnect(lastBleId).catch((bleError: unknown) => {
-          if (isCancelled() || isAutoConnectAbortError(bleError)) {
-            onAutoConnectCancelled();
-            return;
-          }
-          onAutoConnectFailed(bleError);
-        });
+        runBleAutoConnect(lastBleId)
+          .then(() => {
+            clearAutoConnectTimeout();
+            notifyPrimaryAutoConnectSettledIfNeeded(protocol);
+          })
+          .catch((bleError: unknown) => {
+            if (isCancelled() || isAutoConnectAbortError(bleError)) {
+              onAutoConnectCancelled();
+              return;
+            }
+            onAutoConnectFailed(bleError);
+          });
         return;
       }
       onAutoConnectFailed(error, 'serial');
-      notifyPrimaryAutoConnectSettledIfNeeded(protocol);
     };
 
     const onTcpAutoConnectFailed = (error: unknown) => {
@@ -253,7 +258,6 @@ export function useProtocolRfAutoConnect({
       }
       const transport = lastConnection.type === 'http' ? 'http' : 'tcp';
       onAutoConnectFailed(error, transport);
-      notifyPrimaryAutoConnectSettledIfNeeded(protocol);
     };
 
     const runStartupAutoConnect = async (): Promise<void> => {
@@ -279,18 +283,27 @@ export function useProtocolRfAutoConnect({
         startAutoConnectTimeout();
         connectAutomaticRef
           .current('serial', undefined, lastConnection.serialPortId)
+          .then(() => {
+            clearAutoConnectTimeout();
+            notifyPrimaryAutoConnectSettledIfNeeded(protocol);
+          })
           .catch(onSerialAutoConnectFailed);
         return;
       }
 
       if (lastConnection.type === 'ble' && lastBleId && !isLinux) {
-        runBleAutoConnect(lastBleId).catch((error: unknown) => {
-          if (isCancelled() || isAutoConnectAbortError(error)) {
-            onAutoConnectCancelled();
-            return;
-          }
-          onAutoConnectFailed(error);
-        });
+        runBleAutoConnect(lastBleId)
+          .then(() => {
+            clearAutoConnectTimeout();
+            notifyPrimaryAutoConnectSettledIfNeeded(protocol);
+          })
+          .catch((error: unknown) => {
+            if (isCancelled() || isAutoConnectAbortError(error)) {
+              onAutoConnectCancelled();
+              return;
+            }
+            onAutoConnectFailed(error);
+          });
         return;
       }
 
@@ -298,7 +311,13 @@ export function useProtocolRfAutoConnect({
         const addr = lastConnection.httpAddress?.trim();
         if (addr) {
           startAutoConnectTimeout();
-          connectAutomaticRef.current(lastConnection.type, addr).catch(onTcpAutoConnectFailed);
+          connectAutomaticRef
+            .current(lastConnection.type, addr)
+            .then(() => {
+              clearAutoConnectTimeout();
+              notifyPrimaryAutoConnectSettledIfNeeded(protocol);
+            })
+            .catch(onTcpAutoConnectFailed);
           return;
         }
       }
@@ -312,7 +331,6 @@ export function useProtocolRfAutoConnect({
         return;
       }
       onAutoConnectFailed(error);
-      notifyPrimaryAutoConnectSettledIfNeeded(protocol);
     });
 
     return () => {

--- a/src/renderer/lib/meshcoreDualNobleBleInit.test.ts
+++ b/src/renderer/lib/meshcoreDualNobleBleInit.test.ts
@@ -382,6 +382,33 @@ describe('meshcoreDualNobleBleInit', () => {
     localStorage.removeItem('mesh-client:protocol');
   });
 
+  it('initNobleBleDualRadioStartup marks primaryAutoConnectInFlight in the mutex snapshot', () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
+    localStorage.setItem('mesh-client:lastBleDevice:meshtastic', 'mt-peripheral');
+    localStorage.setItem('mesh-client:lastBleDevice:meshcore', 'mc-peripheral');
+    localStorage.setItem('mesh-client:protocol', 'meshtastic');
+    initNobleBleDualRadioStartup();
+    expect(getNobleBleConnectMutexSnapshot().primaryAutoConnectInFlight).toBe(true);
+    expect(getNobleBleConnectMutexSnapshot().primaryProtocol).toBe('meshtastic');
+    localStorage.removeItem('mesh-client:lastBleDevice:meshtastic');
+    localStorage.removeItem('mesh-client:lastBleDevice:meshcore');
+    localStorage.removeItem('mesh-client:protocol');
+  });
+
+  it('notifyNobleBlePrimaryAutoConnectSettled clears primaryAutoConnectInFlight in the mutex snapshot', () => {
+    vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
+    localStorage.setItem('mesh-client:lastBleDevice:meshtastic', 'mt-peripheral');
+    localStorage.setItem('mesh-client:lastBleDevice:meshcore', 'mc-peripheral');
+    localStorage.setItem('mesh-client:protocol', 'meshtastic');
+    initNobleBleDualRadioStartup();
+    expect(getNobleBleConnectMutexSnapshot().primaryAutoConnectInFlight).toBe(true);
+    notifyNobleBlePrimaryAutoConnectSettled();
+    expect(getNobleBleConnectMutexSnapshot().primaryAutoConnectInFlight).toBe(false);
+    localStorage.removeItem('mesh-client:lastBleDevice:meshtastic');
+    localStorage.removeItem('mesh-client:lastBleDevice:meshcore');
+    localStorage.removeItem('mesh-client:protocol');
+  });
+
   it('awaitNobleBlePrimaryAutoConnectSettled unblocks after primary notifies', async () => {
     vi.mocked(window.electronAPI.getPlatform).mockReturnValue('darwin');
     localStorage.setItem('mesh-client:lastBleDevice:meshtastic', 'mt-peripheral');

--- a/src/renderer/lib/meshcoreDualNobleBleInit.ts
+++ b/src/renderer/lib/meshcoreDualNobleBleInit.ts
@@ -139,7 +139,7 @@ export function initNobleBleDualRadioStartup(): void {
     nobleBlePrimaryAutoConnectSettledPromise = Promise.resolve();
     resolveNobleBlePrimaryAutoConnectSettled = null;
   }
-  notifyNobleBleMutexListeners();
+  refreshNobleBleMutexSnapshot();
 }
 
 /** Primary protocol auto-connect finished (success or failure) — unblocks secondary. */
@@ -148,7 +148,7 @@ export function notifyNobleBlePrimaryAutoConnectSettled(): void {
   nobleBlePrimaryAutoConnectSettled = true;
   resolveNobleBlePrimaryAutoConnectSettled?.();
   resolveNobleBlePrimaryAutoConnectSettled = null;
-  notifyNobleBleMutexListeners();
+  refreshNobleBleMutexSnapshot();
 }
 
 /**
@@ -250,6 +250,15 @@ function buildNobleBleMutexSnapshot(
 function setNobleBleMutexSnapshot(next: NobleBleConnectMutexSnapshot): void {
   nobleBleMutexSnapshot = next;
   notifyNobleBleMutexListeners();
+}
+
+function refreshNobleBleMutexSnapshot(): void {
+  setNobleBleMutexSnapshot(
+    buildNobleBleMutexSnapshot({
+      queued: nobleBleMutexSnapshot.queued,
+      active: nobleBleMutexSnapshot.active,
+    }),
+  );
 }
 
 export function getNobleBleConnectMutexSnapshot(): NobleBleConnectMutexSnapshot {


### PR DESCRIPTION
## Summary
- Hide the Connection panel "Auto-reconnect in progress…" banner once MeshCore or Meshtastic is already `configured` / `connected` / `stale`; keep it for real `reconnecting` and disconnected waits.
- Rebuild the dual-radio Noble BLE mutex snapshot when the primary auto-connect attempt settles so `primaryAutoConnectInFlight` does not stay stuck.
- Settle that primary gate on TCP/HTTP/serial/BLE auto-connect success (not only skip/failure).

## Test plan
- [ ] On a dual-radio Mac/Windows install, start with MeshCore already BLE-connected and confirm the Connection panel does **not** show "Auto-reconnect in progress…" while status is `configured`.
- [ ] Repeat on Meshtastic (secondary radio) after MeshCore was the last tab at startup.
- [ ] Trigger a real BLE drop/reconnect and confirm the banner still appears while status is `reconnecting`, then disappears when configured again.
- [ ] Cold-start dual BLE auto-connect still serializes primary then secondary.