### PR TITLE
fix(ci): probe RELEASE_PUSH_TOKEN write access for licenses CPR

### DIFF
--- a/.github/workflows/third-party-licenses.yaml
+++ b/.github/workflows/third-party-licenses.yaml
@@ -62,16 +62,43 @@ jobs:
             echo 'changed=true' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Require RELEASE_PUSH_TOKEN for PR checks
+      # RELEASE_PUSH_TOKEN must be able to git-push a branch; existence alone is not
+      # enough (fine-grained missing Contents/PR write presents as push 403).
+      - name: Verify RELEASE_PUSH_TOKEN can push
         if: steps.licenses_diff.outputs.changed == 'true'
         env:
-          RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          if [ -z "${RELEASE_PUSH_TOKEN}" ]; then
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
             echo '::error::Set repository secret RELEASE_PUSH_TOKEN (admin PAT: contents+workflows+pull_requests).'
             echo 'Default GITHUB_TOKEN PRs do not auto-run required checks under the merge-queue ruleset.'
             exit 1
           fi
+
+          LOGIN=$(gh api user --jq .login)
+          echo "RELEASE_PUSH_TOKEN authenticates as: ${LOGIN}"
+
+          PUSH=$(gh api "repos/${REPO}" --jq '.permissions.push // false')
+          if [ "${PUSH}" != 'true' ]; then
+            echo "::error::RELEASE_PUSH_TOKEN (${LOGIN}) lacks push on ${REPO}."
+            echo 'Grant Contents+Pull requests+Workflows write on this repo,'
+            echo 'then: gh secret set RELEASE_PUSH_TOKEN --repo Colorado-Mesh/mesh-client'
+            exit 1
+          fi
+
+          MAIN_SHA=$(gh api "repos/${REPO}/git/ref/heads/main" --jq .object.sha)
+          PROBE_REF="refs/heads/chore/cpr-token-probe-${RUN_ID}"
+          if ! gh api -X POST "repos/${REPO}/git/refs" -f ref="${PROBE_REF}" -f sha="${MAIN_SHA}" >/dev/null; then
+            echo "::error::RELEASE_PUSH_TOKEN (${LOGIN}) cannot create refs on ${REPO} (Contents write)."
+            echo 'Grant Contents+Pull requests+Workflows write on this repo,'
+            echo 'then: gh secret set RELEASE_PUSH_TOKEN --repo Colorado-Mesh/mesh-client'
+            exit 1
+          fi
+          gh api -X DELETE "repos/${REPO}/git/refs/${PROBE_REF#refs/}" >/dev/null
+          echo "RELEASE_PUSH_TOKEN can create/delete refs on ${REPO}"
 
       # Open a PR instead of pushing to main — the merge-queue ruleset blocks
       # direct pushes, and GitHub Actions cannot be added as a bypass actor

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -147,7 +147,7 @@ After merges to `main` that change `package.json`, `pnpm-lock.yaml`, the generat
 5. Regenerate `docs/third-party-licenses.md` (`pnpm run docs:licenses`)
 6. Open a PR via `peter-evans/create-pull-request` when the file changed (branch `chore/third-party-licenses-<run_id>`)
 
-**Secret:** reuse **`RELEASE_PUSH_TOKEN`** (admin PAT with **contents**, **workflows**, and **pull requests** write). Default `GITHUB_TOKEN` PRs do not auto-run required checks, so they cannot enter the merge queue cleanly. Direct pushes to `main` remain blocked by the merge-queue ruleset.
+**Secret:** reuse **`RELEASE_PUSH_TOKEN`** (admin PAT with **contents**, **workflows**, and **pull requests** write). Default `GITHUB_TOKEN` PRs do not auto-run required checks, so they cannot enter the merge queue cleanly. Direct pushes to `main` remain blocked by the merge-queue ruleset. The workflow probes Contents write (create/delete a short-lived ref) before `create-pull-request` so a token missing write access fails with a clear error instead of a git 403.
 
 ---
 

