### PR TITLE
fix(logs): drop Meshtastic encrypted-packet ignore DEBUG spam

### DIFF
--- a/src/main/log-service.test.ts
+++ b/src/main/log-service.test.ts
@@ -376,6 +376,20 @@ describe('isDroppableMeshtasticSdkLogLine', () => {
     ).toBe(true);
   });
 
+  it('drops DEBUG [iMeshDevice] encrypted data packet ignores', async () => {
+    const { isDroppableMeshtasticSdkLogLine } = await import('./log-service');
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        '20:20:09:810 DEBUG [iMeshDevice] HandleMeshPacket 🔐 Device received encrypted data packet, ignoring.',
+      ),
+    ).toBe(true);
+    expect(
+      isDroppableMeshtasticSdkLogLine(
+        'DEBUG [iMeshDevice] HandleMeshPacket Device received encrypted data packet, ignoring',
+      ),
+    ).toBe(true);
+  });
+
   it('keeps INFO / WARN / ERROR SDK lines', async () => {
     const { isDroppableMeshtasticSdkLogLine } = await import('./log-service');
     expect(

--- a/src/main/log-service.ts
+++ b/src/main/log-service.ts
@@ -394,11 +394,20 @@ const SDK_FAILURE_CONTEXT_REGEX =
 
 /**
  * True for high-volume `@meshtastic/core` console noise with no triage value:
- * routine `TRACE [iMeshDevice]` chatter and periodic `DEBUG [iMeshDevice] Ping`
- * heartbeats. INFO/WARN/ERROR and decode-failure TRACE lines are kept.
+ * routine `TRACE [iMeshDevice]` chatter, periodic `DEBUG [iMeshDevice] Ping`
+ * heartbeats, and DEBUG encrypted-packet ignores (other channel / PKI we cannot
+ * decrypt; no RSSI/SNR/hex for Foreign LoRa). INFO/WARN/ERROR and decode-failure
+ * TRACE lines are kept.
  */
 export function isDroppableMeshtasticSdkLogLine(message: string): boolean {
   if (/\bDEBUG \[iMeshDevice\] Ping\b/.test(message)) return true;
+  if (
+    /\bDEBUG \[iMeshDevice\]/.test(message) &&
+    /encrypted data packet/i.test(message) &&
+    /ignor/i.test(message)
+  ) {
+    return true;
+  }
   if (/\bTRACE \[iMeshDevice\]/.test(message) && !SDK_FAILURE_CONTEXT_REGEX.test(message)) {
     return true;
   }


### PR DESCRIPTION
## Summary
- Drop high-volume `@meshtastic/core` DEBUG lines for encrypted packets the radio cannot decrypt (other channel / PKI) from the app log file.
- These lines carried no RSSI/SNR/hex for Foreign LoRa and were ~half a busy-mesh session; other DEBUG and all INFO/WARN/ERROR stay.

## Test plan
- [x] `pnpm exec vitest run src/main/log-service.test.ts`
- [ ] On a busy Meshtastic mesh, confirm `mesh-client.log` no longer fills with `encrypted data packet, ignoring`
- [ ] Confirm Foreign LoRa still picks up decode-failure TRACE lines