### PR TITLE
docs: update third-party licenses

### DIFF
--- a/docs/third-party-licenses.md
+++ b/docs/third-party-licenses.md
@@ -17,7 +17,7 @@ Bundled binaries, fonts, and vendored sources are attributed in [Credits](credit
 | @stoprocent/noble          | MIT                           | ^2.7.1          | 2.7.1             | git+https://github.com/stoprocent/noble.git                                    |
 | @xterm/addon-fit           | MIT                           | ^0.11.0         | 0.11.0            | git+https://github.com/xtermjs/xterm.js.git#master                             |
 | @xterm/xterm               | MIT                           | ^6.0.0          | 6.0.0             | git+https://github.com/xtermjs/xterm.js.git                                    |
-| @zip.js/zip.js             | BSD-3-Clause                  | ^2.8.47         | 2.8.47            | git+https://github.com/gildas-lormeau/zip.js.git                               |
+| @zip.js/zip.js             | BSD-3-Clause                  | ^2.8.51         | 2.8.51            | git+https://github.com/gildas-lormeau/zip.js.git                               |
 | builder-util-runtime       | MIT                           | 9.7.0           | 9.7.0             | git+https://github.com/electron-userland/electron-builder.git                  |
 | dompurify                  | (MPL-2.0 OR Apache-2.0)       | ^3.4.13         | 3.4.13            | git://github.com/cure53/DOMPurify.git                                          |
 | electron-updater           | MIT                           | ^6.8.9          | 6.8.9             | git+https://github.com/electron-userland/electron-builder.git                  |


### PR DESCRIPTION
Regenerated `docs/third-party-licenses.md` after dependency changes.

Opened automatically by `third-party-licenses.yaml` (direct pushes to
`main` are blocked by the merge-queue ruleset).