### PR TITLE
fix(release): ignore pnpm-forwarded -- in release.sh argv

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -47,7 +47,7 @@ Documentation deploys separately: [`docs.yml`](../.github/workflows/docs.yml) ru
 1. (Optional) Run once with **dry_run** checked to confirm the computed version in the job summary (`feat(scope):` → minor, etc.).
 2. Re-run with dry_run unchecked. Default bump is **auto**; override with `patch` / `minor` / `major` / exact `X.Y.Z` when needed.
 3. **skip_dep_update** defaults to **true** — bump dependencies in a normal PR via `pnpm run update` before cutting.
-4. The workflow sets `MESH_CLIENT_RELEASE_YES=1` (non-interactive). Locally use `pnpm run release -- --yes` or the same env var.
+4. The workflow sets `MESH_CLIENT_RELEASE_YES=1` (non-interactive). Locally use `pnpm run release --yes` or the same env var.
 5. Wait for `release.yaml` + `flatpak.yaml` to attach draft artifacts, then **Publish** on GitHub.
 
 **Secret:** `RELEASE_PUSH_TOKEN` — fine-grained PAT (or GitHub App installation token) owned by a repo **admin** (so the merge-queue ruleset bypass applies), with **contents: write**, **workflows: write**, and **pull requests: write** (also used by `third-party-licenses.yaml` so bot PRs run required checks). Plain `GITHUB_TOKEN` cannot trigger tag workflows, cannot push past the ruleset, and cannot open check-running license PRs.
@@ -73,18 +73,19 @@ Local `scripts/release.sh` remains for emergencies when Actions is unavailable. 
 ```bash
 git checkout main
 git pull origin main
-pnpm run release                                  # auto-detect bump from commits since last tag
-pnpm run release minor                            # force minor
-pnpm run release 5.21.0                           # force exact version
-pnpm run release --auto                           # explicit auto-detect
-pnpm run release --finish                         # complete a mid-release after package.json was already bumped
-pnpm run release -- --yes                         # non-interactive (skip both confirmation prompts)
-pnpm run release -- --yes --skip-dep-update patch # CI-style: no pnpm update
-MESH_CLIENT_RELEASE_YES=1 pnpm run release        # same as --yes (avoids pnpm's own -y)
+pnpm run release                               # auto-detect bump from commits since last tag
+pnpm run release minor                         # force minor
+pnpm run release 5.21.0                        # force exact version
+pnpm run release --auto                        # explicit auto-detect
+pnpm run release --finish                      # complete a mid-release after package.json was already bumped
+pnpm run release --yes                         # non-interactive (skip both confirmation prompts)
+pnpm run release --yes --skip-dep-update patch # CI-style: no pnpm update
+MESH_CLIENT_RELEASE_YES=1 pnpm run release     # same as --yes (avoids pnpm's own -y)
 # Invalid: --auto cannot be combined with patch|minor|major|x.x.x
+# Note: `pnpm run release -- minor` is fine — pnpm 11 forwards bare `--`; release.sh ignores it.
 ```
 
