### PR TITLE
fix(reticulum): rebase Ratspeak overlays onto floated origin/main

### DIFF
--- a/reticulum-sidecar/patches/README.md
+++ b/reticulum-sidecar/patches/README.md
@@ -129,17 +129,16 @@ When [ratspeak/rsReticulum#11](https://github.com/ratspeak/rsReticulum/pull/11) 
 
 Recall cached destination public keys in `LinkClient` before waiting on path-response announces; GC temporary announce handlers without wiping long-lived Nomad directory listeners. Fixes Nomad page loads hanging until overall timeout.
 
+Upstream `a945ba0` landed HasPath-gated `RecallDestination`, but still waits on a fresh announce when the path table is cold and still Deregisters handlers by `aspect_filter`. This overlay uses `RecallDestination` without the HasPath gate, then `await_path`, and GCs closed handlers only.
+
 | Field | Value |
 | ----- | ----- |
-| **Base commit** | `9928abed269a83ec5a7ef165ff1142d938cad706` |
+| **Base commit** | `70b7399` (`ratspeak/rsReticulum` `origin/main`) |
 | **Upstream PR** | https://github.com/ratspeak/rsReticulum/pull/14 |
 
-**Modifies (4 files):**
+**Modifies (1 file):**
 
-- `crates/rns-runtime/src/link_client.rs` — recall + `await_path`; safe announce-handler GC
-- `crates/rns-transport/src/messages.rs` — `RecallDestinationPublicKey`, `PublicKeyResult`
-- `crates/rns-transport/src/actor/rpc.rs` — recall handler
-- `crates/rns-transport/src/actor/mod.rs` — unit tests
+- `crates/rns-runtime/src/link_client.rs` — `discover_remote_public_key` + `await_path`; safe announce-handler GC
 
 ### Apply locally
 
@@ -202,7 +201,7 @@ Debounce BLE RNode reconnect after mid-SMP disconnect (`BLE pairing in progress`
 
 | Field | Value |
 | ----- | ----- |
-| **Base commit** | `9928abed269a83ec5a7ef165ff1142d938cad706` (after prior overlays) |
+| **Base commit** | `70b7399` (`ratspeak/rsReticulum` `origin/main`) |
 | **Upstream PR** | https://github.com/ratspeak/rsReticulum/pull/20 |
 
 **Modifies (1 file):**
@@ -399,7 +398,7 @@ When [ratspeak/rsLXMF#6](https://github.com/ratspeak/rsLXMF/pull/6) merges and f
 
 | Field | Value |
 | ----- | ----- |
-| **Base commit** | tip of `ratspeak/rsLXMF` `main` + `rsLXMF-propagation-node-policy-setters` overlay |
+| **Base commit** | `f9ed81e` (`ratspeak/rsLXMF` `origin/main`) + `rsLXMF-propagation-node-policy-setters` overlay |
 | **Upstream PR** | (none yet — mesh-client local API) |
 
 **Modifies (1 file):**
@@ -461,7 +460,7 @@ Ranked multi-path slots (up to 3 per destination) plus global / per-peer RF-vs-n
 
 | Field | Value |
 | ----- | ----- |
-| **Base commit** | `9928abed269a83ec5a7ef165ff1142d938cad706` (+ prior mesh-client overlays) |
+| **Base commit** | `70b7399` (+ prior mesh-client overlays) |
 | **Upstream PR** | none yet (mesh-client-local) |
 
 **Touches:** `constants.rs`, `path_table.rs`, `messages.rs`, `actor/{inbound,mod,rpc,outbound,persistence}.rs`
@@ -503,7 +502,7 @@ Adds `PropagationClient::abort_transfer` so Cancel / mid-transfer abort leaves t
 
 | Field | Value |
 | ----- | ----- |
-| **Base commit** | floated `origin/main` (regenerate; record short SHA in PR) |
+| **Base commit** | `f9ed81e` (`ratspeak/rsLXMF` `origin/main`) |
 | **Upstream PR** | none yet (mesh-client-local; watch ratspeak/rsLXMF) |
 
 **Touches:** rsLXMF `PropagationClient` (abort in-flight list/get transfer → Idle)

--- a/reticulum-sidecar/patches/rsLXMF-propagation-client-abort-transfer.patch
+++ b/reticulum-sidecar/patches/rsLXMF-propagation-client-abort-transfer.patch
@@ -1,10 +1,11 @@
+diff --git a/crates/lxmf-core/src/propagation_client.rs b/crates/lxmf-core/src/propagation_client.rs
+index a410020..8b8a663 100644
 --- a/crates/lxmf-core/src/propagation_client.rs
 +++ b/crates/lxmf-core/src/propagation_client.rs
-@@ -182,6 +182,24 @@
-         self.status = PropagationTransferStatus::default();
+@@ -202,6 +202,24 @@ impl PropagationClient {
          true
      }
-+
+ 
 +    /// Abort an in-flight or terminal download and return to [`Idle`].
 +    ///
 +    /// Unlike [`Self::acknowledge_transfer`], this also tears down mid-transfer
@@ -22,6 +23,7 @@
 +        self.identified = false;
 +        self.started_at = None;
 +    }
- 
++
      pub fn start_download(&mut self) -> bool {
-         let node_hash = match self.outbound_propagation_node {
+         self.start_download_with_limit(None)
+     }

--- a/reticulum-sidecar/patches/rsLXMF-propagation-node-deferred-messagestore-load.patch
+++ b/reticulum-sidecar/patches/rsLXMF-propagation-node-deferred-messagestore-load.patch
@@ -1,9 +1,12 @@
+diff --git a/crates/lxmf-core/src/propagation_node.rs b/crates/lxmf-core/src/propagation_node.rs
+index 26a6c6f..2cdc924 100644
 --- a/crates/lxmf-core/src/propagation_node.rs
 +++ b/crates/lxmf-core/src/propagation_node.rs
-@@ -333,8 +333,21 @@
+@@ -416,9 +416,22 @@ impl PropagationNode {
+         config: PropagationNodeConfig,
          dest_hash: [u8; 16],
          storage_path: PathBuf,
-     ) -> std::io::Result<Self> {
++    ) -> std::io::Result<Self> {
 +        let mut node = Self::with_storage_unloaded(config, dest_hash, storage_path)?;
 +        node.load_messagestore_from_disk()?;
 +        Ok(node)
@@ -16,17 +19,17 @@
 +        config: PropagationNodeConfig,
 +        dest_hash: [u8; 16],
 +        storage_path: PathBuf,
-+    ) -> std::io::Result<Self> {
+     ) -> std::io::Result<Self> {
          std::fs::create_dir_all(&storage_path)?;
 -        let mut node = Self {
 +        Ok(Self {
              config,
              store: PropagationStore::new(),
              sync_sessions: HashMap::new(),
-@@ -342,9 +355,13 @@
-             storage_path: Some(storage_path),
-             last_offer_times: HashMap::new(),
+@@ -428,9 +441,13 @@ impl PropagationNode {
              offer_generation: 0,
+             pending_write_ids: HashSet::new(),
+             pending_write_bytes: 0,
 -        };
 -        node.load_from_disk()?;
 -        Ok(node)
@@ -39,4 +42,4 @@
 +        self.load_from_disk()
      }
  
-     /// Returns `true` if the message was stored, `false` on duplicate, overflow,
+     fn reserve_store_write(

--- a/reticulum-sidecar/patches/rsReticulum-ble-rnode-bond-desync.patch
+++ b/reticulum-sidecar/patches/rsReticulum-ble-rnode-bond-desync.patch
@@ -1,8 +1,8 @@
 diff --git a/crates/rns-interface/src/ble_rnode.rs b/crates/rns-interface/src/ble_rnode.rs
-index 1111111..2222222 100644
+index 66d5610..dd36309 100644
 --- a/crates/rns-interface/src/ble_rnode.rs
 +++ b/crates/rns-interface/src/ble_rnode.rs
-@@ -190,6 +190,14 @@
+@@ -237,6 +237,14 @@ fn is_pairing_transition_error(error: &InterfaceError) -> bool {
      )
  }
  
@@ -17,7 +17,7 @@ index 1111111..2222222 100644
  /// Android's native bridge can come up immediately after SMP completes, while
  /// rsCardputer's RNode BLE stack is still settling. Probe detect a few times
  /// inside one connection attempt so a single dropped early frame does not cost
-@@ -1319,6 +1327,7 @@
+@@ -1366,6 +1374,7 @@ enum NativeBridgeWrite {
  async fn connect_rnode(
      adapter: &Adapter,
      ble_uri: &str,
@@ -25,7 +25,7 @@ index 1111111..2222222 100644
  ) -> Result<BleRNodeConnection, InterfaceError> {
      ble_diag(format!("[ble] connect_rnode start uri={ble_uri}"));
      let peripheral = resolve_ble_target(adapter, ble_uri).await?;
-@@ -1403,20 +1412,68 @@
+@@ -1450,20 +1459,68 @@ async fn connect_rnode(
      // kills any pending subscribe. iOS/macOS share CoreBluetooth; Windows
      // (WinRT) and Android auto-prompt and retry on encrypted-char reads.
      // Linux used explicit BlueZ pairing before `connect()`, above.
@@ -100,7 +100,7 @@ index 1111111..2222222 100644
  
      // 244 = ATT MTU 247 - 3-byte header. Larger writes silently drop on
      // peripherals with smaller negotiated MTU; 512 (GATT ceiling) isn't
-@@ -1963,6 +2020,9 @@
+@@ -2025,6 +2082,9 @@ pub async fn spawn_ble_rnode_interface_with_driver_and_options(
          let mut tries: usize = 0;
          let mut backoff = RECONNECT_WAIT;
          let mut initial_attempt = true;
@@ -110,7 +110,7 @@ index 1111111..2222222 100644
  
          // Drop guard: every early return must clear the running-flag map
          // entry, or stale entries confuse later spawns reusing the id.
-@@ -2009,9 +2069,25 @@
+@@ -2071,9 +2131,25 @@ pub async fn spawn_ble_rnode_interface_with_driver_and_options(
                  }
              };
  
@@ -138,7 +138,7 @@ index 1111111..2222222 100644
                      let pairing_transition = is_pairing_transition_error(&e);
                      let retry_wait = if pairing_transition {
                          PAIRING_TRANSITION_RETRY_WAIT
-@@ -5432,7 +5508,7 @@
+@@ -5607,7 +5683,7 @@ mod tests {
      #[ignore]
      async fn test_ble_connect_to_rnode() {
          let adapter = get_adapter().await.expect("No BLE adapter");
@@ -147,7 +147,7 @@ index 1111111..2222222 100644
              .await
              .expect("No RNode found. Pair an RNode first.");
          assert!(conn.peripheral.is_connected().await.unwrap_or(false));
-@@ -5466,4 +5542,15 @@
+@@ -5641,4 +5717,15 @@ mod tests {
              "BLE device not found: RNode".into()
          )));
      }

--- a/reticulum-sidecar/patches/rsReticulum-ble-rnode-pairing-transition-debounce.patch
+++ b/reticulum-sidecar/patches/rsReticulum-ble-rnode-pairing-transition-debounce.patch
@@ -1,11 +1,11 @@
 diff --git a/crates/rns-interface/src/ble_rnode.rs b/crates/rns-interface/src/ble_rnode.rs
-index a0cf11a..9bd4780 100644
+index e431f77..66d5610 100644
 --- a/crates/rns-interface/src/ble_rnode.rs
 +++ b/crates/rns-interface/src/ble_rnode.rs
-@@ -53,6 +53,10 @@ pub const NUS_TX_CHAR_UUID: Uuid = Uuid::from_u128(0x6E400003_B5A3_F393_E0A9_E50
- const RECONNECT_WAIT: u64 = 5;
- /// Capped below TCP's 300s — a BLE radio is either in range or not.
- const RECONNECT_WAIT_MAX: u64 = 120;
+@@ -54,6 +54,10 @@ const RECONNECT_WAIT: u64 = 1;
+ /// Fast early recovery, then indefinite low-duty retries. A two-minute cap made
+ /// a reachable radio appear dead long after returning to range.
+ const RECONNECT_WAIT_MAX: u64 = 30;
 +/// After a mid-SMP disconnect (`BLE pairing in progress`), wait before
 +/// reconnecting so the OS passkey dialog is not re-fired every second while
 +/// the user is typing the PIN (desktop BLE pairing UX).
@@ -13,7 +13,7 @@ index a0cf11a..9bd4780 100644
  /// `None` retries forever; teardown goes via `stop_ble_rnode_interface`.
  const MAX_RECONNECT_TRIES: Option<usize> = None;
  const SCAN_TIMEOUT: u64 = 3;
-@@ -2009,7 +2013,11 @@ pub async fn spawn_ble_rnode_interface_with_driver_and_options(
+@@ -2071,7 +2075,11 @@ pub async fn spawn_ble_rnode_interface_with_driver_and_options(
                  Ok(c) => c,
                  Err(e) => {
                      let pairing_transition = is_pairing_transition_error(&e);
@@ -26,7 +26,7 @@ index a0cf11a..9bd4780 100644
                      snapshot_publisher.connection_attempt_failed();
                      tracing::warn!(name = %log_name, error = %e, "BLE RNode connect failed");
                      ble_diag(format!(
-@@ -5447,4 +5455,15 @@ mod tests {
+@@ -5622,4 +5630,15 @@ mod tests {
          tokio::time::sleep(Duration::from_secs(2)).await;
          handle.online.store(false, Ordering::SeqCst);
      }

--- a/reticulum-sidecar/patches/rsReticulum-link-client-nomad.patch
+++ b/reticulum-sidecar/patches/rsReticulum-link-client-nomad.patch
@@ -1,75 +1,93 @@
 diff --git a/crates/rns-runtime/src/link_client.rs b/crates/rns-runtime/src/link_client.rs
-index fcfc3dc..c024504 100644
+index 9874942..631d014 100644
 --- a/crates/rns-runtime/src/link_client.rs
 +++ b/crates/rns-runtime/src/link_client.rs
-@@ -16,8 +16,15 @@ use rns_identity::identity::Identity;
+@@ -16,11 +16,15 @@ use rns_identity::identity::Identity;
  use rns_link::link::{CloseReason, Link};
  use rns_protocol::resource::{InboundTransfer, TransferAction};
  use rns_protocol::resource_adv::ResourceAdvertisement;
 +use rns_transport::await_path::{AwaitPathError, await_path};
  use rns_transport::link_messages::DestinationEvent;
--use rns_transport::messages::{AnnounceHandlerEvent, OutboundRequest, TransportMessage};
-+use rns_transport::messages::{
-+    AnnounceHandlerEvent, OutboundRequest, TransportMessage, TransportQuery, TransportQueryResponse,
-+};
-+use tokio::sync::oneshot;
-+
+ use rns_transport::messages::{
+     AnnounceHandlerEvent, OutboundRequest, TransportMessage, TransportQuery, TransportQueryResponse,
+ };
+ 
 +/// MeshChat `NomadnetDownloader` path_lookup_timeout default (seconds).
 +const PATH_LOOKUP_TIMEOUT: Duration = Duration::from_secs(15);
- 
++
  #[derive(Debug, thiserror::Error)]
  pub enum LinkClientError {
-@@ -70,27 +77,9 @@ impl LinkClient {
+     #[error("transport channel closed or full")]
+@@ -72,36 +76,9 @@ impl LinkClient {
          let dest_hash =
              Destination::hash_from_name_and_identity(app_name, Some(&remote_transport_hash));
  
--        // Register the handler before the path request so the answering
--        // announce (carrying the pubkey) is observed.
--        let (ann_tx, mut ann_rx) = mpsc::channel::<AnnounceHandlerEvent>(64);
--        self.send_msg(TransportMessage::RegisterAnnounceHandler {
--            aspect_filter: Some(app_name.to_string()),
--            receive_path_responses: true,
--            callback_tx: ann_tx,
--        })
--        .await?;
+-        let pubkey =
+-            if let Some(public_key) = self.recall_routable_pubkey(dest_hash, deadline).await? {
+-                public_key
+-            } else {
+-                // Register the handler before the path request so the answering
+-                // announce (carrying the pubkey) is observed.
+-                let (ann_tx, mut ann_rx) = mpsc::channel::<AnnounceHandlerEvent>(64);
+-                self.send_msg(TransportMessage::RegisterAnnounceHandler {
+-                    aspect_filter: Some(app_name.to_string()),
+-                    receive_path_responses: true,
+-                    callback_tx: ann_tx,
+-                })
+-                .await?;
 -
--        self.send_msg(TransportMessage::RequestPath {
--            destination_hash: dest_hash,
--        })
--        .await?;
+-                self.send_msg(TransportMessage::RequestPath {
+-                    destination_hash: dest_hash,
+-                })
+-                .await?;
 -
--        let pubkey = wait_for_pubkey(&mut ann_rx, dest_hash, time_remaining(deadline)?).await?;
--        let _ = self
--            .transport_tx
--            .try_send(TransportMessage::DeregisterAnnounceHandler {
--                aspect_filter: Some(app_name.to_string()),
--            });
+-                let public_key = match time_remaining(deadline) {
+-                    Ok(remaining) => wait_for_pubkey(&mut ann_rx, dest_hash, remaining).await,
+-                    Err(error) => Err(error),
+-                };
+-                let _ = self
+-                    .transport_tx
+-                    .try_send(TransportMessage::DeregisterAnnounceHandler {
+-                        aspect_filter: Some(app_name.to_string()),
+-                    });
+-                public_key?
+-            };
 +        let pubkey = self
 +            .discover_remote_public_key(dest_hash, app_name, deadline)
 +            .await?;
  
          let (mut link, request_data) = Link::new_initiator(dest_hash, hops);
          let link_id = link.link_id;
-@@ -190,6 +179,90 @@ impl LinkClient {
-         response
+@@ -208,34 +185,66 @@ impl LinkClient {
+             .map_err(|_| LinkClientError::TransportUnavailable)
      }
  
+-    async fn recall_routable_pubkey(
 +    /// Resolve remote identity public key + path before link establishment.
 +    ///
 +    /// Prefer recalling a key already cached from a prior announce (Nomad nodes
-+    /// that appear in the directory almost always have one). Fall back to the
-+    /// historical RequestPath + announce wait only when the cache misses.
-+    /// Temporary announce handlers are always GC'd without wiping other
-+    /// `aspect_filter` registrations (e.g. a long-lived Nomad discoverer).
++    /// that appear in the directory almost always have one), even when `HasPath`
++    /// is currently false. Fall back to RequestPath + announce wait only on a
++    /// cache miss. Temporary announce handlers are always GC'd without wiping
++    /// other `aspect_filter` registrations (e.g. a long-lived Nomad discoverer).
 +    async fn discover_remote_public_key(
-+        &self,
+         &self,
+-        destination_hash: [u8; 16],
 +        dest_hash: [u8; 16],
 +        app_name: &str,
-+        deadline: Instant,
+         deadline: Instant,
+-    ) -> Result<Option<[u8; 64]>, LinkClientError> {
+-        let has_path = self
+-            .transport_query(
+-                TransportQuery::HasPath {
+-                    dest: destination_hash,
+-                },
+-                deadline,
+-            )
 +    ) -> Result<[u8; 64], LinkClientError> {
 +        let path_budget = PATH_LOOKUP_TIMEOUT.min(time_remaining(deadline)?);
 +
-+        if let Some(pubkey) = self.recall_destination_public_key(dest_hash).await? {
++        if let Some(pubkey) = self.recall_cached_pubkey(dest_hash, deadline).await? {
 +            self.await_path_or_timeout(dest_hash, path_budget).await?;
 +            return Ok(pubkey);
 +        }
@@ -89,34 +107,44 @@ index fcfc3dc..c024504 100644
 +            self.send_msg(TransportMessage::RequestPath {
 +                destination_hash: dest_hash,
 +            })
-+            .await?;
+             .await?;
+-        if !matches!(has_path, TransportQueryResponse::BoolResult(true)) {
+-            return Ok(None);
 +            wait_for_pubkey(&mut ann_rx, dest_hash, time_remaining(deadline)?).await
-+        }
+         }
 +        .await;
 +
 +        drop(ann_rx);
 +        self.gc_closed_announce_handlers();
 +        discovery
 +    }
-+
-+    async fn recall_destination_public_key(
+ 
++    /// Recall pubkey from `recent_announces` without requiring a live path.
++    async fn recall_cached_pubkey(
 +        &self,
 +        dest_hash: [u8; 16],
++        deadline: Instant,
 +    ) -> Result<Option<[u8; 64]>, LinkClientError> {
-+        let (response_tx, response_rx) = oneshot::channel();
-+        self.send_msg(TransportMessage::Rpc {
-+            query: TransportQuery::RecallDestinationPublicKey { dest: dest_hash },
-+            response_tx,
-+        })
-+        .await?;
-+        match timeout(Duration::from_secs(5), response_rx).await {
-+            Ok(Ok(TransportQueryResponse::PublicKeyResult(pk))) => Ok(pk),
-+            Ok(Ok(_)) => Ok(None),
-+            Ok(Err(_)) => Err(LinkClientError::TransportUnavailable),
-+            Err(_) => Err(LinkClientError::Timeout("pubkey recall")),
-+        }
-+    }
-+
+         match self
+             .transport_query(
+-                TransportQuery::RecallDestination {
+-                    dest: destination_hash,
+-                },
++                TransportQuery::RecallDestination { dest: dest_hash },
+                 deadline,
+             )
+             .await?
+         {
+             TransportQueryResponse::RecalledDestination(Some(destination))
+-                if destination.dest_hash == destination_hash =>
++                if destination.dest_hash == dest_hash =>
+             {
+                 Ok(Some(destination.public_key))
+             }
+@@ -246,6 +255,27 @@ impl LinkClient {
+         }
+     }
+ 
 +    async fn await_path_or_timeout(
 +        &self,
 +        dest_hash: [u8; 16],
@@ -138,40 +166,105 @@ index fcfc3dc..c024504 100644
 +            });
 +    }
 +
-     async fn send_msg(&self, msg: TransportMessage) -> Result<(), LinkClientError> {
-         self.transport_tx
-             .send(msg)
-@@ -697,4 +770,42 @@ mod tests {
-         assert_eq!(header.context, rns_wire::context::PacketContext::LinkClose);
-         assert!(responder.receive_teardown(&request.raw[offset..]));
+     async fn transport_query(
+         &self,
+         query: TransportQuery,
+@@ -737,7 +767,7 @@ mod tests {
      }
+ 
+     #[tokio::test]
+-    async fn validated_cached_identity_and_live_path_skip_network_discovery() {
++    async fn recall_cached_pubkey_hits_announce_cache_without_has_path() {
+         let destination_hash = [0xD4; 16];
+         let remote_identity = Identity::new();
+         let public_key = remote_identity.get_public_key();
+@@ -745,16 +775,48 @@ mod tests {
+         let responder = tokio::spawn(async move {
+             let Some(TransportMessage::Rpc { query, response_tx }) = transport_rx.recv().await
+             else {
+-                panic!("expected path query");
++                panic!("expected destination recall");
+             };
+             assert!(matches!(
+                 query,
+-                TransportQuery::HasPath { dest } if dest == destination_hash
++                TransportQuery::RecallDestination { dest } if dest == destination_hash
+             ));
+             response_tx
+-                .send(TransportQueryResponse::BoolResult(true))
++                .send(TransportQueryResponse::RecalledDestination(Some(
++                    rns_transport::messages::RecalledDestinationRpcEntry {
++                        dest_hash: destination_hash,
++                        public_key,
++                        app_data: None,
++                        ratchet: None,
++                        hops: 1,
++                        timestamp: 1.0,
++                    },
++                )))
+                 .unwrap();
++            assert!(
++                transport_rx.try_recv().is_err(),
++                "cache hit must not emit HasPath or a path request"
++            );
++        });
 +
-+    #[tokio::test]
-+    async fn recall_destination_public_key_reads_rpc_result() {
-+        let dest = [0xAB; 16];
-+        let expected = [0x42u8; 64];
-+        let (transport_tx, mut transport_rx) = mpsc::channel(4);
 +        let client = LinkClient::new(transport_tx, Identity::new());
-+
-+        let recall = tokio::spawn(async move { client.recall_destination_public_key(dest).await });
-+
-+        let msg = transport_rx.recv().await.expect("rpc message");
-+        let TransportMessage::Rpc {
-+            query: TransportQuery::RecallDestinationPublicKey { dest: got_dest },
-+            response_tx,
-+        } = msg
-+        else {
-+            panic!("expected RecallDestinationPublicKey rpc, got {msg:?}");
-+        };
-+        assert_eq!(got_dest, dest);
-+        response_tx
-+            .send(TransportQueryResponse::PublicKeyResult(Some(expected)))
-+            .unwrap();
-+
-+        let recalled = recall.await.unwrap().unwrap();
-+        assert_eq!(recalled, Some(expected));
++        assert_eq!(
++            client
++                .recall_cached_pubkey(destination_hash, Instant::now() + Duration::from_secs(1),)
++                .await
++                .unwrap(),
++            Some(public_key)
++        );
++        responder.await.unwrap();
 +    }
+ 
++    #[tokio::test]
++    async fn discover_remote_public_key_cache_hit_awaits_path_without_announce_wait() {
++        let destination_hash = [0xD4; 16];
++        let remote_identity = Identity::new();
++        let public_key = remote_identity.get_public_key();
++        let (transport_tx, mut transport_rx) = mpsc::channel(8);
++        let responder = tokio::spawn(async move {
+             let Some(TransportMessage::Rpc { query, response_tx }) = transport_rx.recv().await
+             else {
+                 panic!("expected destination recall");
+@@ -775,23 +837,48 @@ mod tests {
+                     },
+                 )))
+                 .unwrap();
 +
++            let Some(TransportMessage::AwaitPath { dest, reply }) = transport_rx.recv().await
++            else {
++                panic!("expected AwaitPath");
++            };
++            assert_eq!(dest, destination_hash);
++            reply.send(true).unwrap();
+             assert!(
+                 transport_rx.try_recv().is_err(),
+-                "cache hit must not emit a path request"
++                "cache hit must not emit a path request or announce handler"
+             );
+         });
+ 
+         let client = LinkClient::new(transport_tx, Identity::new());
+         assert_eq!(
+             client
+-                .recall_routable_pubkey(destination_hash, Instant::now() + Duration::from_secs(1),)
++                .discover_remote_public_key(
++                    destination_hash,
++                    "nomadnetwork.node",
++                    Instant::now() + Duration::from_secs(2),
++                )
+                 .await
+                 .unwrap(),
+-            Some(public_key)
++            public_key
+         );
+         responder.await.unwrap();
+     }
+ 
 +    #[test]
 +    fn gc_closed_announce_handlers_sends_aspect_filter_none() {
 +        let (transport_tx, mut transport_rx) = mpsc::channel(4);
@@ -179,118 +272,13 @@ index fcfc3dc..c024504 100644
 +        client.gc_closed_announce_handlers();
 +        let msg = transport_rx.try_recv().unwrap();
 +        match msg {
-+            TransportMessage::DeregisterAnnounceHandler { aspect_filter: None } => {}
++            TransportMessage::DeregisterAnnounceHandler {
++                aspect_filter: None,
++            } => {}
 +            other => panic!("expected GC deregister, got {other:?}"),
 +        }
 +    }
- }
-diff --git a/crates/rns-transport/src/actor/mod.rs b/crates/rns-transport/src/actor/mod.rs
-index 0b5a20e..13313f1 100644
---- a/crates/rns-transport/src/actor/mod.rs
-+++ b/crates/rns-transport/src/actor/mod.rs
-@@ -10809,6 +10809,60 @@ mod tests {
-         ));
-     }
- 
-+    #[test]
-+    fn recall_destination_public_key_hit_and_miss() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        let identity = rns_identity::identity::Identity::new();
-+        let dest_hash = [0xD1; 16];
-+        insert_announce_for(&mut actor, dest_hash, &identity);
 +
-+        let hit = actor.handle_query(crate::messages::TransportQuery::RecallDestinationPublicKey {
-+            dest: dest_hash,
-+        });
-+        match hit {
-+            crate::messages::TransportQueryResponse::PublicKeyResult(Some(pk)) => {
-+                assert_eq!(pk, identity.get_public_key());
-+            }
-+            other => panic!("expected PublicKeyResult(Some(_)), got {other:?}"),
-+        }
-+
-+        let miss =
-+            actor.handle_query(crate::messages::TransportQuery::RecallDestinationPublicKey {
-+                dest: [0xEE; 16],
-+            });
-+        assert!(matches!(
-+            miss,
-+            crate::messages::TransportQueryResponse::PublicKeyResult(None)
-+        ));
-+    }
-+
-+    #[test]
-+    fn deregister_announce_handler_none_only_sweeps_closed() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        let (live_tx, _live_rx) = tokio::sync::mpsc::channel(4);
-+        let (dead_tx, dead_rx) = tokio::sync::mpsc::channel(4);
-+        drop(dead_rx);
-+
-+        actor.announce_handlers.push(AnnounceHandlerRegistration {
-+            aspect_filter: Some("nomadnetwork.node".into()),
-+            receive_path_responses: false,
-+            tx: live_tx,
-+        });
-+        actor.announce_handlers.push(AnnounceHandlerRegistration {
-+            aspect_filter: Some("nomadnetwork.node".into()),
-+            receive_path_responses: true,
-+            tx: dead_tx,
-+        });
-+
-+        actor.handle_message(TransportMessage::DeregisterAnnounceHandler { aspect_filter: None });
-+        assert_eq!(actor.announce_handlers.len(), 1);
-+        assert_eq!(
-+            actor.announce_handlers[0].aspect_filter.as_deref(),
-+            Some("nomadnetwork.node")
-+        );
-+        assert!(!actor.announce_handlers[0].tx.is_closed());
-+    }
-+
-     #[test]
-     fn filter_blackholed_dests_returns_only_blackholed() {
-         let (mut actor, _tx) = TransportActor::new();
-diff --git a/crates/rns-transport/src/actor/rpc.rs b/crates/rns-transport/src/actor/rpc.rs
-index 07f3b52..8113412 100644
---- a/crates/rns-transport/src/actor/rpc.rs
-+++ b/crates/rns-transport/src/actor/rpc.rs
-@@ -616,6 +616,13 @@ impl TransportActor {
-                 }
-                 TransportQueryResponse::HashResult(None)
-             }
-+            TransportQuery::RecallDestinationPublicKey { dest } => {
-+                let public_key = self
-+                    .recent_announces
-+                    .get(&dest)
-+                    .and_then(|entry| entry.public_key);
-+                TransportQueryResponse::PublicKeyResult(public_key)
-+            }
-             TransportQuery::FilterBlackholedDests { dests } => {
-                 let mut hits = Vec::new();
-                 for dest in &dests {
-diff --git a/crates/rns-transport/src/messages.rs b/crates/rns-transport/src/messages.rs
-index 34b0443..23ae6c8 100644
---- a/crates/rns-transport/src/messages.rs
-+++ b/crates/rns-transport/src/messages.rs
-@@ -768,6 +768,13 @@ pub enum TransportQuery {
-     /// `recent_announces`. Returns `IntResult(count_purged)`. Use sparingly —
-     /// this can drop legit-but-unseen entries.
-     PurgeUnverifiedBlackholes,
-+    /// Recall the 64-byte identity public key for a destination previously
-+    /// learned from a validated announce (`recent_announces`). Used by
-+    /// `LinkClient` so Nomad/page browsers skip a fresh path-response wait when
-+    /// the key is already cached. Response: `PublicKeyResult`.
-+    RecallDestinationPublicKey {
-+        dest: [u8; 16],
-+    },
- }
- 
- #[derive(Debug)]
-@@ -781,6 +788,8 @@ pub enum TransportQueryResponse {
-     FloatResult(Option<f64>),
-     StringResult(Option<String>),
-     HashResult(Option<[u8; 16]>),
-+    /// 64-byte `X25519_pub || Ed25519_pub` for `RecallDestinationPublicKey`.
-+    PublicKeyResult(Option<[u8; 64]>),
-     BoolResult(bool),
-     PathStateResult(crate::constants::PathState),
-     BlackholeList(Vec<BlackholeRpcEntry>),
+     #[tokio::test]
+     async fn send_close_uses_authenticated_teardown_payload() {
+         let dest_hash = [0xCC; 16];

--- a/reticulum-sidecar/patches/rsReticulum-path-medium-slots.patch
+++ b/reticulum-sidecar/patches/rsReticulum-path-medium-slots.patch
@@ -1,6 +1,819 @@
+diff --git a/crates/rns-transport/src/actor/inbound.rs b/crates/rns-transport/src/actor/inbound.rs
+index e63666c..830cfb2 100644
+--- a/crates/rns-transport/src/actor/inbound.rs
++++ b/crates/rns-transport/src/actor/inbound.rs
+@@ -375,24 +375,51 @@ impl TransportActor {
+             .unwrap_or_default();
+         let suppressed =
+             self.is_path_interface_suppressed(header.destination_hash, interface_id, now_f64());
+-        let should_add = if suppressed {
+-            false
+-        } else if let Some(existing) = self.path_table.get(&header.destination_hash) {
+-            let random_seen = existing.has_random_blob(&announce_random_hash);
+-            let path_timebase = path_timebase_from_random_blobs(existing.random_blobs.iter());
+-            if header.hops <= existing.hops {
+-                !random_seen && announce_emitted > path_timebase
+-            } else if existing.is_expired() || announce_emitted > path_timebase {
+-                !random_seen
+-            } else if announce_emitted == path_timebase {
+-                self.path_table.get_state(&header.destination_hash)
+-                    == crate::constants::PathState::Unresponsive
+-            } else {
+-                false
+-            }
+-        } else {
+-            true
++        let candidate = crate::path_table::AnnouncedPath {
++            interface_id,
++            next_hop: header.transport_id,
++            hops: header.hops,
++            medium: crate::path_table::path_medium(iface_mode),
++            random_blob: announce_random_hash,
++            emitted: announce_emitted,
++            suppressed,
+         };
++        let preference = self.effective_path_medium_preference(&header.destination_hash);
++        let rank = self
++            .path_table
++            .rank_announced(&header.destination_hash, &candidate, preference);
++        if rank == crate::path_table::PathRank::Reject {
++            debug!(
++                dest = hex::encode(header.destination_hash),
++                hops = header.hops,
++                announce_emitted,
++                interface_id,
++                suppressed,
++                "ignoring replayed or stale announce"
++            );
++            return;
++        }
++        let should_add = rank == crate::path_table::PathRank::Activate;
++
++        // For Header2 announces via a transport node, next_hop is the relay's
++        // hash from transport_id; for Header1 announces the destination is
++        // directly reachable and next_hop stays None.
++        let mut entry = crate::path_table::PathEntry::new(
++            header.transport_id,
++            header.hops,
++            interface_id,
++            iface_mode,
++        );
++        if !random_blobs.contains(&announce_random_hash) {
++            if random_blobs.len() >= MAX_RANDOM_BLOBS {
++                random_blobs.pop_front();
++            }
++            random_blobs.push_back(announce_random_hash);
++        }
++        entry.random_blobs = random_blobs;
++        // Store the announce packet hash so a later CacheRequest for this
++        // destination can replay the exact announce bytes.
++        entry.packet_hash = Some(rns_wire::hash::packet_hash(raw, header.flags.header_type));
+ 
+         if should_add {
+             // Announce-table update MUST precede path-table update — the dedup
+@@ -434,26 +461,6 @@ impl TransportActor {
+                     .insert(header.destination_hash, announce_entry);
+             }
+ 
+-            // For Header2 announces via a transport node, next_hop is the relay's
+-            // hash from transport_id; for Header1 announces the destination is
+-            // directly reachable and next_hop stays None.
+-            let mut entry = crate::path_table::PathEntry::new(
+-                header.transport_id,
+-                header.hops,
+-                interface_id,
+-                iface_mode,
+-            );
+-            if !random_blobs.contains(&announce_random_hash) {
+-                if random_blobs.len() >= MAX_RANDOM_BLOBS {
+-                    random_blobs.pop_front();
+-                }
+-                random_blobs.push_back(announce_random_hash);
+-            }
+-            entry.random_blobs = random_blobs;
+-            // Store the announce packet hash so a later CacheRequest for this
+-            // destination can replay the exact announce bytes.
+-            let announce_packet_hash = rns_wire::hash::packet_hash(raw, header.flags.header_type);
+-            entry.packet_hash = Some(announce_packet_hash);
+             let tunnel_path = crate::tunnel::TunnelPath {
+                 timestamp: entry.timestamp,
+                 next_hop: entry.next_hop,
+@@ -462,7 +469,12 @@ impl TransportActor {
+                 random_blobs: entry.random_blobs.iter().copied().collect(),
+                 packet_hash: entry.packet_hash,
+             };
+-            self.path_table.insert(header.destination_hash, entry);
++            self.path_table.upsert_ranked(
++                header.destination_hash,
++                entry,
++                crate::path_table::PathRank::Activate,
++                preference,
++            );
+             if let Some(tunnel) = self.tunnel_table.get_mut_by_interface(interface_id) {
+                 tunnel
+                     .tunnel_paths
+@@ -494,13 +506,24 @@ impl TransportActor {
+                 "path learned from announce"
+             );
+         } else {
++            // A route that loses the active slot can still be worth keeping:
++            // parking it in a backup slot lets a later probe or link failure
++            // reroute without a fresh announce. Everything else about the
++            // announce is still ignored — no rebroadcast, no handler dispatch,
++            // no announce-cache refresh — so replays stay inert.
++            let stored_hops = entry.hops;
++            self.path_table.upsert_ranked(
++                header.destination_hash,
++                entry,
++                crate::path_table::PathRank::Backup,
++                preference,
++            );
++            self.state_dirty = true;
+             debug!(
+                 dest = hex::encode(header.destination_hash),
+-                hops = header.hops,
+-                announce_emitted,
++                hops = stored_hops,
+                 interface_id,
+-                suppressed,
+-                "ignoring replayed or stale announce"
++                "alternate path stored in backup slot"
+             );
+             return;
+         }
+diff --git a/crates/rns-transport/src/actor/mod.rs b/crates/rns-transport/src/actor/mod.rs
+index 9670424..34b4128 100644
+--- a/crates/rns-transport/src/actor/mod.rs
++++ b/crates/rns-transport/src/actor/mod.rs
+@@ -19,6 +19,7 @@ use crate::messages::{
+     InterfaceEntry, InterfaceId, InterfaceRole, TransportMessage, msg_variant_name,
+ };
+ use crate::path_table::PathTable;
++pub(crate) use crate::path_table::{announce_timebase, path_timebase_from_random_blobs};
+ use crate::rate_limit::RateTable;
+ use crate::reverse_table::ReverseTable;
+ use crate::traffic::TrafficCounter;
+@@ -99,6 +100,11 @@ pub struct TransportActor {
+     /// Used when a Direct LinkRequest timed out on one route, so the next
+     /// path request can discover alternates instead of instantly reusing it.
+     pub path_interface_suppressions: HashMap<([u8; 16], InterfaceId), f64>,
++    /// Global medium preference for the active path slot.
++    pub path_medium_preference: PathMediumPreference,
++    /// Per-destination medium pins overriding `path_medium_preference`. Only
++    /// pinned destinations appear here; clearing a pin removes the entry.
++    pub peer_medium_pins: HashMap<[u8; 16], PathMedium>,
+     last_discovery_pr_tx: f64,
+     /// External interface waiting for a path response from a local shared client.
+     /// Python calls this `pending_local_path_requests`.
+@@ -334,6 +340,8 @@ impl TransportActor {
+             discovery_pr_tags: HashMap::new(),
+             pending_discovery_prs: VecDeque::new(),
+             path_interface_suppressions: HashMap::new(),
++            path_medium_preference: PathMediumPreference::default(),
++            peer_medium_pins: HashMap::new(),
+             last_discovery_pr_tx: 0.0,
+             pending_local_path_requests: HashMap::new(),
+             path_states: HashMap::new(),
+@@ -1269,15 +1277,92 @@ impl TransportActor {
+         let until = now_f64() + duration;
+         self.path_interface_suppressions
+             .insert((dest, interface_id), until);
++        // Reroute onto the best remaining slot now: rediscovery would otherwise
++        // run with the failed route still installed.
++        let preference = self.effective_path_medium_preference(&dest);
++        let rerouted = self
++            .path_table
++            .suppress_interface(&dest, interface_id, preference);
++        if rerouted {
++            self.state_dirty = true;
++        }
+         debug!(
+             dest = %hex::encode(dest),
+             interface_id,
+             duration,
++            rerouted,
+             "temporarily suppressing path interface"
+         );
+         true
+     }
+ 
++    /// Preference in force for a destination: its pin if any, else the global
++    /// setting.
++    pub(super) fn effective_path_medium_preference(&self, dest: &[u8; 16]) -> PathMediumPreference {
++        crate::path_table::effective_path_medium_preference(
++            self.path_medium_preference,
++            self.peer_medium_pins.get(dest).copied(),
++        )
++    }
++
++    /// Set the global medium preference and re-rank every known destination so
++    /// the change applies without waiting for fresh announces. Returns the
++    /// number of destinations whose active route moved.
++    pub(super) fn set_path_medium_preference(&mut self, preference: PathMediumPreference) -> usize {
++        self.path_medium_preference = preference;
++        self.path_table.set_preference(preference);
++        let moved = self.rerank_all_paths();
++        debug!(
++            preference = ?preference,
++            moved, "path medium preference updated"
++        );
++        moved
++    }
++
++    /// Pin or unpin a destination to a medium. Returns `true` when the pin
++    /// changed the destination's active route.
++    pub(super) fn set_peer_medium_pin(&mut self, dest: [u8; 16], pin: Option<PathMedium>) -> bool {
++        match pin {
++            Some(medium) => {
++                self.peer_medium_pins.insert(dest, medium);
++            }
++            None => {
++                self.peer_medium_pins.remove(&dest);
++            }
++        }
++        let preference = self.effective_path_medium_preference(&dest);
++        let moved = self.path_table.rerank(&dest, preference);
++        if moved {
++            self.state_dirty = true;
++        }
++        debug!(
++            dest = %hex::encode(dest),
++            pin = ?pin,
++            moved,
++            "peer medium pin updated"
++        );
++        moved
++    }
++
++    fn rerank_all_paths(&mut self) -> usize {
++        let dests: Vec<[u8; 16]> = self
++            .path_table
++            .iter()
++            .map(|(hash, _)| hash.into_bytes())
++            .collect();
++        let mut moved = 0usize;
++        for dest in dests {
++            let preference = self.effective_path_medium_preference(&dest);
++            if self.path_table.rerank(&dest, preference) {
++                moved += 1;
++            }
++        }
++        if moved > 0 {
++            self.state_dirty = true;
++        }
++        moved
++    }
++
+     fn is_path_interface_suppressed(
+         &mut self,
+         dest: [u8; 16],
+@@ -1731,16 +1816,6 @@ fn interface_marked_offline(entry: &InterfaceEntry) -> bool {
+         .unwrap_or(false)
+ }
+ 
+-fn announce_timebase(random_blob: &[u8; 10]) -> u64 {
+-    let mut emitted = [0u8; 8];
+-    emitted[3..].copy_from_slice(&random_blob[5..10]);
+-    u64::from_be_bytes(emitted)
+-}
+-
+-fn path_timebase_from_random_blobs<'a>(random_blobs: impl Iterator<Item = &'a [u8; 10]>) -> u64 {
+-    random_blobs.map(announce_timebase).max().unwrap_or(0)
+-}
+-
+ /// Random jitter in `[0, PATHFINDER_RW)` for announce rebroadcast timing.
+ /// The jitter avoids synchronized retransmits when many nodes learn the
+ /// same announce in the same tick.
+@@ -2043,6 +2118,14 @@ mod tests {
+         (entry, rx)
+     }
+ 
++    /// Radio interfaces run in access-point mode, so paths learned here rank as
++    /// [`PathMedium::Rf`].
++    fn make_rf_test_interface(name: &str) -> (InterfaceEntry, mpsc::Receiver<Bytes>) {
++        let (mut entry, rx) = make_test_interface(name);
++        entry.mode = InterfaceMode::AccessPoint;
++        (entry, rx)
++    }
++
+     #[test]
+     fn test_actor_creation() {
+         let (actor, _tx) = TransportActor::new();
+@@ -4383,6 +4466,9 @@ mod tests {
+         assert!(actor.state_dirty);
+     }
+ 
++    /// A replay of the same announce on another interface that is *no closer*
++    /// to the source keeps its hands off the active route — it only earns a
++    /// backup slot, and none of the announce-driven side effects fire.
+     #[test]
+     fn test_replayed_announce_random_blob_does_not_replace_path() {
+         let (mut actor, _tx) = TransportActor::new();
+@@ -4395,9 +4481,9 @@ mod tests {
+         let identity = rns_identity::identity::Identity::new();
+         let blob = random_blob(0xA1, 100);
+         let (raw_first, dest_hash) =
+-            make_announce_for_with_random_blob(&identity, "test.replay.same", 3, blob);
+-        let (raw_replay, _) =
+             make_announce_for_with_random_blob(&identity, "test.replay.same", 1, blob);
++        let (raw_replay, _) =
++            make_announce_for_with_random_blob(&identity, "test.replay.same", 3, blob);
+         let (htx, mut hrx) = mpsc::channel(8);
+         actor.announce_handlers.push(AnnounceHandlerRegistration {
+             id: crate::messages::AnnounceHandlerId(0),
+@@ -4415,7 +4501,7 @@ mod tests {
+             q: None,
+         });
+         let first_event = hrx.try_recv().expect("fresh announce should dispatch");
+-        assert_eq!(first_event.hops, 4);
++        assert_eq!(first_event.hops, 2);
+ 
+         actor.on_inbound(InboundPacket {
+             raw: raw_replay,
+@@ -4426,13 +4512,19 @@ mod tests {
+         });
+ 
+         let path = actor.path_table.get(&dest_hash).unwrap();
+-        assert_eq!(path.hops, 4);
++        assert_eq!(path.hops, 2);
+         assert_eq!(path.interface_id, 1);
+         assert_eq!(path.random_blobs.len(), 1);
+         assert!(path.has_random_blob(&blob));
++        assert_eq!(
++            actor.path_table.backups(&dest_hash).len(),
++            1,
++            "the longer route is still worth keeping as an alternate"
++        );
++        assert_eq!(actor.path_table.backups(&dest_hash)[0].interface_id, 2);
+         assert_eq!(
+             actor.recent_announces.get(&dest_hash).unwrap().hops,
+-            4,
++            2,
+             "replayed announces must not refresh recent announce state"
+         );
+         assert!(
+@@ -4450,6 +4542,334 @@ mod tests {
+         );
+     }
+ 
++    /// Same announce, fewer hops, second interface: the shorter route wins even
++    /// though the random blob was already seen. This is the multi-TCP / RF+TCP
++    /// case that the pre-multipath replay guard used to block.
++    #[test]
++    fn replayed_announce_with_fewer_hops_takes_over_and_demotes_the_old_route() {
++        let (mut actor, _tx) = TransportActor::new();
++        actor.is_transport_enabled = true;
++        let (entry1, _rx1) = make_test_interface("iface1");
++        let (entry2, _rx2) = make_test_interface("iface2");
++        actor.interfaces.insert(1, entry1);
++        actor.interfaces.insert(2, entry2);
++
++        let identity = rns_identity::identity::Identity::new();
++        let blob = random_blob(0xA5, 100);
++        let (raw_far, dest_hash) =
++            make_announce_for_with_random_blob(&identity, "test.replay.closer", 3, blob);
++        let (raw_close, _) =
++            make_announce_for_with_random_blob(&identity, "test.replay.closer", 1, blob);
++
++        actor.on_inbound(InboundPacket {
++            raw: raw_far,
++            interface_id: 1,
++            rssi: None,
++            snr: None,
++            q: None,
++        });
++        actor.on_inbound(InboundPacket {
++            raw: raw_close,
++            interface_id: 2,
++            rssi: None,
++            snr: None,
++            q: None,
++        });
++
++        let path = actor.path_table.get(&dest_hash).unwrap();
++        assert_eq!(path.hops, 2);
++        assert_eq!(path.interface_id, 2);
++        let backups = actor.path_table.backups(&dest_hash);
++        assert_eq!(backups.len(), 1);
++        assert_eq!(backups[0].interface_id, 1);
++        assert_eq!(backups[0].hops, 4);
++    }
++
++    /// A failed probe or link attempt reroutes onto the backup immediately —
++    /// no path request, no fresh announce.
++    #[test]
++    fn suppressing_the_current_path_interface_promotes_the_backup_route() {
++        let (mut actor, _tx) = TransportActor::new();
++        actor.is_transport_enabled = true;
++        let (entry1, _rx1) = make_test_interface("iface1");
++        let (entry2, _rx2) = make_test_interface("iface2");
++        actor.interfaces.insert(1, entry1);
++        actor.interfaces.insert(2, entry2);
++
++        let identity = rns_identity::identity::Identity::new();
++        let blob = random_blob(0xA6, 100);
++        let (raw_close, dest_hash) =
++            make_announce_for_with_random_blob(&identity, "test.multipath.failover", 1, blob);
++        let (raw_far, _) =
++            make_announce_for_with_random_blob(&identity, "test.multipath.failover", 4, blob);
++        for (raw, interface_id) in [(raw_close, 1u64), (raw_far, 2)] {
++            actor.on_inbound(InboundPacket {
++                raw,
++                interface_id,
++                rssi: None,
++                snr: None,
++                q: None,
++            });
++        }
++        assert_eq!(actor.path_table.get(&dest_hash).unwrap().interface_id, 1);
++        assert_eq!(actor.path_table.backups(&dest_hash).len(), 1);
++
++        match actor.handle_query(TransportQuery::SuppressCurrentPathInterface {
++            dest: dest_hash,
++            duration: 30.0,
++        }) {
++            TransportQueryResponse::BoolResult(true) => {}
++            other => panic!("expected current path-interface suppression, got {other:?}"),
++        }
++
++        let path = actor
++            .path_table
++            .get(&dest_hash)
++            .expect("the backup route should now carry the destination");
++        assert_eq!(path.interface_id, 2);
++        assert_eq!(path.hops, 5);
++        assert!(actor.path_table.backups(&dest_hash).is_empty());
++    }
++
++    #[test]
++    fn network_preference_keeps_an_rf_shortcut_out_of_the_active_slot() {
++        let (mut actor, _tx) = TransportActor::new();
++        actor.is_transport_enabled = true;
++        let (tcp, _tcp_rx) = make_test_interface("tcp");
++        let (rf, _rf_rx) = make_rf_test_interface("rnode");
++        actor.interfaces.insert(1, tcp);
++        actor.interfaces.insert(2, rf);
++        assert_eq!(
++            actor.set_path_medium_preference(PathMediumPreference::Network),
++            0
++        );
++
++        let identity = rns_identity::identity::Identity::new();
++        let blob = random_blob(0xA7, 100);
++        let (raw_tcp, dest_hash) =
++            make_announce_for_with_random_blob(&identity, "test.multipath.netpref", 4, blob);
++        let (raw_rf, _) =
++            make_announce_for_with_random_blob(&identity, "test.multipath.netpref", 0, blob);
++        for (raw, interface_id) in [(raw_tcp, 1u64), (raw_rf, 2)] {
++            actor.on_inbound(InboundPacket {
++                raw,
++                interface_id,
++                rssi: None,
++                snr: None,
++                q: None,
++            });
++        }
++
++        let path = actor.path_table.get(&dest_hash).unwrap();
++        assert_eq!(path.medium, PathMedium::Network);
++        assert_eq!(path.interface_id, 1);
++        let backups = actor.path_table.backups(&dest_hash);
++        assert_eq!(backups.len(), 1);
++        assert_eq!(backups[0].medium, PathMedium::Rf);
++        assert_eq!(backups[0].hops, 1);
++    }
++
++    /// A per-destination RF pin beats the global `Lowest` default, survives an
++    /// RF failure, and reclaims the route once RF is heard again.
++    #[test]
++    fn rf_pin_overrides_global_preference_and_survives_failover() {
++        let (mut actor, _tx) = TransportActor::new();
++        actor.is_transport_enabled = true;
++        let (tcp, _tcp_rx) = make_test_interface("tcp");
++        let (rf, _rf_rx) = make_rf_test_interface("rnode");
++        actor.interfaces.insert(1, tcp);
++        actor.interfaces.insert(2, rf);
++
++        let identity = rns_identity::identity::Identity::new();
++        let (raw_tcp, dest_hash) = make_announce_for_with_random_blob(
++            &identity,
++            "test.multipath.pin",
++            0,
++            random_blob(0xA8, 100),
++        );
++        let (raw_rf, _) = make_announce_for_with_random_blob(
++            &identity,
++            "test.multipath.pin",
++            5,
++            random_blob(0xA9, 101),
++        );
++        assert!(!actor.set_peer_medium_pin(dest_hash, Some(PathMedium::Rf)));
++        for (raw, interface_id) in [(raw_tcp, 1u64), (raw_rf, 2)] {
++            actor.on_inbound(InboundPacket {
++                raw,
++                interface_id,
++                rssi: None,
++                snr: None,
++                q: None,
++            });
++        }
++
++        // The 6-hop RF route wins over a 1-hop network route because of the pin.
++        assert_eq!(
++            actor.path_table.get(&dest_hash).unwrap().medium,
++            PathMedium::Rf
++        );
++
++        match actor.handle_query(TransportQuery::SuppressCurrentPathInterface {
++            dest: dest_hash,
++            duration: 30.0,
++        }) {
++            TransportQueryResponse::BoolResult(true) => {}
++            other => panic!("expected suppression, got {other:?}"),
++        }
++        assert_eq!(
++            actor.path_table.get(&dest_hash).unwrap().medium,
++            PathMedium::Network,
++            "with no live RF slot the network route must carry traffic"
++        );
++        assert_eq!(
++            actor.peer_medium_pins.get(&dest_hash).copied(),
++            Some(PathMedium::Rf),
++            "failover must not clear the pin"
++        );
++
++        // Once suppression lapses, a fresh RF announce reclaims the route.
++        actor.path_interface_suppressions.clear();
++        let (raw_rf_again, _) = make_announce_for_with_random_blob(
++            &identity,
++            "test.multipath.pin",
++            5,
++            random_blob(0xAA, 102),
++        );
++        actor.on_inbound(InboundPacket {
++            raw: raw_rf_again,
++            interface_id: 2,
++            rssi: None,
++            snr: None,
++            q: None,
++        });
++        assert_eq!(
++            actor.path_table.get(&dest_hash).unwrap().medium,
++            PathMedium::Rf
++        );
++    }
++
++    #[test]
++    fn changing_the_global_preference_reranks_known_destinations() {
++        let (mut actor, _tx) = TransportActor::new();
++        actor.is_transport_enabled = true;
++        let (tcp, _tcp_rx) = make_test_interface("tcp");
++        let (rf, _rf_rx) = make_rf_test_interface("rnode");
++        actor.interfaces.insert(1, tcp);
++        actor.interfaces.insert(2, rf);
++
++        let identity = rns_identity::identity::Identity::new();
++        let blob = random_blob(0xAB, 100);
++        let (raw_rf, dest_hash) =
++            make_announce_for_with_random_blob(&identity, "test.multipath.rerank", 0, blob);
++        let (raw_tcp, _) =
++            make_announce_for_with_random_blob(&identity, "test.multipath.rerank", 4, blob);
++        for (raw, interface_id) in [(raw_rf, 2u64), (raw_tcp, 1)] {
++            actor.on_inbound(InboundPacket {
++                raw,
++                interface_id,
++                rssi: None,
++                snr: None,
++                q: None,
++            });
++        }
++        assert_eq!(
++            actor.path_table.get(&dest_hash).unwrap().medium,
++            PathMedium::Rf,
++            "Lowest preference should pick the 1-hop RF route"
++        );
++
++        assert_eq!(
++            actor.set_path_medium_preference(PathMediumPreference::Network),
++            1
++        );
++        assert_eq!(
++            actor.path_table.get(&dest_hash).unwrap().medium,
++            PathMedium::Network
++        );
++        assert_eq!(
++            actor.path_table.backups(&dest_hash)[0].medium,
++            PathMedium::Rf
++        );
++    }
++
++    #[test]
++    fn get_path_slots_reports_ranked_slots_and_the_pin() {
++        let (mut actor, _tx) = TransportActor::new();
++        actor.is_transport_enabled = true;
++        let (tcp, _tcp_rx) = make_test_interface("tcp");
++        let (rf, _rf_rx) = make_rf_test_interface("rnode");
++        actor.interfaces.insert(1, tcp);
++        actor.interfaces.insert(2, rf);
++
++        let identity = rns_identity::identity::Identity::new();
++        let blob = random_blob(0xAC, 100);
++        let (raw_tcp, dest_hash) =
++            make_announce_for_with_random_blob(&identity, "test.multipath.slots", 1, blob);
++        let (raw_rf, _) =
++            make_announce_for_with_random_blob(&identity, "test.multipath.slots", 4, blob);
++        for (raw, interface_id) in [(raw_tcp, 1u64), (raw_rf, 2)] {
++            actor.on_inbound(InboundPacket {
++                raw,
++                interface_id,
++                rssi: None,
++                snr: None,
++                q: None,
++            });
++        }
++        assert!(actor.set_peer_medium_pin(dest_hash, Some(PathMedium::Rf)));
++
++        match actor.handle_query(TransportQuery::GetPathSlots { dest: dest_hash }) {
++            TransportQueryResponse::PathSlots(entry) => {
++                assert_eq!(entry.dest, dest_hash);
++                assert_eq!(entry.pin, Some(PathMedium::Rf));
++                assert_eq!(entry.preference, PathMediumPreference::Rf);
++                assert_eq!(entry.slots.len(), 2);
++                assert!(entry.slots[0].active);
++                assert_eq!(entry.slots[0].medium, PathMedium::Rf);
++                assert_eq!(entry.slots[0].interface, "rnode");
++                assert!(!entry.slots[0].expired);
++                assert!(!entry.slots[1].active);
++                assert_eq!(entry.slots[1].medium, PathMedium::Network);
++                assert_eq!(entry.slots[1].interface, "tcp");
++            }
++            other => panic!("expected PathSlots, got {other:?}"),
++        }
++
++        match actor.handle_query(TransportQuery::GetPathSlots { dest: [0xFE; 16] }) {
++            TransportQueryResponse::PathSlots(entry) => {
++                assert!(entry.slots.is_empty());
++                assert_eq!(entry.pin, None);
++                assert_eq!(entry.preference, PathMediumPreference::Lowest);
++            }
++            other => panic!("expected PathSlots, got {other:?}"),
++        }
++    }
++
++    #[test]
++    fn clearing_a_peer_medium_pin_restores_the_global_preference() {
++        let (mut actor, _tx) = TransportActor::new();
++        let dest = [0xCD; 16];
++        actor.set_peer_medium_pin(dest, Some(PathMedium::Network));
++        assert_eq!(
++            actor.effective_path_medium_preference(&dest),
++            PathMediumPreference::Network
++        );
++
++        actor.set_peer_medium_pin(dest, None);
++        assert!(actor.peer_medium_pins.is_empty());
++        assert_eq!(
++            actor.effective_path_medium_preference(&dest),
++            PathMediumPreference::Lowest
++        );
++
++        actor.set_path_medium_preference(PathMediumPreference::Rf);
++        assert_eq!(
++            actor.effective_path_medium_preference(&dest),
++            PathMediumPreference::Rf
++        );
++    }
++
+     #[test]
+     fn test_newer_equal_or_higher_hop_announce_replaces_path() {
+         let (mut actor, _tx) = TransportActor::new();
+@@ -7377,6 +7797,7 @@ mod tests {
+                 expires: now - 1.0,
+                 random_blobs: Default::default(),
+                 interface_id: 7,
++                medium: crate::path_table::PathMedium::Network,
+                 packet_hash: None,
+             },
+         );
+diff --git a/crates/rns-transport/src/actor/outbound.rs b/crates/rns-transport/src/actor/outbound.rs
+index 4fd8692..82470e8 100644
+--- a/crates/rns-transport/src/actor/outbound.rs
++++ b/crates/rns-transport/src/actor/outbound.rs
+@@ -925,6 +925,12 @@ impl TransportActor {
+                     expires: tunnel_path.expires,
+                     random_blobs: tunnel_path.random_blobs.iter().copied().collect(),
+                     interface_id,
++                    medium: crate::path_table::path_medium(
++                        self.interfaces
++                            .get(&interface_id)
++                            .map(|entry| entry.mode)
++                            .unwrap_or(crate::constants::InterfaceMode::Full),
++                    ),
+                     packet_hash: tunnel_path.packet_hash,
+                 };
+                 self.path_table.insert(*dest_hash, entry);
+diff --git a/crates/rns-transport/src/actor/persistence.rs b/crates/rns-transport/src/actor/persistence.rs
+index cfeb09d..ee7b3c2 100644
+--- a/crates/rns-transport/src/actor/persistence.rs
++++ b/crates/rns-transport/src/actor/persistence.rs
+@@ -1061,6 +1061,14 @@ impl TransportActor {
+     /// just-registered interface. Bound to `RegisterInterface` so each entry
+     /// rebinds to whatever `interface_id` the runtime allocated this boot.
+     pub(super) fn drain_pending_for_interface(&mut self, id: InterfaceId, name: &str) {
++        // Restored entries have no persisted medium — recover it from the
++        // interface that is registering now.
++        let medium = crate::path_table::path_medium(
++            self.interfaces
++                .get(&id)
++                .map(|entry| entry.mode)
++                .unwrap_or(crate::constants::InterfaceMode::Full),
++        );
+         if !self.pending_path_entries.is_empty() {
+             let mut promoted = 0usize;
+             self.pending_path_entries.retain(|pe| {
+@@ -1104,6 +1112,7 @@ impl TransportActor {
+                         })
+                         .collect(),
+                     interface_id: id,
++                    medium,
+                     packet_hash: pe.packet_hash.as_ref().and_then(|h| {
+                         if h.len() == 32 {
+                             let mut arr = [0u8; 32];
+@@ -1316,6 +1325,7 @@ mod announce_sweep_actor_tests {
+                 expires: crate::now_f64() + 600.0,
+                 random_blobs: std::collections::VecDeque::new(),
+                 interface_id: 7,
++                medium: crate::path_table::PathMedium::Network,
+                 packet_hash: Some(path_hash),
+             },
+         );
+@@ -1471,6 +1481,7 @@ mod async_save_tests {
+                 expires: crate::now_f64() + 600.0,
+                 random_blobs: std::collections::VecDeque::new(),
+                 interface_id: 7,
++                medium: crate::path_table::PathMedium::Network,
+                 packet_hash: Some([0x33; 32]),
+             },
+         );
+@@ -1587,6 +1598,7 @@ mod async_save_tests {
+                     expires: crate::now_f64() + 600.0,
+                     random_blobs: std::collections::VecDeque::new(),
+                     interface_id: 7,
++                    medium: crate::path_table::PathMedium::Network,
+                     packet_hash: Some([0x66; 32]),
+                 },
+             );
+diff --git a/crates/rns-transport/src/actor/rpc.rs b/crates/rns-transport/src/actor/rpc.rs
+index 07f3b52..2ec775d 100644
+--- a/crates/rns-transport/src/actor/rpc.rs
++++ b/crates/rns-transport/src/actor/rpc.rs
+@@ -262,6 +262,41 @@ impl TransportActor {
+                     self.suppress_path_interface(dest, interface_id, duration)
+                 }))
+             }
++            TransportQuery::SetPathMediumPreference { preference } => {
++                TransportQueryResponse::IntResult(self.set_path_medium_preference(preference) as i64)
++            }
++            TransportQuery::SetPeerMediumPin { dest, pin } => {
++                TransportQueryResponse::BoolResult(self.set_peer_medium_pin(dest, pin))
++            }
++            TransportQuery::GetPathSlots { dest } => {
++                let slots: Vec<PathSlotRpcEntry> = self
++                    .path_table
++                    .slots(&dest)
++                    .into_iter()
++                    .enumerate()
++                    .map(|(index, entry)| PathSlotRpcEntry {
++                        active: index == 0,
++                        hops: entry.hops,
++                        via: entry.next_hop,
++                        interface_id: entry.interface_id,
++                        interface: self
++                            .interfaces
++                            .get(&entry.interface_id)
++                            .map(|e| e.name.clone())
++                            .unwrap_or_else(|| format!("interface_{}", entry.interface_id)),
++                        medium: entry.medium,
++                        timestamp: entry.timestamp,
++                        expires: entry.expires,
++                        expired: entry.is_expired(),
++                    })
++                    .collect();
++                TransportQueryResponse::PathSlots(PathSlotsRpcEntry {
++                    dest,
++                    preference: self.effective_path_medium_preference(&dest),
++                    pin: self.peer_medium_pins.get(&dest).copied(),
++                    slots,
++                })
++            }
+             TransportQuery::DropAnnounceQueues => {
+                 for entry in self.interfaces.values_mut() {
+                     entry.announce_queue.clear();
+diff --git a/crates/rns-transport/src/constants.rs b/crates/rns-transport/src/constants.rs
+index 879a965..350ee3e 100644
 --- a/crates/rns-transport/src/constants.rs
 +++ b/crates/rns-transport/src/constants.rs
-@@ -47,6 +47,12 @@
+@@ -47,6 +47,12 @@ pub const MAX_RANDOM_BLOBS: usize = 64;
  /// Max local rebroadcasts before stopping.
  pub const LOCAL_REBROADCASTS_MAX: u32 = 2;
  
@@ -13,12 +826,10 @@
  /// Path request timeout (seconds).
  pub const PATH_REQUEST_TIMEOUT: f64 = 15.0;
  
-@@ -272,8 +278,74 @@
-     Unknown = 0x00,
-     Unresponsive = 0x01,
+@@ -274,6 +280,72 @@ pub enum PathState {
      Responsive = 0x02,
-+}
-+
+ }
+ 
 +/// Transport medium a path was learned over.
 +///
 +/// Coarser than [`InterfaceMode`] on purpose: routing preference is only ever
@@ -48,8 +859,8 @@
 +            _ => None,
 +        }
 +    }
- }
- 
++}
++
 +/// Which medium should own the active path slot when both are reachable.
 +///
 +/// `Lowest` applies no medium bias and ranks purely by hop count. The other
@@ -88,9 +899,80 @@
  /// Configured operating mode for an interface.
  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
  pub enum InterfaceMode {
+diff --git a/crates/rns-transport/src/messages.rs b/crates/rns-transport/src/messages.rs
+index 1229814..486ee33 100644
+--- a/crates/rns-transport/src/messages.rs
++++ b/crates/rns-transport/src/messages.rs
+@@ -668,6 +668,23 @@ pub enum TransportQuery {
+         dest: [u8; 16],
+         duration: f64,
+     },
++    /// Set the global medium preference for the active path slot and re-rank
++    /// known destinations. Response: `IntResult(destinations_rerouted)`.
++    SetPathMediumPreference {
++        preference: crate::constants::PathMediumPreference,
++    },
++    /// Pin `dest` to a medium (or clear the pin with `None`), overriding the
++    /// global preference for that destination.
++    /// Response: `BoolResult(active_route_moved)`.
++    SetPeerMediumPin {
++        dest: [u8; 16],
++        pin: Option<crate::constants::PathMedium>,
++    },
++    /// Ranked path slots for `dest` — the active route plus up to
++    /// `MAX_PATH_SLOTS - 1` alternates. Response: `PathSlots`.
++    GetPathSlots {
++        dest: [u8; 16],
++    },
+     DropAnnounceQueues,
+     GetBlackholedIdentities,
+     BlackholeIdentity {
+@@ -776,6 +793,7 @@ pub enum TransportQuery {
+ #[derive(Debug)]
+ pub enum TransportQueryResponse {
+     PathTable(Vec<PathTableRpcEntry>),
++    PathSlots(PathSlotsRpcEntry),
+     InterfaceStats(Vec<InterfaceStatRpcEntry>),
+     RateTable(Vec<RateTableRpcEntry>),
+     Announces(Vec<AnnounceRpcEntry>),
+@@ -809,6 +827,32 @@ pub struct PathTableRpcEntry {
+     pub interface_role: InterfaceRole,
+ }
+ 
++/// Ranked path slots for one destination, active first.
++#[derive(Debug, Clone)]
++pub struct PathSlotsRpcEntry {
++    pub dest: [u8; 16],
++    /// Preference actually applied to this destination (pin resolved against
++    /// the global setting).
++    pub preference: crate::constants::PathMediumPreference,
++    /// Per-destination pin, when one is set.
++    pub pin: Option<crate::constants::PathMedium>,
++    pub slots: Vec<PathSlotRpcEntry>,
++}
++
++#[derive(Debug, Clone)]
++pub struct PathSlotRpcEntry {
++    /// True for the route currently used for outbound traffic.
++    pub active: bool,
++    pub hops: u8,
++    pub via: Option<[u8; 16]>,
++    pub interface_id: InterfaceId,
++    pub interface: String,
++    pub medium: crate::constants::PathMedium,
++    pub timestamp: f64,
++    pub expires: f64,
++    pub expired: bool,
++}
++
+ #[derive(Debug, Clone)]
+ pub struct InterfaceStatRpcEntry {
+     pub id: InterfaceId,
+diff --git a/crates/rns-transport/src/path_table.rs b/crates/rns-transport/src/path_table.rs
+index e051675..23a7728 100644
 --- a/crates/rns-transport/src/path_table.rs
 +++ b/crates/rns-transport/src/path_table.rs
-@@ -8,6 +8,8 @@
+@@ -8,6 +8,8 @@ use crate::constants::{
  use crate::messages::InterfaceId;
  use rns_wire::types::DestHash;
  
@@ -99,7 +981,7 @@
  /// One known path to a destination.
  #[derive(Debug, Clone)]
  pub struct PathEntry {
-@@ -22,6 +24,9 @@
+@@ -22,6 +24,9 @@ pub struct PathEntry {
      /// anti-replay memory on long-lived paths.
      pub random_blobs: VecDeque<[u8; 10]>,
      pub interface_id: InterfaceId,
@@ -109,7 +991,7 @@
      /// Hash of the cached announce packet — used to satisfy CacheRequest
      /// without holding the full packet bytes.
      pub packet_hash: Option<[u8; 32]>,
-@@ -44,6 +49,7 @@
+@@ -44,6 +49,7 @@ impl PathEntry {
              expires,
              random_blobs: VecDeque::new(),
              interface_id,
@@ -117,7 +999,7 @@
              packet_hash: None,
          }
      }
-@@ -86,20 +92,76 @@
+@@ -86,22 +92,78 @@ impl PathEntry {
      }
  }
  
@@ -182,8 +1064,8 @@
              states: HashMap::new(),
 +            preference: PathMediumPreference::default(),
          }
-+    }
-+
+     }
+ 
 +    /// Set the global medium preference used by promotions that have no
 +    /// per-destination pin available. Callers that own pins should follow this
 +    /// with a `rerank` pass over known destinations.
@@ -193,10 +1075,12 @@
 +
 +    pub fn preference(&self) -> PathMediumPreference {
 +        self.preference
-     }
- 
++    }
++
      /// Insert or replace a path entry. The parallel liveness state is
-@@ -113,9 +175,15 @@
+     /// cleared so a fresh/replacement entry never inherits a stale
+     /// `Responsive`/`Unresponsive` reading from its predecessor. `get_state`
+@@ -113,9 +175,15 @@ impl PathTable {
      /// sites (announce install, PathResponse install, tunnel path restore, disk
      /// load), so the invariant is enforced here: state is never older than the
      /// entry it describes.
@@ -212,7 +1096,7 @@
          self.entries.insert(hash, entry);
      }
  
-@@ -145,29 +213,39 @@
+@@ -145,29 +213,39 @@ impl PathTable {
          self.get_live(dest_hash).map(|e| e.hops)
      }
  
@@ -262,7 +1146,7 @@
          if let Some(entry) = self.entries.get_mut(dest_hash) {
              entry.expires = 0.0;
              self.cull_expired();
-@@ -189,17 +267,17 @@
+@@ -189,17 +267,17 @@ impl PathTable {
      }
  
      /// Full cull pass. Prefer `cull_expired_batch` on the hot path to bound
@@ -287,7 +1171,7 @@
      pub fn cull_expired_batch(&mut self, limit: usize) -> usize {
          let to_remove: Vec<DestHash> = self
              .entries
-@@ -212,21 +290,321 @@
+@@ -212,21 +290,321 @@ impl PathTable {
          for hash in &to_remove {
              self.entries.remove(hash.as_bytes());
              self.states.remove(hash.as_bytes());
@@ -614,7 +1498,7 @@
      }
  
      pub fn len(&self) -> usize {
-@@ -263,10 +641,153 @@
+@@ -263,10 +641,153 @@ fn path_expiry(mode: InterfaceMode) -> u64 {
      }
  }
  
@@ -768,10 +1652,11 @@
      #[test]
      fn test_path_table_basic() {
          let mut table = PathTable::new();
-@@ -392,6 +913,448 @@
+@@ -391,6 +912,448 @@ mod tests {
+         assert!(!result);
      }
  
-     #[test]
++    #[test]
 +    fn path_medium_maps_radio_modes_to_rf() {
 +        assert_eq!(path_medium(InterfaceMode::AccessPoint), PathMedium::Rf);
 +        assert_eq!(path_medium(InterfaceMode::Roaming), PathMedium::Rf);
@@ -1213,941 +2098,6 @@
 +        assert!(table.backups(&[0xFF; 16]).is_empty());
 +    }
 +
-+    #[test]
+     #[test]
      fn test_cull_dead_interfaces() {
          let mut table = PathTable::new();
-         let mut active = std::collections::HashSet::new();
---- a/crates/rns-transport/src/messages.rs
-+++ b/crates/rns-transport/src/messages.rs
-@@ -664,7 +664,24 @@
-     SuppressCurrentPathInterface {
-         dest: [u8; 16],
-         duration: f64,
-+    },
-+    /// Set the global medium preference for the active path slot and re-rank
-+    /// known destinations. Response: `IntResult(destinations_rerouted)`.
-+    SetPathMediumPreference {
-+        preference: crate::constants::PathMediumPreference,
-+    },
-+    /// Pin `dest` to a medium (or clear the pin with `None`), overriding the
-+    /// global preference for that destination.
-+    /// Response: `BoolResult(active_route_moved)`.
-+    SetPeerMediumPin {
-+        dest: [u8; 16],
-+        pin: Option<crate::constants::PathMedium>,
-     },
-+    /// Ranked path slots for `dest` — the active route plus up to
-+    /// `MAX_PATH_SLOTS - 1` alternates. Response: `PathSlots`.
-+    GetPathSlots {
-+        dest: [u8; 16],
-+    },
-     DropAnnounceQueues,
-     GetBlackholedIdentities,
-     BlackholeIdentity {
-@@ -780,6 +797,7 @@
- #[derive(Debug)]
- pub enum TransportQueryResponse {
-     PathTable(Vec<PathTableRpcEntry>),
-+    PathSlots(PathSlotsRpcEntry),
-     InterfaceStats(Vec<InterfaceStatRpcEntry>),
-     RateTable(Vec<RateTableRpcEntry>),
-     Announces(Vec<AnnounceRpcEntry>),
-@@ -813,9 +831,35 @@
-     pub interface_id: InterfaceId,
-     pub interface_mode: InterfaceMode,
-     pub interface_role: InterfaceRole,
-+}
-+
-+/// Ranked path slots for one destination, active first.
-+#[derive(Debug, Clone)]
-+pub struct PathSlotsRpcEntry {
-+    pub dest: [u8; 16],
-+    /// Preference actually applied to this destination (pin resolved against
-+    /// the global setting).
-+    pub preference: crate::constants::PathMediumPreference,
-+    /// Per-destination pin, when one is set.
-+    pub pin: Option<crate::constants::PathMedium>,
-+    pub slots: Vec<PathSlotRpcEntry>,
- }
- 
- #[derive(Debug, Clone)]
-+pub struct PathSlotRpcEntry {
-+    /// True for the route currently used for outbound traffic.
-+    pub active: bool,
-+    pub hops: u8,
-+    pub via: Option<[u8; 16]>,
-+    pub interface_id: InterfaceId,
-+    pub interface: String,
-+    pub medium: crate::constants::PathMedium,
-+    pub timestamp: f64,
-+    pub expires: f64,
-+    pub expired: bool,
-+}
-+
-+#[derive(Debug, Clone)]
- pub struct InterfaceStatRpcEntry {
-     pub id: InterfaceId,
-     pub name: String,
---- a/crates/rns-transport/src/actor/inbound.rs
-+++ b/crates/rns-transport/src/actor/inbound.rs
-@@ -375,25 +375,52 @@
-             .unwrap_or_default();
-         let suppressed =
-             self.is_path_interface_suppressed(header.destination_hash, interface_id, now_f64());
--        let should_add = if suppressed {
--            false
--        } else if let Some(existing) = self.path_table.get(&header.destination_hash) {
--            let random_seen = existing.has_random_blob(&announce_random_hash);
--            let path_timebase = path_timebase_from_random_blobs(existing.random_blobs.iter());
--            if header.hops <= existing.hops {
--                !random_seen && announce_emitted > path_timebase
--            } else if existing.is_expired() || announce_emitted > path_timebase {
--                !random_seen
--            } else if announce_emitted == path_timebase {
--                self.path_table.get_state(&header.destination_hash)
--                    == crate::constants::PathState::Unresponsive
--            } else {
--                false
--            }
--        } else {
--            true
-+        let candidate = crate::path_table::AnnouncedPath {
-+            interface_id,
-+            next_hop: header.transport_id,
-+            hops: header.hops,
-+            medium: crate::path_table::path_medium(iface_mode),
-+            random_blob: announce_random_hash,
-+            emitted: announce_emitted,
-+            suppressed,
-         };
-+        let preference = self.effective_path_medium_preference(&header.destination_hash);
-+        let rank = self
-+            .path_table
-+            .rank_announced(&header.destination_hash, &candidate, preference);
-+        if rank == crate::path_table::PathRank::Reject {
-+            debug!(
-+                dest = hex::encode(header.destination_hash),
-+                hops = header.hops,
-+                announce_emitted,
-+                interface_id,
-+                suppressed,
-+                "ignoring replayed or stale announce"
-+            );
-+            return;
-+        }
-+        let should_add = rank == crate::path_table::PathRank::Activate;
- 
-+        // For Header2 announces via a transport node, next_hop is the relay's
-+        // hash from transport_id; for Header1 announces the destination is
-+        // directly reachable and next_hop stays None.
-+        let mut entry = crate::path_table::PathEntry::new(
-+            header.transport_id,
-+            header.hops,
-+            interface_id,
-+            iface_mode,
-+        );
-+        if !random_blobs.contains(&announce_random_hash) {
-+            if random_blobs.len() >= MAX_RANDOM_BLOBS {
-+                random_blobs.pop_front();
-+            }
-+            random_blobs.push_back(announce_random_hash);
-+        }
-+        entry.random_blobs = random_blobs;
-+        // Store the announce packet hash so a later CacheRequest for this
-+        // destination can replay the exact announce bytes.
-+        entry.packet_hash = Some(rns_wire::hash::packet_hash(raw, header.flags.header_type));
-+
-         if should_add {
-             // Announce-table update MUST precede path-table update — the dedup
-             // check above compares against our own queued copy. Non-transport
-@@ -434,26 +461,6 @@
-                     .insert(header.destination_hash, announce_entry);
-             }
- 
--            // For Header2 announces via a transport node, next_hop is the relay's
--            // hash from transport_id; for Header1 announces the destination is
--            // directly reachable and next_hop stays None.
--            let mut entry = crate::path_table::PathEntry::new(
--                header.transport_id,
--                header.hops,
--                interface_id,
--                iface_mode,
--            );
--            if !random_blobs.contains(&announce_random_hash) {
--                if random_blobs.len() >= MAX_RANDOM_BLOBS {
--                    random_blobs.pop_front();
--                }
--                random_blobs.push_back(announce_random_hash);
--            }
--            entry.random_blobs = random_blobs;
--            // Store the announce packet hash so a later CacheRequest for this
--            // destination can replay the exact announce bytes.
--            let announce_packet_hash = rns_wire::hash::packet_hash(raw, header.flags.header_type);
--            entry.packet_hash = Some(announce_packet_hash);
-             let tunnel_path = crate::tunnel::TunnelPath {
-                 timestamp: entry.timestamp,
-                 next_hop: entry.next_hop,
-@@ -462,7 +469,12 @@
-                 random_blobs: entry.random_blobs.iter().copied().collect(),
-                 packet_hash: entry.packet_hash,
-             };
--            self.path_table.insert(header.destination_hash, entry);
-+            self.path_table.upsert_ranked(
-+                header.destination_hash,
-+                entry,
-+                crate::path_table::PathRank::Activate,
-+                preference,
-+            );
-             if let Some(tunnel) = self.tunnel_table.get_mut_by_interface(interface_id) {
-                 tunnel
-                     .tunnel_paths
-@@ -494,13 +506,24 @@
-                 "path learned from announce"
-             );
-         } else {
-+            // A route that loses the active slot can still be worth keeping:
-+            // parking it in a backup slot lets a later probe or link failure
-+            // reroute without a fresh announce. Everything else about the
-+            // announce is still ignored — no rebroadcast, no handler dispatch,
-+            // no announce-cache refresh — so replays stay inert.
-+            let stored_hops = entry.hops;
-+            self.path_table.upsert_ranked(
-+                header.destination_hash,
-+                entry,
-+                crate::path_table::PathRank::Backup,
-+                preference,
-+            );
-+            self.state_dirty = true;
-             debug!(
-                 dest = hex::encode(header.destination_hash),
--                hops = header.hops,
--                announce_emitted,
-+                hops = stored_hops,
-                 interface_id,
--                suppressed,
--                "ignoring replayed or stale announce"
-+                "alternate path stored in backup slot"
-             );
-             return;
-         }
---- a/crates/rns-transport/src/actor/mod.rs
-+++ b/crates/rns-transport/src/actor/mod.rs
-@@ -19,6 +19,7 @@
-     InterfaceEntry, InterfaceId, InterfaceRole, TransportMessage, msg_variant_name,
- };
- use crate::path_table::PathTable;
-+pub(crate) use crate::path_table::{announce_timebase, path_timebase_from_random_blobs};
- use crate::rate_limit::RateTable;
- use crate::reverse_table::ReverseTable;
- use crate::traffic::TrafficCounter;
-@@ -81,6 +82,11 @@
-     /// Used when a Direct LinkRequest timed out on one route, so the next
-     /// path request can discover alternates instead of instantly reusing it.
-     pub path_interface_suppressions: HashMap<([u8; 16], InterfaceId), f64>,
-+    /// Global medium preference for the active path slot.
-+    pub path_medium_preference: PathMediumPreference,
-+    /// Per-destination medium pins overriding `path_medium_preference`. Only
-+    /// pinned destinations appear here; clearing a pin removes the entry.
-+    pub peer_medium_pins: HashMap<[u8; 16], PathMedium>,
-     last_discovery_pr_tx: f64,
-     /// External interface waiting for a path response from a local shared client.
-     /// Python calls this `pending_local_path_requests`.
-@@ -315,6 +321,8 @@
-             discovery_pr_tags: HashMap::new(),
-             pending_discovery_prs: VecDeque::new(),
-             path_interface_suppressions: HashMap::new(),
-+            path_medium_preference: PathMediumPreference::default(),
-+            peer_medium_pins: HashMap::new(),
-             last_discovery_pr_tx: 0.0,
-             pending_local_path_requests: HashMap::new(),
-             path_states: HashMap::new(),
-@@ -1237,13 +1245,90 @@
-         let until = now_f64() + duration;
-         self.path_interface_suppressions
-             .insert((dest, interface_id), until);
-+        // Reroute onto the best remaining slot now: rediscovery would otherwise
-+        // run with the failed route still installed.
-+        let preference = self.effective_path_medium_preference(&dest);
-+        let rerouted = self
-+            .path_table
-+            .suppress_interface(&dest, interface_id, preference);
-+        if rerouted {
-+            self.state_dirty = true;
-+        }
-         debug!(
-             dest = %hex::encode(dest),
-             interface_id,
-             duration,
-+            rerouted,
-             "temporarily suppressing path interface"
-         );
-         true
-+    }
-+
-+    /// Preference in force for a destination: its pin if any, else the global
-+    /// setting.
-+    pub(super) fn effective_path_medium_preference(&self, dest: &[u8; 16]) -> PathMediumPreference {
-+        crate::path_table::effective_path_medium_preference(
-+            self.path_medium_preference,
-+            self.peer_medium_pins.get(dest).copied(),
-+        )
-+    }
-+
-+    /// Set the global medium preference and re-rank every known destination so
-+    /// the change applies without waiting for fresh announces. Returns the
-+    /// number of destinations whose active route moved.
-+    pub(super) fn set_path_medium_preference(&mut self, preference: PathMediumPreference) -> usize {
-+        self.path_medium_preference = preference;
-+        self.path_table.set_preference(preference);
-+        let moved = self.rerank_all_paths();
-+        debug!(
-+            preference = ?preference,
-+            moved, "path medium preference updated"
-+        );
-+        moved
-+    }
-+
-+    /// Pin or unpin a destination to a medium. Returns `true` when the pin
-+    /// changed the destination's active route.
-+    pub(super) fn set_peer_medium_pin(&mut self, dest: [u8; 16], pin: Option<PathMedium>) -> bool {
-+        match pin {
-+            Some(medium) => {
-+                self.peer_medium_pins.insert(dest, medium);
-+            }
-+            None => {
-+                self.peer_medium_pins.remove(&dest);
-+            }
-+        }
-+        let preference = self.effective_path_medium_preference(&dest);
-+        let moved = self.path_table.rerank(&dest, preference);
-+        if moved {
-+            self.state_dirty = true;
-+        }
-+        debug!(
-+            dest = %hex::encode(dest),
-+            pin = ?pin,
-+            moved,
-+            "peer medium pin updated"
-+        );
-+        moved
-+    }
-+
-+    fn rerank_all_paths(&mut self) -> usize {
-+        let dests: Vec<[u8; 16]> = self
-+            .path_table
-+            .iter()
-+            .map(|(hash, _)| hash.into_bytes())
-+            .collect();
-+        let mut moved = 0usize;
-+        for dest in dests {
-+            let preference = self.effective_path_medium_preference(&dest);
-+            if self.path_table.rerank(&dest, preference) {
-+                moved += 1;
-+            }
-+        }
-+        if moved > 0 {
-+            self.state_dirty = true;
-+        }
-+        moved
-     }
- 
-     fn is_path_interface_suppressed(
-@@ -1697,16 +1782,6 @@
-         .as_ref()
-         .map(|online| !online.load(std::sync::atomic::Ordering::SeqCst))
-         .unwrap_or(false)
--}
--
--fn announce_timebase(random_blob: &[u8; 10]) -> u64 {
--    let mut emitted = [0u8; 8];
--    emitted[3..].copy_from_slice(&random_blob[5..10]);
--    u64::from_be_bytes(emitted)
--}
--
--fn path_timebase_from_random_blobs<'a>(random_blobs: impl Iterator<Item = &'a [u8; 10]>) -> u64 {
--    random_blobs.map(announce_timebase).max().unwrap_or(0)
- }
- 
- /// Random jitter in `[0, PATHFINDER_RW)` for announce rebroadcast timing.
-@@ -2011,6 +2086,14 @@
-         (entry, rx)
-     }
- 
-+    /// Radio interfaces run in access-point mode, so paths learned here rank as
-+    /// [`PathMedium::Rf`].
-+    fn make_rf_test_interface(name: &str) -> (InterfaceEntry, mpsc::Receiver<Bytes>) {
-+        let (mut entry, rx) = make_test_interface(name);
-+        entry.mode = InterfaceMode::AccessPoint;
-+        (entry, rx)
-+    }
-+
-     #[test]
-     fn test_actor_creation() {
-         let (actor, _tx) = TransportActor::new();
-@@ -4242,6 +4325,9 @@
-         assert!(actor.state_dirty);
-     }
- 
-+    /// A replay of the same announce on another interface that is *no closer*
-+    /// to the source keeps its hands off the active route — it only earns a
-+    /// backup slot, and none of the announce-driven side effects fire.
-     #[test]
-     fn test_replayed_announce_random_blob_does_not_replace_path() {
-         let (mut actor, _tx) = TransportActor::new();
-@@ -4254,9 +4340,9 @@
-         let identity = rns_identity::identity::Identity::new();
-         let blob = random_blob(0xA1, 100);
-         let (raw_first, dest_hash) =
--            make_announce_for_with_random_blob(&identity, "test.replay.same", 3, blob);
--        let (raw_replay, _) =
-             make_announce_for_with_random_blob(&identity, "test.replay.same", 1, blob);
-+        let (raw_replay, _) =
-+            make_announce_for_with_random_blob(&identity, "test.replay.same", 3, blob);
-         let (htx, mut hrx) = mpsc::channel(8);
-         actor.announce_handlers.push(AnnounceHandlerRegistration {
-             id: crate::messages::AnnounceHandlerId(0),
-@@ -4274,7 +4360,7 @@
-             q: None,
-         });
-         let first_event = hrx.try_recv().expect("fresh announce should dispatch");
--        assert_eq!(first_event.hops, 4);
-+        assert_eq!(first_event.hops, 2);
- 
-         actor.on_inbound(InboundPacket {
-             raw: raw_replay,
-@@ -4285,13 +4371,19 @@
-         });
- 
-         let path = actor.path_table.get(&dest_hash).unwrap();
--        assert_eq!(path.hops, 4);
-+        assert_eq!(path.hops, 2);
-         assert_eq!(path.interface_id, 1);
-         assert_eq!(path.random_blobs.len(), 1);
-         assert!(path.has_random_blob(&blob));
-         assert_eq!(
-+            actor.path_table.backups(&dest_hash).len(),
-+            1,
-+            "the longer route is still worth keeping as an alternate"
-+        );
-+        assert_eq!(actor.path_table.backups(&dest_hash)[0].interface_id, 2);
-+        assert_eq!(
-             actor.recent_announces.get(&dest_hash).unwrap().hops,
--            4,
-+            2,
-             "replayed announces must not refresh recent announce state"
-         );
-         assert!(
-@@ -4309,7 +4401,335 @@
-         );
-     }
- 
-+    /// Same announce, fewer hops, second interface: the shorter route wins even
-+    /// though the random blob was already seen. This is the multi-TCP / RF+TCP
-+    /// case that the pre-multipath replay guard used to block.
-     #[test]
-+    fn replayed_announce_with_fewer_hops_takes_over_and_demotes_the_old_route() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        actor.is_transport_enabled = true;
-+        let (entry1, _rx1) = make_test_interface("iface1");
-+        let (entry2, _rx2) = make_test_interface("iface2");
-+        actor.interfaces.insert(1, entry1);
-+        actor.interfaces.insert(2, entry2);
-+
-+        let identity = rns_identity::identity::Identity::new();
-+        let blob = random_blob(0xA5, 100);
-+        let (raw_far, dest_hash) =
-+            make_announce_for_with_random_blob(&identity, "test.replay.closer", 3, blob);
-+        let (raw_close, _) =
-+            make_announce_for_with_random_blob(&identity, "test.replay.closer", 1, blob);
-+
-+        actor.on_inbound(InboundPacket {
-+            raw: raw_far,
-+            interface_id: 1,
-+            rssi: None,
-+            snr: None,
-+            q: None,
-+        });
-+        actor.on_inbound(InboundPacket {
-+            raw: raw_close,
-+            interface_id: 2,
-+            rssi: None,
-+            snr: None,
-+            q: None,
-+        });
-+
-+        let path = actor.path_table.get(&dest_hash).unwrap();
-+        assert_eq!(path.hops, 2);
-+        assert_eq!(path.interface_id, 2);
-+        let backups = actor.path_table.backups(&dest_hash);
-+        assert_eq!(backups.len(), 1);
-+        assert_eq!(backups[0].interface_id, 1);
-+        assert_eq!(backups[0].hops, 4);
-+    }
-+
-+    /// A failed probe or link attempt reroutes onto the backup immediately —
-+    /// no path request, no fresh announce.
-+    #[test]
-+    fn suppressing_the_current_path_interface_promotes_the_backup_route() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        actor.is_transport_enabled = true;
-+        let (entry1, _rx1) = make_test_interface("iface1");
-+        let (entry2, _rx2) = make_test_interface("iface2");
-+        actor.interfaces.insert(1, entry1);
-+        actor.interfaces.insert(2, entry2);
-+
-+        let identity = rns_identity::identity::Identity::new();
-+        let blob = random_blob(0xA6, 100);
-+        let (raw_close, dest_hash) =
-+            make_announce_for_with_random_blob(&identity, "test.multipath.failover", 1, blob);
-+        let (raw_far, _) =
-+            make_announce_for_with_random_blob(&identity, "test.multipath.failover", 4, blob);
-+        for (raw, interface_id) in [(raw_close, 1u64), (raw_far, 2)] {
-+            actor.on_inbound(InboundPacket {
-+                raw,
-+                interface_id,
-+                rssi: None,
-+                snr: None,
-+                q: None,
-+            });
-+        }
-+        assert_eq!(actor.path_table.get(&dest_hash).unwrap().interface_id, 1);
-+        assert_eq!(actor.path_table.backups(&dest_hash).len(), 1);
-+
-+        match actor.handle_query(TransportQuery::SuppressCurrentPathInterface {
-+            dest: dest_hash,
-+            duration: 30.0,
-+        }) {
-+            TransportQueryResponse::BoolResult(true) => {}
-+            other => panic!("expected current path-interface suppression, got {other:?}"),
-+        }
-+
-+        let path = actor
-+            .path_table
-+            .get(&dest_hash)
-+            .expect("the backup route should now carry the destination");
-+        assert_eq!(path.interface_id, 2);
-+        assert_eq!(path.hops, 5);
-+        assert!(actor.path_table.backups(&dest_hash).is_empty());
-+    }
-+
-+    #[test]
-+    fn network_preference_keeps_an_rf_shortcut_out_of_the_active_slot() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        actor.is_transport_enabled = true;
-+        let (tcp, _tcp_rx) = make_test_interface("tcp");
-+        let (rf, _rf_rx) = make_rf_test_interface("rnode");
-+        actor.interfaces.insert(1, tcp);
-+        actor.interfaces.insert(2, rf);
-+        assert_eq!(
-+            actor.set_path_medium_preference(PathMediumPreference::Network),
-+            0
-+        );
-+
-+        let identity = rns_identity::identity::Identity::new();
-+        let blob = random_blob(0xA7, 100);
-+        let (raw_tcp, dest_hash) =
-+            make_announce_for_with_random_blob(&identity, "test.multipath.netpref", 4, blob);
-+        let (raw_rf, _) =
-+            make_announce_for_with_random_blob(&identity, "test.multipath.netpref", 0, blob);
-+        for (raw, interface_id) in [(raw_tcp, 1u64), (raw_rf, 2)] {
-+            actor.on_inbound(InboundPacket {
-+                raw,
-+                interface_id,
-+                rssi: None,
-+                snr: None,
-+                q: None,
-+            });
-+        }
-+
-+        let path = actor.path_table.get(&dest_hash).unwrap();
-+        assert_eq!(path.medium, PathMedium::Network);
-+        assert_eq!(path.interface_id, 1);
-+        let backups = actor.path_table.backups(&dest_hash);
-+        assert_eq!(backups.len(), 1);
-+        assert_eq!(backups[0].medium, PathMedium::Rf);
-+        assert_eq!(backups[0].hops, 1);
-+    }
-+
-+    /// A per-destination RF pin beats the global `Lowest` default, survives an
-+    /// RF failure, and reclaims the route once RF is heard again.
-+    #[test]
-+    fn rf_pin_overrides_global_preference_and_survives_failover() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        actor.is_transport_enabled = true;
-+        let (tcp, _tcp_rx) = make_test_interface("tcp");
-+        let (rf, _rf_rx) = make_rf_test_interface("rnode");
-+        actor.interfaces.insert(1, tcp);
-+        actor.interfaces.insert(2, rf);
-+
-+        let identity = rns_identity::identity::Identity::new();
-+        let (raw_tcp, dest_hash) = make_announce_for_with_random_blob(
-+            &identity,
-+            "test.multipath.pin",
-+            0,
-+            random_blob(0xA8, 100),
-+        );
-+        let (raw_rf, _) = make_announce_for_with_random_blob(
-+            &identity,
-+            "test.multipath.pin",
-+            5,
-+            random_blob(0xA9, 101),
-+        );
-+        assert!(!actor.set_peer_medium_pin(dest_hash, Some(PathMedium::Rf)));
-+        for (raw, interface_id) in [(raw_tcp, 1u64), (raw_rf, 2)] {
-+            actor.on_inbound(InboundPacket {
-+                raw,
-+                interface_id,
-+                rssi: None,
-+                snr: None,
-+                q: None,
-+            });
-+        }
-+
-+        // The 6-hop RF route wins over a 1-hop network route because of the pin.
-+        assert_eq!(
-+            actor.path_table.get(&dest_hash).unwrap().medium,
-+            PathMedium::Rf
-+        );
-+
-+        match actor.handle_query(TransportQuery::SuppressCurrentPathInterface {
-+            dest: dest_hash,
-+            duration: 30.0,
-+        }) {
-+            TransportQueryResponse::BoolResult(true) => {}
-+            other => panic!("expected suppression, got {other:?}"),
-+        }
-+        assert_eq!(
-+            actor.path_table.get(&dest_hash).unwrap().medium,
-+            PathMedium::Network,
-+            "with no live RF slot the network route must carry traffic"
-+        );
-+        assert_eq!(
-+            actor.peer_medium_pins.get(&dest_hash).copied(),
-+            Some(PathMedium::Rf),
-+            "failover must not clear the pin"
-+        );
-+
-+        // Once suppression lapses, a fresh RF announce reclaims the route.
-+        actor.path_interface_suppressions.clear();
-+        let (raw_rf_again, _) = make_announce_for_with_random_blob(
-+            &identity,
-+            "test.multipath.pin",
-+            5,
-+            random_blob(0xAA, 102),
-+        );
-+        actor.on_inbound(InboundPacket {
-+            raw: raw_rf_again,
-+            interface_id: 2,
-+            rssi: None,
-+            snr: None,
-+            q: None,
-+        });
-+        assert_eq!(
-+            actor.path_table.get(&dest_hash).unwrap().medium,
-+            PathMedium::Rf
-+        );
-+    }
-+
-+    #[test]
-+    fn changing_the_global_preference_reranks_known_destinations() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        actor.is_transport_enabled = true;
-+        let (tcp, _tcp_rx) = make_test_interface("tcp");
-+        let (rf, _rf_rx) = make_rf_test_interface("rnode");
-+        actor.interfaces.insert(1, tcp);
-+        actor.interfaces.insert(2, rf);
-+
-+        let identity = rns_identity::identity::Identity::new();
-+        let blob = random_blob(0xAB, 100);
-+        let (raw_rf, dest_hash) =
-+            make_announce_for_with_random_blob(&identity, "test.multipath.rerank", 0, blob);
-+        let (raw_tcp, _) =
-+            make_announce_for_with_random_blob(&identity, "test.multipath.rerank", 4, blob);
-+        for (raw, interface_id) in [(raw_rf, 2u64), (raw_tcp, 1)] {
-+            actor.on_inbound(InboundPacket {
-+                raw,
-+                interface_id,
-+                rssi: None,
-+                snr: None,
-+                q: None,
-+            });
-+        }
-+        assert_eq!(
-+            actor.path_table.get(&dest_hash).unwrap().medium,
-+            PathMedium::Rf,
-+            "Lowest preference should pick the 1-hop RF route"
-+        );
-+
-+        assert_eq!(
-+            actor.set_path_medium_preference(PathMediumPreference::Network),
-+            1
-+        );
-+        assert_eq!(
-+            actor.path_table.get(&dest_hash).unwrap().medium,
-+            PathMedium::Network
-+        );
-+        assert_eq!(
-+            actor.path_table.backups(&dest_hash)[0].medium,
-+            PathMedium::Rf
-+        );
-+    }
-+
-+    #[test]
-+    fn get_path_slots_reports_ranked_slots_and_the_pin() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        actor.is_transport_enabled = true;
-+        let (tcp, _tcp_rx) = make_test_interface("tcp");
-+        let (rf, _rf_rx) = make_rf_test_interface("rnode");
-+        actor.interfaces.insert(1, tcp);
-+        actor.interfaces.insert(2, rf);
-+
-+        let identity = rns_identity::identity::Identity::new();
-+        let blob = random_blob(0xAC, 100);
-+        let (raw_tcp, dest_hash) =
-+            make_announce_for_with_random_blob(&identity, "test.multipath.slots", 1, blob);
-+        let (raw_rf, _) =
-+            make_announce_for_with_random_blob(&identity, "test.multipath.slots", 4, blob);
-+        for (raw, interface_id) in [(raw_tcp, 1u64), (raw_rf, 2)] {
-+            actor.on_inbound(InboundPacket {
-+                raw,
-+                interface_id,
-+                rssi: None,
-+                snr: None,
-+                q: None,
-+            });
-+        }
-+        assert!(actor.set_peer_medium_pin(dest_hash, Some(PathMedium::Rf)));
-+
-+        match actor.handle_query(TransportQuery::GetPathSlots { dest: dest_hash }) {
-+            TransportQueryResponse::PathSlots(entry) => {
-+                assert_eq!(entry.dest, dest_hash);
-+                assert_eq!(entry.pin, Some(PathMedium::Rf));
-+                assert_eq!(entry.preference, PathMediumPreference::Rf);
-+                assert_eq!(entry.slots.len(), 2);
-+                assert!(entry.slots[0].active);
-+                assert_eq!(entry.slots[0].medium, PathMedium::Rf);
-+                assert_eq!(entry.slots[0].interface, "rnode");
-+                assert!(!entry.slots[0].expired);
-+                assert!(!entry.slots[1].active);
-+                assert_eq!(entry.slots[1].medium, PathMedium::Network);
-+                assert_eq!(entry.slots[1].interface, "tcp");
-+            }
-+            other => panic!("expected PathSlots, got {other:?}"),
-+        }
-+
-+        match actor.handle_query(TransportQuery::GetPathSlots { dest: [0xFE; 16] }) {
-+            TransportQueryResponse::PathSlots(entry) => {
-+                assert!(entry.slots.is_empty());
-+                assert_eq!(entry.pin, None);
-+                assert_eq!(entry.preference, PathMediumPreference::Lowest);
-+            }
-+            other => panic!("expected PathSlots, got {other:?}"),
-+        }
-+    }
-+
-+    #[test]
-+    fn clearing_a_peer_medium_pin_restores_the_global_preference() {
-+        let (mut actor, _tx) = TransportActor::new();
-+        let dest = [0xCD; 16];
-+        actor.set_peer_medium_pin(dest, Some(PathMedium::Network));
-+        assert_eq!(
-+            actor.effective_path_medium_preference(&dest),
-+            PathMediumPreference::Network
-+        );
-+
-+        actor.set_peer_medium_pin(dest, None);
-+        assert!(actor.peer_medium_pins.is_empty());
-+        assert_eq!(
-+            actor.effective_path_medium_preference(&dest),
-+            PathMediumPreference::Lowest
-+        );
-+
-+        actor.set_path_medium_preference(PathMediumPreference::Rf);
-+        assert_eq!(
-+            actor.effective_path_medium_preference(&dest),
-+            PathMediumPreference::Rf
-+        );
-+    }
-+
-+    #[test]
-     fn test_newer_equal_or_higher_hop_announce_replaces_path() {
-         let (mut actor, _tx) = TransportActor::new();
-         let (entry1, _rx1) = make_test_interface("iface1");
-@@ -7232,6 +7652,7 @@
-                 expires: now - 1.0,
-                 random_blobs: Default::default(),
-                 interface_id: 7,
-+                medium: crate::path_table::PathMedium::Network,
-                 packet_hash: None,
-             },
-         );
-@@ -10903,9 +11324,9 @@
-         let dest_hash = [0xD1; 16];
-         insert_announce_for(&mut actor, dest_hash, &identity);
- 
--        let hit = actor.handle_query(crate::messages::TransportQuery::RecallDestinationPublicKey {
--            dest: dest_hash,
--        });
-+        let hit = actor.handle_query(
-+            crate::messages::TransportQuery::RecallDestinationPublicKey { dest: dest_hash },
-+        );
-         match hit {
-             crate::messages::TransportQueryResponse::PublicKeyResult(Some(pk)) => {
-                 assert_eq!(pk, identity.get_public_key());
-@@ -10913,10 +11334,9 @@
-             other => panic!("expected PublicKeyResult(Some(_)), got {other:?}"),
-         }
- 
--        let miss =
--            actor.handle_query(crate::messages::TransportQuery::RecallDestinationPublicKey {
--                dest: [0xEE; 16],
--            });
-+        let miss = actor.handle_query(
-+            crate::messages::TransportQuery::RecallDestinationPublicKey { dest: [0xEE; 16] },
-+        );
-         assert!(matches!(
-             miss,
-             crate::messages::TransportQueryResponse::PublicKeyResult(None)
-@@ -10924,33 +11344,6 @@
-     }
- 
-     #[test]
--    fn deregister_announce_handler_none_only_sweeps_closed() {
--        let (mut actor, _tx) = TransportActor::new();
--        let (live_tx, _live_rx) = tokio::sync::mpsc::channel(4);
--        let (dead_tx, dead_rx) = tokio::sync::mpsc::channel(4);
--        drop(dead_rx);
--
--        actor.announce_handlers.push(AnnounceHandlerRegistration {
--            aspect_filter: Some("nomadnetwork.node".into()),
--            receive_path_responses: false,
--            tx: live_tx,
--        });
--        actor.announce_handlers.push(AnnounceHandlerRegistration {
--            aspect_filter: Some("nomadnetwork.node".into()),
--            receive_path_responses: true,
--            tx: dead_tx,
--        });
--
--        actor.handle_message(TransportMessage::DeregisterAnnounceHandler { aspect_filter: None });
--        assert_eq!(actor.announce_handlers.len(), 1);
--        assert_eq!(
--            actor.announce_handlers[0].aspect_filter.as_deref(),
--            Some("nomadnetwork.node")
--        );
--        assert!(!actor.announce_handlers[0].tx.is_closed());
--    }
--
--    #[test]
-     fn filter_blackholed_dests_returns_only_blackholed() {
-         let (mut actor, _tx) = TransportActor::new();
-         let blocked = rns_identity::identity::Identity::new();
---- a/crates/rns-transport/src/actor/rpc.rs
-+++ b/crates/rns-transport/src/actor/rpc.rs
-@@ -261,7 +261,42 @@
-                 TransportQueryResponse::BoolResult(interface_id.is_some_and(|interface_id| {
-                     self.suppress_path_interface(dest, interface_id, duration)
-                 }))
-+            }
-+            TransportQuery::SetPathMediumPreference { preference } => {
-+                TransportQueryResponse::IntResult(self.set_path_medium_preference(preference) as i64)
-+            }
-+            TransportQuery::SetPeerMediumPin { dest, pin } => {
-+                TransportQueryResponse::BoolResult(self.set_peer_medium_pin(dest, pin))
-             }
-+            TransportQuery::GetPathSlots { dest } => {
-+                let slots: Vec<PathSlotRpcEntry> = self
-+                    .path_table
-+                    .slots(&dest)
-+                    .into_iter()
-+                    .enumerate()
-+                    .map(|(index, entry)| PathSlotRpcEntry {
-+                        active: index == 0,
-+                        hops: entry.hops,
-+                        via: entry.next_hop,
-+                        interface_id: entry.interface_id,
-+                        interface: self
-+                            .interfaces
-+                            .get(&entry.interface_id)
-+                            .map(|e| e.name.clone())
-+                            .unwrap_or_else(|| format!("interface_{}", entry.interface_id)),
-+                        medium: entry.medium,
-+                        timestamp: entry.timestamp,
-+                        expires: entry.expires,
-+                        expired: entry.is_expired(),
-+                    })
-+                    .collect();
-+                TransportQueryResponse::PathSlots(PathSlotsRpcEntry {
-+                    dest,
-+                    preference: self.effective_path_medium_preference(&dest),
-+                    pin: self.peer_medium_pins.get(&dest).copied(),
-+                    slots,
-+                })
-+            }
-             TransportQuery::DropAnnounceQueues => {
-                 for entry in self.interfaces.values_mut() {
-                     entry.announce_queue.clear();
---- a/crates/rns-transport/src/actor/outbound.rs
-+++ b/crates/rns-transport/src/actor/outbound.rs
-@@ -801,6 +801,12 @@
-                     expires: tunnel_path.expires,
-                     random_blobs: tunnel_path.random_blobs.iter().copied().collect(),
-                     interface_id,
-+                    medium: crate::path_table::path_medium(
-+                        self.interfaces
-+                            .get(&interface_id)
-+                            .map(|entry| entry.mode)
-+                            .unwrap_or(crate::constants::InterfaceMode::Full),
-+                    ),
-                     packet_hash: tunnel_path.packet_hash,
-                 };
-                 self.path_table.insert(*dest_hash, entry);
---- a/crates/rns-transport/src/actor/persistence.rs
-+++ b/crates/rns-transport/src/actor/persistence.rs
-@@ -1061,6 +1061,14 @@
-     /// just-registered interface. Bound to `RegisterInterface` so each entry
-     /// rebinds to whatever `interface_id` the runtime allocated this boot.
-     pub(super) fn drain_pending_for_interface(&mut self, id: InterfaceId, name: &str) {
-+        // Restored entries have no persisted medium — recover it from the
-+        // interface that is registering now.
-+        let medium = crate::path_table::path_medium(
-+            self.interfaces
-+                .get(&id)
-+                .map(|entry| entry.mode)
-+                .unwrap_or(crate::constants::InterfaceMode::Full),
-+        );
-         if !self.pending_path_entries.is_empty() {
-             let mut promoted = 0usize;
-             self.pending_path_entries.retain(|pe| {
-@@ -1104,6 +1112,7 @@
-                         })
-                         .collect(),
-                     interface_id: id,
-+                    medium,
-                     packet_hash: pe.packet_hash.as_ref().and_then(|h| {
-                         if h.len() == 32 {
-                             let mut arr = [0u8; 32];
-@@ -1316,6 +1325,7 @@
-                 expires: crate::now_f64() + 600.0,
-                 random_blobs: std::collections::VecDeque::new(),
-                 interface_id: 7,
-+                medium: crate::path_table::PathMedium::Network,
-                 packet_hash: Some(path_hash),
-             },
-         );
-@@ -1471,6 +1481,7 @@
-                 expires: crate::now_f64() + 600.0,
-                 random_blobs: std::collections::VecDeque::new(),
-                 interface_id: 7,
-+                medium: crate::path_table::PathMedium::Network,
-                 packet_hash: Some([0x33; 32]),
-             },
-         );
-@@ -1587,6 +1598,7 @@
-                     expires: crate::now_f64() + 600.0,
-                     random_blobs: std::collections::VecDeque::new(),
-                     interface_id: 7,
-+                    medium: crate::path_table::PathMedium::Network,
-                     packet_hash: Some([0x66; 32]),
-                 },
-             );

--- a/reticulum-sidecar/src/stack/lxmf_outbound.rs
+++ b/reticulum-sidecar/src/stack/lxmf_outbound.rs
@@ -143,6 +143,12 @@ enum InProcessDepositOutcome {
     Failed,
 }
 
+fn enqueue_router(router: &mut LxmRouter, message: LxMessage) {
+    if let Err(error) = router.try_send(message) {
+        tracing::warn!(target: "lxmf-outbound", error = %error, "router.try_send failed");
+    }
+}
+
 pub struct LxmfOutboundDriver {
     transport_tx: mpsc::Sender<TransportMessage>,
     link_delivery: LinkDeliveryManager,
@@ -554,7 +560,7 @@ impl LxmfOutboundDriver {
                     Some(prop_hex.clone()),
                 );
             }
-            router.send(message);
+            enqueue_router(router, message);
             return;
         }
         if let Some(hash) = message.hash.or(message.message_id) {
@@ -628,7 +634,7 @@ impl LxmfOutboundDriver {
                     if let Some(hash) = message.hash.or(message.message_id) {
                         self.pending_pn_targets.insert(hash, prop_hash);
                     }
-                    router.send(message);
+                    enqueue_router(router, message);
                     return;
                 }
                 Err(InProcessDepositOutcome::Failed | InProcessDepositOutcome::Completed) => {
@@ -699,7 +705,7 @@ impl LxmfOutboundDriver {
                         self.pending_pn_deposits.remove(&hash);
                         self.pending_pn_targets.insert(hash, prop_hash);
                     }
-                    router.send(message);
+                    enqueue_router(router, message);
                     return;
                 }
                 InProcessDepositOutcome::Failed => {
@@ -947,7 +953,7 @@ impl LxmfOutboundDriver {
         match plan {
             DirectDeliveryPlan::WaitForReusableLink => {
                 if !router_owned {
-                    router.send(message);
+                    enqueue_router(router, message);
                 }
             }
             DirectDeliveryPlan::RequestPath { drop_existing } => {
@@ -974,7 +980,7 @@ impl LxmfOutboundDriver {
                         message.method = DeliveryMethod::Direct;
                         message.last_delivery_attempt = now;
                         message.next_delivery_attempt = now + f64::from(PATH_REQUEST_WAIT as u32);
-                        router.send(message);
+                        enqueue_router(router, message);
                     }
                     // router_owned: message remains in pending_outbound; cleared path
                     // forces RequestPath on the next tick after Auto suppress.
@@ -993,7 +999,7 @@ impl LxmfOutboundDriver {
                         error = %err.error,
                         "direct link delivery start failed"
                     );
-                    router.send(*err.message);
+                    enqueue_router(router, *err.message);
                 }
             }
         }
@@ -1049,7 +1055,7 @@ impl LxmfOutboundDriver {
                 if try_queue_path_request(&self.transport_tx, request_hash, drop_existing, reason) {
                     self.path_request_gate.record_send(request_hash, now);
                     if !router_owned {
-                        router.send(message);
+                        enqueue_router(router, message);
                     }
                 } else {
                     self.path_request_gate
@@ -1062,13 +1068,13 @@ impl LxmfOutboundDriver {
                         );
                     }
                     if !router_owned {
-                        router.send(message);
+                        enqueue_router(router, message);
                     }
                 }
             }
             PathRequestDecision::Backoff => {
                 if !router_owned {
-                    router.send(message);
+                    enqueue_router(router, message);
                 }
             }
             PathRequestDecision::MaxAttempts => {
@@ -1269,7 +1275,7 @@ impl LxmfOutboundDriver {
             is_local = pick.is_local(),
             "LXMF advancing PN cascade"
         );
-        router.send(message);
+        enqueue_router(router, message);
         emit_outbound_status_with_via(
             event_tx,
             Some(serde_json::Value::String(hex::encode(msg_hash))),
@@ -1542,7 +1548,7 @@ impl LxmfOutboundDriver {
             Some(tried),
             Some(rounds),
         );
-        router.send(message);
+        enqueue_router(router, message);
         Ok(())
     }
 
@@ -1581,7 +1587,7 @@ impl LxmfOutboundDriver {
                 Some(hex::encode(prop_hash)),
             );
         }
-        router.send(message);
+        enqueue_router(router, message);
     }
 }
 

--- a/reticulum-sidecar/src/stack/lxmf_outbound.rs
+++ b/reticulum-sidecar/src/stack/lxmf_outbound.rs
@@ -14,7 +14,7 @@ use lxmf_core::message::LxMessage;
 use lxmf_core::propagation_node::PropagationNode;
 use lxmf_core::router::{
     DirectDeliveryPlan, DirectDeliveryPlanInput, DirectReusableLinkState, DirectRouteSnapshot,
-    LxmRouter, OutboundAction, plan_direct_delivery,
+    LxmRouter, OutboundAction, SendError, plan_direct_delivery,
 };
 use lxmf_core::stamper;
 use rns_identity::identity::Identity;
@@ -143,9 +143,14 @@ enum InProcessDepositOutcome {
     Failed,
 }
 
-fn enqueue_router(router: &mut LxmRouter, message: LxMessage) {
-    if let Err(error) = router.try_send(message) {
-        tracing::warn!(target: "lxmf-outbound", error = %error, "router.try_send failed");
+fn enqueue_router(router: &mut LxmRouter, message: LxMessage) -> Result<(), SendError> {
+    router.try_send(message)
+}
+
+fn take_send_error_message(error: SendError) -> Box<LxMessage> {
+    match error {
+        SendError::MissingOutboundPropagationNode(message)
+        | SendError::TicketPreparation { message, .. } => message,
     }
 }
 
@@ -385,6 +390,27 @@ impl LxmfOutboundDriver {
             .contains(&destination_hex.to_lowercase())
     }
 
+    fn enqueue_or_fail(
+        &mut self,
+        router: &mut LxmRouter,
+        event_tx: &broadcast::Sender<String>,
+        message: LxMessage,
+    ) -> bool {
+        match enqueue_router(router, message) {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(
+                    target: "lxmf-outbound",
+                    error = %error,
+                    "router.try_send failed"
+                );
+                let failed = *take_send_error_message(error);
+                self.emit_outbound_failed(router, event_tx, failed);
+                false
+            }
+        }
+    }
+
     pub fn identity_known_for(&self, destination_hex: &str) -> bool {
         let key = destination_hex.to_lowercase();
         self.pinned_identities.contains_key(&key) || self.known_identities.contains_key(&key)
@@ -560,7 +586,7 @@ impl LxmfOutboundDriver {
                     Some(prop_hex.clone()),
                 );
             }
-            enqueue_router(router, message);
+            self.enqueue_or_fail(router, event_tx, message);
             return;
         }
         if let Some(hash) = message.hash.or(message.message_id) {
@@ -634,7 +660,7 @@ impl LxmfOutboundDriver {
                     if let Some(hash) = message.hash.or(message.message_id) {
                         self.pending_pn_targets.insert(hash, prop_hash);
                     }
-                    enqueue_router(router, message);
+                    self.enqueue_or_fail(router, event_tx, message);
                     return;
                 }
                 Err(InProcessDepositOutcome::Failed | InProcessDepositOutcome::Completed) => {
@@ -705,7 +731,7 @@ impl LxmfOutboundDriver {
                         self.pending_pn_deposits.remove(&hash);
                         self.pending_pn_targets.insert(hash, prop_hash);
                     }
-                    enqueue_router(router, message);
+                    self.enqueue_or_fail(router, event_tx, message);
                     return;
                 }
                 InProcessDepositOutcome::Failed => {
@@ -953,7 +979,7 @@ impl LxmfOutboundDriver {
         match plan {
             DirectDeliveryPlan::WaitForReusableLink => {
                 if !router_owned {
-                    enqueue_router(router, message);
+                    self.enqueue_or_fail(router, event_tx, message);
                 }
             }
             DirectDeliveryPlan::RequestPath { drop_existing } => {
@@ -980,7 +1006,7 @@ impl LxmfOutboundDriver {
                         message.method = DeliveryMethod::Direct;
                         message.last_delivery_attempt = now;
                         message.next_delivery_attempt = now + f64::from(PATH_REQUEST_WAIT as u32);
-                        enqueue_router(router, message);
+                        self.enqueue_or_fail(router, event_tx, message);
                     }
                     // router_owned: message remains in pending_outbound; cleared path
                     // forces RequestPath on the next tick after Auto suppress.
@@ -999,7 +1025,7 @@ impl LxmfOutboundDriver {
                         error = %err.error,
                         "direct link delivery start failed"
                     );
-                    enqueue_router(router, *err.message);
+                    self.enqueue_or_fail(router, event_tx, *err.message);
                 }
             }
         }
@@ -1055,7 +1081,7 @@ impl LxmfOutboundDriver {
                 if try_queue_path_request(&self.transport_tx, request_hash, drop_existing, reason) {
                     self.path_request_gate.record_send(request_hash, now);
                     if !router_owned {
-                        enqueue_router(router, message);
+                        self.enqueue_or_fail(router, event_tx, message);
                     }
                 } else {
                     self.path_request_gate
@@ -1068,13 +1094,13 @@ impl LxmfOutboundDriver {
                         );
                     }
                     if !router_owned {
-                        enqueue_router(router, message);
+                        self.enqueue_or_fail(router, event_tx, message);
                     }
                 }
             }
             PathRequestDecision::Backoff => {
                 if !router_owned {
-                    enqueue_router(router, message);
+                    self.enqueue_or_fail(router, event_tx, message);
                 }
             }
             PathRequestDecision::MaxAttempts => {
@@ -1275,15 +1301,16 @@ impl LxmfOutboundDriver {
             is_local = pick.is_local(),
             "LXMF advancing PN cascade"
         );
-        enqueue_router(router, message);
-        emit_outbound_status_with_via(
-            event_tx,
-            Some(serde_json::Value::String(hex::encode(msg_hash))),
-            None,
-            "sending",
-            Some(method_label),
-            Some(hex::encode(pn_hash)),
-        );
+        if self.enqueue_or_fail(router, event_tx, message) {
+            emit_outbound_status_with_via(
+                event_tx,
+                Some(serde_json::Value::String(hex::encode(msg_hash))),
+                None,
+                "sending",
+                Some(method_label),
+                Some(hex::encode(pn_hash)),
+            );
+        }
         Ok(())
     }
 
@@ -1538,17 +1565,18 @@ impl LxmfOutboundDriver {
             "Direct path failover: suppress/drop via + RequestPath; re-queuing Direct"
         );
         let sent_via = iface.as_deref().map(classify_interface).map(str::to_string);
-        emit_outbound_status_detailed(
-            event_tx,
-            Some(serde_json::Value::String(hex::encode(msg_hash))),
-            Some(serde_json::Value::String(hex::encode(dest_hash))),
-            "sending",
-            Some("direct"),
-            sent_via,
-            Some(tried),
-            Some(rounds),
-        );
-        enqueue_router(router, message);
+        if self.enqueue_or_fail(router, event_tx, message) {
+            emit_outbound_status_detailed(
+                event_tx,
+                Some(serde_json::Value::String(hex::encode(msg_hash))),
+                Some(serde_json::Value::String(hex::encode(dest_hash))),
+                "sending",
+                Some("direct"),
+                sent_via,
+                Some(tried),
+                Some(rounds),
+            );
+        }
         Ok(())
     }
 
@@ -1577,17 +1605,20 @@ impl LxmfOutboundDriver {
         );
         if let Some(hash) = msg_hash {
             self.pending_pn_targets.insert(hash, prop_hash);
-            // Keep chat UI in sending/propagated while PN rediscovery proceeds.
-            emit_outbound_status_with_via(
-                event_tx,
-                Some(serde_json::Value::String(hex::encode(hash))),
-                None,
-                "sending",
-                Some(self.cascade_wire_delivery_method(hash)),
-                Some(hex::encode(prop_hash)),
-            );
         }
-        enqueue_router(router, message);
+        if self.enqueue_or_fail(router, event_tx, message) {
+            if let Some(hash) = msg_hash {
+                // Keep chat UI in sending/propagated while PN rediscovery proceeds.
+                emit_outbound_status_with_via(
+                    event_tx,
+                    Some(serde_json::Value::String(hex::encode(hash))),
+                    None,
+                    "sending",
+                    Some(self.cascade_wire_delivery_method(hash)),
+                    Some(hex::encode(prop_hash)),
+                );
+            }
+        }
     }
 }
 
@@ -1996,6 +2027,112 @@ mod tests {
         gate.record_queue_failure(dest(3), 100.0);
         gate.clear_destination(dest(3));
         assert_eq!(gate.decide(dest(3), 101.0), PathRequestDecision::Send);
+    }
+
+    #[test]
+    fn enqueue_router_missing_propagation_node_keeps_message_and_fails_outbound() {
+        use lxmf_core::constants::{DeliveryMethod, MessageState};
+        use lxmf_core::message::LxMessage;
+        use lxmf_core::router::{LxmRouter, RouterConfig, SendError};
+        use tokio::sync::broadcast;
+
+        let identity = Identity::new();
+        let (tx, _rx) = mpsc::channel(8);
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let dest_hash = dest(0xab);
+        let msg_hash = [0x42u8; 32];
+        let pn_hash = dest(0x11);
+        driver
+            .pn_cascade_tried
+            .insert(msg_hash, HashSet::from([pn_hash]));
+        driver.pending_pn_targets.insert(msg_hash, pn_hash);
+        driver.pn_cascade_local.insert(msg_hash);
+
+        let mut router = LxmRouter::new(RouterConfig::default());
+        let (event_tx, mut event_rx) = broadcast::channel(8);
+
+        let mut msg = LxMessage::new(dest_hash, [1u8; 16], "", "hi", DeliveryMethod::Propagated);
+        msg.hash = Some(msg_hash);
+
+        let typed = enqueue_router(&mut router, msg.clone());
+        let Err(SendError::MissingOutboundPropagationNode(failed)) = typed else {
+            panic!("expected MissingOutboundPropagationNode, got {typed:?}");
+        };
+        assert_eq!(failed.hash, Some(msg_hash));
+        assert_eq!(failed.state, MessageState::Failed);
+        assert!(router.pending_outbound.is_empty());
+
+        assert!(!driver.enqueue_or_fail(&mut router, &event_tx, msg));
+        assert!(!driver.pn_cascade_tried.contains_key(&msg_hash));
+        assert!(!driver.pending_pn_targets.contains_key(&msg_hash));
+        assert!(!driver.pn_cascade_local.contains(&msg_hash));
+
+        let mut saw_failed = false;
+        while let Ok(frame) = event_rx.try_recv() {
+            if frame.contains("\"status\":\"failed\"") && frame.contains(&hex::encode(msg_hash)) {
+                saw_failed = true;
+            }
+        }
+        assert!(saw_failed, "missing PN must emit outbound failed status");
+    }
+
+    #[test]
+    fn enqueue_router_ticket_preparation_keeps_message_and_fails_outbound() {
+        use lxmf_core::constants::{DeliveryMethod, MessageState};
+        use lxmf_core::message::LxMessage;
+        use lxmf_core::router::{LxmRouter, RouterConfig, SendError, TicketPreparationError};
+        use tokio::sync::broadcast;
+
+        let identity = Identity::new();
+        let (tx, _rx) = mpsc::channel(8);
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let dest_hash = dest(0xcd);
+        let mut msg = LxMessage::new(
+            dest_hash,
+            [1u8; 16],
+            "ticket",
+            "late",
+            DeliveryMethod::Direct,
+        );
+        msg.include_ticket = true;
+        msg.sign(&identity.get_signing_key().expect("sk"))
+            .expect("sign");
+        let msg_hash = msg.hash.expect("hash after sign");
+        driver
+            .pn_cascade_tried
+            .insert(msg_hash, HashSet::from([dest(0x22)]));
+        driver.pending_pn_targets.insert(msg_hash, dest(0x22));
+
+        let mut router = LxmRouter::new(RouterConfig::default());
+        let (event_tx, mut event_rx) = broadcast::channel(8);
+
+        let typed = enqueue_router(&mut router, msg.clone());
+        match typed {
+            Err(SendError::TicketPreparation {
+                message,
+                source: TicketPreparationError::AlreadySigned,
+            }) => {
+                assert_eq!(message.hash, Some(msg_hash));
+                assert_eq!(message.state, MessageState::Failed);
+            }
+            other => panic!("expected TicketPreparation::AlreadySigned, got {other:?}"),
+        }
+        assert!(router.pending_outbound.is_empty());
+
+        assert!(!driver.enqueue_or_fail(&mut router, &event_tx, msg));
+        assert!(!driver.pn_cascade_tried.contains_key(&msg_hash));
+        assert!(!driver.pending_pn_targets.contains_key(&msg_hash));
+
+        let mut saw_failed = false;
+        while let Ok(frame) = event_rx.try_recv() {
+            if frame.contains("\"status\":\"failed\"") && frame.contains(&hex::encode(msg_hash)) {
+                saw_failed = true;
+            }
+        }
+        assert!(
+            saw_failed,
+            "ticket preparation failure must emit outbound failed status"
+        );
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/mod.rs
+++ b/reticulum-sidecar/src/stack/mod.rs
@@ -333,14 +333,14 @@ impl StackHandle {
             return;
         }
         let started = std::time::Instant::now();
-        match live::LiveBridge::spawn(
+        match Box::pin(live::LiveBridge::spawn(
             self.config_dir.clone(),
             self.storage_dir.clone(),
             self.event_tx.clone(),
             self.packet_log.clone(),
             self.inbound_lxmf.clone(),
             self.inner.clone(),
-        )
+        ))
         .await
         {
             Ok(bridge) => {

--- a/reticulum-sidecar/src/stack/propagation_bridge.rs
+++ b/reticulum-sidecar/src/stack/propagation_bridge.rs
@@ -1115,8 +1115,20 @@ pub(crate) fn apply_peer_sync_terminal(
     let Some(peer) = router.peers.get_mut(&result.peer_hash) else {
         return;
     };
+    // lxmd parity: apply link/sync accounting before terminal state (Ratspeak
+    // `lxmd.rs` peer_terminal_result).
+    if let Some(rate) = result.link_establishment_rate {
+        peer.link_establishment_rate = rate;
+        peer.heard();
+    }
     match result.state {
         PeerSyncTerminalState::Complete => {
+            peer.offered = peer.offered.saturating_add(result.offered);
+            peer.outgoing = peer.outgoing.saturating_add(result.outgoing);
+            peer.tx_bytes = peer.tx_bytes.saturating_add(result.tx_bytes);
+            if let Some(rate) = result.sync_transfer_rate {
+                peer.sync_transfer_rate = rate;
+            }
             peer.sync_complete();
             if result.generation_exhausted {
                 if let Some(generation) = result.offer_generation {
@@ -1652,10 +1664,20 @@ mod tests {
                 state: PeerSyncTerminalState::Complete,
                 offer_generation: Some(5),
                 generation_exhausted: true,
+                offered: 4,
+                outgoing: 2,
+                tx_bytes: 128,
+                link_establishment_rate: Some(1234.0),
+                sync_transfer_rate: Some(56.0),
             },
         );
         let peer = router.peers.get(&peer_hash).expect("peer");
         assert_eq!(peer.state, PeerState::Idle);
+        assert_eq!(peer.offered, 4);
+        assert_eq!(peer.outgoing, 2);
+        assert_eq!(peer.tx_bytes, 128);
+        assert!((peer.link_establishment_rate - 1234.0).abs() < 1e-9);
+        assert!((peer.sync_transfer_rate - 56.0).abs() < 1e-9);
         assert!(
             !peer.needs_offer_generation(5),
             "exhausted generation must not remain due"
@@ -1705,10 +1727,19 @@ mod tests {
                 state: PeerSyncTerminalState::Failed,
                 offer_generation: Some(3),
                 generation_exhausted: false,
+                offered: 9,
+                outgoing: 9,
+                tx_bytes: 9,
+                link_establishment_rate: None,
+                sync_transfer_rate: Some(99.0),
             },
         );
         let peer = router.peers.get(&peer_hash).expect("peer");
         assert_eq!(peer.state, PeerState::Idle);
+        assert_eq!(peer.offered, 0, "failed sync must not count offered");
+        assert_eq!(peer.outgoing, 0);
+        assert_eq!(peer.tx_bytes, 0);
+        assert!(peer.sync_transfer_rate.abs() < 1e-9);
         assert!(
             peer.needs_offer_generation(3),
             "failed sync must leave generation retryable"

--- a/reticulum-sidecar/src/stack/propagation_bridge.rs
+++ b/reticulum-sidecar/src/stack/propagation_bridge.rs
@@ -1652,6 +1652,11 @@ mod tests {
         let peer_hash = [0x11u8; 16];
         let mut router = LxmRouter::new(RouterConfig::default());
         let mut peer = LxmPeer::new(peer_hash);
+        peer.offered = 10;
+        peer.outgoing = 3;
+        peer.tx_bytes = 50;
+        peer.link_establishment_rate = 100.0;
+        peer.sync_transfer_rate = 20.0;
         peer.begin_sync();
         assert_ne!(peer.state, PeerState::Idle);
         router.peers.insert(peer_hash, peer);
@@ -1673,9 +1678,9 @@ mod tests {
         );
         let peer = router.peers.get(&peer_hash).expect("peer");
         assert_eq!(peer.state, PeerState::Idle);
-        assert_eq!(peer.offered, 4);
-        assert_eq!(peer.outgoing, 2);
-        assert_eq!(peer.tx_bytes, 128);
+        assert_eq!(peer.offered, 14);
+        assert_eq!(peer.outgoing, 5);
+        assert_eq!(peer.tx_bytes, 178);
         assert!((peer.link_establishment_rate - 1234.0).abs() < 1e-9);
         assert!((peer.sync_transfer_rate - 56.0).abs() < 1e-9);
         assert!(
@@ -1716,6 +1721,11 @@ mod tests {
         let peer_hash = [0x22u8; 16];
         let mut router = LxmRouter::new(RouterConfig::default());
         let mut peer = LxmPeer::new(peer_hash);
+        peer.offered = 7;
+        peer.outgoing = 3;
+        peer.tx_bytes = 11;
+        peer.link_establishment_rate = 88.0;
+        peer.sync_transfer_rate = 12.0;
         peer.begin_sync();
         router.peers.insert(peer_hash, peer);
 
@@ -1736,10 +1746,11 @@ mod tests {
         );
         let peer = router.peers.get(&peer_hash).expect("peer");
         assert_eq!(peer.state, PeerState::Idle);
-        assert_eq!(peer.offered, 0, "failed sync must not count offered");
-        assert_eq!(peer.outgoing, 0);
-        assert_eq!(peer.tx_bytes, 0);
-        assert!(peer.sync_transfer_rate.abs() < 1e-9);
+        assert_eq!(peer.offered, 7, "failed sync must not count offered");
+        assert_eq!(peer.outgoing, 3);
+        assert_eq!(peer.tx_bytes, 11);
+        assert!((peer.link_establishment_rate - 88.0).abs() < 1e-9);
+        assert!((peer.sync_transfer_rate - 12.0).abs() < 1e-9);
         assert!(
             peer.needs_offer_generation(3),
             "failed sync must leave generation retryable"

--- a/reticulum-sidecar/src/stack/rrc_link.rs
+++ b/reticulum-sidecar/src/stack/rrc_link.rs
@@ -457,13 +457,17 @@ async fn recall_destination_public_key(
     send_msg(
         transport_tx,
         TransportMessage::Rpc {
-            query: TransportQuery::RecallDestinationPublicKey { dest: dest_hash },
+            query: TransportQuery::RecallDestination { dest: dest_hash },
             response_tx,
         },
     )
     .await?;
     match timeout(Duration::from_secs(5), response_rx).await {
-        Ok(Ok(TransportQueryResponse::PublicKeyResult(pk))) => Ok(pk),
+        Ok(Ok(TransportQueryResponse::RecalledDestination(Some(destination))))
+            if destination.dest_hash == dest_hash =>
+        {
+            Ok(Some(destination.public_key))
+        }
         Ok(Ok(_)) => Ok(None),
         Ok(Err(_)) => Err(RrcLinkError::TransportUnavailable),
         Err(_) => Err(RrcLinkError::Timeout("pubkey recall")),
@@ -635,5 +639,42 @@ mod tests {
             guard.disarm();
         }
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn recall_destination_public_key_uses_upstream_recall_destination() {
+        let dest_hash = [0xD4; 16];
+        let public_key = [0x42u8; 64];
+        let (transport_tx, mut transport_rx) = mpsc::channel(4);
+        let responder = tokio::spawn(async move {
+            let Some(TransportMessage::Rpc { query, response_tx }) = transport_rx.recv().await
+            else {
+                panic!("expected destination recall");
+            };
+            assert!(matches!(
+                query,
+                TransportQuery::RecallDestination { dest } if dest == dest_hash
+            ));
+            response_tx
+                .send(TransportQueryResponse::RecalledDestination(Some(
+                    rns_transport::messages::RecalledDestinationRpcEntry {
+                        dest_hash,
+                        public_key,
+                        app_data: None,
+                        ratchet: None,
+                        hops: 1,
+                        timestamp: 1.0,
+                    },
+                )))
+                .unwrap();
+        });
+
+        assert_eq!(
+            recall_destination_public_key(&transport_tx, dest_hash)
+                .await
+                .unwrap(),
+            Some(public_key)
+        );
+        responder.await.unwrap();
     }
 }

--- a/scripts/apply-rsReticulum-link-client-nomad.sh
+++ b/scripts/apply-rsReticulum-link-client-nomad.sh
@@ -8,7 +8,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/lib/apply-ratspeak-overlay.sh"
 PATCH_FILE="${REPO_ROOT}/reticulum-sidecar/patches/rsReticulum-link-client-nomad.patch"
 RNS_DIR="${RS_RETICULUM_DIR:-${REPO_ROOT}/.rsstack/rsReticulum}"
-MESSAGES_RS="${RNS_DIR}/crates/rns-transport/src/messages.rs"
+LINK_CLIENT_RS="${RNS_DIR}/crates/rns-runtime/src/link_client.rs"
 
 if [[ ! -d "${RNS_DIR}/.git" ]]; then
   echo "error: rsReticulum not found at ${RNS_DIR}" >&2
@@ -21,8 +21,23 @@ if [[ ! -f "${PATCH_FILE}" ]]; then
   exit 1
 fi
 
+# Upstream has HasPath-gated RecallDestination (a945ba0) but still Deregisters
+# announce handlers by aspect. This overlay is present when LinkClient recalls
+# without HasPath, awaits path, and GCs handlers with aspect_filter: None.
 # Upstream PR: https://github.com/ratspeak/rsReticulum/pull/14
-if [[ -f "${MESSAGES_RS}" ]] && grep -q 'RecallDestinationPublicKey' "${MESSAGES_RS}"; then
+overlay_already_present() {
+  [[ -f "${LINK_CLIENT_RS}" ]] || return 1
+  grep -qE 'fn discover_remote_public_key\(' "${LINK_CLIENT_RS}" \
+    && grep -qE 'fn gc_closed_announce_handlers\(' "${LINK_CLIENT_RS}" \
+    && grep -qE 'const PATH_LOOKUP_TIMEOUT' "${LINK_CLIENT_RS}"
+}
+
+if git -C "${RNS_DIR}" apply --reverse --check "${PATCH_FILE}" > /dev/null 2>&1; then
+  echo "link-client nomad overlay already present on rsReticulum @ $(git -C "${RNS_DIR}" rev-parse --short HEAD)"
+  exit 0
+fi
+
+if overlay_already_present; then
   echo "link-client nomad overlay already present on rsReticulum @ $(git -C "${RNS_DIR}" rev-parse --short HEAD)"
   exit 0
 fi

--- a/scripts/apply-rsReticulum-link-client-nomad.sh
+++ b/scripts/apply-rsReticulum-link-client-nomad.sh
@@ -22,14 +22,18 @@ if [[ ! -f "${PATCH_FILE}" ]]; then
 fi
 
 # Upstream has HasPath-gated RecallDestination (a945ba0) but still Deregisters
-# announce handlers by aspect. This overlay is present when LinkClient recalls
-# without HasPath, awaits path, and GCs handlers with aspect_filter: None.
-# Upstream PR: https://github.com/ratspeak/rsReticulum/pull/14
+# announce handlers by aspect. Marker fallback (when reverse-apply misses) is
+# the Nomad recall path: RecallDestination without HasPath, await_path, and GC
+# with aspect_filter: None. Upstream PR: https://github.com/ratspeak/rsReticulum/pull/14
 overlay_already_present() {
   [[ -f "${LINK_CLIENT_RS}" ]] || return 1
   grep -qE 'fn discover_remote_public_key\(' "${LINK_CLIENT_RS}" \
     && grep -qE 'fn gc_closed_announce_handlers\(' "${LINK_CLIENT_RS}" \
-    && grep -qE 'const PATH_LOOKUP_TIMEOUT' "${LINK_CLIENT_RS}"
+    && grep -qE 'const PATH_LOOKUP_TIMEOUT' "${LINK_CLIENT_RS}" \
+    && grep -qE 'TransportQuery::RecallDestination' "${LINK_CLIENT_RS}" \
+    && grep -qE 'await_path\(' "${LINK_CLIENT_RS}" \
+    && grep -qE 'aspect_filter: None' "${LINK_CLIENT_RS}" \
+    && ! grep -qE 'TransportQuery::HasPath' "${LINK_CLIENT_RS}"
 }
 
 if git -C "${RNS_DIR}" apply --reverse --check "${PATCH_FILE}" > /dev/null 2>&1; then

--- a/scripts/apply-rsReticulum-link-client-nomad.test.mjs
+++ b/scripts/apply-rsReticulum-link-client-nomad.test.mjs
@@ -26,9 +26,26 @@ const LXMF_ABORT_PATCH = path.join(
   'reticulum-sidecar/patches/rsLXMF-propagation-client-abort-transfer.patch',
 );
 
-const ALREADY_PRESENT = `impl LinkClient {
-    async fn discover_remote_public_key() {}
-    fn gc_closed_announce_handlers() {}
+const GIT_TEST_ENV = {
+  ...process.env,
+  GIT_CONFIG_NOSYSTEM: '1',
+  GIT_CONFIG_GLOBAL: '/dev/null',
+};
+
+/** Marker fallback: recall + GC semantics without matching the exact patch hunks. */
+const MARKER_FALLBACK = `impl LinkClient {
+    async fn discover_remote_public_key() {
+        match self.transport_query(TransportQuery::RecallDestination { dest: dest_hash }).await? {
+            TransportQueryResponse::RecalledDestination(Some(destination)) => destination.public_key,
+            _ => return Err(LinkClientError::PubkeyNotDiscovered),
+        };
+        await_path(&self.transport_tx, dest_hash, PATH_LOOKUP_TIMEOUT).await?;
+    }
+    fn gc_closed_announce_handlers() {
+        let _ = self.transport_tx.try_send(TransportMessage::DeregisterAnnounceHandler {
+            aspect_filter: None,
+        });
+    }
 }
 const PATH_LOOKUP_TIMEOUT: Duration = Duration::from_secs(15);
 `;
@@ -40,18 +57,93 @@ const INCOMPATIBLE = `impl LinkClient {
 
 const temps = [];
 
+function git(cwd, args) {
+  return spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: GIT_TEST_ENV,
+  });
+}
+
+function parseUnifiedHunkHeader(line) {
+  if (!line.startsWith('@@ -')) {
+    return null;
+  }
+  const close = line.indexOf(' @@', 4);
+  if (close < 0) {
+    return null;
+  }
+  const [oldSpec, newSpec] = line.slice(4, close).split(' +');
+  if (!oldSpec || !newSpec) {
+    return null;
+  }
+  const oldStart = Number(oldSpec.split(',')[0]);
+  const newStart = Number(newSpec.split(',')[0]);
+  if (!Number.isInteger(oldStart) || !Number.isInteger(newStart)) {
+    return null;
+  }
+  return { oldStart, newStart };
+}
+
+function materializeLinkClientFromPatch(patchText, side) {
+  const lines = [];
+  const patchLines = patchText.replace(/\n$/, '').split('\n');
+  let i = 0;
+  while (i < patchLines.length && !patchLines[i].startsWith('@@ ')) {
+    i += 1;
+  }
+  while (i < patchLines.length) {
+    const hunk = parseUnifiedHunkHeader(patchLines[i]);
+    if (!hunk) {
+      i += 1;
+      continue;
+    }
+    const start = side === 'old' ? hunk.oldStart : hunk.newStart;
+    while (lines.length < start - 1) {
+      lines.push(`// overlay-fixture-pad ${lines.length + 1}`);
+    }
+    i += 1;
+    while (i < patchLines.length && !patchLines[i].startsWith('@@ ')) {
+      const line = patchLines[i];
+      if (line.startsWith('\\')) {
+        i += 1;
+        continue;
+      }
+      if (
+        line.startsWith('diff ') ||
+        line.startsWith('index ') ||
+        line.startsWith('--- ') ||
+        line.startsWith('+++ ')
+      ) {
+        break;
+      }
+      const tag = line[0];
+      const body = line.slice(1);
+      if (tag === ' ') {
+        lines.push(body);
+      } else if (tag === '-' && side === 'old') {
+        lines.push(body);
+      } else if (tag === '+' && side === 'new') {
+        lines.push(body);
+      }
+      i += 1;
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
 function makeFakeRsReticulum(linkClientSource) {
   const root = mkdtempSync(path.join(os.tmpdir(), 'mesh-link-client-nomad-rns-'));
   temps.push(root);
   const linkClientPath = path.join(root, 'crates/rns-runtime/src/link_client.rs');
   mkdirSync(path.dirname(linkClientPath), { recursive: true });
   writeFileSync(linkClientPath, linkClientSource);
-  const gitInit = spawnSync('git', ['init'], { cwd: root, encoding: 'utf8' });
+  const gitInit = git(root, ['init']);
   expect(gitInit.status).toBe(0);
-  spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
-  spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
-  spawnSync('git', ['add', '.'], { cwd: root });
-  const commit = spawnSync('git', ['commit', '-m', 'init'], { cwd: root, encoding: 'utf8' });
+  git(root, ['config', 'user.email', 'test@example.com']);
+  git(root, ['config', 'user.name', 'test']);
+  git(root, ['add', '.']);
+  const commit = git(root, ['commit', '-m', 'init']);
   expect(commit.status).toBe(0);
   return root;
 }
@@ -60,7 +152,7 @@ function runApply(rnsDir) {
   return spawnSync('bash', [APPLY_SCRIPT], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
-    env: { ...process.env, RS_RETICULUM_DIR: rnsDir },
+    env: { ...GIT_TEST_ENV, RS_RETICULUM_DIR: rnsDir },
   });
 }
 
@@ -83,11 +175,15 @@ describe('apply-rsReticulum-link-client-nomad.sh', () => {
     expect(rrcLink).not.toContain('PublicKeyResult');
   });
 
-  it('uses LinkClient markers, not the retired RecallDestinationPublicKey RPC', () => {
+  it('uses LinkClient recall/GC semantics, not the retired RecallDestinationPublicKey RPC', () => {
     const applyScript = readFileSync(APPLY_SCRIPT, 'utf8');
     expect(applyScript).toContain('discover_remote_public_key');
     expect(applyScript).toContain('gc_closed_announce_handlers');
     expect(applyScript).toContain('PATH_LOOKUP_TIMEOUT');
+    expect(applyScript).toContain('TransportQuery::RecallDestination');
+    expect(applyScript).toContain('await_path\\(');
+    expect(applyScript).toContain('aspect_filter: None');
+    expect(applyScript).toContain('TransportQuery::HasPath');
     expect(applyScript).not.toContain('RecallDestinationPublicKey');
     expect(applyScript).not.toContain('MESSAGES_RS');
   });
@@ -125,8 +221,21 @@ describe('apply-rsReticulum-link-client-nomad.sh', () => {
     expect(patch).toContain('start_download_with_limit');
   });
 
-  it('is a no-op when discover_remote_public_key + GC markers are already present', () => {
-    const rns = makeFakeRsReticulum(ALREADY_PRESENT);
+  it('is a no-op when the exact applied overlay reverse-checks', () => {
+    const patch = readFileSync(PATCH_FILE, 'utf8');
+    const applied = materializeLinkClientFromPatch(patch, 'new');
+    const rns = makeFakeRsReticulum(applied);
+    const reverse = git(rns, ['apply', '--reverse', '--check', PATCH_FILE]);
+    expect(reverse.status, reverse.stderr || reverse.stdout).toBe(0);
+    const result = runApply(rns);
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toMatch(/already present/);
+  });
+
+  it('is a no-op when recall/GC markers are present but reverse-check misses', () => {
+    const rns = makeFakeRsReticulum(MARKER_FALLBACK);
+    const reverse = git(rns, ['apply', '--reverse', '--check', PATCH_FILE]);
+    expect(reverse.status).not.toBe(0);
     const result = runApply(rns);
     expect(result.status, result.stderr || result.stdout).toBe(0);
     expect(result.stdout).toMatch(/already present/);

--- a/scripts/apply-rsReticulum-link-client-nomad.test.mjs
+++ b/scripts/apply-rsReticulum-link-client-nomad.test.mjs
@@ -1,0 +1,141 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const APPLY_SCRIPT = path.join(SCRIPT_DIR, 'apply-rsReticulum-link-client-nomad.sh');
+const PATCH_FILE = path.join(
+  REPO_ROOT,
+  'reticulum-sidecar/patches/rsReticulum-link-client-nomad.patch',
+);
+const PATH_MEDIUM_PATCH = path.join(
+  REPO_ROOT,
+  'reticulum-sidecar/patches/rsReticulum-path-medium-slots.patch',
+);
+const LXMF_DEFERRED_PATCH = path.join(
+  REPO_ROOT,
+  'reticulum-sidecar/patches/rsLXMF-propagation-node-deferred-messagestore-load.patch',
+);
+const LXMF_ABORT_PATCH = path.join(
+  REPO_ROOT,
+  'reticulum-sidecar/patches/rsLXMF-propagation-client-abort-transfer.patch',
+);
+
+const ALREADY_PRESENT = `impl LinkClient {
+    async fn discover_remote_public_key() {}
+    fn gc_closed_announce_handlers() {}
+}
+const PATH_LOOKUP_TIMEOUT: Duration = Duration::from_secs(15);
+`;
+
+const INCOMPATIBLE = `impl LinkClient {
+    pub async fn query() {}
+}
+`;
+
+const temps = [];
+
+function makeFakeRsReticulum(linkClientSource) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'mesh-link-client-nomad-rns-'));
+  temps.push(root);
+  const linkClientPath = path.join(root, 'crates/rns-runtime/src/link_client.rs');
+  mkdirSync(path.dirname(linkClientPath), { recursive: true });
+  writeFileSync(linkClientPath, linkClientSource);
+  const gitInit = spawnSync('git', ['init'], { cwd: root, encoding: 'utf8' });
+  expect(gitInit.status).toBe(0);
+  spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+  spawnSync('git', ['add', '.'], { cwd: root });
+  const commit = spawnSync('git', ['commit', '-m', 'init'], { cwd: root, encoding: 'utf8' });
+  expect(commit.status).toBe(0);
+  return root;
+}
+
+function runApply(rnsDir) {
+  return spawnSync('bash', [APPLY_SCRIPT], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, RS_RETICULUM_DIR: rnsDir },
+  });
+}
+
+afterEach(() => {
+  while (temps.length > 0) {
+    const dir = temps.pop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('apply-rsReticulum-link-client-nomad.sh', () => {
+  it('keeps RRC LinkClient recall on upstream RecallDestination', () => {
+    const rrcLink = readFileSync(
+      path.join(REPO_ROOT, 'reticulum-sidecar/src/stack/rrc_link.rs'),
+      'utf8',
+    );
+    expect(rrcLink).toContain('TransportQuery::RecallDestination');
+    expect(rrcLink).toContain('TransportQueryResponse::RecalledDestination');
+    expect(rrcLink).not.toContain('RecallDestinationPublicKey');
+    expect(rrcLink).not.toContain('PublicKeyResult');
+  });
+
+  it('uses LinkClient markers, not the retired RecallDestinationPublicKey RPC', () => {
+    const applyScript = readFileSync(APPLY_SCRIPT, 'utf8');
+    expect(applyScript).toContain('discover_remote_public_key');
+    expect(applyScript).toContain('gc_closed_announce_handlers');
+    expect(applyScript).toContain('PATH_LOOKUP_TIMEOUT');
+    expect(applyScript).not.toContain('RecallDestinationPublicKey');
+    expect(applyScript).not.toContain('MESSAGES_RS');
+  });
+
+  it('rebases Nomad recall onto upstream RecallDestination + await_path', () => {
+    const patch = readFileSync(PATCH_FILE, 'utf8');
+    expect(patch).toContain('discover_remote_public_key');
+    expect(patch).toContain('gc_closed_announce_handlers');
+    expect(patch).toContain('RecallDestination');
+    expect(patch).toContain('await_path');
+    expect(patch).toContain('PATH_LOOKUP_TIMEOUT');
+    expect(patch).not.toContain('RecallDestinationPublicKey');
+    expect(patch).not.toContain('PublicKeyResult');
+    expect(patch).toMatch(/crates\/rns-runtime\/src\/link_client\.rs/);
+    expect(patch).not.toMatch(/crates\/rns-transport\/src\/messages\.rs/);
+  });
+
+  it('does not keep retired Nomad RPC tests in the path-medium-slots overlay', () => {
+    const patch = readFileSync(PATH_MEDIUM_PATCH, 'utf8');
+    expect(patch).not.toContain('RecallDestinationPublicKey');
+    expect(patch).toContain('MAX_PATH_SLOTS');
+  });
+
+  it('rebases LXMF deferred messagestore load onto pending_write fields', () => {
+    const patch = readFileSync(LXMF_DEFERRED_PATCH, 'utf8');
+    expect(patch).toContain('with_storage_unloaded');
+    expect(patch).toContain('load_messagestore_from_disk');
+    expect(patch).toContain('pending_write_ids');
+    expect(patch).toContain('pending_write_bytes');
+  });
+
+  it('inserts abort_transfer after acknowledge_transfer on current rsLXMF', () => {
+    const patch = readFileSync(LXMF_ABORT_PATCH, 'utf8');
+    expect(patch).toContain('fn abort_transfer');
+    expect(patch).toContain('start_download_with_limit');
+  });
+
+  it('is a no-op when discover_remote_public_key + GC markers are already present', () => {
+    const rns = makeFakeRsReticulum(ALREADY_PRESENT);
+    const result = runApply(rns);
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toMatch(/already present/);
+  });
+
+  it('fails with git diagnostic on incompatible checkouts', () => {
+    const rns = makeFakeRsReticulum(INCOMPATIBLE);
+    const result = runApply(rns);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/did not apply|regenerate overlay/);
+  });
+});


### PR DESCRIPTION
## Summary
- Release packaging (`clone-ratspeak-stack.sh`) failed on [run 31725861996](https://github.com/Colorado-Mesh/mesh-client/actions/runs/31725861996) because the LinkClient Nomad overlay would not apply on rsReticulum `70b7399`.
- Regenerated drifted Ratspeak overlays (Nomad recall, BLE pairing/bond-desync, path-medium-slots, LXMF deferred load / abort-transfer) against floated `origin/main` (rsReticulum `70b7399`, rsLXMF `f9ed81e`).
- Sidecar: RRC pubkey recall uses upstream `RecallDestination`; host-peer terminal accounting stays lxmd-parity; `LxmRouter::send` → `try_send` for Clippy `-D warnings`.

## Test plan
- [x] `scripts/apply-rsReticulum-link-client-nomad.test.mjs` (8 tests)
- [x] `pnpm run check:reticulum-sidecar` (fmt + Clippy `-D warnings` + tests)
- [ ] Re-run **Build/Release Electron App** (`workflow_dispatch`) after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound message delivery by preserving failed messages and reporting delivery failures accurately.
  * Improved destination key lookup and link establishment behavior.
  * Ensured synchronization metrics remain accurate when transfers fail.

* **Improvements**
  * Added message, byte, and transfer-rate statistics for successful synchronization.
  * Improved patch application behavior for updated or incompatible installations.

* **Tests**
  * Added coverage for delivery failures, synchronization metrics, key lookup, and patch application scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->