### PR TITLE
feat(connection): show Bluetooth MAC on Radio Connection picker

### DIFF
--- a/src/main/darwinBluetoothNameAddressMap.test.ts
+++ b/src/main/darwinBluetoothNameAddressMap.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  loadDarwinBluetoothNameAddressMap,
+  parseDarwinBluetoothNameAddressMap,
+  resolveDarwinScanAddress,
+} from './darwinBluetoothNameAddressMap';
+
+const FIXTURE = {
+  SPBluetoothDataType: [
+    {
+      device_connected: [
+        {
+          'MeshCore-🛜 NV0N 01': {
+            device_address: 'AC:A7:04:00:D6:F1',
+            device_services: '0x400000 < BLE >',
+          },
+        },
+        {
+          'RNode 41F4': {
+            device_address: 'F0:9E:9E:77:98:D5',
+            device_services: '0x400000 < BLE >',
+          },
+        },
+      ],
+      device_not_connected: [
+        {
+          MeshCore: { device_address: 'AA:BB:CC:DD:EE:01' },
+        },
+        {
+          MeshCore: { device_address: 'AA:BB:CC:DD:EE:02' },
+        },
+        {
+          Basement: { device_address: 'D4:A3:3D:7D:E4:CC' },
+        },
+      ],
+    },
+  ],
+};
+
+describe('parseDarwinBluetoothNameAddressMap', () => {
+  it('maps unique names including emoji MeshCore GAP names', () => {
+    const map = parseDarwinBluetoothNameAddressMap(FIXTURE);
+    expect(map.get('MeshCore-🛜 NV0N 01')).toBe('ac:a7:04:00:d6:f1');
+    expect(map.get('RNode 41F4')).toBe('f0:9e:9e:77:98:d5');
+    expect(map.get('Basement')).toBe('d4:a3:3d:7d:e4:cc');
+  });
+
+  it('omits names that resolve to more than one MAC', () => {
+    const map = parseDarwinBluetoothNameAddressMap(FIXTURE);
+    expect(map.has('MeshCore')).toBe(false);
+  });
+
+  it('returns empty for malformed input', () => {
+    expect(parseDarwinBluetoothNameAddressMap(null).size).toBe(0);
+    expect(parseDarwinBluetoothNameAddressMap({}).size).toBe(0);
+  });
+});
+
+describe('loadDarwinBluetoothNameAddressMap', () => {
+  it('parses JSON from the reader', async () => {
+    const map = await loadDarwinBluetoothNameAddressMap(() =>
+      Promise.resolve(JSON.stringify(FIXTURE)),
+    );
+    expect(map.get('MeshCore-🛜 NV0N 01')).toBe('ac:a7:04:00:d6:f1');
+  });
+});
+
+describe('resolveDarwinScanAddress', () => {
+  const map = new Map([
+    ['MeshCore-🛜 NV0N 01', 'ac:a7:04:00:d6:f1'],
+    ['Basement', 'd4:a3:3d:7d:e4:cc'],
+  ]);
+
+  it('prefers Noble address when the OS exposes one', () => {
+    expect(resolveDarwinScanAddress('AA:BB:CC:DD:EE:FF', 'MeshCore-🛜 NV0N 01', map)).toBe(
+      'AA:BB:CC:DD:EE:FF',
+    );
+  });
+
+  it('falls back to unique GAP name when Noble address is empty (macOS)', () => {
+    expect(resolveDarwinScanAddress('', 'MeshCore-🛜 NV0N 01', map)).toBe('ac:a7:04:00:d6:f1');
+    expect(resolveDarwinScanAddress('unknown', 'MeshCore-🛜 NV0N 01', map)).toBe(
+      'ac:a7:04:00:d6:f1',
+    );
+  });
+
+  it('matches GAP names case-insensitively when the exact key is missing', () => {
+    expect(resolveDarwinScanAddress(undefined, 'basement', map)).toBe('d4:a3:3d:7d:e4:cc');
+  });
+
+  it('returns undefined when the advertised name is missing or not unique', () => {
+    expect(resolveDarwinScanAddress('', undefined, map)).toBeUndefined();
+    expect(resolveDarwinScanAddress('', 'MeshCore', map)).toBeUndefined();
+  });
+});

--- a/src/main/darwinBluetoothNameAddressMap.ts
+++ b/src/main/darwinBluetoothNameAddressMap.ts
@@ -1,0 +1,147 @@
+import { spawn } from 'child_process';
+
+import { isTwelveHexBleMac, normalizeBleMac } from '../shared/normalizeBleMac';
+import { MS_PER_SECOND } from '../shared/timeConstants';
+
+/** Bound `system_profiler SPBluetoothDataType -json` so scan start cannot hang IPC. */
+export const DARWIN_BT_PROFILER_TIMEOUT_MS = 5 * MS_PER_SECOND;
+
+type NameToMacSets = Map<string, Set<string>>;
+
+function addNamedAddress(acc: NameToMacSets, name: string, address: string): void {
+  const trimmedName = name.trim();
+  if (!trimmedName || !isTwelveHexBleMac(address)) return;
+  const mac = normalizeBleMac(address);
+  const existing = acc.get(trimmedName);
+  if (existing) {
+    existing.add(mac);
+    return;
+  }
+  acc.set(trimmedName, new Set([mac]));
+}
+
+function collectNamedDevices(list: unknown, acc: NameToMacSets): void {
+  if (!Array.isArray(list)) return;
+  for (const item of list) {
+    if (!item || typeof item !== 'object') continue;
+    for (const [name, info] of Object.entries(item as Record<string, unknown>)) {
+      if (!info || typeof info !== 'object') continue;
+      const address = (info as { device_address?: unknown }).device_address;
+      if (typeof address !== 'string') continue;
+      addNamedAddress(acc, name, address);
+    }
+  }
+}
+
+/**
+ * Unique advertised-name → BLE MAC from `system_profiler SPBluetoothDataType -json`.
+ * Names that map to more than one MAC are omitted (ambiguous).
+ */
+export function parseDarwinBluetoothNameAddressMap(raw: unknown): Map<string, string> {
+  const acc: NameToMacSets = new Map();
+  if (!raw || typeof raw !== 'object') return new Map();
+  const blocks = (raw as { SPBluetoothDataType?: unknown }).SPBluetoothDataType;
+  if (!Array.isArray(blocks)) return new Map();
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue;
+    const rec = block as { device_connected?: unknown; device_not_connected?: unknown };
+    collectNamedDevices(rec.device_connected, acc);
+    collectNamedDevices(rec.device_not_connected, acc);
+  }
+  const unique = new Map<string, string>();
+  for (const [name, macs] of acc) {
+    if (macs.size !== 1) continue;
+    const mac = [...macs][0];
+    if (mac) unique.set(name, mac);
+  }
+  return unique;
+}
+
+/**
+ * Prefer Noble's OS-exposed MAC (linux/win32). On modern macOS that field is empty, so
+ * fall back to a unique GAP-name → MAC map from system_profiler.
+ */
+export function resolveDarwinScanAddress(
+  nobleAddress: string | undefined,
+  localName: string | undefined,
+  nameToMac: ReadonlyMap<string, string>,
+): string | undefined {
+  const trimmed = nobleAddress?.trim();
+  if (trimmed && trimmed.toLowerCase() !== 'unknown') {
+    return trimmed;
+  }
+  const name = localName?.trim();
+  if (!name) return undefined;
+  const exact = nameToMac.get(name);
+  if (exact) return exact;
+  const lower = name.toLowerCase();
+  let match: string | undefined;
+  for (const [mappedName, mac] of nameToMac) {
+    if (mappedName.toLowerCase() !== lower) continue;
+    if (match && match !== mac) return undefined;
+    match = mac;
+  }
+  return match;
+}
+
+export async function readSystemProfilerBluetoothJson(): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    // OS-specific: absolute path so packaged Electron still finds the binary.
+    const proc = spawn('/usr/sbin/system_profiler', ['SPBluetoothDataType', '-json'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+    const timer = setTimeout(() => {
+      proc.kill();
+      finish(() => {
+        reject(
+          new Error(
+            `system_profiler SPBluetoothDataType timed out after ${DARWIN_BT_PROFILER_TIMEOUT_MS}ms`,
+          ),
+        );
+      });
+    }, DARWIN_BT_PROFILER_TIMEOUT_MS);
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    proc.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    proc.on('error', (err) => {
+      finish(() => {
+        reject(err);
+      });
+    });
+    proc.on('close', (code) => {
+      finish(() => {
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+        reject(new Error(`system_profiler SPBluetoothDataType exited ${code}: ${stderr.trim()}`));
+      });
+    });
+  });
+}
+
+/** Load unique GAP-name → MAC map for darwin Noble scans (Noble `peripheral.address` is empty). */
+export async function loadDarwinBluetoothNameAddressMap(
+  readJson: () => Promise<string> = readSystemProfilerBluetoothJson,
+): Promise<Map<string, string>> {
+  const rawText = await readJson();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText) as unknown;
+  } catch {
+    throw new Error('system_profiler SPBluetoothDataType returned invalid JSON');
+  }
+  return parseDarwinBluetoothNameAddressMap(parsed);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -155,7 +155,7 @@ import { ensureMicrophoneAccess, isAllowedMicrophonePrivacySettingsUrl } from '.
 import { resolveMqttBrokerClientId } from './mqtt-broker-client-id';
 import { type CachedNode, MQTTManager, parsePsk } from './mqtt-manager';
 import { handleNobleBleToRadioWrite } from './noble-ble-ipc';
