### PR TITLE
fix: RRC unread panel focus + Node 24 Actions bumps

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload Playwright artifacts on failure
         if: failure() && github.actor != 'nektos/act'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-${{ matrix.os }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/third-party-licenses.yaml
+++ b/.github/workflows/third-party-licenses.yaml
@@ -107,7 +107,7 @@ jobs:
       # Unique branch per run avoids thrashing one tip under concurrent main pushes.
       - name: Create pull request
         if: steps.licenses_diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.RELEASE_PUSH_TOKEN }}
           commit-message: 'docs: update third-party licenses'

--- a/src/renderer/components/RrcPanel.tsx
+++ b/src/renderer/components/RrcPanel.tsx
@@ -124,6 +124,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
   const capabilities = useRrcSessionStore((s) => s.capabilities);
   const setNickname = useRrcSessionStore((s) => s.setNickname);
   const setFocusedHub = useRrcSessionStore((s) => s.setFocusedHub);
+  const setRrcPanelFocused = useRrcSessionStore((s) => s.setRrcPanelFocused);
   const setActiveRoom = useRrcSessionStore((s) => s.setActiveRoom);
   const setShowTimestamps = useRrcSessionStore((s) => s.setShowTimestamps);
   const clearUnread = useRrcSessionStore((s) => s.clearUnread);
@@ -231,6 +232,13 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
       unsub();
     };
   }, [refreshFromSidecar]);
