### PR TITLE
fix(release): scoped conventional bumps and Actions-first cut

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -1,12 +1,16 @@
-# Optional maintainer path: cut a release from Actions.
-# Prefer local `pnpm run release --yes` when practical — full preflight needs
-# cargo, flatpak-node-generator, actionlint, and several minutes of Vitest.
+# Primary maintainer path: cut a release from Actions.
 #
-# Requires repository secret RELEASE_PUSH_TOKEN (PAT / GitHub App) with
-# contents:write + workflows:write so the tag push can trigger release.yaml /
-# flatpak.yaml. Default GITHUB_TOKEN will not re-trigger those workflows.
+# Requires repository secret RELEASE_PUSH_TOKEN — a PAT (or GitHub App token)
+# owned by a repo **admin** (so the main merge-queue ruleset bypass applies)
+# with contents:write + workflows:write. Default GITHUB_TOKEN will not trigger
+# release.yaml / flatpak.yaml on the tag push (GitHub recursion guard).
 #
-# Does NOT publish the draft GitHub Release — review artifacts, then Publish.
+# Does NOT publish the GitHub Release draft — review artifacts, then Publish.
+#
+# Version bump: default `auto` uses scripts/detectReleaseBump.mjs (scoped
+# Conventional Commits: feat(scope): → minor). Override with patch|minor|major
+# or an exact X.Y.Z. Dep bumps stay on separate PRs (`pnpm run update`); this
+# workflow defaults to --skip-dep-update.
 
 name: Cut release
 
@@ -21,10 +25,15 @@ on:
         required: false
         default: auto
         type: string
-      skip_dep_update:
-        description: 'Skip pnpm update/dedupe (use when lockfile is already current)'
+      dry_run:
+        description: 'Preview auto/computed version only — do not bump, tag, or push'
         required: false
         default: false
+        type: boolean
+      skip_dep_update:
+        description: 'Skip pnpm update/dedupe (recommended; bump deps in a prior PR)'
+        required: false
+        default: true
         type: boolean
 
 concurrency:
@@ -33,19 +42,20 @@ concurrency:
 
 jobs:
   release:
-    name: Cut release (--yes)
+    name: Cut release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Require RELEASE_PUSH_TOKEN
+      - name: Require RELEASE_PUSH_TOKEN (unless dry-run)
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         env:
           RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
         run: |
           if [ -z "${RELEASE_PUSH_TOKEN}" ]; then
-            echo '::error::Set repository secret RELEASE_PUSH_TOKEN (contents+workflows).'
-            echo 'Default GITHUB_TOKEN cannot trigger release.yaml / flatpak.yaml on tag push.'
-            echo 'Prefer local: pnpm run release --yes'
+            echo '::error::Set repository secret RELEASE_PUSH_TOKEN (admin PAT: contents+workflows).'
+            echo 'Default GITHUB_TOKEN cannot trigger release.yaml / flatpak.yaml on tag push,'
+            echo 'and cannot bypass the main merge-queue ruleset.'
             exit 1
           fi
 
@@ -54,7 +64,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          # dry_run uses GITHUB_TOKEN; real cuts need admin RELEASE_PUSH_TOKEN.
+          token: >-
+            ${{ (inputs.dry_run == true || inputs.dry_run == 'true')
+              && github.token
+              || secrets.RELEASE_PUSH_TOKEN }}
           persist-credentials: true
 
       - name: Setup pnpm
@@ -67,57 +81,131 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        # dry_run only needs the detect script + package.json; still install so
+        # node_modules layout matches (detect has no deps beyond node builtins).
         run: pnpm install --frozen-lockfile
 