-import { NobleBleManager, type NobleSessionId } from './noble-ble-manager';
+import { type NobleBleDevice, NobleBleManager, type NobleSessionId } from './noble-ble-manager';
 import { readFileUpTo } from './readFileUpTo';
 import { createRendererHeartbeatWatchdog } from './rendererHeartbeatWatchdog';
 import {
@@ -2655,12 +2655,9 @@ ipcMain.on('device-disconnected', (event) => {
 nobleBleManager.on('adapterState', (state: string) => {
   mainWindow?.webContents.send('noble-ble-adapter-state', state);
 });
-nobleBleManager.on(
-  'deviceDiscovered',
-  (device: { deviceId: string; deviceName: string; rssi: number | null }) => {
-    mainWindow?.webContents.send('noble-ble-device-discovered', device);
-  },
-);
+nobleBleManager.on('deviceDiscovered', (device: NobleBleDevice) => {
+  mainWindow?.webContents.send('noble-ble-device-discovered', device);
+});
 nobleBleManager.on(
   'linkRssi',
   ({ sessionId, rssi }: { sessionId: NobleSessionId; rssi: number | null }) => {

--- a/src/main/noble-ble-manager.test.ts
+++ b/src/main/noble-ble-manager.test.ts
@@ -93,11 +93,11 @@ describe('NobleBleManager.connect — per-session UUID selection (regression)', 
     );
   });
 
-  it('emits deviceDiscovered with rssi on scan and at connect start', () => {
-    expect(SOURCE).toMatch(
-      /emit\('deviceDiscovered',\s*\{\s*deviceId:\s*id,\s*deviceName:\s*name,\s*rssi\s*\}\)/,
-    );
+  it('emits deviceDiscovered with rssi and address on scan and at connect start', () => {
+    expect(SOURCE).toContain('toNobleDiscoveredDevice');
+    expect(SOURCE).toMatch(/toNobleDiscoveredDevice\(id, name, rssi, peripheral\.address\)/);
     expect(SOURCE).toContain('Refresh picker / connecting banner with connect-time RSSI');
+    expect(SOURCE).toMatch(/toNobleDiscoveredDevice\(\s*peripheralId,/);
   });
 
   it('branches on sessionId to pick the correct service UUID for discovery', () => {

--- a/src/main/noble-ble-manager.test.ts
+++ b/src/main/noble-ble-manager.test.ts
@@ -95,9 +95,27 @@ describe('NobleBleManager.connect — per-session UUID selection (regression)', 
 
   it('emits deviceDiscovered with rssi and address on scan and at connect start', () => {
     expect(SOURCE).toContain('toNobleDiscoveredDevice');
-    expect(SOURCE).toMatch(/toNobleDiscoveredDevice\(id, name, rssi, peripheral\.address\)/);
+    expect(SOURCE).toContain('toDiscoveredDevice');
+    expect(SOURCE).toContain('resolvePeripheralMac');
     expect(SOURCE).toContain('Refresh picker / connecting banner with connect-time RSSI');
-    expect(SOURCE).toMatch(/toNobleDiscoveredDevice\(\s*peripheralId,/);
+    expect(SOURCE).toMatch(/this\.toDiscoveredDevice\(peripheral\)/);
+  });
+
+  it('loads darwin GAP name→MAC map before scanning so picker rows can show sticker MACs', () => {
+    expect(SOURCE).toContain('refreshDarwinNameAddressMap');
+    expect(SOURCE).toContain('loadDarwinBluetoothNameAddressMap');
+    expect(SOURCE).toContain('resolveDarwinScanAddress');
+    const fnMatch = /async startScanning\b[\s\S]+?(?=\n {2}async stopScanning)/.exec(SOURCE);
+    expect(fnMatch).not.toBeNull();
+    const body = fnMatch![0];
+    const refreshIdx = body.indexOf('await this.refreshDarwinNameAddressMap()');
+    const requestersIdx = body.indexOf('this.scanRequesters.add(sessionId)');
+    const scanIdx = body.indexOf('this.doStartScanning()');
+    expect(refreshIdx).toBeGreaterThan(-1);
+    expect(requestersIdx).toBeGreaterThan(-1);
+    expect(scanIdx).toBeGreaterThan(-1);
+    expect(refreshIdx).toBeLessThan(requestersIdx);
+    expect(refreshIdx).toBeLessThan(scanIdx);
   });
 
   it('branches on sessionId to pick the correct service UUID for discovery', () => {

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -183,9 +183,30 @@ export interface NobleBleDevice {
   deviceName: string;
   /** Advertised / last-seen BLE RSSI in dBm; null when unknown. */
   rssi: number | null;
+  /**
+   * Hardware BLE MAC when the OS exposes one (Noble `peripheral.address`).
+   * On macOS this is typically empty until after a prior GATT connect (CoreBluetoothCache).
+   */
+  address?: string | null;
 }
 
 import type { MeshProtocol } from '../shared/meshProtocol';
+
+function noblePeripheralAddress(address: string | undefined): string | undefined {
+  const trimmed = address?.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'unknown') return undefined;
+  return trimmed;
+}
+
+function toNobleDiscoveredDevice(
+  deviceId: string,
+  deviceName: string,
+  rssi: number | null,
+  address?: string,
+): NobleBleDevice {
+  const mac = noblePeripheralAddress(address);
+  return mac ? { deviceId, deviceName, rssi, address: mac } : { deviceId, deviceName, rssi };
+}
 
 export type NobleSessionId = MeshProtocol;
 
@@ -329,7 +350,7 @@ export class NobleBleManager extends EventEmitter {
           : null;
       this.knownPeripherals.set(id, peripheral);
       // Re-emit on rediscover so Connection pickers can refresh RSSI (not first-seen only).
-      this.emit('deviceDiscovered', { deviceId: id, deviceName: name, rssi });
+      this.emit('deviceDiscovered', toNobleDiscoveredDevice(id, name, rssi, peripheral.address));
     });
   }
 
@@ -777,7 +798,7 @@ export class NobleBleManager extends EventEmitter {
         typeof peripheral.rssi === 'number' && Number.isFinite(peripheral.rssi)
           ? peripheral.rssi
           : null;
-      this.emit('deviceDiscovered', { deviceId: id, deviceName: name, rssi });
+      this.emit('deviceDiscovered', toNobleDiscoveredDevice(id, name, rssi, peripheral.address));
     }
     this.scanRequesters.add(sessionId);
     if (!this.adapterReady) {
@@ -1194,11 +1215,15 @@ export class NobleBleManager extends EventEmitter {
         `[BLE:${sessionId}] peripheral info — address=${peripheral.address ?? 'unknown'} addressType=${peripheral.addressType ?? 'unknown'} rssi=${connectRssi ?? 'unknown'} state=${peripheral.state} platform=${process.platform}`,
       );
       // Refresh picker / connecting banner with connect-time RSSI (scan may have been empty).
-      this.emit('deviceDiscovered', {
-        deviceId: peripheralId,
-        deviceName: peripheral.advertisement?.localName || peripheral.address || peripheralId,
-        rssi: connectRssi,
-      });
+      this.emit(
+        'deviceDiscovered',
+        toNobleDiscoveredDevice(
+          peripheralId,
+          peripheral.advertisement?.localName || peripheral.address || peripheralId,
+          connectRssi,
+          peripheral.address,
+        ),
+      );
       bleCoexistenceCoordinator.assertCanConnect(
         peripheralOwner,
         peripheral.address ?? peripheralId,

--- a/src/main/noble-ble-manager.ts
+++ b/src/main/noble-ble-manager.ts
@@ -3,6 +3,10 @@ import { EventEmitter } from 'events';
 import { attMtuOrDefault, maxWriteRequestPayloadBytes } from '../shared/bleAttWriteLimit';
 import { withTimeout } from '../shared/withTimeout';
 import { bleCoexistenceCoordinator, type BlePeripheralOwner } from './ble-coexistence-coordinator';
+import {
+  loadDarwinBluetoothNameAddressMap,
+  resolveDarwinScanAddress,
+} from './darwinBluetoothNameAddressMap';
 import { logDeviceConnection, sanitizeLogMessage } from './log-service';
 
 interface NobleAdvertisement {
@@ -184,8 +188,8 @@ export interface NobleBleDevice {
   /** Advertised / last-seen BLE RSSI in dBm; null when unknown. */
   rssi: number | null;
   /**
-   * Hardware BLE MAC when the OS exposes one (Noble `peripheral.address`).
-   * On macOS this is typically empty until after a prior GATT connect (CoreBluetoothCache).
+   * Hardware BLE MAC when the OS exposes one (Noble `peripheral.address`, or on
+   * macOS a unique GAP-name lookup from system_profiler when CoreBluetooth omits the MAC).
    */
   address?: string | null;
 }
@@ -298,6 +302,11 @@ export class NobleBleManager extends EventEmitter {
   private scanStartInFlight: Promise<void> | null = null;
   private lastAdapterState = noble?.state ?? 'unknown';
   private releaseHandlesCallCount = 0;
+  /**
+   * macOS: unique GAP name → sticker MAC from system_profiler (Noble `peripheral.address` is
+   * empty — CoreBluetoothCache is no longer in the readable Bluetooth plist).
+   */
+  private darwinNameToMac = new Map<string, string>();
 
   constructor() {
     super();
@@ -343,14 +352,9 @@ export class NobleBleManager extends EventEmitter {
         }
       }
       const id: string = peripheral.id;
-      const name: string = peripheral.advertisement?.localName || peripheral.address || id;
-      const rssi =
-        typeof peripheral.rssi === 'number' && Number.isFinite(peripheral.rssi)
-          ? peripheral.rssi
-          : null;
       this.knownPeripherals.set(id, peripheral);
       // Re-emit on rediscover so Connection pickers can refresh RSSI (not first-seen only).
-      this.emit('deviceDiscovered', toNobleDiscoveredDevice(id, name, rssi, peripheral.address));
+      this.emit('deviceDiscovered', this.toDiscoveredDevice(peripheral));
     });
   }
 
@@ -386,6 +390,45 @@ export class NobleBleManager extends EventEmitter {
       sessionEstablishedAtMs: null,
       lastConnectedPeripheralId: null,
     };
+  }
+
+  /**
+   * macOS: load unique Bluetooth GAP name → MAC from system_profiler before scanning.
+   * Noble's `peripheral.address` is empty because CoreBluetoothCache is no longer in the
+   * readable Bluetooth plist. Duplicate names are omitted (ambiguous).
+   * OS-specific: darwin only — linux/win32 already get MACs from Noble.
+   */
+  private async refreshDarwinNameAddressMap(): Promise<void> {
+    if (process.platform !== 'darwin') return;
+    try {
+      this.darwinNameToMac = await loadDarwinBluetoothNameAddressMap();
+      console.debug(
+        `[NobleBleManager] darwin Bluetooth name→MAC map: ${this.darwinNameToMac.size} unique names`,
+      );
+    } catch (error) {
+      console.debug(
+        `[NobleBleManager] darwin Bluetooth name→MAC map unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /** Noble MAC when present (linux/win32); else unique GAP-name lookup from system_profiler. */
+  private resolvePeripheralMac(peripheral: NoblePeripheral): string | undefined {
+    return resolveDarwinScanAddress(
+      peripheral.address,
+      peripheral.advertisement?.localName,
+      this.darwinNameToMac,
+    );
+  }
+
+  private toDiscoveredDevice(peripheral: NoblePeripheral): NobleBleDevice {
+    const id = peripheral.id;
+    const name = peripheral.advertisement?.localName || peripheral.address || id;
+    const rssi =
+      typeof peripheral.rssi === 'number' && Number.isFinite(peripheral.rssi)
+        ? peripheral.rssi
+        : null;
+    return toNobleDiscoveredDevice(id, name, rssi, this.resolvePeripheralMac(peripheral));
   }
 
   private stopLinkRssiPolling(session: NobleBleSession): void {
@@ -781,6 +824,9 @@ export class NobleBleManager extends EventEmitter {
 
   async startScanning(sessionId: NobleSessionId): Promise<void> {
     await bleCoexistenceCoordinator.acquireScan('noble');
+    // Load darwin GAP name→MAC before adding scan requesters so a concurrent stateChange
+    // doStartScanning cannot emit picker rows before the map is ready.
+    await this.refreshDarwinNameAddressMap();
     // Clear known peripherals so every device is re-emitted as discovered on each new scan.
     // Without this, devices found in a previous scan are never re-emitted (isNew = false),
     // so the picker stays empty on second and subsequent scan attempts.
@@ -793,12 +839,7 @@ export class NobleBleManager extends EventEmitter {
     this.knownPeripherals.clear();
     for (const [id, peripheral] of stillConnected) {
       this.knownPeripherals.set(id, peripheral);
-      const name: string = peripheral.advertisement?.localName || peripheral.address || id;
-      const rssi =
-        typeof peripheral.rssi === 'number' && Number.isFinite(peripheral.rssi)
-          ? peripheral.rssi
-          : null;
-      this.emit('deviceDiscovered', toNobleDiscoveredDevice(id, name, rssi, peripheral.address));
+      this.emit('deviceDiscovered', this.toDiscoveredDevice(peripheral));
     }
     this.scanRequesters.add(sessionId);
     if (!this.adapterReady) {
@@ -1212,18 +1253,10 @@ export class NobleBleManager extends EventEmitter {
           ? peripheral.rssi
           : null;
       console.debug(
-        `[BLE:${sessionId}] peripheral info — address=${peripheral.address ?? 'unknown'} addressType=${peripheral.addressType ?? 'unknown'} rssi=${connectRssi ?? 'unknown'} state=${peripheral.state} platform=${process.platform}`,
+        `[BLE:${sessionId}] peripheral info — address=${peripheral.address ?? 'unknown'} resolvedMac=${this.resolvePeripheralMac(peripheral) ?? 'none'} addressType=${peripheral.addressType ?? 'unknown'} rssi=${connectRssi ?? 'unknown'} state=${peripheral.state} platform=${process.platform}`,
       );
       // Refresh picker / connecting banner with connect-time RSSI (scan may have been empty).
-      this.emit(
-        'deviceDiscovered',
-        toNobleDiscoveredDevice(
-          peripheralId,
-          peripheral.advertisement?.localName || peripheral.address || peripheralId,
-          connectRssi,
-          peripheral.address,
-        ),
-      );
+      this.emit('deviceDiscovered', this.toDiscoveredDevice(peripheral));
       bleCoexistenceCoordinator.assertCanConnect(
         peripheralOwner,
         peripheral.address ?? peripheralId,

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -2283,6 +2283,65 @@ describe('ConnectionPanel BLE MAC identity', () => {
     }
   });
 
+  it('shows formatted MAC in the MeshCore BLE picker when address is provided', async () => {
+    const user = userEvent.setup();
+    const { restore } = mockMacNoblePlatform();
+    let capturedCb:
+      | ((device: {
+          deviceId: string;
+          deviceName: string;
+          rssi?: number | null;
+          address?: string | null;
+        }) => void)
+      | undefined;
+    vi.mocked(window.electronAPI.onNobleBleDeviceDiscovered).mockImplementation((cb) => {
+      capturedCb = cb;
+      return () => {};
+    });
+    const onConnect = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          /* leave connecting so picker stays open */
+        }),
+    );
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={onConnect}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshcore"
+        />,
+      );
+
+      const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
+      expect(radioCard).toBeTruthy();
+      await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
+
+      await waitFor(() => {
+        expect(capturedCb).toBeTruthy();
+      });
+      act(() => {
+        capturedCb?.({
+          deviceId: darwinUuid,
+          deviceName: 'MeshCore-NV0N',
+          address: 'ac:a7:04:00:d6:f1',
+          rssi: -62,
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('ac:a7:04:00:d6:f1')).toBeInTheDocument();
+      });
+      expect(screen.queryByText(darwinUuid)).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
   it('shows Bluetooth MAC on Last Connection and the connected Radio Connection card', () => {
     localStorage.setItem(
       lastConnKey,

--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -5,7 +5,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 import { act } from 'react';
 import { flushSync } from 'react-dom';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import type { SerialPort } from '@/shared/electron-api.types';
@@ -2205,5 +2205,208 @@ describe('ConnectionPanel device picker sort', () => {
 
     await user.click(screen.getByRole('button', { name: 'Sort by Name, A to Z' }));
     expect(names()).toEqual(['Zulu USB', 'Alpha USB']);
+  });
+});
+
+describe('ConnectionPanel BLE MAC identity', () => {
+  const darwinUuid = 'eccf2847e1fd3f5f0811064db1639a3d';
+  const lastConnKey = 'mesh-client:lastConnection:meshtastic';
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(window.electronAPI.startNobleBleScanning).mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows formatted MAC in the picker when Noble provides address for a CoreBluetooth UUID', async () => {
+    const user = userEvent.setup();
+    const { restore } = mockMacNoblePlatform();
+    let capturedCb:
+      | ((device: {
+          deviceId: string;
+          deviceName: string;
+          rssi?: number | null;
+          address?: string | null;
+        }) => void)
+      | undefined;
+    vi.mocked(window.electronAPI.onNobleBleDeviceDiscovered).mockImplementation((cb) => {
+      capturedCb = cb;
+      return () => {};
+    });
+    const onConnect = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          /* leave connecting so picker stays open */
+        }),
+    );
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={onConnect}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+
+      const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
+      expect(radioCard).toBeTruthy();
+      await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
+
+      await waitFor(() => {
+        expect(capturedCb).toBeTruthy();
+      });
+      act(() => {
+        capturedCb?.({
+          deviceId: darwinUuid,
+          deviceName: 'MeshCore',
+          address: 'aa-bb-cc-dd-ee-ff',
+          rssi: -55,
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('aa:bb:cc:dd:ee:ff')).toBeInTheDocument();
+      });
+      expect(screen.queryByText(darwinUuid)).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /MeshCore aa:bb:cc:dd:ee:ff/ }),
+      ).toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
+  it('shows Bluetooth MAC on Last Connection and the connected Radio Connection card', () => {
+    localStorage.setItem(
+      lastConnKey,
+      JSON.stringify({
+        type: 'ble',
+        bleDeviceId: darwinUuid,
+        bleDeviceName: 'MeshCore',
+        bleMac: 'aa:bb:cc:dd:ee:ff',
+      }),
+    );
+
+    try {
+      const { unmount } = render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+      expect(screen.getByText('MeshCore')).toBeInTheDocument();
+      expect(screen.getByText('aa:bb:cc:dd:ee:ff')).toBeInTheDocument();
+      unmount();
+
+      render(
+        <ConnectionPanel
+          state={configuredState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+      expect(screen.getByText('Bluetooth MAC')).toBeInTheDocument();
+      expect(screen.getByText('aa:bb:cc:dd:ee:ff')).toBeInTheDocument();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+    }
+  });
+
+  it('labels a UUID-only last device as Bluetooth ID, not MAC', () => {
+    localStorage.setItem(
+      lastConnKey,
+      JSON.stringify({
+        type: 'ble',
+        bleDeviceId: darwinUuid,
+        bleDeviceName: 'MeshCore',
+      }),
+    );
+
+    try {
+      render(
+        <ConnectionPanel
+          state={configuredState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+      expect(screen.getByText('Bluetooth ID')).toBeInTheDocument();
+      expect(screen.getByText(darwinUuid)).toBeInTheDocument();
+      expect(screen.queryByText('Bluetooth MAC')).not.toBeInTheDocument();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+    }
+  });
+
+  it('formats a compact 12-hex picker deviceId as a colon MAC', async () => {
+    const user = userEvent.setup();
+    const userAgentSpy = vi.spyOn(window.navigator, 'userAgent', 'get');
+    userAgentSpy.mockReturnValue(
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124 Safari/537.36',
+    );
+
+    const discovered = {
+      cb: null as
+        | ((
+            devices: { deviceId: string; deviceName: string; rssi?: number | null }[],
+            generation?: number,
+          ) => void)
+        | null,
+    };
+    vi.mocked(window.electronAPI.onBluetoothDevicesDiscovered).mockImplementation((cb) => {
+      discovered.cb = cb;
+      return () => {};
+    });
+    const onConnect = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          /* leave connecting so picker stays open */
+        }),
+    );
+
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={onConnect}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+
+      const radioCard = screen.getByText('Radio Connection').closest('.bg-deep-black');
+      expect(radioCard).toBeTruthy();
+      await user.click(within(radioCard as HTMLElement).getByRole('button', { name: 'Connect' }));
+
+      await waitFor(() => {
+        expect(discovered.cb).toBeTruthy();
+      });
+      discovered.cb?.([{ deviceId: 'AABBCCDDEEFF', deviceName: 'MeshCore', rssi: -40 }], 1);
+
+      await waitFor(() => {
+        expect(screen.getByText('aa:bb:cc:dd:ee:ff')).toBeInTheDocument();
+      });
+    } finally {
+      userAgentSpy.mockRestore();
+    }
   });
 });

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -26,6 +26,7 @@ import {
   MQTT_MAX_RECONNECT_ATTEMPTS,
 } from '@/shared/meshtasticMqttReconnect';
 import { formatMeshtasticNodeId } from '@/shared/nodeNameUtils';
+import { type BlePickerIdentity, resolveBlePickerIdentity } from '@/shared/normalizeBleMac';
 import { clampTcpPort, parseTcpPortFromString } from '@/shared/tcpPort';
 
 import { useActiveMeshIdentity } from '../hooks/useActiveMeshIdentity';
@@ -37,6 +38,11 @@ import {
   loadProtocolMqttSettings,
   persistMqttSettingsIfChanged,
 } from '../hooks/useProtocolMqttSettings';
+import {
+  cacheBleDeviceMac,
+  getBleDeviceMac,
+  loadBleDeviceMacCache,
+} from '../lib/bleDeviceMacCache';
 import { reconnectBleWithScan, startNobleBleScanningWithRetry } from '../lib/bleReconnectHelper';
 import {
   humanizeBleError,
@@ -139,6 +145,8 @@ interface LastConnection {
   httpAddress?: string;
   bleDeviceId?: string;
   bleDeviceName?: string;
+  /** Formatted BLE MAC when known (macOS UUID deviceId + CoreBluetoothCache address). */
+  bleMac?: string;
   serialPortId?: string;
 }
 
@@ -324,6 +332,20 @@ function getBleDeviceName(deviceId: string): string | null {
       'ConnectionPanel bleDeviceNames',
     ) ?? {};
   return cache[deviceId] ?? null;
+}
+
+function resolveLastBleIdentity(
+  last: LastConnection | null,
+  protocol: MeshProtocol,
+): BlePickerIdentity | null {
+  const deviceId = last?.bleDeviceId ?? loadLastBleDevice(protocol) ?? '';
+  if (!deviceId && !last?.bleMac) return null;
+  const identity = resolveBlePickerIdentity({
+    deviceId,
+    address: last?.bleMac,
+    cachedMac: deviceId ? getBleDeviceMac(deviceId) : null,
+  });
+  return identity.display ? identity : null;
 }
 
 function MqttGlobeStatusIcon({ status }: { status: MQTTStatus }) {
@@ -720,6 +742,15 @@ export default function ConnectionPanel({
     }
     return cache;
   }, [bleDevices]);
+  const bleDeviceMacsCache = useMemo(() => {
+    const parsed = loadBleDeviceMacCache();
+    const cache: Record<string, string> = {};
+    for (const device of bleDevices) {
+      const cached = parsed[device.deviceId];
+      if (cached) cache[device.deviceId] = cached;
+    }
+    return cache;
+  }, [bleDevices]);
   const getBlePickerName = useCallback(
     (device: NobleBleDevice) =>
       blePickerDisplayName(
@@ -777,6 +808,8 @@ export default function ConnectionPanel({
   const [autoConnectBleTarget, setAutoConnectBleTarget] = useState<string | null>(null);
   // Tracks BLE device name at selection time, used when saving LastConnection
   const lastSelectedBleNameRef = useRef<string | null>(null);
+  // Noble `peripheral.address` (sticker MAC) at selection time — distinct from Linux pairing MAC id
+  const lastSelectedBleAddressRef = useRef<string | null>(null);
   // Tracks BLE device MAC for potential re-pairing on Linux
   const lastSelectedBleMacRef = useRef<string | null>(null);
   /**
@@ -792,6 +825,8 @@ export default function ConnectionPanel({
   const meshcoreLinuxReconnectPairingCheckRef = useRef(false);
   const lastConnectionBleDeviceNameFallbackRef = useRef(lastConnection?.bleDeviceName);
   lastConnectionBleDeviceNameFallbackRef.current = lastConnection?.bleDeviceName;
+  const lastConnectionBleMacFallbackRef = useRef(lastConnection?.bleMac);
+  lastConnectionBleMacFallbackRef.current = lastConnection?.bleMac;
   /** Prior store status for distinguishing pre-connect BLE scan from failed RF attempts. */
   const prevStoreStatusRef = useRef(state.status);
   /** Mount-only auto-connect reads latest props/state via refs so the effect can stay `[]`. */
@@ -859,14 +894,21 @@ export default function ConnectionPanel({
         if (state.connectionType === 'http' || state.connectionType === 'tcp') {
           conn.httpAddress = activeHostAddress;
         } else if (state.connectionType === 'ble') {
-          const bleId = loadLastBleDevice(protocol);
+          const prev = lastConnectionRef.current;
+          const bleId = loadLastBleDevice(protocol) ?? prev?.bleDeviceId;
           if (bleId) {
             conn.bleDeviceId = bleId;
             conn.bleDeviceName =
               getBleDeviceName(bleId) ??
               lastSelectedBleNameRef.current ??
               lastConnectionBleDeviceNameFallbackRef.current ??
-              undefined;
+              prev?.bleDeviceName;
+            const bleIdentity = resolveBlePickerIdentity({
+              deviceId: bleId,
+              address: lastSelectedBleAddressRef.current,
+              cachedMac: getBleDeviceMac(bleId) ?? lastConnectionBleMacFallbackRef.current,
+            });
+            if (bleIdentity.isMac) conn.bleMac = bleIdentity.display;
           }
         } else if (state.connectionType === 'serial') {
           const serialId = loadLastSerialPort();
@@ -914,17 +956,28 @@ export default function ConnectionPanel({
   // Listen for BLE devices discovered by noble in main process
   useEffect(() => {
     return window.electronAPI.onNobleBleDeviceDiscovered((device) => {
+      if (device.address) cacheBleDeviceMac(device.deviceId, device.address);
       setBleDevices((prev) => {
         const idx = prev.findIndex((d) => d.deviceId === device.deviceId);
         if (idx >= 0) {
           const existing = prev[idx];
           if (!existing) return prev;
           const nextRssi = device.rssi !== undefined ? device.rssi : existing.rssi;
-          if (existing.deviceName === device.deviceName && existing.rssi === nextRssi) {
+          const nextAddress = device.address ?? existing.address;
+          if (
+            existing.deviceName === device.deviceName &&
+            existing.rssi === nextRssi &&
+            existing.address === nextAddress
+          ) {
             return prev;
           }
           const next = [...prev];
-          next[idx] = { ...existing, deviceName: device.deviceName, rssi: nextRssi };
+          next[idx] = {
+            ...existing,
+            deviceName: device.deviceName,
+            rssi: nextRssi,
+            address: nextAddress,
+          };
           return next;
         }
         return [...prev, device];
@@ -956,6 +1009,9 @@ export default function ConnectionPanel({
     return window.electronAPI.onBluetoothDevicesDiscovered((devices, generation) => {
       if (typeof generation === 'number' && Number.isFinite(generation)) {
         linuxBleChooserGenerationRef.current = generation;
+      }
+      for (const device of devices) {
+        if (device.address) cacheBleDeviceMac(device.deviceId, device.address);
       }
       setBleDevices(devices);
       const lastId = lastConnectionRef.current?.bleDeviceId ?? loadLastBleDevice(protocol);
@@ -1424,6 +1480,12 @@ export default function ConnectionPanel({
       // Save BLE advertisement name for use in LastConnection display
       const found = bleDevices.find((d) => d.deviceId === deviceId);
       lastSelectedBleNameRef.current = found?.deviceName ?? null;
+      if (found?.address) {
+        cacheBleDeviceMac(deviceId, found.address);
+        lastSelectedBleAddressRef.current = found.address;
+      } else {
+        lastSelectedBleAddressRef.current = getBleDeviceMac(deviceId);
+      }
       // Store MAC address for potential re-pairing on Linux
       lastSelectedBleMacRef.current = deviceId;
       setShowBlePicker(false);
@@ -1676,6 +1738,7 @@ export default function ConnectionPanel({
     state.status === 'configured' ||
     state.status === 'stale' ||
     state.status === 'reconnecting';
+  const lastBleIdentity = resolveLastBleIdentity(lastConnection, protocol);
 
   useEffect(() => {
     const rfBusy =
@@ -1891,10 +1954,22 @@ export default function ConnectionPanel({
               ) : (
                 sortedBleDevices.map((device) => {
                   const displayName = getBlePickerName(device);
+                  const identity = resolveBlePickerIdentity({
+                    deviceId: device.deviceId,
+                    address: device.address,
+                    cachedMac: bleDeviceMacsCache[device.deviceId],
+                  });
                   const hasRssi = device.rssi != null && Number.isFinite(device.rssi);
                   const bleAriaLabel = hasRssi
-                    ? `${displayName} ${device.deviceId} ${Math.round(device.rssi!)} dBm`
-                    : `${displayName} ${device.deviceId}`;
+                    ? t('connectionPanel.pickerDeviceAriaWithRssi', {
+                        name: displayName,
+                        address: identity.display,
+                        rssi: Math.round(device.rssi!),
+                      })
+                    : t('connectionPanel.pickerDeviceAria', {
+                        name: displayName,
+                        address: identity.display,
+                      });
                   return (
                     <button
                       key={device.deviceId}
@@ -1918,7 +1993,9 @@ export default function ConnectionPanel({
                           </span>
                         ) : null}
                       </div>
-                      <div className="text-muted ml-7 font-mono text-xs">{device.deviceId}</div>
+                      {identity.display !== displayName ? (
+                        <div className="text-muted ml-7 font-mono text-xs">{identity.display}</div>
+                      ) : null}
                     </button>
                   );
                 })
@@ -2999,6 +3076,18 @@ export default function ConnectionPanel({
               <span className="text-muted">{t('connectionPanel.connectionType')}</span>
               <span className="text-gray-200 uppercase">{state.connectionType}</span>
             </div>
+            {state.connectionType === 'ble' && lastBleIdentity ? (
+              <div className="flex justify-between text-sm">
+                <span className="text-muted">
+                  {t(
+                    lastBleIdentity.isMac
+                      ? 'connectionPanel.bluetoothMac'
+                      : 'connectionPanel.bluetoothId',
+                  )}
+                </span>
+                <span className="font-mono text-gray-200">{lastBleIdentity.display}</span>
+              </div>
+            ) : null}
             {hostLinkMeter.kind != null && (
               <ConnectionLinkMeter
                 kind={hostLinkMeter.kind}
@@ -3113,7 +3202,11 @@ export default function ConnectionPanel({
                       ? t('connectionPanel.serialDevice')
                       : (lastConnection.httpAddress ?? t('connectionPanel.wifiDevice'))}
                 </p>
-                <p className="text-muted text-xs uppercase">{lastConnection.type}</p>
+                {lastConnection.type === 'ble' && lastBleIdentity ? (
+                  <p className="text-muted font-mono text-xs">{lastBleIdentity.display}</p>
+                ) : (
+                  <p className="text-muted text-xs uppercase">{lastConnection.type}</p>
+                )}
               </div>
             </div>
             <button

--- a/src/renderer/lib/bleDeviceMacCache.test.ts
+++ b/src/renderer/lib/bleDeviceMacCache.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BLE_DEVICE_MACS_KEY, cacheBleDeviceMac, getBleDeviceMac } from './bleDeviceMacCache';
+
+const DARWIN_UUID = 'eccf2847e1fd3f5f0811064db1639a3d';
+
+describe('bleDeviceMacCache', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('stores a hyphen MAC against a CoreBluetooth UUID', () => {
+    cacheBleDeviceMac(DARWIN_UUID, 'AA-BB-CC-DD-EE-FF');
+    expect(getBleDeviceMac(DARWIN_UUID)).toBe('aa:bb:cc:dd:ee:ff');
+    expect(JSON.parse(localStorage.getItem(BLE_DEVICE_MACS_KEY) ?? '{}')).toEqual({
+      [DARWIN_UUID]: 'aa:bb:cc:dd:ee:ff',
+    });
+  });
+
+  it('does not cache when deviceId is already a MAC', () => {
+    cacheBleDeviceMac('aa:bb:cc:dd:ee:ff', 'aa:bb:cc:dd:ee:ff');
+    expect(localStorage.getItem(BLE_DEVICE_MACS_KEY)).toBeNull();
+  });
+
+  it('ignores non-MAC addresses', () => {
+    cacheBleDeviceMac(DARWIN_UUID, DARWIN_UUID);
+    expect(getBleDeviceMac(DARWIN_UUID)).toBeNull();
+  });
+});

--- a/src/renderer/lib/bleDeviceMacCache.ts
+++ b/src/renderer/lib/bleDeviceMacCache.ts
@@ -1,0 +1,30 @@
+import { isTwelveHexBleMac, normalizeBleMac } from '@/shared/normalizeBleMac';
+
+import { cacheTransportDisplayName } from './meshtastic/transportDisplayNameCache';
+import { parseStoredJson } from './parseStoredJson';
+
+export const BLE_DEVICE_MACS_KEY = 'mesh-client:bleDeviceMacs';
+
+/** Persist UUID → MAC so later scans can show the sticker address when Noble `address` is empty. */
+export function cacheBleDeviceMac(deviceId: string, address: string): void {
+  const id = deviceId.trim();
+  const mac = address.trim();
+  if (!id || !isTwelveHexBleMac(mac)) return;
+  if (isTwelveHexBleMac(id)) return;
+  cacheTransportDisplayName(BLE_DEVICE_MACS_KEY, id, normalizeBleMac(mac));
+}
+
+export function loadBleDeviceMacCache(): Record<string, string> {
+  return (
+    parseStoredJson<Record<string, string>>(
+      localStorage.getItem(BLE_DEVICE_MACS_KEY),
+      'bleDeviceMacCache',
+    ) ?? {}
+  );
+}
+
+export function getBleDeviceMac(deviceId: string): string | null {
+  const id = deviceId.trim();
+  if (!id) return null;
+  return loadBleDeviceMacCache()[id] ?? null;
+}

--- a/src/renderer/lib/lastConnectionStorage.ts
+++ b/src/renderer/lib/lastConnectionStorage.ts
@@ -7,6 +7,8 @@ export interface LastConnection {
   httpAddress?: string;
   bleDeviceId?: string;
   bleDeviceName?: string;
+  /** Formatted BLE MAC when known (macOS UUID deviceId + CoreBluetoothCache address). */
+  bleMac?: string;
   serialPortId?: string;
 }
 

--- a/src/renderer/lib/types.ts
+++ b/src/renderer/lib/types.ts
@@ -493,6 +493,11 @@ export interface NobleBleDevice {
   deviceName: string;
   /** Advertised / last-seen BLE RSSI in dBm; null/undefined when unknown. */
   rssi?: number | null;
+  /**
+   * Hardware BLE MAC when the OS exposes one (Noble `peripheral.address`).
+   * On macOS this is typically empty until after a prior GATT connect (CoreBluetoothCache).
+   */
+  address?: string | null;
 }
 export type NobleBleSessionId = MeshProtocol;
 export type NobleBleConnectResult = { ok: true } | { ok: false; error: string };

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -1431,7 +1431,11 @@
     "sortByNameAsc": "Seřadit podle názvu: A až Z",
     "sortByNameDesc": "Řadit podle názvu (Z až A)",
     "sortByRssiAsc": "Řadit podle RSSI, nejdříve nejslabší",
-    "sortByRssiDesc": "Řadit podle RSSI, nejdřív nejsilnější"
+    "sortByRssiDesc": "Řadit podle RSSI, nejdřív nejsilnější",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Bluetooth ID"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Nepodařilo se načíst členy: {{message}}",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "Name des Empfängers: *",
     "sortByNameDesc": "Nach Name sortieren: Z bis A",
     "sortByRssiAsc": "Sortieren nach RSSI, schwächste zuerst",
-    "sortByRssiDesc": "Sortieren nach RSSI, stärkste zuerst"
+    "sortByRssiDesc": "Sortieren nach RSSI, stärkste zuerst",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Bluetooth-ID"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Mitglieder konnten nicht geladen werden: {{message}}",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -867,6 +867,8 @@
     "selectBluetoothDevice": "Select Bluetooth Device",
     "bleWeakSignalWarning": "Bluetooth signal is weak ({{rssi}} dBm). Move closer for a stable connection.",
     "bleRssiDbm": "{{rssi}} dBm",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
     "hostSignal": "Signal",
     "hostSignalUnavailable": "—",
     "linkQuality": "Link quality",
@@ -1318,6 +1320,8 @@
       "disable": "Disable"
     },
     "connectionType": "Connection Type",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Bluetooth ID",
     "myNode": "My Node",
     "battery": "Battery",
     "firmware": "Firmware",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "Ordenar por nombre A->Z",
     "sortByNameDesc": "Ordenar por nombre Z->A",
     "sortByRssiAsc": "Ordenar por RSSI, el más débil primero",
-    "sortByRssiDesc": "Ordenar por RSSI, el más fuerte primero"
+    "sortByRssiDesc": "Ordenar por RSSI, el más fuerte primero",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Bluetooth ID"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "No se han podido cargar los miembros: {{message}}",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "Tri par nom : A à Z",
     "sortByNameDesc": "Tri par nom : Z à A",
     "sortByRssiAsc": "Trier par RSSI, le plus faible en premier",
-    "sortByRssiDesc": "Trier par RSSI, le plus fort en premier"
+    "sortByRssiDesc": "Trier par RSSI, le plus fort en premier",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Bluetooth ID"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Échec du chargement des membres : {{message}}",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "Menurut Nama - A ke Z",
     "sortByNameDesc": "Menurut Nama - Z ke A",
     "sortByRssiAsc": "Urutkan berdasarkan RSSI, terlemah dulu",
-    "sortByRssiDesc": "Urutkan berdasarkan RSSI, terkuat dulu"
+    "sortByRssiDesc": "Urutkan berdasarkan RSSI, terkuat dulu",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "ID Bluetooth"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Gagal memuat anggota: {{message}}",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "Ordina per nome - dalla A alla Z",
     "sortByNameDesc": "Ordina per nome - dalla Z alla A",
     "sortByRssiAsc": "Ordina per RSSI, prima i più deboli",
-    "sortByRssiDesc": "Ordina per RSSI, più forte prima"
+    "sortByRssiDesc": "Ordina per RSSI, più forte prima",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "BlueTooth MAC",
+    "bluetoothId": "ID Bluetooth"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Impossibile caricare i membri: {{message}}",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "名前で並べ替え、AからZ",
     "sortByNameDesc": "名前で並べ替え、ZからA",
     "sortByRssiAsc": "RSSIで並べ替え、弱い順",
-    "sortByRssiDesc": "RSSIで並べ替え、最強順"
+    "sortByRssiDesc": "RSSIで並べ替え、最強順",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}、{{rssi}} dBm",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Bluetooth ID"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "メンバーのロードに失敗しました: {{message}}",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "이름 A-Z",
     "sortByNameDesc": "이름 Z-A",
     "sortByRssiAsc": "RSSI 기준으로 정렬, 가장 먼저 약함",
-    "sortByRssiDesc": "RSSI로 정렬, 최강자 우선"
+    "sortByRssiDesc": "RSSI로 정렬, 최강자 우선",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "블루투스 맥",
+    "bluetoothId": "블루투스 ID"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "멤버를 로드하지 못했습니다: {{message}}",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "Sorteer op naam: A tot Z",
     "sortByNameDesc": "Sorteer op Naam, Z tot A",
     "sortByRssiAsc": "Sorteren op RSSI, zwakste eerst",
-    "sortByRssiDesc": "Sorteren op RSSI, sterkste eerst"
+    "sortByRssiDesc": "Sorteren op RSSI, sterkste eerst",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Bluetooth-ID"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Kan leden niet laden: {{message}}",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -1433,7 +1433,11 @@
     "sortByNameAsc": "Sortuj wg nazwy: od A do Z",
     "sortByNameDesc": "Sortuj wg nazwy: od Z do A",
     "sortByRssiAsc": "Sortuj według RSSI, najpierw najsłabsze",
-    "sortByRssiDesc": "Sortuj według RSSI, najpierw najsilniejsze"
+    "sortByRssiDesc": "Sortuj według RSSI, najpierw najsilniejsze",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "KOMPUTER MAC z Bluetooth",
+    "bluetoothId": "Identyfikator Bluetooth"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Nie udało się załadować członków: {{message}}",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "Ordenar por nome de A a Z",
     "sortByNameDesc": "Ordenar por nome: z à a",
     "sortByRssiAsc": "Ordenar por RSSI, mais fraco primeiro",
-    "sortByRssiDesc": "Ordenar por RSSI, mais forte primeiro"
+    "sortByRssiDesc": "Ordenar por RSSI, mais forte primeiro",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "MAC BLUETOOTH",
+    "bluetoothId": "ID Bluetooth"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Falha ao carregar membros: {{message}}",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -1431,7 +1431,11 @@
     "sortByNameAsc": "Сортировать по имени А - Я",
     "sortByNameDesc": "Сортировать по имени Я - А",
     "sortByRssiAsc": "Сортировать по RSSI, сначала самые слабые",
-    "sortByRssiDesc": "Сортировать по RSSI, сначала сильнейшие"
+    "sortByRssiDesc": "Сортировать по RSSI, сначала сильнейшие",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} дБм",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Идентификатор Bluetooth"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Не удалось загрузить участников: {{message}}.",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "Alfabetik sırala (A'dan Z'ye)",
     "sortByNameDesc": "Alfabetik sırala (Z'den A'ya)",
     "sortByRssiAsc": "RSSI'ye göre sırala, önce en zayıf",
-    "sortByRssiDesc": "RSSI'ye göre sırala, önce en güçlü"
+    "sortByRssiDesc": "RSSI'ye göre sırala, önce en güçlü",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} dBm",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Bluetooth Kimliği"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Üyeler yüklenemedi: {{message}}",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -1431,7 +1431,11 @@
     "sortByNameAsc": "Сортувати за назвою, від А до Я",
     "sortByNameDesc": "Сортувати за назвою, від Я до А",
     "sortByRssiAsc": "Сортувати за RSSI, спочатку найслабші",
-    "sortByRssiDesc": "Сортувати за RSSI, спочатку найсильніші"
+    "sortByRssiDesc": "Сортувати за RSSI, спочатку найсильніші",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}}, {{rssi}} дБм",
+    "bluetoothMac": "Bluetooth MAC",
+    "bluetoothId": "Ідентифікатор Bluetooth"
   },
   "contactGroupsModal": {
     "failedLoadMembers": "Не вдалося завантажити учасників: {{message}}",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -1429,7 +1429,11 @@
     "sortByNameAsc": "按名称排序 - A 到 Z",
     "sortByNameDesc": "按名称排序 - Z 到 A",
     "sortByRssiAsc": "按RSSI排序，最弱者优先",
-    "sortByRssiDesc": "按RSSI排序，最强优先"
+    "sortByRssiDesc": "按RSSI排序，最强优先",
+    "pickerDeviceAria": "{{name}} {{address}}",
+    "pickerDeviceAriaWithRssi": "{{name}} {{address}} ， {{rssi}} dBm",
+    "bluetoothMac": "蓝牙MAC",
+    "bluetoothId": "蓝牙编号："
   },
   "contactGroupsModal": {
     "failedLoadMembers": "无法加载会员： {{message}}",

--- a/src/shared/electron-api.types.ts
+++ b/src/shared/electron-api.types.ts
@@ -179,6 +179,11 @@ export interface NobleBleDevice {
   deviceName: string;
   /** Advertised / last-seen BLE RSSI in dBm; null when unknown (e.g. Linux Web Bluetooth). */
   rssi?: number | null;
+  /**
+   * Hardware BLE MAC when the OS exposes one (Noble `peripheral.address`).
+   * On macOS this is typically empty until after a prior GATT connect (CoreBluetoothCache).
+   */
+  address?: string | null;
 }
 
 export type NobleBleSessionId = MeshProtocol;

--- a/src/shared/normalizeBleMac.test.ts
+++ b/src/shared/normalizeBleMac.test.ts
@@ -24,6 +24,18 @@ describe('normalizeBleMac', () => {
   it('returns empty string for blank input', () => {
     expect(normalizeBleMac('   ')).toBe('');
   });
+
+  it('rejects malformed suffixes instead of stripping them into a MAC', () => {
+    expect(normalizeBleMac('AA:BB:CC:DD:EE:FF-extra')).toBe('aa:bb:cc:dd:ee:ff-extra');
+    expect(normalizeBleMac('AABBCCDDEEFF00')).toBe('aabbccddeeff00');
+    expect(normalizeBleMac('aa:bb:cc:dd:ee:ff/dev')).toBe('aa:bb:cc:dd:ee:ff/dev');
+  });
+
+  it('rejects unsupported separators instead of stripping them into a MAC', () => {
+    expect(normalizeBleMac('AA.BB.CC.DD.EE.FF')).toBe('aa.bb.cc.dd.ee.ff');
+    expect(normalizeBleMac('AA BB CC DD EE FF')).toBe('aa bb cc dd ee ff');
+    expect(normalizeBleMac('AA:BB-CC:DD:EE:FF')).toBe('aa:bb-cc:dd:ee:ff');
+  });
 });
 
 describe('isTwelveHexBleMac', () => {
@@ -37,6 +49,11 @@ describe('isTwelveHexBleMac', () => {
     expect(isTwelveHexBleMac('eccf2847-e1fd-3f5f-0811-064db1639a3d')).toBe(false);
     expect(isTwelveHexBleMac('eccf2847e1fd3f5f0811064db1639a3d')).toBe(false);
     expect(isTwelveHexBleMac('linux-web-bt-opaque-id')).toBe(false);
+  });
+
+  it('rejects suffixes and unsupported separators', () => {
+    expect(isTwelveHexBleMac('aa:bb:cc:dd:ee:ff-extra')).toBe(false);
+    expect(isTwelveHexBleMac('aa.bb.cc.dd.ee.ff')).toBe(false);
   });
 });
 

--- a/src/shared/normalizeBleMac.test.ts
+++ b/src/shared/normalizeBleMac.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest';
 
-import { normalizeBleMac } from './normalizeBleMac';
+import {
+  formatBleDeviceIdForDisplay,
+  isTwelveHexBleMac,
+  normalizeBleMac,
+  resolveBlePickerIdentity,
+} from './normalizeBleMac';
 
 describe('normalizeBleMac', () => {
   it('normalizes colon-separated MAC addresses', () => {
@@ -12,7 +17,74 @@ describe('normalizeBleMac', () => {
     expect(normalizeBleMac('AABBCCDDEEFF')).toBe('aa:bb:cc:dd:ee:ff');
   });
 
+  it('normalizes hyphen-separated macOS CoreBluetoothCache MACs', () => {
+    expect(normalizeBleMac('AA-BB-CC-DD-EE-FF')).toBe('aa:bb:cc:dd:ee:ff');
+  });
+
   it('returns empty string for blank input', () => {
     expect(normalizeBleMac('   ')).toBe('');
+  });
+});
+
+describe('isTwelveHexBleMac', () => {
+  it('accepts colon, hyphen, and compact 12-hex', () => {
+    expect(isTwelveHexBleMac('aa:bb:cc:dd:ee:ff')).toBe(true);
+    expect(isTwelveHexBleMac('AA-BB-CC-DD-EE-FF')).toBe(true);
+    expect(isTwelveHexBleMac('AABBCCDDEEFF')).toBe(true);
+  });
+
+  it('rejects CoreBluetooth UUIDs and opaque Web Bluetooth ids', () => {
+    expect(isTwelveHexBleMac('eccf2847-e1fd-3f5f-0811-064db1639a3d')).toBe(false);
+    expect(isTwelveHexBleMac('eccf2847e1fd3f5f0811064db1639a3d')).toBe(false);
+    expect(isTwelveHexBleMac('linux-web-bt-opaque-id')).toBe(false);
+  });
+});
+
+describe('formatBleDeviceIdForDisplay', () => {
+  it('formats compact and hyphen MACs as colon-separated lowercase', () => {
+    expect(formatBleDeviceIdForDisplay('AABBCCDDEEFF')).toBe('aa:bb:cc:dd:ee:ff');
+    expect(formatBleDeviceIdForDisplay('AA-BB-CC-DD-EE-FF')).toBe('aa:bb:cc:dd:ee:ff');
+  });
+
+  it('leaves UUIDs unchanged', () => {
+    expect(formatBleDeviceIdForDisplay('ECCF2847-E1FD-3F5F-0811-064DB1639A3D')).toBe(
+      'ECCF2847-E1FD-3F5F-0811-064DB1639A3D',
+    );
+  });
+});
+
+describe('resolveBlePickerIdentity', () => {
+  const darwinUuid = 'eccf2847e1fd3f5f0811064db1639a3d';
+
+  it('prefers scan address over UUID deviceId', () => {
+    expect(
+      resolveBlePickerIdentity({
+        deviceId: darwinUuid,
+        address: 'aa-bb-cc-dd-ee-ff',
+      }),
+    ).toEqual({ display: 'aa:bb:cc:dd:ee:ff', isMac: true });
+  });
+
+  it('uses cached MAC when address is missing', () => {
+    expect(
+      resolveBlePickerIdentity({
+        deviceId: darwinUuid,
+        cachedMac: 'aa:bb:cc:dd:ee:ff',
+      }),
+    ).toEqual({ display: 'aa:bb:cc:dd:ee:ff', isMac: true });
+  });
+
+  it('falls back to deviceId when it is already a MAC', () => {
+    expect(resolveBlePickerIdentity({ deviceId: 'AA:BB:CC:DD:EE:FF' })).toEqual({
+      display: 'aa:bb:cc:dd:ee:ff',
+      isMac: true,
+    });
+  });
+
+  it('returns UUID as Bluetooth ID when no MAC is known', () => {
+    expect(resolveBlePickerIdentity({ deviceId: darwinUuid })).toEqual({
+      display: darwinUuid,
+      isMac: false,
+    });
   });
 });

--- a/src/shared/normalizeBleMac.ts
+++ b/src/shared/normalizeBleMac.ts
@@ -1,12 +1,40 @@
+function isHexChar(ch: string | undefined): boolean {
+  if (!ch) return false;
+  const code = ch.charCodeAt(0);
+  return (code >= 48 && code <= 57) || (code >= 65 && code <= 70) || (code >= 97 && code <= 102);
+}
+
+/**
+ * Compact 12-hex, or six 2-hex octets with a consistent `:` or `-` separator.
+ * Rejects suffixes and unsupported separators (do not strip them into a MAC).
+ */
+function isStrictBleMacShape(id: string): boolean {
+  if (id.length === 12) {
+    for (let i = 0; i < 12; i++) {
+      if (!isHexChar(id[i])) return false;
+    }
+    return true;
+  }
+  if (id.length !== 17) return false;
+  const sep = id[2];
+  if (sep !== ':' && sep !== '-') return false;
+  for (let i = 0; i < 6; i++) {
+    const offset = i * 3;
+    if (!isHexChar(id[offset]) || !isHexChar(id[offset + 1])) return false;
+    if (i < 5 && id[offset + 2] !== sep) return false;
+  }
+  return true;
+}
+
 /** Normalize MAC / BLE address for registry keys (case-insensitive, colon-separated). */
 export function normalizeBleMac(mac: string): string {
   const trimmed = mac.trim();
   if (!trimmed) return trimmed;
-  const hex = bleIdHexDigits(trimmed);
-  if (hex.length === 12) {
-    return hex.match(/.{1,2}/g)!.join(':');
+  if (!isStrictBleMacShape(trimmed)) {
+    return trimmed.toLowerCase();
   }
-  return trimmed.toLowerCase();
+  const hex = bleIdHexDigits(trimmed);
+  return hex.match(/.{1,2}/g)!.join(':');
 }
 
 /** Stripped lowercase hex digits from a MAC, UUID, or other BLE identifier. */
@@ -19,7 +47,7 @@ function bleIdHexDigits(id: string): string {
 
 /** True when `id` is a 48-bit BLE MAC (colon, hyphen, or compact 12-hex). */
 export function isTwelveHexBleMac(id: string): boolean {
-  return bleIdHexDigits(id).length === 12;
+  return isStrictBleMacShape(id.trim());
 }
 
 /**

--- a/src/shared/normalizeBleMac.ts
+++ b/src/shared/normalizeBleMac.ts
@@ -2,9 +2,58 @@
 export function normalizeBleMac(mac: string): string {
   const trimmed = mac.trim();
   if (!trimmed) return trimmed;
-  const hex = trimmed.replace(/[^0-9a-fA-F]/g, '').toLowerCase();
+  const hex = bleIdHexDigits(trimmed);
   if (hex.length === 12) {
     return hex.match(/.{1,2}/g)!.join(':');
   }
   return trimmed.toLowerCase();
+}
+
+/** Stripped lowercase hex digits from a MAC, UUID, or other BLE identifier. */
+function bleIdHexDigits(id: string): string {
+  return id
+    .trim()
+    .replace(/[^0-9a-fA-F]/g, '')
+    .toLowerCase();
+}
+
+/** True when `id` is a 48-bit BLE MAC (colon, hyphen, or compact 12-hex). */
+export function isTwelveHexBleMac(id: string): boolean {
+  return bleIdHexDigits(id).length === 12;
+}
+
+/**
+ * Colon-separated lowercase MAC when `id` is 12-hex; otherwise the original identifier
+ * (CoreBluetooth UUIDs must not be lowercased).
+ */
+export function formatBleDeviceIdForDisplay(id: string): string {
+  const trimmed = id.trim();
+  if (!trimmed) return trimmed;
+  if (isTwelveHexBleMac(trimmed)) return normalizeBleMac(trimmed);
+  return trimmed;
+}
+
+export interface BlePickerIdentityInput {
+  deviceId: string;
+  address?: string | null;
+  cachedMac?: string | null;
+}
+
+export interface BlePickerIdentity {
+  /** Formatted MAC or the original non-MAC identifier. */
+  display: string;
+  isMac: boolean;
+}
+
+/** Prefer a real MAC from scan `address`, then a cached UUID→MAC mapping, then `deviceId`. */
+export function resolveBlePickerIdentity(input: BlePickerIdentityInput): BlePickerIdentity {
+  for (const candidate of [input.address, input.cachedMac, input.deviceId]) {
+    const trimmed = candidate?.trim() ?? '';
+    if (!trimmed) continue;
+    if (isTwelveHexBleMac(trimmed)) {
+      return { display: formatBleDeviceIdForDisplay(trimmed), isMac: true };
+    }
+  }
+  const deviceId = input.deviceId.trim();
+  return { display: formatBleDeviceIdForDisplay(deviceId), isMac: false };
 }


### PR DESCRIPTION
## Summary

Radios that share a GAP name (or a custom label) could not be told apart in **Connection → Radio Connection**, because the BLE picker and Last Connection row showed the CoreBluetooth UUID on macOS and nothing that matched the sticker MAC.

This PR shows the hardware BLE MAC wherever we can resolve it, for Meshtastic and MeshCore Noble scans.

### What users see

- **BLE picker:** device name on the first line; formatted MAC (or UUID if no MAC) on the second line, omitted when it duplicates the name. Screen-reader labels include name + address (+ RSSI).
- **Connected Radio Connection card:** **Bluetooth MAC** when the id is a 12-hex address, otherwise **Bluetooth ID**.
- **Last Connection:** name stays the title; subtitle is the formatted MAC/UUID.

### How the MAC is resolved

1. **Noble `peripheral.address`** (linux/win32, and older macOS after a prior GATT connect).
2. **UUID → MAC cache** (`mesh-client:bleDeviceMacs`) so later scans still show the sticker address when Noble omits it.
3. **macOS fallback:** before each Noble scan, load unique GAP name → MAC from `system_profiler SPBluetoothDataType -json` (5s timeout, child killed on hang). Duplicate names are omitted so two identically labeled radios are not mixed up.

Step 3 is required on current macOS: CoreBluetoothCache is no longer in the readable Bluetooth plist, so Noble’s `address` is empty and the picker would otherwise still show only the UUID (the MeshCore path uses the same picker).

Last Connection persists `bleMac` and must not drop `bleDeviceId` / `bleMac` on configured-status saves.

## Commits

- `ed9d1f8a` feat(connection): show BLE MAC on Radio Connection picker — plumb `address`, cache, UI, i18n
- `75b9bfd5` fix(connection): show BLE MAC in macOS picker when Noble omits address — system_profiler unique-name map

## Test plan

- [ ] **macOS:** MeshCore BLE picker for a uniquely named radio shows `aa:bb:cc:dd:ee:ff` (sticker MAC), not the CoreBluetooth UUID
- [ ] **macOS:** Meshtastic BLE picker shows the same MAC treatment
- [ ] Two radios with the **same** GAP name still show UUIDs (ambiguous; do not guess)
- [ ] Linux / Windows: picker still shows the Noble MAC as `deviceId` / `address` (no system_profiler path)
- [ ] After connect, Radio Connection card shows **Bluetooth MAC**; Last Connection subtitle matches
- [ ] Disconnect / reopen picker: cached MAC still appears if Noble `address` is empty
- [ ] First macOS scan may take a couple of extra seconds (`system_profiler`); picker still completes
- [ ] VoiceOver / screen reader: picker row announces name + MAC (and RSSI when present)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BLE devices now display formatted hardware MAC addresses when available.
  * macOS Bluetooth discovery resolves device names to stable MAC addresses.
  * Device identities are preserved across scans, connections, saved connections, and reconnect views.
  * Added fallback handling for UUID-only and other non-MAC device identifiers.

* **Bug Fixes**
  * Improved BLE address resolution and graceful handling of unavailable or ambiguous Bluetooth data.
  * Added persistent caching for discovered BLE MAC addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->