-The script prompts twice by default (start pre-flight, then confirm after checks pass). Pass **`-- --yes`** after `pnpm run release` (or set `MESH_CLIENT_RELEASE_YES=1`) to skip those prompts — useful for automation. Use `--` so pnpm does not swallow `-y`/`--yes`. **`--auto` plus an explicit bump is rejected.** **Expect several minutes** for the full validation chain.
+The script prompts twice by default (start pre-flight, then confirm after checks pass). Pass **`--yes`** after `pnpm run release` (or set `MESH_CLIENT_RELEASE_YES=1`) to skip those prompts — useful for automation. **`--auto` plus an explicit bump is rejected.** **Expect several minutes** for the full validation chain.
 
 **Full suite only:** Release must never use `test:staged`, `test:changed`, or `vitest related`. Pre-commit may run a staged subset for speed; release matches PR CI by running the unrestricted `pnpm run test:run` (`vitest run`) and does not soft-skip actionlint/yamllint when those tools are missing.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -110,9 +110,10 @@ print_release_usage() {
   echo "       pnpm run release minor          # Force minor release"
   echo "       pnpm run release 2.0.0          # Force specific version"
   echo "       pnpm run release --finish       # Complete mid-release (no re-bump)"
-  echo "       pnpm run release -- --yes       # Skip confirmation prompts ( -- so pnpm keeps -y )"
-  echo "       pnpm run release -- --skip-dep-update  # Skip pnpm update/dedupe"
+  echo "       pnpm run release --yes          # Skip confirmation prompts"
+  echo "       pnpm run release --skip-dep-update  # Skip pnpm update/dedupe"
   echo "       MESH_CLIENT_RELEASE_YES=1 pnpm run release   # Same as --yes"
+  echo "       (Bare -- from \`pnpm run release -- …\` is ignored; pnpm 11 forwards it.)"
 }
 
 commit_tag_and_push_release() {
@@ -290,6 +291,9 @@ fi
 POSITIONAL_COUNT=0
 for arg in "$@"; do
   case "$arg" in
+    # pnpm 11+ forwards the run-script separator: `pnpm run release -- minor`
+    # becomes argv `-- minor`. Treat bare `--` as a no-op so CI/docs stay valid.
+    --) ;;
     --yes | -y)
       RELEASE_YES=true
       ;;

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -167,6 +167,42 @@ describe('release.sh argv subprocess', () => {
     expect(r.stdout).toMatch(/^VERSION_TYPE=patch$/m);
   });
 
+  it('PARSE_ONLY: ignores bare -- (pnpm 11 run-script separator)', () => {
+    // Cut release / docs historically used `pnpm run release -- minor …`.
+    // pnpm 11 forwards that `--` into argv; rejecting it broke the workflow.
+    const r = spawnSync('bash', [RELEASE_SH, '--', 'minor', '--skip-dep-update'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        MESH_CLIENT_RELEASE_PARSE_ONLY: '1',
+        MESH_CLIENT_ALLOW_PARSE_ONLY_IN_CI: '1',
+        MESH_CLIENT_RELEASE_YES: '1',
+      },
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/^VERSION_TYPE=minor$/m);
+    expect(r.stdout).toMatch(/^SKIP_DEP_UPDATE=true$/m);
+    expect(r.stdout).toMatch(/^RELEASE_YES=true$/m);
+  });
+
+  it('PARSE_ONLY: pnpm run release -- minor --skip-dep-update (Cut release argv)', () => {
+    const r = spawnSync('pnpm', ['run', 'release', '--', 'minor', '--skip-dep-update'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        MESH_CLIENT_RELEASE_PARSE_ONLY: '1',
+        MESH_CLIENT_ALLOW_PARSE_ONLY_IN_CI: '1',
+        MESH_CLIENT_RELEASE_YES: '1',
+      },
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/^VERSION_TYPE=minor$/m);
+    expect(r.stdout).toMatch(/^SKIP_DEP_UPDATE=true$/m);
+  });
+
   it('PARSE_ONLY: rejects under GitHub Actions without allow flag', () => {
     const r = spawnSync('bash', [RELEASE_SH, '--yes', '--auto'], {
       encoding: 'utf8',


### PR DESCRIPTION
## Summary
- Cut release failed because pnpm 11 forwards the run-script `--` separator into `scripts/release.sh`, which rejected it as an unknown arg before bump/tag
- Ignore bare `--` in release argv parsing; cover the Cut release `pnpm run release -- minor --skip-dep-update` path in tests
- Update release-process docs to match (`pnpm run release --yes`, note that forwarded `--` is ignored)

## Test plan
- [x] `scripts/release.test.mjs` (42 tests) — includes PARSE_ONLY + live `pnpm run` argv cases
- [ ] After merge, re-run **Cut release** (no tag was created by the failed run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release command examples for direct confirmation and dependency-update options.
  * Clarified handling of pnpm argument separators and equivalent environment-variable options.

* **Bug Fixes**
  * Improved release command parsing when a standalone `--` separator is provided.

* **Tests**
  * Added coverage for release commands using standalone separators and pnpm invocation syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->