+
+  useEffect(() => {
+    setRrcPanelFocused(isActive);
+    return () => {
+      setRrcPanelFocused(false);
+    };
+  }, [isActive, setRrcPanelFocused]);
 
   useEffect(() => {
     if (isActive && activeRoom) clearUnread(activeRoom);

--- a/src/renderer/runtime/useReticulumRuntime.rrc-alert.contract.test.ts
+++ b/src/renderer/runtime/useReticulumRuntime.rrc-alert.contract.test.ts
@@ -130,6 +130,20 @@ describe('useReticulumRuntime RRC unread ingest (handleSidecarEvent)', () => {
     unmount();
   });
 
+  it('bumps unread for active-room traffic when RRC panel is not focused', async () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ rrcUnreadAllRoomMessages: true }),
+    );
+    useRrcSessionStore.getState().roomJoined('#lobby');
+    useRrcSessionStore.getState().setActiveRoom('#lobby');
+    expect(useRrcSessionStore.getState().rrcPanelFocused).toBe(false);
+    const { onEvent, unmount } = await connectAndGetOnEvent();
+    sendRrcMessage(onEvent, { id: 'active-1', room: '#lobby', kind: 'msg', body: 'hello active' });
+    expect(lobbyUnread()).toBe(1);
+    unmount();
+  });
+
   it('skips plain room traffic in mentions mode and bumps @nick', async () => {
     localStorage.setItem(
       APP_SETTINGS_STORAGE_KEY,

--- a/src/renderer/stores/rrcSessionStore.test.ts
+++ b/src/renderer/stores/rrcSessionStore.test.ts
@@ -12,6 +12,7 @@ describe('rrcSessionStore', () => {
   beforeEach(() => {
     useRrcSessionStore.setState({ unreadByHub: new Map(), unreadByRoom: new Map() });
     useRrcSessionStore.getState().clearSession();
+    useRrcSessionStore.getState().setRrcPanelFocused(false);
     useRrcSessionStore.getState().setNickname('tester');
     useRrcSessionStore.getState().setLocalIdentityHash('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     vi.mocked(window.electronAPI.db.insertRrcMessage).mockClear();
@@ -139,6 +140,48 @@ describe('rrcSessionStore', () => {
     expect(useRrcSessionStore.getState().unreadByRoom.get('lobby')).toBe(1);
     expect(useRrcSessionStore.getState().totalUnread()).toBe(1);
     expect(useRrcSessionStore.getState().unreadForHub('28c7c1a68c735693aa8e6b8193ed44b2')).toBe(1);
+  });
+
+  it('bumps unread for active room when RRC panel is not focused', () => {
+    const store = useRrcSessionStore.getState();
+    store.applyStatus('active', '28c7c1a68c735693aa8e6b8193ed44b2', 'Community');
+    store.roomJoined('#lobby');
+    store.setActiveRoom('#lobby');
+    store.setRrcPanelFocused(false);
+    store.addMessage(
+      {
+        id: '1',
+        room: '#lobby',
+        kind: 'msg',
+        body: 'hi',
+        sender_hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        timestamp: 1,
+      },
+      { bumpUnread: true },
+    );
+    expect(useRrcSessionStore.getState().unreadByRoom.get('lobby')).toBe(1);
+    expect(useRrcSessionStore.getState().totalUnread()).toBe(1);
+  });
+
+  it('does not bump unread for active room when RRC panel is focused', () => {
+    const store = useRrcSessionStore.getState();
+    store.applyStatus('active', '28c7c1a68c735693aa8e6b8193ed44b2', 'Community');
+    store.roomJoined('#lobby');
+    store.setActiveRoom('#lobby');
+    store.setRrcPanelFocused(true);
+    store.addMessage(
+      {
+        id: '1',
+        room: '#lobby',
+        kind: 'msg',
+        body: 'hi',
+        sender_hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        timestamp: 1,
+      },
+      { bumpUnread: true },
+    );
+    expect(useRrcSessionStore.getState().unreadByRoom.get('lobby')).toBeUndefined();
+    expect(useRrcSessionStore.getState().totalUnread()).toBe(0);
   });
 
   it('stashes hub unread across disconnect wipe', () => {

--- a/src/renderer/stores/rrcSessionStore.ts
+++ b/src/renderer/stores/rrcSessionStore.ts
@@ -279,6 +279,12 @@ interface RrcSessionStoreState {
   /** Per-hub unread totals stashed when a hub session is removed (survives disconnect). */
   unreadByHub: Map<string, number>;
   showTimestamps: boolean;
+  /**
+   * True while the RRC panel tab is focused (not merely mounted / last-visited).
+   * Unread bumps are suppressed only when this is true and the message matches
+   * the focused hub's activeRoom — sticky activeRoom alone must not suppress.
+   */
+  rrcPanelFocused: boolean;
 
   // ── Mirror fields: always reflect `sessionsByHub.get(focusedHubHash)`. ──
   status: RrcSessionStatus;
@@ -296,6 +302,8 @@ interface RrcSessionStoreState {
 
   /** Focus a hub in the main pane. Never disconnects or wipes other hubs. */
   setFocusedHub: (hash: string | null) => void;
+  /** Whether the RRC panel is the focused tab (drives unread suppress). */
+  setRrcPanelFocused: (focused: boolean) => void;
   setNickname: (nick: string) => void;
   setLocalIdentityHash: (hash: string | null) => void;
   setActiveRoom: (room: string | null, hubHash?: string) => void;
@@ -397,6 +405,7 @@ export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
   messages: new Map(),
   unreadByHub: new Map(),
   showTimestamps: false,
+  rrcPanelFocused: false,
 
   status: 'disconnected',
   hubDestHash: null,
@@ -417,6 +426,10 @@ export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
       const session = hub ? (s.sessionsByHub.get(hub) ?? emptyHubSession()) : emptyHubSession();
       return { focusedHubHash: hub, ...mirrorFromSession(hub, session) };
     });
+  },
+
+  setRrcPanelFocused: (focused) => {
+    set({ rrcPanelFocused: focused });
   },
 
   setNickname: (nick) => {
@@ -809,9 +822,11 @@ export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
       const isSelf =
         Boolean(selfHash && msg.sender_hash?.toLowerCase() === selfHash) ||
         Boolean(msg.nickname && msg.nickname === s.nickname && !msg.sender_hash);
-      // Only the focused hub+room counts as "viewing" — a background hub's
-      // activeRoom must not suppress unread for that hub.
+      // Only the focused RRC panel + hub+room counts as "viewing" — sticky
+      // activeRoom after leaving the panel (or switching protocols) must not
+      // suppress unread. A background hub's activeRoom also must not suppress.
       const viewing =
+        s.rrcPanelFocused &&
         hub === s.focusedHubHash &&
         session.activeRoom != null &&
         rrcRoomsMatch(session.activeRoom, roomKey);


### PR DESCRIPTION
## Summary

- **RRC unread badge:** Unread suppression for the active room now requires the RRC panel to actually be focused (`rrcPanelFocused`), not just a sticky `activeRoom` left behind after leaving RRC or switching protocols. Leaving the panel (or unmount) clears focus so room replies bump the Reticulum pill again.
- **CI Actions Node 24:** Bump the last remaining Node 20 action pins — `actions/upload-artifact` v4 → v7 in E2E, and `peter-evans/create-pull-request` to a Node 24 release — ahead of the September 2026 runner removal.

## Changes

### RRC (`rrcSessionStore` / `RrcPanel`)
- Add `rrcPanelFocused` + `setRrcPanelFocused` to the session store.
- `RrcPanel` sets focus from `isActive` and clears it on cleanup.
- `addMessage` viewing check: `rrcPanelFocused && focusedHub && activeRoom match` (previously hub+room alone).
- Tests: store cases for focused vs unfocused active-room traffic; runtime contract for ingest when panel is not focused.

### CI
- `.github/workflows/e2e.yaml`: `actions/upload-artifact@v7`
- `.github/workflows/third-party-licenses.yaml`: `peter-evans/create-pull-request@5f6978f…` (Node 24)

## Test plan

- [ ] Open RRC, join a room, leave the RRC tab (or switch protocol) → send/receive a room message → Reticulum unread pill increments
- [ ] Stay on RRC with that room focused → inbound room messages do **not** bump unread for that room
- [ ] Background hub with sticky `activeRoom` still does not suppress unread for that hub
- [ ] `pnpm run test:run` covers `rrcSessionStore.test.ts` and `useReticulumRuntime.rrc-alert.contract.test.ts`
- [ ] CI: E2E artifact upload and licenses CPR still succeed with the bumped actions