--- a/docs/third-party-licenses.md
+++ b/docs/third-party-licenses.md
@@ -12,12 +12,12 @@ Bundled binaries, fonts, and vendored sources are attributed in [Credits](credit
 
 | Name                       | License type                  | Defined version | Installed version | Link                                                                           |
 | :------------------------- | :---------------------------- | :-------------- | :---------------- | :----------------------------------------------------------------------------- |
-| @bufbuild/protobuf         | (Apache-2.0 AND BSD-3-Clause) | ^2.13.0         | 2.13.0            | git+https://github.com/bufbuild/protobuf-es.git                                |
+| @bufbuild/protobuf         | (Apache-2.0 AND BSD-3-Clause) | ^2.14.0         | 2.14.0            | git+https://github.com/bufbuild/protobuf-es.git                                |
 | @jsr/meshtastic__protobufs | n/a                           | ^2.7.26         | 2.7.26            | n/a                                                                            |
 | @stoprocent/noble          | MIT                           | ^2.7.1          | 2.7.1             | git+https://github.com/stoprocent/noble.git                                    |
 | @xterm/addon-fit           | MIT                           | ^0.11.0         | 0.11.0            | git+https://github.com/xtermjs/xterm.js.git#master                             |
 | @xterm/xterm               | MIT                           | ^6.0.0          | 6.0.0             | git+https://github.com/xtermjs/xterm.js.git                                    |
-| @zip.js/zip.js             | BSD-3-Clause                  | ^2.8.43         | 2.8.43            | git+https://github.com/gildas-lormeau/zip.js.git                               |
+| @zip.js/zip.js             | BSD-3-Clause                  | ^2.8.47         | 2.8.47            | git+https://github.com/gildas-lormeau/zip.js.git                               |
 | builder-util-runtime       | MIT                           | 9.7.0           | 9.7.0             | git+https://github.com/electron-userland/electron-builder.git                  |
 | dompurify                  | (MPL-2.0 OR Apache-2.0)       | ^3.4.13         | 3.4.13            | git://github.com/cure53/DOMPurify.git                                          |
 | electron-updater           | MIT                           | ^6.8.9          | 6.8.9             | git+https://github.com/electron-userland/electron-builder.git                  |
@@ -102,4 +102,4 @@ Bundled binaries, fonts, and vendored sources are attributed in [Credits](credit
 | vite                                  | MIT             | ^8.2.1          | 8.2.1             | git+https://github.com/vitejs/vite.git                                               |
 | vitest                                | MIT             | ^4.1.10         | 4.1.10            | git+https://github.com/vitest-dev/vitest.git                                         |
 | vitest-axe                            | MIT             | 1.0.0-pre.5     | 1.0.0-pre.5       | git+https://github.com/chaance/vitest-axe.git                                        |
-| zustand                               | MIT             | ^5.0.14         | 5.0.14            | git+https://github.com/pmndrs/zustand.git                                            |
+| zustand                               | MIT             | ^5.0.15         | 5.0.15            | git+https://github.com/pmndrs/zustand.git                                            |


### PR DESCRIPTION
## Summary
- Probe `RELEASE_PUSH_TOKEN` Contents write (create/delete a short-lived ref) before `create-pull-request`, so missing write access fails with a clear error instead of a git 403 (as in run 31758749284).
- Document the probe and required PAT scopes (contents + workflows + pull requests) without incorrect SAML/SSO mentions (org has no SSO).
- Land the pending `docs/third-party-licenses.md` regeneration (protobuf / zip.js / zustand bumps).

## Test plan
- [ ] Confirm workflow/docs have no SAML/SSO wording
- [ ] After merge, `gh workflow run "Third-party licenses" --ref main` with updated `RELEASE_PUSH_TOKEN` (Contents R/W + PRs R/W + Workflows R/W) — probe should pass; PR opens only if licenses doc drifted
- [ ] Optional: if licenses already match on main, dispatch may no-op on PR creation (probe still validates token when `changed=true`)