### PR TITLE
docs: update third-party licenses

### DIFF
--- a/docs/third-party-licenses.md
+++ b/docs/third-party-licenses.md
@@ -12,12 +12,12 @@ Bundled binaries, fonts, and vendored sources are attributed in [Credits](credit
 
 | Name                       | License type                  | Defined version | Installed version | Link                                                                           |
 | :------------------------- | :---------------------------- | :-------------- | :---------------- | :----------------------------------------------------------------------------- |
-| @bufbuild/protobuf         | (Apache-2.0 AND BSD-3-Clause) | ^2.13.0         | 2.13.0            | git+https://github.com/bufbuild/protobuf-es.git                                |
+| @bufbuild/protobuf         | (Apache-2.0 AND BSD-3-Clause) | ^2.14.0         | 2.14.0            | git+https://github.com/bufbuild/protobuf-es.git                                |
 | @jsr/meshtastic__protobufs | n/a                           | ^2.7.26         | 2.7.26            | n/a                                                                            |
 | @stoprocent/noble          | MIT                           | ^2.7.1          | 2.7.1             | git+https://github.com/stoprocent/noble.git                                    |
 | @xterm/addon-fit           | MIT                           | ^0.11.0         | 0.11.0            | git+https://github.com/xtermjs/xterm.js.git#master                             |
 | @xterm/xterm               | MIT                           | ^6.0.0          | 6.0.0             | git+https://github.com/xtermjs/xterm.js.git                                    |
-| @zip.js/zip.js             | BSD-3-Clause                  | ^2.8.43         | 2.8.43            | git+https://github.com/gildas-lormeau/zip.js.git                               |
+| @zip.js/zip.js             | BSD-3-Clause                  | ^2.8.47         | 2.8.47            | git+https://github.com/gildas-lormeau/zip.js.git                               |
 | builder-util-runtime       | MIT                           | 9.7.0           | 9.7.0             | git+https://github.com/electron-userland/electron-builder.git                  |
 | dompurify                  | (MPL-2.0 OR Apache-2.0)       | ^3.4.13         | 3.4.13            | git://github.com/cure53/DOMPurify.git                                          |
 | electron-updater           | MIT                           | ^6.8.9          | 6.8.9             | git+https://github.com/electron-userland/electron-builder.git                  |
@@ -102,4 +102,4 @@ Bundled binaries, fonts, and vendored sources are attributed in [Credits](credit
 | vite                                  | MIT             | ^8.2.1          | 8.2.1             | git+https://github.com/vitejs/vite.git                                               |
 | vitest                                | MIT             | ^4.1.10         | 4.1.10            | git+https://github.com/vitest-dev/vitest.git                                         |
 | vitest-axe                            | MIT             | 1.0.0-pre.5     | 1.0.0-pre.5       | git+https://github.com/chaance/vitest-axe.git                                        |
-| zustand                               | MIT             | ^5.0.14         | 5.0.14            | git+https://github.com/pmndrs/zustand.git                                            |
+| zustand                               | MIT             | ^5.0.15         | 5.0.15            | git+https://github.com/pmndrs/zustand.git                                            |


### PR DESCRIPTION
Regenerated `docs/third-party-licenses.md` after dependency changes.

Opened automatically by `third-party-licenses.yaml` (direct pushes to
`main` are blocked by the merge-queue ruleset).