+      - name: Preview version bump
+        id: preview
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git describe --tags --abbrev=0)
+          CURRENT=$(node -p "require('./package.json').version")
+          BUMP_INPUT='${{ inputs.bump }}'
+          case "$BUMP_INPUT" in
+            auto|'')
+              JSON=$(node scripts/detectReleaseBump.mjs --since "$LAST_TAG" --current "$CURRENT")
+              BUMP=$(node -e "process.stdout.write(JSON.parse(process.argv[1]).bump)" "$JSON")
+              NEXT=$(node -e "process.stdout.write(JSON.parse(process.argv[1]).nextVersion)" "$JSON")
+              SUBJECTS=$(node -e "process.stdout.write(String(JSON.parse(process.argv[1]).subjectCount))" "$JSON")
+              MODE=auto
+              ;;
+            patch|minor|major)
+              BUMP=$BUMP_INPUT
+              NEXT=$(node --input-type=module -e "
+                import { previewNextVersion } from './scripts/detectReleaseBump.mjs';
+                process.stdout.write(previewNextVersion(process.argv[1], process.argv[2]));
+              " "$CURRENT" "$BUMP")
+              SUBJECTS=$(git log "$LAST_TAG"..HEAD --oneline | wc -l | tr -d ' ')
+              MODE=manual
+              ;;
+            *)
+              if [[ "$BUMP_INPUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                BUMP=$BUMP_INPUT
+                NEXT=$BUMP_INPUT
+                SUBJECTS=$(git log "$LAST_TAG"..HEAD --oneline | wc -l | tr -d ' ')
+                MODE=exact
+              else
+                echo "::error::Invalid bump input: $BUMP_INPUT"
+                exit 1
+              fi
+              ;;
+          esac
+          {
+            echo "## Cut release preview"
+            echo ""
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Last tag | \`$LAST_TAG\` |"
+            echo "| Current package.json | \`$CURRENT\` |"
+            echo "| Mode | \`$MODE\` (input=\`$BUMP_INPUT\`) |"
+            echo "| Detected / chosen bump | \`$BUMP\` |"
+            echo "| Next version | **\`v$NEXT\`** |"
+            echo "| Commits since tag | $SUBJECTS |"
+            echo "| dry_run | \`${{ inputs.dry_run }}\` |"
+            echo "| skip_dep_update | \`${{ inputs.skip_dep_update }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "bump=$BUMP"
+            echo "next=$NEXT"
+            echo "last_tag=$LAST_TAG"
+          } >> "$GITHUB_OUTPUT"
+          echo "Preview: $LAST_TAG → v$NEXT (bump=$BUMP, mode=$MODE)"
+
+      - name: Stop after dry-run preview
+        if: ${{ inputs.dry_run == true || inputs.dry_run == 'true' }}
+        run: |
+          echo "dry_run=true — not bumping or tagging."
+          echo "Re-run with dry_run unchecked to cut v${{ steps.preview.outputs.next }}."
+
       - name: Install actionlint
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         run: pnpm run setup:actionlint
 
       - name: Install yamllint
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         run: pip install yamllint
 
       - name: Install flatpak-node-generator
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         run: |
-          FBTOOLS=git+https://github.com/flatpak/flatpak-builder-tools
-          # Keep in sync with scripts/flatpakPnpmStoreVersion.mjs FLATPAK_NODE_GENERATOR_COMMIT.
+          # Keep pin in sync with scripts/flatpakPnpmStoreVersion.mjs FLATPAK_NODE_GENERATOR_COMMIT.
+          COMMIT=$(node --input-type=module -e "
+            import { FLATPAK_NODE_GENERATOR_COMMIT } from './scripts/flatpakPnpmStoreVersion.mjs';
+            process.stdout.write(FLATPAK_NODE_GENERATOR_COMMIT);
+          ")
           pip3 install --force-reinstall --no-cache-dir \
-            "${FBTOOLS}@b97a6e66f3fa46efad54738168e34e61b2b8c6f4#subdirectory=node"
+            "git+https://github.com/flatpak/flatpak-builder-tools@${COMMIT}#subdirectory=node"
 
       - name: Install Linux build deps (sidecar / Flatpak checks)
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
       - name: Setup Rust
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Add actionlint to PATH
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         run: echo "${{ github.workspace }}/.githooks/bin" >> "$GITHUB_PATH"
 
       - name: Configure git identity
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Run release (MESH_CLIENT_RELEASE_YES)
+        if: ${{ inputs.dry_run != true && inputs.dry_run != 'true' }}
         env:
           MESH_CLIENT_RELEASE_YES: '1'
         run: |
           set -euo pipefail
-          BUMP='${{ inputs.bump }}'
+          BUMP='${{ steps.preview.outputs.bump }}'
           EXTRA=()
           if [ '${{ inputs.skip_dep_update }}' = 'true' ]; then
             EXTRA+=(--skip-dep-update)
           fi
           case "$BUMP" in
-            auto|'')
-              pnpm run release -- --auto "${EXTRA[@]}"
-              ;;
             patch|minor|major)
               pnpm run release -- "$BUMP" "${EXTRA[@]}"
               ;;
             *)
+              # Exact X.Y.Z from preview (auto resolves to patch|minor|major already)
               if [[ "$BUMP" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                 pnpm run release -- "$BUMP" "${EXTRA[@]}"
               else
-                echo "::error::Invalid bump input: $BUMP"
+                echo "::error::Unexpected bump from preview: $BUMP"
                 exit 1
               fi
               ;;

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -15,7 +15,7 @@ Mesh-Client uses GitHub Actions for continuous integration and deployment.
 | `reticulum-sidecar.yaml`    | Path-filtered push/PR to `main`              | Sidecar fmt + Clippy (ubuntu); multi-OS matrix build/test                       |
 | `release.yaml`              | Version tags (`v*`)                          | Build & publish releases (AppImage/deb/rpm)                                     |
 | `flatpak.yaml`              | Version tags (`v*`), manual                  | Build Flatpak (+ schema compare vs last official); publish to release on tags   |
-| `cut-release.yaml`          | Manual `workflow_dispatch`                   | Optional Actions-driven `pnpm run release --yes` (needs `RELEASE_PUSH_TOKEN`)   |
+| `cut-release.yaml`          | Manual `workflow_dispatch`                   | **Primary** release cut in Actions (needs admin `RELEASE_PUSH_TOKEN`)           |
 | `docs.yml`                  | Push to `main`                               | Deploy MkDocs to GitHub Pages                                                   |
 | `third-party-licenses.yaml` | Path-filtered push to `main` + dispatch      | Regenerate `docs/third-party-licenses.md` after dependency changes              |
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,7 +6,7 @@ This document describes how maintainers create releases for Mesh-Client.
 
 ## Overview
 
-Releases are driven by **annotated version tags** (`v*`) on `main`. Pushing a tag triggers:
+Cut releases from **Actions → Cut release** ([`cut-release.yaml`](../.github/workflows/cut-release.yaml)), which bumps/tags `main`. Pushing an annotated version tag (`v*`) then triggers:
 
 | Workflow                                            | Purpose                                                                                              |
 | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
@@ -40,14 +40,29 @@ Documentation deploys separately: [`docs.yml`](../.github/workflows/docs.yml) ru
 
 ---
 
-## Recommended: `pnpm run release`
+## Recommended: Cut release from GitHub Actions
 
-The release script (`scripts/release.sh`) is the supported maintainer path. It:
+**Preferred path:** Actions → **Cut release** ([`cut-release.yaml`](../.github/workflows/cut-release.yaml)).
+
+1. (Optional) Run once with **dry_run** checked to confirm the computed version in the job summary (`feat(scope):` → minor, etc.).
+2. Re-run with dry_run unchecked. Default bump is **auto**; override with `patch` / `minor` / `major` / exact `X.Y.Z` when needed.
+3. **skip_dep_update** defaults to **true** — bump dependencies in a normal PR via `pnpm run update` before cutting.
+4. Wait for `release.yaml` + `flatpak.yaml` to attach draft artifacts, then **Publish** on GitHub.
+
+**Secret:** `RELEASE_PUSH_TOKEN` — fine-grained PAT (or GitHub App installation token) owned by a repo **admin** (so the merge-queue ruleset bypass applies), with **contents: write** and **workflows: write**. Plain `GITHUB_TOKEN` cannot trigger tag workflows and cannot push past the ruleset.
+
+Version detection lives in [`scripts/detectReleaseBump.mjs`](../scripts/detectReleaseBump.mjs) (handles scoped Conventional Commits such as `feat(rrc): …`).
+
+---
+
+## Local fallback: `pnpm run release`
+
+Local `scripts/release.sh` remains for emergencies when Actions is unavailable. It:
 
 1. Verifies you are on `main` and pulls latest
 2. Runs **`pnpm update`** and **`pnpm dedupe`** (updates lockfile before the bump)
 3. Syncs **`org.coloradomesh.MeshClient.yml`** Electron vendored archives to match `package.json` (`node scripts/sync-flatpak-electron.mjs`)
-4. Auto-detects **patch / minor / major** from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag (or accept an explicit bump — see below)
+4. Auto-detects **patch / minor / major** via [`detectReleaseBump.mjs`](../scripts/detectReleaseBump.mjs) (scoped Conventional Commits such as `feat(rrc):` count as **minor**) since the last tag (or accept an explicit bump — see below)
 5. Runs **pre-flight validation** (`check:environment`, release CLI health, format, lint, typecheck, **all** `check:*` scanners including path-gated pre-commit ones, **`check:flatpak`**, **`check:flatpak-offline-pnpm`**, **`check:i18n`**, lockfile re-dedupe stability (not `pnpm dedupe --check` — that breaks hoisted `node_modules/.bin`), audit, **required** actionlint + yamllint, **full** Vitest via `pnpm run test:run`, Reticulum sidecar `cargo test`)
 6. Prints **copy-paste release notes** grouped by feat/fix/other/breaking
 7. Bumps `package.json` via `pnpm version`
@@ -71,15 +86,7 @@ The script prompts twice by default (start pre-flight, then confirm after checks
 
 **Full suite only:** Release must never use `test:staged`, `test:changed`, or `vitest related`. Pre-commit may run a staged subset for speed; release matches PR CI by running the unrestricted `pnpm run test:run` (`vitest run`) and does not soft-skip actionlint/yamllint when those tools are missing.
 
-If pre-flight fails, fix the issue on `main` and run `pnpm run release` again — do not tag manually until checks pass.
-
-### Optional: cut release from Actions
-
-[`cut-release.yaml`](../.github/workflows/cut-release.yaml) is a **manual** `workflow_dispatch` that runs `pnpm run release --yes` on `ubuntu-latest`. Prefer local `pnpm run release --yes` for day-to-day cuts (full preflight is heavy and needs `cargo`, Flatpak tooling, etc.).
-
-**Required secret:** `RELEASE_PUSH_TOKEN` — a fine-grained PAT (or GitHub App installation token) with **contents: write** and **workflows: write**. Do **not** use the default `GITHUB_TOKEN`: pushes authenticated with it will **not** trigger `release.yaml` / `flatpak.yaml` on the new tag (GitHub recursion guard).
-
-The workflow never publishes the GitHub Release draft — maintainers still review artifacts and click **Publish**.
+If pre-flight fails, fix the issue on `main` and cut again — do not tag manually until checks pass.
 
 ### Mid-release MetaInfo failure
 
@@ -103,6 +110,7 @@ Configure these in **Settings → Secrets and variables → Actions** (maintaine
 
 | Secret                            | Purpose                                                                 |
 | --------------------------------- | ----------------------------------------------------------------------- |
+| **`RELEASE_PUSH_TOKEN`**          | Admin PAT for **Cut release** (contents + workflows); see above         |
 | **`CSC_LINK`**                    | Base64-encoded `.p12` **Developer ID Application** certificate          |
 | **`CSC_KEY_PASSWORD`**            | Password protecting the `.p12` file                                     |
 | **`APPLE_ID`**                    | Apple ID email used with App Store Connect / notarytool                 |

--- a/scripts/detectReleaseBump.mjs
+++ b/scripts/detectReleaseBump.mjs
@@ -1,0 +1,144 @@
+/**
+ * Conventional Commits → semver bump for mesh-client releases.
+ *
+ * Matches `type:`, `type(scope):`, and breaking `type!:` / `type(scope)!:`
+ * (the historical bash regex only matched unscoped `type:` and missed squash
+ * titles like `feat(rrc): …`, so auto-detect often returned patch for minors).
+ */
+
+/** @typedef {'major' | 'minor' | 'patch'} ReleaseBump */
+
+const RELEASE_TYPES = new Set([
+  'feat',
+  'fix',
+  'chore',
+  'docs',
+  'refactor',
+  'test',
+  'style',
+  'perf',
+  'build',
+  'ci',
+]);
+
+/**
+ * Parse Conventional Commit type / breaking bang from a subject line.
+ * @param {string} subject
+ * @returns {{ type: string, breakingBang: boolean } | null}
+ */
+export function parseConventionalSubject(subject) {
+  const trimmed = subject.trim();
+  const colon = trimmed.indexOf(':');
+  if (colon <= 0) return null;
+  // Require conventional "type: " / "type(scope): " (space after colon is usual;
+  // allow missing space for robustness).
+  let head = trimmed.slice(0, colon);
+  let breakingBang = false;
+  if (head.endsWith('!')) {
+    breakingBang = true;
+    head = head.slice(0, -1);
+  }
+  let type = head;
+  const open = head.indexOf('(');
+  if (open !== -1) {
+    if (!head.endsWith(')')) return null;
+    type = head.slice(0, open);
+  }
+  type = type.toLowerCase();
+  if (!RELEASE_TYPES.has(type)) return null;
+  return { type, breakingBang };
+}
+
+/**
+ * @param {string[]} subjects - commit subjects only (one per commit)
+ * @param {string} [bodiesJoined] - concatenated commit bodies (for BREAKING CHANGE footers)
+ * @returns {ReleaseBump}
+ */
+export function detectReleaseBump(subjects, bodiesJoined = '') {
+  let hasBreaking = bodiesJoined.includes('BREAKING CHANGE:');
+  let hasFeat = false;
+  let hasOther = false;
+
+  for (const raw of subjects) {
+    const parsed = parseConventionalSubject(raw);
+    if (!parsed) continue;
+    if (parsed.breakingBang) hasBreaking = true;
+    if (parsed.type === 'feat') hasFeat = true;
+    hasOther = true;
+  }
+
+  if (hasBreaking) return 'major';
+  if (hasFeat) return 'minor';
+  if (hasOther) return 'patch';
+  return 'patch';
+}
+
+/**
+ * @param {string} currentVersion - X.Y.Z
+ * @param {ReleaseBump | string} bump - patch|minor|major|or exact X.Y.Z
+ * @returns {string} next X.Y.Z
+ */
+export function previewNextVersion(currentVersion, bump) {
+  if (/^\d+\.\d+\.\d+$/.test(bump)) return bump;
+  const parts = currentVersion.split('.').map((n) => Number(n));
+  if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n) || n < 0)) {
+    throw new Error(`Invalid current version: ${currentVersion}`);
+  }
+  let [major, minor, patch] = parts;
+  if (bump === 'major') {
+    major += 1;
+    minor = 0;
+    patch = 0;
+  } else if (bump === 'minor') {
+    minor += 1;
+    patch = 0;
+  } else if (bump === 'patch') {
+    patch += 1;
+  } else {
+    throw new Error(`Invalid bump: ${bump}`);
+  }
+  return `${major}.${minor}.${patch}`;
+}
+
+/**
+ * CLI: node scripts/detectReleaseBump.mjs --since vX.Y.Z [--current X.Y.Z]
+ * Prints bump (and optionally next version) as JSON on stdout.
+ */
+async function main() {
+  const args = process.argv.slice(2);
+  let since = '';
+  let current = '';
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--since') since = args[++i] ?? '';
+    else if (args[i] === '--current') current = args[++i] ?? '';
+  }
+  if (!since) {
+    console.error('Usage: node scripts/detectReleaseBump.mjs --since <tag> [--current X.Y.Z]');
+    process.exit(2);
+  }
+
+  const { execFileSync } = await import('node:child_process');
+  const subjectsRaw = execFileSync('git', ['log', `${since}..HEAD`, '--pretty=format:%s'], {
+    encoding: 'utf8',
+  });
+  const bodiesRaw = execFileSync('git', ['log', `${since}..HEAD`, '--pretty=format:%b'], {
+    encoding: 'utf8',
+  });
+  const subjects = subjectsRaw.split('\n').filter(Boolean);
+  const bump = detectReleaseBump(subjects, bodiesRaw);
+  /** @type {{ bump: ReleaseBump; subjectCount: number; nextVersion?: string }} */
+  const out = { bump, subjectCount: subjects.length };
+  if (current) out.nextVersion = previewNextVersion(current, bump);
+  process.stdout.write(`${JSON.stringify(out)}\n`);
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  (process.argv[1].endsWith('detectReleaseBump.mjs') ||
+    process.argv[1].endsWith('detectReleaseBump.js'));
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/scripts/detectReleaseBump.test.mjs
+++ b/scripts/detectReleaseBump.test.mjs
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  detectReleaseBump,
+  parseConventionalSubject,
+  previewNextVersion,
+} from './detectReleaseBump.mjs';
+
+describe('parseConventionalSubject', () => {
+  it('parses scoped and breaking subjects without regex', () => {
+    expect(parseConventionalSubject('feat(rrc): toggle')).toEqual({
+      type: 'feat',
+      breakingBang: false,
+    });
+    expect(parseConventionalSubject('fix(reticulum)!: drop ipc')).toEqual({
+      type: 'fix',
+      breakingBang: true,
+    });
+    expect(parseConventionalSubject('not conventional')).toBeNull();
+  });
+});
+
+describe('detectReleaseBump', () => {
+  it('treats scoped feat(scope): as minor (squash-merge titles)', () => {
+    expect(
+      detectReleaseBump([
+        'fix(ci): licenses PR flow (#850)',
+        'feat(rrc): App toggle for all-room unread (#847)',
+        'chore: bump deps',
+      ]),
+    ).toBe('minor');
+  });
+
+  it('does not miss feat when only scoped feats exist (historical bash bug)', () => {
+    // Old bash regex ^feat[[:space:]]*: matched zero of these → wrongly patch.
+    expect(
+      detectReleaseBump([
+        'feat(reticulum): real Ratspeak .rsi backup (#843)',
+        'fix(logs): drop DEBUG spam (#844)',
+        'docs: Reticulum ownership layers (#842)',
+      ]),
+    ).toBe('minor');
+  });
+
+  it('returns patch for fix/chore/docs only', () => {
+    expect(
+      detectReleaseBump([
+        'fix(ci): keep NSIS stub (#840)',
+        'chore(ci): merge queue support (#849)',
+        'docs: generate third-party licenses (#846)',
+      ]),
+    ).toBe('patch');
+  });
+
+  it('detects breaking via type!: and type(scope)!:', () => {
+    expect(detectReleaseBump(['feat!: remove legacy API'])).toBe('major');
+    expect(detectReleaseBump(['fix(reticulum)!: drop old IPC'])).toBe('major');
+  });
+
+  it('detects BREAKING CHANGE footer in bodies', () => {
+    expect(
+      detectReleaseBump(['feat(app): new thing'], 'BREAKING CHANGE: config keys renamed\n'),
+    ).toBe('major');
+  });
+
+  it('ignores body bullet lines that look like commits (subjects-only)', () => {
+    expect(detectReleaseBump(['chore: release prep'])).toBe('patch');
+  });
+
+  it('defaults to patch when no conventional subjects', () => {
+    expect(detectReleaseBump(['Merge branch main', 'WIP'])).toBe('patch');
+  });
+});
+
+describe('previewNextVersion', () => {
+  it('bumps patch/minor/major', () => {
+    expect(previewNextVersion('5.27.1', 'patch')).toBe('5.27.2');
+    expect(previewNextVersion('5.27.1', 'minor')).toBe('5.28.0');
+    expect(previewNextVersion('5.27.1', 'major')).toBe('6.0.0');
+  });
+
+  it('accepts exact versions', () => {
+    expect(previewNextVersion('5.27.1', '5.30.0')).toBe('5.30.0');
+  });
+});

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -231,8 +231,8 @@ EOF
 
   echo ""
   echo "### Breaking Changes"
-  if printf '%s\n' "$commit_logs" | grep -qE "(BREAKING CHANGE|!)"; then
-    printf '%s\n' "$commit_logs" | grep -E "(BREAKING CHANGE|!)" | sed 's/^/* /'
+  if printf '%s\n' "$commit_logs" | grep -qE "(BREAKING CHANGE:|^\* [^:]+!:)"; then
+    printf '%s\n' "$commit_logs" | grep -E "(BREAKING CHANGE:|^\* [^:]+!:)" | sed 's/^/* /'
   else
     echo "*(None)*"
   fi
@@ -246,46 +246,15 @@ EOF
   echo "-> Copy the text above and paste it into your GitHub Release"
 }
 
-# Function to detect version bump from conventional commits
+# Function to detect version bump from conventional commits (scoped + unscoped).
+# Implementation lives in scripts/detectReleaseBump.mjs (unit-tested) so squash
+# titles like feat(rrc): … count as minor — the old bash regex missed scopes.
 detect_version_bump() {
   local last_tag="$1"
-  local commits
-  commits=$(git log "$last_tag"..HEAD --pretty=format:"%s%n%b" 2> /dev/null || echo "")
-
-  if [ -z "$commits" ]; then
-    echo "none"
-    return
-  fi
-
-  local has_breaking=false
-  local has_feat=false
-  local has_other=false
-
-  if echo "$commits" | grep -q "BREAKING CHANGE:"; then
-    has_breaking=true
-  fi
-
-  if echo "$commits" | grep -qE "^(feat|fix|chore|docs|refactor|test|style|perf|build|ci)!:"; then
-    has_breaking=true
-  fi
-
-  if echo "$commits" | grep -qE "^feat[[:space:]]*:"; then
-    has_feat=true
-  fi
-
-  if echo "$commits" | grep -qE "^(feat|fix|chore|docs|refactor|test|style|perf|build|ci)[[:space:]]*:"; then
-    has_other=true
-  fi
-
-  if [ "$has_breaking" = true ]; then
-    echo "major"
-  elif [ "$has_feat" = true ]; then
-    echo "minor"
-  elif [ "$has_other" = true ]; then
-    echo "patch"
-  else
-    echo "patch"
-  fi
+  local current
+  current=$(read_package_version)
+  node scripts/detectReleaseBump.mjs --since "$last_tag" --current "$current" \
+    | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const j=JSON.parse(s);process.stdout.write(j.bump);});"
 }
 
 # 1. Parse version / finish / non-interactive flags (order-independent).

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -102,6 +102,13 @@ describe('release.sh full-suite gate', () => {
     expect(script).toMatch(/Skipping pnpm update\/dedupe/);
   });
 
+  it('delegates conventional bump detection to detectReleaseBump.mjs (scoped feats)', () => {
+    expect(script).toMatch(/detectReleaseBump\.mjs/);
+    expect(script).toMatch(/detect_version_bump/);
+    // Historical bug: unscoped-only feat: regex missed feat(scope):
+    expect(script).not.toMatch(/\^feat\[\[:space:\]\]\*:/);
+  });
+
   it('requires actionlint and yamllint (no soft-skip)', () => {
     expect(script).toMatch(/actionlint not found/);
     expect(script).toMatch(/yamllint not found/);


### PR DESCRIPTION
## Summary
- **Bug:** auto version detect only matched unscoped `feat:` / `fix:`, so squash titles like `feat(rrc): …` were ignored and releases with real features became **patch** (today’s main would have been `5.27.2` instead of **`5.28.0`**)
- Move bump logic to [`scripts/detectReleaseBump.mjs`](scripts/detectReleaseBump.mjs) with unit tests (`type(scope):`, `type!:`, `BREAKING CHANGE` footers)
- Make **Actions → Cut release** the primary path: `dry_run` preview in the job summary, default `skip_dep_update`, docs updated; local `pnpm run release` is emergency fallback
- `RELEASE_PUSH_TOKEN` must be an **admin** PAT (ruleset bypass + tag workflow trigger)

## Test plan
- [x] `vitest run scripts/detectReleaseBump.test.mjs scripts/release.test.mjs`
- [x] `node scripts/detectReleaseBump.mjs --since v5.27.1 --current 5.27.1` → `minor` / `5.28.0`
- [ ] CI green; merge via queue
- [ ] After merge: set `RELEASE_PUSH_TOKEN` if missing, run **Cut release** with `dry_run=true` and confirm summary shows `v5.28.0`