### PR TITLE
fix(meshcore): persist live advert names and fill Repeaters list height

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3885,7 +3885,7 @@ function AppContent() {
                       role="tabpanel"
                       aria-labelledby={`tab-${Math.max(0, findFilteredTabIndexForPanel(selectByProtocol(tabsByProtocol, protocol), MODULES_PANEL_INDEX))}`}
                       hidden={activePanelIndex !== MODULES_PANEL_INDEX}
-                      className="w-full min-w-0"
+                      className="h-full min-h-0 w-full min-w-0"
                     >
                       {activePanelIndex === MODULES_PANEL_INDEX &&
                       capabilities.modulesTabUsesRepeatersLabel ? (

--- a/src/renderer/components/RepeatersPanel.test.tsx
+++ b/src/renderer/components/RepeatersPanel.test.tsx
@@ -122,12 +122,15 @@ describe('RepeatersPanel', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('fills leftover height with the table scroller instead of a 70vh cap', () => {
-    render(<RepeatersPanel {...makeBaseProps()} />);
+  it('fills leftover height with the table scroller instead of a 70vh cap', async () => {
+    const { container } = render(<RepeatersPanel {...makeBaseProps()} />);
     const table = screen.getByRole('table');
     const scroller = table.parentElement;
     expect(scroller).toHaveClass('flex-1', 'min-h-0');
     expect(scroller?.className).not.toContain('70vh');
+    hydrateAxeThemeColors(container);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 
   it('shows error toast when requestRepeaterStatus fails', async () => {

--- a/src/renderer/components/RepeatersPanel.test.tsx
+++ b/src/renderer/components/RepeatersPanel.test.tsx
@@ -122,6 +122,14 @@ describe('RepeatersPanel', () => {
     expect(results).toHaveNoViolations();
   });
 
+  it('fills leftover height with the table scroller instead of a 70vh cap', () => {
+    render(<RepeatersPanel {...makeBaseProps()} />);
+    const table = screen.getByRole('table');
+    const scroller = table.parentElement;
+    expect(scroller).toHaveClass('flex-1', 'min-h-0');
+    expect(scroller?.className).not.toContain('70vh');
+  });
+
   it('shows error toast when requestRepeaterStatus fails', async () => {
     const props = makeBaseProps();
     props.onRequestRepeaterStatus = vi.fn().mockRejectedValue(new Error('radio timeout'));

--- a/src/renderer/components/RepeatersPanel.tsx
+++ b/src/renderer/components/RepeatersPanel.tsx
@@ -841,7 +841,7 @@ export default function RepeatersPanel({
 
   return (
     <>
-      <div className="flex flex-col gap-4">
+      <div className="flex h-full min-h-0 flex-col gap-4">
         <div className="flex flex-col flex-wrap items-stretch justify-between gap-3 min-[480px]:flex-row min-[480px]:items-center">
           <h2 className="text-bright-green text-lg font-semibold">{t('repeatersPanel.title')}</h2>
           <div className="flex flex-wrap items-center gap-2">
@@ -962,10 +962,10 @@ export default function RepeatersPanel({
             {t('repeatersPanel.noRepeatersMatch')}
           </div>
         ) : (
-          <div ref={repeaterTableScrollRef} className="max-h-[min(70vh,48rem)] overflow-auto">
+          <div ref={repeaterTableScrollRef} className="min-h-0 min-w-0 flex-1 overflow-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-gray-700 text-left text-gray-400">
+                <tr className="bg-app-bg sticky top-0 z-10 border-b border-gray-700 text-left text-gray-400">
                   {(
                     [
                       ['status', 'repeatersPanel.columnStatus'],

--- a/src/renderer/lib/ingest/meshcoreIngest.test.ts
+++ b/src/renderer/lib/ingest/meshcoreIngest.test.ts
@@ -84,7 +84,7 @@ describe('attachMeshcoreIngest', () => {
       ID,
     );
     expect(saveMeshcoreContact).not.toHaveBeenCalled();
-    expect(updateAdvert).toHaveBeenCalledWith(nid, 1_700_000_100, null, null, undefined);
+    expect(updateAdvert).toHaveBeenCalledWith(nid, 1_700_000_100, null, null, 'LiveAdvert');
     detach();
   });
 

--- a/src/renderer/lib/meshcore/meshcoreLiveContactPersist.test.ts
+++ b/src/renderer/lib/meshcore/meshcoreLiveContactPersist.test.ts
@@ -44,9 +44,60 @@ describe('meshcoreLiveContactPersist', () => {
       1_700_000_000,
       null,
       null,
-      undefined,
+      'Alice',
     );
     expect(window.electronAPI.db.saveMeshcoreContact).not.toHaveBeenCalled();
+  });
+
+  it('persists a rename even when the store already has a real name', () => {
+    upsertNode(ID, { nodeId: NODE_ID, longName: 'Alice', lastHeardAt: 1_699_000_000 });
+    persistMeshcoreNodeInfoAfterAdvert(ID, advertEvent({ longName: 'Bob' }));
+    expect(window.electronAPI.db.updateMeshcoreContactAdvert).toHaveBeenCalledWith(
+      NODE_ID,
+      1_700_000_000,
+      null,
+      null,
+      'Bob',
+    );
+  });
+
+  it('persists the advert name after PacketRouter already upserted it', () => {
+    upsertNode(ID, { nodeId: NODE_ID, longName: 'Bob', lastHeardAt: 1_700_000_000 });
+    persistMeshcoreNodeInfoAfterAdvert(ID, advertEvent({ longName: 'Bob' }));
+    expect(window.electronAPI.db.updateMeshcoreContactAdvert).toHaveBeenCalledWith(
+      NODE_ID,
+      1_700_000_000,
+      null,
+      null,
+      'Bob',
+    );
+  });
+
+  it('does not persist an empty pubkey-only advert name over an existing contact', () => {
+    upsertNode(ID, { nodeId: NODE_ID, longName: 'Alice', lastHeardAt: 1_699_000_000 });
+    persistMeshcoreNodeInfoAfterAdvert(ID, advertEvent({ longName: '' }));
+    expect(window.electronAPI.db.updateMeshcoreContactAdvert).toHaveBeenCalledWith(
+      NODE_ID,
+      1_700_000_000,
+      null,
+      null,
+      undefined,
+    );
+  });
+
+  it('does not persist a Node-HEX placeholder name over an existing contact', () => {
+    upsertNode(ID, { nodeId: NODE_ID, longName: 'Alice', lastHeardAt: 1_699_000_000 });
+    persistMeshcoreNodeInfoAfterAdvert(
+      ID,
+      advertEvent({ longName: `Node-${NODE_ID.toString(16).toUpperCase()}` }),
+    );
+    expect(window.electronAPI.db.updateMeshcoreContactAdvert).toHaveBeenCalledWith(
+      NODE_ID,
+      1_700_000_000,
+      null,
+      null,
+      undefined,
+    );
   });
 
   it('inserts a new contact when store row is missing', () => {

--- a/src/renderer/lib/meshcore/meshcoreLiveContactPersist.test.ts
+++ b/src/renderer/lib/meshcore/meshcoreLiveContactPersist.test.ts
@@ -10,6 +10,7 @@ import type { NodeInfoEvent } from '../protocols/Protocol';
 import {
   persistMeshcoreNodeInfoAfterAdvert,
   persistMeshcorePathUpdatedNewContact,
+  resetMeshcoreLiveAdvertNamesForTests,
 } from './meshcoreLiveContactPersist';
 
 const ID = 'meshcore-persist-test';
@@ -30,6 +31,7 @@ describe('meshcoreLiveContactPersist', () => {
   beforeEach(() => {
     useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
     resetMeshcoreLocallyDeletedContactsForTests();
+    resetMeshcoreLiveAdvertNamesForTests();
     vi.clearAllMocks();
     vi.mocked(window.electronAPI.db.updateMeshcoreContactAdvert).mockResolvedValue(undefined);
     vi.mocked(window.electronAPI.db.saveMeshcoreContact).mockResolvedValue(undefined);
@@ -109,6 +111,38 @@ describe('meshcoreLiveContactPersist', () => {
         on_radio: 1,
       }),
     );
+  });
+
+  it('inserts a new contact with null adv_name for a Node-HEX advert', () => {
+    persistMeshcoreNodeInfoAfterAdvert(
+      ID,
+      advertEvent({ longName: `Node-${NODE_ID.toString(16).toUpperCase()}` }),
+      { contactType: 1 },
+    );
+    expect(window.electronAPI.db.saveMeshcoreContact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adv_name: null,
+        contact_type: 1,
+        on_radio: 1,
+      }),
+    );
+    expect(window.electronAPI.db.updateMeshcoreContactAdvert).not.toHaveBeenCalled();
+  });
+
+  it('revives a tombstoned contact with stored name when advert is Node-HEX', () => {
+    upsertNode(ID, { nodeId: NODE_ID, longName: 'Alice', lastHeardAt: 1_699_000_000 });
+    markMeshcoreLocallyDeletedContact(NODE_ID);
+    persistMeshcoreNodeInfoAfterAdvert(
+      ID,
+      advertEvent({ longName: `Node-${NODE_ID.toString(16).toUpperCase()}` }),
+    );
+    expect(window.electronAPI.db.saveMeshcoreContact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        node_id: NODE_ID,
+        adv_name: 'Alice',
+      }),
+    );
+    expect(window.electronAPI.db.updateMeshcoreContactAdvert).not.toHaveBeenCalled();
   });
 
   it('skips persist when public key is invalid', () => {

--- a/src/renderer/lib/meshcore/meshcoreLiveContactPersist.ts
+++ b/src/renderer/lib/meshcore/meshcoreLiveContactPersist.ts
@@ -29,6 +29,8 @@ import { registerMeshcorePubKey } from './meshcorePubKeyRegistry';
 
 const MESHCORE_COORD_SCALE = 1e6;
 
+const liveAdvertNamesByNodeId = new Map<number, string>();
+
 /** Non-empty, non-placeholder advert name to write to SQLite; otherwise omit the column. */
 function persistableMeshcoreAdvertName(
   longName: string | undefined,
@@ -37,6 +39,23 @@ function persistableMeshcoreAdvertName(
   const trim = typeof longName === 'string' && longName.trim() ? longName.trim() : undefined;
   if (!trim || meshcoreIsPlaceholderNodeLongName(trim, nodeId)) return undefined;
   return trim;
+}
+
+/** Keep the last real advert name so PathUpdated rebuilds can merge independently of nicknames. */
+export function rememberMeshcoreLiveAdvertName(
+  nodeId: number,
+  name: string | null | undefined,
+): void {
+  const persistable = persistableMeshcoreAdvertName(name ?? undefined, nodeId);
+  if (persistable) liveAdvertNamesByNodeId.set(nodeId, persistable);
+}
+
+export function rememberedMeshcoreLiveAdvertName(nodeId: number): string | undefined {
+  return liveAdvertNamesByNodeId.get(nodeId);
+}
+
+export function resetMeshcoreLiveAdvertNamesForTests(): void {
+  liveAdvertNamesByNodeId.clear();
 }
 
 export interface PersistMeshcoreNodeInfoOpts {
@@ -115,15 +134,15 @@ export function persistMeshcoreNodeInfoAfterAdvert(
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime guard protects external or callback-mutated state.
   if (!existingRecord || tombstoned) {
     if (built) {
-      let advName: string | null =
-        typeof event.longName === 'string' && event.longName.trim() ? event.longName.trim() : null;
+      let advName: string | null = persistableMeshcoreAdvertName(event.longName, nodeId) ?? null;
       if (!advName) {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Node may be absent when its identity bucket is missing.
         const stored = existingRecord?.longName?.trim();
-        if (stored && !meshcoreIsPlaceholderNodeLongName(existingRecord.longName, nodeId)) {
+        if (stored && !meshcoreIsPlaceholderNodeLongName(stored, nodeId)) {
           advName = stored;
         }
       }
+      rememberMeshcoreLiveAdvertName(nodeId, advName);
       void window.electronAPI.db
         .saveMeshcoreContact({
           node_id: nodeId,
@@ -149,6 +168,7 @@ export function persistMeshcoreNodeInfoAfterAdvert(
   // before this runs; companion getContacts often keeps the old advName). Empty / Node-HEX
   // 128 payloads must not wipe a known name.
   const persistAdvName = persistableMeshcoreAdvertName(event.longName, nodeId);
+  rememberMeshcoreLiveAdvertName(nodeId, persistAdvName);
   const existingHw = existingRecord.hwModel;
   if (opts?.contactType != null && Number.isFinite(opts.contactType)) {
     const newHw = CONTACT_TYPE_LABELS[Math.floor(opts.contactType)] ?? 'Unknown';

--- a/src/renderer/lib/meshcore/meshcoreLiveContactPersist.ts
+++ b/src/renderer/lib/meshcore/meshcoreLiveContactPersist.ts
@@ -29,6 +29,16 @@ import { registerMeshcorePubKey } from './meshcorePubKeyRegistry';
 
 const MESHCORE_COORD_SCALE = 1e6;
 
+/** Non-empty, non-placeholder advert name to write to SQLite; otherwise omit the column. */
+function persistableMeshcoreAdvertName(
+  longName: string | undefined,
+  nodeId: number,
+): string | undefined {
+  const trim = typeof longName === 'string' && longName.trim() ? longName.trim() : undefined;
+  if (!trim || meshcoreIsPlaceholderNodeLongName(trim, nodeId)) return undefined;
+  return trim;
+}
+
 export interface PersistMeshcoreNodeInfoOpts {
   /** MeshCore contact type from advert (138) when known. */
   contactType?: number;
@@ -135,17 +145,11 @@ export function persistMeshcoreNodeInfoAfterAdvert(
     return;
   }
 
-  const advNameTrim =
-    typeof event.longName === 'string' && event.longName.trim() ? event.longName.trim() : undefined;
+  // Persist a real on-air name even when the store already has one (PacketRouter upserts
+  // before this runs; companion getContacts often keeps the old advName). Empty / Node-HEX
+  // 128 payloads must not wipe a known name.
+  const persistAdvName = persistableMeshcoreAdvertName(event.longName, nodeId);
   const existingHw = existingRecord.hwModel;
-  let persistAdvName: string | undefined;
-  if (
-    advNameTrim &&
-    (!existingRecord.longName?.trim() ||
-      meshcoreIsPlaceholderNodeLongName(existingRecord.longName, nodeId))
-  ) {
-    persistAdvName = advNameTrim;
-  }
   if (opts?.contactType != null && Number.isFinite(opts.contactType)) {
     const newHw = CONTACT_TYPE_LABELS[Math.floor(opts.contactType)] ?? 'Unknown';
     const merged = mergeHwModelOnContactUpdate(existingHw, newHw);

--- a/src/renderer/lib/meshcore/meshcoreRfRxRuntime.test.ts
+++ b/src/renderer/lib/meshcore/meshcoreRfRxRuntime.test.ts
@@ -311,6 +311,42 @@ describe('handleMeshcoreRfRx advert identity', () => {
     expect(window.electronAPI.db.updateMeshcoreContactAdvert).not.toHaveBeenCalled();
   });
 
+  it('persists an on-air rename for an existing contact via updateMeshcoreContactAdvert', () => {
+    const publicKey = Uint8Array.from({ length: 32 }, (_, i) => (i + 9) & 0xff);
+    const nodeId = pubkeyToNodeId(publicKey);
+    upsertNodeRecord(ID, {
+      nodeId,
+      longName: 'Alice',
+      hwModel: 'Companion',
+      lastHeardAt: 1_699_000_000,
+      publicKey,
+    });
+    const { deps } = makeDeps({ myNodeNumRef: ref(1) });
+    vi.mocked(window.electronAPI.db.saveMeshcoreContact).mockClear();
+    vi.mocked(window.electronAPI.db.updateMeshcoreContactAdvert).mockClear();
+    vi.mocked(window.electronAPI.db.saveMeshcoreContact).mockResolvedValue(undefined);
+    vi.mocked(window.electronAPI.db.updateMeshcoreContactAdvert).mockResolvedValue(undefined);
+
+    handleMeshcoreRfRx(
+      {
+        lastSnr: 7,
+        lastRssi: -28,
+        raw: buildFloodAdvertPacket({ publicKey, name: 'Bob', deviceRole: 1 }),
+      },
+      deps,
+    );
+
+    expect(useNodeStore.getState().nodes[ID][nodeId].longName).toBe('Bob');
+    expect(window.electronAPI.db.updateMeshcoreContactAdvert).toHaveBeenCalledWith(
+      nodeId,
+      1_700_000_000,
+      null,
+      null,
+      'Bob',
+    );
+    expect(window.electronAPI.db.saveMeshcoreContact).not.toHaveBeenCalled();
+  });
+
   it('revives a locally deleted contact when a live RF advert is heard', () => {
     const publicKey = Uint8Array.from({ length: 32 }, (_, i) => (i + 5) & 0xff);
     const nodeId = pubkeyToNodeId(publicKey);

--- a/src/renderer/lib/meshcoreUtils.test.ts
+++ b/src/renderer/lib/meshcoreUtils.test.ts
@@ -28,6 +28,7 @@ import {
   meshcoreMergeContactHopsAwayFromPrevious,
   meshcoreMilliVoltsToApproximateBatteryPercent,
   meshcoreMinimalNodeFromAdvertEvent,
+  meshcorePreviousAdvertNameForRebuild,
   meshcorePubkeyShortId,
   meshcoreRemoveContactErrorMessage,
   meshcoreResolvedTxPowerMax,
@@ -612,6 +613,33 @@ describe('meshcoreMergeContactAdvNameFromPrevious', () => {
   });
 });
 
+describe('meshcorePreviousAdvertNameForRebuild', () => {
+  const nodeId = 0xabcd1234;
+
+  it('uses prev long name when it is not the nickname overlay', () => {
+    expect(meshcorePreviousAdvertNameForRebuild('NewRoom', 'MyNick', 'OldRoom', nodeId)).toBe(
+      'NewRoom',
+    );
+  });
+
+  it('uses stored advert name when UI long name is the nickname', () => {
+    expect(meshcorePreviousAdvertNameForRebuild('MyNick', 'MyNick', 'NewRoom', nodeId)).toBe(
+      'NewRoom',
+    );
+  });
+
+  it('ignores placeholder stored names', () => {
+    expect(
+      meshcorePreviousAdvertNameForRebuild(
+        'MyNick',
+        'MyNick',
+        `Node-${nodeId.toString(16).toUpperCase()}`,
+        nodeId,
+      ),
+    ).toBeUndefined();
+  });
+});
+
 describe('buildNodesFromContacts advert-name merge (path-updated rebuild)', () => {
   const key32 = new Uint8Array(32);
   for (let i = 0; i < 32; i++) key32[i] = (i * 13 + 5) & 0xff;
@@ -633,6 +661,39 @@ describe('buildNodesFromContacts advert-name merge (path-updated rebuild)', () =
       { prevLastHeard: 1_700_000_100, radioLastAdvert: contact.lastAdvert },
     );
     expect(merged).toBe('NewRoom');
+  });
+
+  it('keeps stored advert name when nickname overlays long name and radio is stale or placeholder', () => {
+    const contact = {
+      publicKey: key32,
+      type: 3,
+      advName: 'OldRoom',
+      lastAdvert: 1_700_000_100,
+      advLat: 0,
+      advLon: 0,
+    };
+    const radio = meshcoreContactToMeshNode(contact);
+    const nick = 'MyNick';
+    const storedAdvName = 'NewRoom';
+    const prevAdvertName = meshcorePreviousAdvertNameForRebuild(
+      nick,
+      nick,
+      storedAdvName,
+      radio.node_id,
+    );
+    expect(
+      meshcoreMergeContactAdvNameFromPrevious(radio.long_name, prevAdvertName, radio.node_id, {
+        prevLastHeard: 1_700_000_100,
+        radioLastAdvert: contact.lastAdvert,
+      }),
+    ).toBe('NewRoom');
+    expect(
+      meshcoreMergeContactAdvNameFromPrevious(
+        `Node-${radio.node_id.toString(16).toUpperCase()}`,
+        prevAdvertName,
+        radio.node_id,
+      ),
+    ).toBe('NewRoom');
   });
 });
 

--- a/src/renderer/lib/meshcoreUtils.test.ts
+++ b/src/renderer/lib/meshcoreUtils.test.ts
@@ -24,6 +24,7 @@ import {
   meshcoreIsPlaceholderNodeLongName,
   meshcoreManufacturerModelFromDeviceQuery,
   meshcoreMergeChannelDisplayNameOntoNode,
+  meshcoreMergeContactAdvNameFromPrevious,
   meshcoreMergeContactHopsAwayFromPrevious,
   meshcoreMilliVoltsToApproximateBatteryPercent,
   meshcoreMinimalNodeFromAdvertEvent,
@@ -547,6 +548,91 @@ describe('meshcoreMergeContactHopsAwayFromPrevious', () => {
 
   it('fills from previous when inferred is undefined and prev is direct', () => {
     expect(meshcoreMergeContactHopsAwayFromPrevious(undefined, 0, 1)).toBe(0);
+  });
+});
+
+describe('meshcoreMergeContactAdvNameFromPrevious', () => {
+  const nodeId = 0xabcd1234;
+
+  it('keeps a real previous name when radio reports a placeholder', () => {
+    expect(
+      meshcoreMergeContactAdvNameFromPrevious(
+        `Node-${nodeId.toString(16).toUpperCase()}`,
+        'Room',
+        nodeId,
+      ),
+    ).toBe('Room');
+  });
+
+  it('uses radio name when previous is empty or placeholder', () => {
+    expect(meshcoreMergeContactAdvNameFromPrevious('NewRoom', '', nodeId)).toBe('NewRoom');
+    expect(
+      meshcoreMergeContactAdvNameFromPrevious(
+        'NewRoom',
+        `Node-${nodeId.toString(16).toUpperCase()}`,
+        nodeId,
+      ),
+    ).toBe('NewRoom');
+  });
+
+  it('keeps a live advert rename when radio lastAdvert is not newer', () => {
+    expect(
+      meshcoreMergeContactAdvNameFromPrevious('OldRoom', 'NewRoom', nodeId, {
+        prevLastHeard: 1_700_000_100,
+        radioLastAdvert: 1_700_000_100,
+      }),
+    ).toBe('NewRoom');
+  });
+
+  it('keeps previous on a lastAdvert tie (companion updated time without renaming)', () => {
+    expect(
+      meshcoreMergeContactAdvNameFromPrevious('Alice', 'Bob', nodeId, {
+        prevLastHeard: 50,
+        radioLastAdvert: 50,
+      }),
+    ).toBe('Bob');
+  });
+
+  it('takes radio name when radio lastAdvert is strictly newer', () => {
+    expect(
+      meshcoreMergeContactAdvNameFromPrevious('FirmwareRename', 'OldName', nodeId, {
+        prevLastHeard: 1_700_000_000,
+        radioLastAdvert: 1_700_000_500,
+      }),
+    ).toBe('FirmwareRename');
+  });
+
+  it('keeps previous when radio lastAdvert is 0', () => {
+    expect(
+      meshcoreMergeContactAdvNameFromPrevious('OldRoom', 'NewRoom', nodeId, {
+        prevLastHeard: 1_700_000_100,
+        radioLastAdvert: 0,
+      }),
+    ).toBe('NewRoom');
+  });
+});
+
+describe('buildNodesFromContacts advert-name merge (path-updated rebuild)', () => {
+  const key32 = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) key32[i] = (i * 13 + 5) & 0xff;
+
+  it('keeps a live advert rename when getContacts still has the old advName', () => {
+    const contact = {
+      publicKey: key32,
+      type: 3,
+      advName: 'OldRoom',
+      lastAdvert: 1_700_000_100,
+      advLat: 0,
+      advLon: 0,
+    };
+    const radio = meshcoreContactToMeshNode(contact);
+    const merged = meshcoreMergeContactAdvNameFromPrevious(
+      radio.long_name,
+      'NewRoom',
+      radio.node_id,
+      { prevLastHeard: 1_700_000_100, radioLastAdvert: contact.lastAdvert },
+    );
+    expect(merged).toBe('NewRoom');
   });
 });
 

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -617,6 +617,47 @@ export function meshcoreMergeContactHopsAwayFromPrevious(
   return inferred;
 }
 
+export interface MeshcoreMergeContactAdvNameOpts {
+  prevLastHeard?: number;
+  radioLastAdvert?: number;
+}
+
+/**
+ * When rebuilding from `getContacts`, companion firmware often keeps the name from when the
+ * contact was first stored. Prefer a live advert name already in the UI unless the radio dump
+ * is strictly newer (connect/refresh after firmware actually renamed the contact).
+ */
+export function meshcoreMergeContactAdvNameFromPrevious(
+  radioAdvName: string | undefined,
+  prevLongName: string | undefined,
+  nodeId: number,
+  opts?: MeshcoreMergeContactAdvNameOpts,
+): string {
+  const radioTrim = (radioAdvName ?? '').trim();
+  const prevTrim = (prevLongName ?? '').trim();
+  const radioReal = radioTrim.length > 0 && !meshcoreIsPlaceholderNodeLongName(radioTrim, nodeId);
+  const prevReal = prevTrim.length > 0 && !meshcoreIsPlaceholderNodeLongName(prevTrim, nodeId);
+  const hexFallback = `Node-${nodeId.toString(16).toUpperCase()}`;
+
+  if (!radioReal && prevReal) return prevTrim;
+  if (!prevReal) return radioTrim || prevTrim || hexFallback;
+  if (radioTrim === prevTrim) return radioTrim;
+
+  const radioAdvert =
+    opts?.radioLastAdvert != null &&
+    Number.isFinite(opts.radioLastAdvert) &&
+    opts.radioLastAdvert > 0
+      ? opts.radioLastAdvert
+      : 0;
+  const prevHeard =
+    opts?.prevLastHeard != null && Number.isFinite(opts.prevLastHeard) ? opts.prevLastHeard : 0;
+  // Tie or missing radio time: companion often updates lastAdvert without renaming.
+  if (radioAdvert === 0 || prevHeard >= radioAdvert) {
+    return prevTrim;
+  }
+  return radioTrim;
+}
+
 /** Result of mapping a heard RF advert (push 0x80) into UI + DB when the node is not yet a contact. */
 export interface MeshcoreMinimalAdvertNodeResult {
   node: MeshNode;

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -623,6 +623,29 @@ export interface MeshcoreMergeContactAdvNameOpts {
 }
 
 /**
+ * Advert name to merge against a `getContacts` dump. UI `long_name` is often the nickname overlay,
+ * so prefer a real previous advert name and fall back to the stored SQLite/live advert name.
+ */
+export function meshcorePreviousAdvertNameForRebuild(
+  prevLongName: string | undefined,
+  nickname: string | undefined,
+  storedAdvertName: string | undefined,
+  nodeId: number,
+): string | undefined {
+  const prev = (prevLongName ?? '').trim();
+  const nick = (nickname ?? '').trim();
+  const stored = (storedAdvertName ?? '').trim();
+  const prevIsNick = nick.length > 0 && prev === nick;
+  if (prev && !prevIsNick && !meshcoreIsPlaceholderNodeLongName(prev, nodeId)) {
+    return prev;
+  }
+  if (stored && !meshcoreIsPlaceholderNodeLongName(stored, nodeId)) {
+    return stored;
+  }
+  return undefined;
+}
+
+/**
  * When rebuilding from `getContacts`, companion firmware often keeps the name from when the
  * contact was first stored. Prefer a live advert name already in the UI unless the radio dump
  * is strictly newer (connect/refresh after firmware actually renamed the contact).

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -390,6 +390,7 @@ import {
   meshcoreIsSyntheticPlaceholderPubKeyHex,
   meshcoreManufacturerModelFromDeviceQuery,
   meshcoreMergeChannelDisplayNameOntoNode,
+  meshcoreMergeContactAdvNameFromPrevious,
   meshcoreMergeContactHopsAwayFromPrevious,
   meshcoreMilliVoltsToApproximateBatteryPercent,
   meshcoreMinimalNodeFromAdvertEvent,
@@ -1582,7 +1583,23 @@ export function useMeshcoreRuntime() {
           effectivePrevHops,
           slicedPath.length,
         );
-        const node: MeshNode = { ...base, last_heard, hops_away: hopsAway };
+        const nick = nicknameMapRef.current.get(base.node_id);
+        // Nickname overlay runs after this loop; do not treat the nick as advert name for SQLite.
+        const mergedAdvName = meshcoreMergeContactAdvNameFromPrevious(
+          base.long_name,
+          nick ? undefined : prevNode?.long_name,
+          base.node_id,
+          {
+            prevLastHeard: prevNode?.last_heard,
+            radioLastAdvert: contact.lastAdvert,
+          },
+        );
+        const node: MeshNode = {
+          ...base,
+          last_heard,
+          hops_away: hopsAway,
+          long_name: mergedAdvName,
+        };
         if (prevNode?.channel_utilization != null) {
           node.channel_utilization = prevNode.channel_utilization;
         }
@@ -1619,7 +1636,13 @@ export function useMeshcoreRuntime() {
         const onRadio = opts?.contactsFromRadio ? 1 : 0;
         const prevHopsAway = prevNode?.hops_away;
         const hopsToSave = hopsAway ?? prevHopsAway ?? undefined;
-        const dbRow = contactToDbRow(contact, undefined, onRadio, now, hopsToSave);
+        const dbRow = contactToDbRow(
+          { ...contact, advName: mergedAdvName },
+          undefined,
+          onRadio,
+          now,
+          hopsToSave,
+        );
         pendingDbRows.push(dbRow);
       }
       replaceMeshcorePubKeyRegistry(
@@ -1800,7 +1823,10 @@ export function useMeshcoreRuntime() {
         });
       } else {
         setNodes((prev) => {
-          const existing = prev.get(nodeId);
+          // Live RF/advert upserts nodeStore, not this useState map. Seed from Zustand so the
+          // syncNodesMapToIdentityStore effect cannot restore the companion's old advName.
+          const fromStore = readMeshcoreNodes().get(nodeId);
+          const existing = fromStore ?? prev.get(nodeId);
           if (!existing) return prev;
           const next = new Map(prev);
           next.set(nodeId, {
@@ -1854,7 +1880,7 @@ export function useMeshcoreRuntime() {
       }, MESHCORE_PATH_UPDATED_CONTACTS_REBUILD_DEBOUNCE_MS);
       requestChatOutboxDrain('meshcore');
     },
-    [meshcorePreviousNodesBaselineForBuild],
+    [meshcorePreviousNodesBaselineForBuild, readMeshcoreNodes],
   );
 
   /** Returned by {@link setupEventListeners}; run before `conn.close()` or replacing the connection. */

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -152,6 +152,10 @@ import type {
   RxPacketEntry,
 } from '../lib/meshcore/meshcoreHookTypes';
 import {
+  rememberedMeshcoreLiveAdvertName,
+  rememberMeshcoreLiveAdvertName,
+} from '../lib/meshcore/meshcoreLiveContactPersist';
+import {
   MESHCORE_ERR_NODE_NOT_FOUND,
   MESHCORE_ERR_NOT_CONNECTED,
   MESHCORE_ERR_REQUEST_FAILED,
@@ -394,6 +398,7 @@ import {
   meshcoreMergeContactHopsAwayFromPrevious,
   meshcoreMilliVoltsToApproximateBatteryPercent,
   meshcoreMinimalNodeFromAdvertEvent,
+  meshcorePreviousAdvertNameForRebuild,
   meshcoreRemoveContactErrorMessage,
   meshcoreScaledAdvLatLonToDeg,
   meshcoreSyntheticPlaceholderPubKeyHex,
@@ -1194,6 +1199,7 @@ export function useMeshcoreRuntime() {
       const dbPubKeyHexByNodeId = new Map<number, string>();
       for (const row of dbContacts) {
         if (row.nickname) nicknameMapRef.current.set(row.node_id, row.nickname);
+        rememberMeshcoreLiveAdvertName(row.node_id, row.adv_name);
         const hex = row.public_key.replace(/\s/g, '').toLowerCase();
         if (!meshcoreIsSyntheticPlaceholderPubKeyHex(hex) && hex.length >= 12) {
           const pairs = hex.match(/.{2}/g);
@@ -1584,16 +1590,22 @@ export function useMeshcoreRuntime() {
           slicedPath.length,
         );
         const nick = nicknameMapRef.current.get(base.node_id);
-        // Nickname overlay runs after this loop; do not treat the nick as advert name for SQLite.
+        // Nickname overlay runs after this loop; merge stored advert name, not the nick.
         const mergedAdvName = meshcoreMergeContactAdvNameFromPrevious(
           base.long_name,
-          nick ? undefined : prevNode?.long_name,
+          meshcorePreviousAdvertNameForRebuild(
+            prevNode?.long_name,
+            nick,
+            rememberedMeshcoreLiveAdvertName(base.node_id),
+            base.node_id,
+          ),
           base.node_id,
           {
             prevLastHeard: prevNode?.last_heard,
             radioLastAdvert: contact.lastAdvert,
           },
         );
+        rememberMeshcoreLiveAdvertName(base.node_id, mergedAdvName);
         const node: MeshNode = {
           ...base,
           last_heard,


### PR DESCRIPTION
## Summary

Two MeshCore UI/runtime fixes: Room and Companion **Long Name** no longer snaps back to the companion’s stale `advName` after a path-updated contact rebuild, and the Repeaters & Rooms table now fills leftover window height instead of sitting under a `70vh` cap.

### 1. Keep on-air advert names after path-updated contact rebuild (`1085af6a`)

Renaming a Room or Companion on air updated Contacts immediately, then **reverted ~2s later**. Companion `getContacts` often still has the old `advName` (and may bump `lastAdvert` without renaming), so the PathUpdated rebuild restored the previous label.

- **Persist** a real on-air name to SQLite even when the store already has one (PacketRouter upserts before persist). Empty / `Node-HEX` 128 payloads still do not wipe a known name.
- **Merge** live advert names on rebuild like hops: `meshcoreMergeContactAdvNameFromPrevious` keeps the UI/SQLite name unless the radio dump’s `lastAdvert` is **strictly newer** (connect/refresh after firmware actually renamed the contact). Tie or missing radio time prefers the live name, because companions often update `lastAdvert` without renaming.
- Nickname overlay is not treated as advert name for SQLite.
- PathUpdated `setNodes` seeds from Zustand (`readMeshcoreNodes`) so the `syncNodesMapToIdentityStore` effect cannot restore the companion’s old `advName`.

### 2. Fill Repeaters list to leftover window height (`98ac0189`)

The Repeaters & Rooms table was capped at `max-h-[min(70vh,48rem)]`, so a large empty band sat below the list on tall windows.

- Modules tab panel and RepeatersPanel root are `h-full min-h-0` flex columns.
- Table scroller is `flex-1 min-h-0 overflow-auto` so it fills leftover height below the header/filters.
- Sticky table header (`bg-app-bg sticky top-0`) so column labels stay visible while scrolling.

## Commits

- `1085af6a` fix(meshcore): keep on-air advert names after path-updated contact rebuild
- `98ac0189` fix(meshcore): fill Repeaters list to leftover window height

## Test plan

### Advert names (rename revert)

- [ ] MeshCore: hear a Room or Companion advert that **renames** an existing contact — Contacts Long Name updates immediately
- [ ] Wait for PathUpdated / `getContacts` rebuild (~2s): Long Name **stays** the new on-air name (does not snap back)
- [ ] Repeat for a Companion (not only a Room)
- [ ] Empty / `Node-HEX` advert payloads do **not** wipe a known Long Name
- [ ] User nickname overlay still applies in the UI and is **not** written as advert name to SQLite
- [ ] Connect / refresh after firmware actually renamed the contact (radio `lastAdvert` strictly newer): radio name wins
- [ ] Vitest: `meshcoreLiveContactPersist.test.ts`, `meshcoreUtils.test.ts` (adv-name merge), `meshcoreRfRxRuntime.test.ts`, `meshcoreIngest.test.ts`

### Repeaters list height

- [ ] MeshCore → Repeaters: table scroller fills leftover window height (no large empty band below the list on a tall window)
- [ ] Header / filters stay at the top; only the table scrolls
- [ ] Column headers stay visible (sticky) while scrolling a long list
- [ ] Empty / no-match states still look correct
- [ ] Vitest: `RepeatersPanel.test.tsx` (scroller uses `flex-1 min-h-0`, no `70vh`)
- [ ] Linux / macOS / Windows: layout still fills leftover height (shared flex, no OS-specific path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Modules and Repeaters panels now make better use of available screen height.
  - Repeater tables use flexible scrolling, with headers remaining visible while browsing.
  - MeshCore contact names now update reliably from newer on-air adverts.
  - Existing names are preserved when incoming adverts contain blank or placeholder names.
  - Contact rebuilds retain known advert names when current radio data is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->