### PR TITLE
fix(meshcore): show channel share QR under the clicked row

### DIFF
--- a/src/renderer/components/RadioPanel.test.tsx
+++ b/src/renderer/components/RadioPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
@@ -741,11 +741,20 @@ describe('RadioPanel MeshCore Open wire and path hash', () => {
 });
 
 describe('RadioPanel MeshCore channel share QR placement', () => {
+  async function openMeshcoreChannelsDetails(user: ReturnType<typeof userEvent.setup>) {
+    const channelsDetails = [...document.querySelectorAll('details')].find((d) => {
+      const span = d.querySelector(':scope > summary > span');
+      return span?.textContent?.trim() === 'Channels (MeshCore)';
+    });
+    expect(channelsDetails).toBeDefined();
+    await user.click(channelsDetails!.querySelector('summary')!);
+  }
+
   it('renders the share QR under the clicked channel row, not after the list', async () => {
     const user = userEvent.setup();
     const secretA = new Uint8Array(16).fill(0x11);
     const secretB = new Uint8Array(16).fill(0x22);
-    render(
+    const { container } = render(
       <ToastProvider>
         <RadioPanel
           {...defaultProps}
@@ -759,12 +768,7 @@ describe('RadioPanel MeshCore channel share QR placement', () => {
       </ToastProvider>,
     );
 
-    const channelsDetails = [...document.querySelectorAll('details')].find((d) => {
-      const span = d.querySelector(':scope > summary > span');
-      return span?.textContent?.trim() === 'Channels (MeshCore)';
-    });
-    expect(channelsDetails).toBeDefined();
-    await user.click(channelsDetails!.querySelector('summary')!);
+    await openMeshcoreChannelsDetails(user);
 
     const alphaQrButton = screen.getByRole('button', {
       name: 'Show MeshCore channel QR for Alpha',
@@ -791,5 +795,54 @@ describe('RadioPanel MeshCore channel share QR placement', () => {
     expect(betaItem).toBeDefined();
     expect(betaItem?.textContent).toContain('Beta');
     expect(betaItem?.querySelector('img')).toBeNull();
+
+    hydrateAxeThemeColors(container);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('scrolls the share QR into view and clears it after deleting the channel', async () => {
+    const user = userEvent.setup();
+    const secretA = new Uint8Array(16).fill(0x11);
+    const secretB = new Uint8Array(16).fill(0x22);
+    const onMeshcoreDeleteChannel = vi.fn().mockResolvedValue(undefined);
+    const scrollIntoView = vi
+      .spyOn(HTMLElement.prototype, 'scrollIntoView')
+      .mockImplementation(() => {});
+
+    render(
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          capabilities={MESHCORE_CAPABILITIES}
+          meshcoreChannels={[
+            { index: 0, name: 'Alpha', secret: secretA },
+            { index: 1, name: 'Beta', secret: secretB },
+          ]}
+          onMeshcoreDeleteChannel={onMeshcoreDeleteChannel}
+        />
+      </ToastProvider>,
+    );
+
+    await openMeshcoreChannelsDetails(user);
+
+    scrollIntoView.mockClear();
+    await user.click(screen.getByRole('button', { name: 'Show MeshCore channel QR for Alpha' }));
+    await screen.findByRole('img', { name: 'Show MeshCore channel QR for Alpha' });
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalled();
+    });
+
+    const alphaRow = screen.getByText('Alpha').closest('.space-y-1');
+    expect(alphaRow).not.toBeNull();
+    await user.click(within(alphaRow as HTMLElement).getByRole('button', { name: 'Delete' }));
+    await user.click(within(alphaRow as HTMLElement).getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(onMeshcoreDeleteChannel).toHaveBeenCalledWith(0);
+    });
+    expect(
+      screen.queryByRole('img', { name: 'Show MeshCore channel QR for Alpha' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/RadioPanel.test.tsx
+++ b/src/renderer/components/RadioPanel.test.tsx
@@ -11,6 +11,12 @@ import { hydrateAxeThemeColors } from '../lib/a11yTestHelpers';
 import RadioPanel, { ConfigNumber } from './RadioPanel';
 import { ToastProvider } from './Toast';
 
+vi.mock('./QrCodeImage', () => ({
+  default: ({ value, ariaLabel }: { value: string; ariaLabel?: string }) => (
+    <img alt={ariaLabel ?? 'qr'} data-qr-value={value} />
+  ),
+}));
+
 /**
  * Returns true if the label element with the given text has a sibling HelpTooltip
  * (.cursor-help) inside the same flex row. Add entries to the checklists below
@@ -731,5 +737,59 @@ describe('RadioPanel MeshCore Open wire and path hash', () => {
     ).toBeInTheDocument();
     hydrateAxeThemeColors(container);
     expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe('RadioPanel MeshCore channel share QR placement', () => {
+  it('renders the share QR under the clicked channel row, not after the list', async () => {
+    const user = userEvent.setup();
+    const secretA = new Uint8Array(16).fill(0x11);
+    const secretB = new Uint8Array(16).fill(0x22);
+    render(
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          capabilities={MESHCORE_CAPABILITIES}
+          meshcoreChannels={[
+            { index: 0, name: 'Alpha', secret: secretA },
+            { index: 1, name: 'Beta', secret: secretB },
+          ]}
+        />
+      </ToastProvider>,
+    );
+
+    const channelsDetails = [...document.querySelectorAll('details')].find((d) => {
+      const span = d.querySelector(':scope > summary > span');
+      return span?.textContent?.trim() === 'Channels (MeshCore)';
+    });
+    expect(channelsDetails).toBeDefined();
+    await user.click(channelsDetails!.querySelector('summary')!);
+
+    const alphaQrButton = screen.getByRole('button', {
+      name: 'Show MeshCore channel QR for Alpha',
+    });
+    expect(alphaQrButton).toHaveAttribute('aria-expanded', 'false');
+    await user.click(alphaQrButton);
+
+    const qr = await screen.findByRole('img', {
+      name: 'Show MeshCore channel QR for Alpha',
+    });
+    expect(alphaQrButton).toHaveAttribute('aria-expanded', 'true');
+
+    const itemWrapper = qr.closest('.space-y-1');
+    expect(itemWrapper).not.toBeNull();
+    expect(itemWrapper!.textContent).toContain('Alpha');
+    expect(itemWrapper!.textContent).not.toContain('Beta');
+
+    const channelList = itemWrapper!.parentElement;
+    expect(channelList).not.toBeNull();
+    const items = [...channelList!.children].filter((el) => el.classList.contains('space-y-1'));
+    expect(items).toHaveLength(2);
+    expect(items[0]).toBe(itemWrapper);
+    const betaItem = items[1];
+    expect(betaItem).toBeDefined();
+    expect(betaItem?.textContent).toContain('Beta');
+    expect(betaItem?.querySelector('img')).toBeNull();
   });
 });

--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -3869,12 +3869,14 @@ function MeshcoreChannelSection({
           )}
           {channels.map((ch) => {
             const revealed = revealedIdx.has(ch.index);
+            const channelName =
+              ch.name || t('radioPanel.meshcoreChannel.defaultName', { index: ch.index });
             const showShareQr = shareQrIdx === ch.index && ch.secret?.length === 16;
             let shareQrUri: string | null = null;
             if (showShareQr) {
               try {
                 shareQrUri = buildMeshcoreChannelAddUri({
-                  name: ch.name || t('radioPanel.meshcoreChannel.defaultName', { index: ch.index }),
+                  name: channelName,
                   secretHex: bytesToHex(ch.secret),
                 });
               } catch {
@@ -3888,9 +3890,7 @@ function MeshcoreChannelSection({
                   <span className="rounded bg-gray-700 px-1.5 py-0.5 font-mono text-xs font-bold text-gray-400">
                     {ch.index}
                   </span>
-                  <span className="flex-1 text-sm text-gray-200">
-                    {ch.name || t('radioPanel.meshcoreChannel.defaultName', { index: ch.index })}
-                  </span>
+                  <span className="flex-1 text-sm text-gray-200">{channelName}</span>
                   <span className="text-muted font-mono text-xs">
                     {revealed ? bytesToHex(ch.secret) : '••••••••••••••••'}
                   </span>
@@ -3928,7 +3928,9 @@ function MeshcoreChannelSection({
                         setShareQrIdx((prev) => (prev === ch.index ? null : ch.index));
                       }}
                       aria-expanded={shareQrIdx === ch.index}
-                      aria-label={t('radioPanel.meshcoreChannel.shareQrAria', { name: ch.name })}
+                      aria-label={t('radioPanel.meshcoreChannel.shareQrAria', {
+                        name: channelName,
+                      })}
                       className="px-1 text-xs text-amber-400 hover:text-amber-300"
                     >
                       {t('radioPanel.meshcoreChannel.shareQr')}
@@ -3975,7 +3977,7 @@ function MeshcoreChannelSection({
                     <QrCodeImage
                       value={shareQrUri}
                       size={160}
-                      ariaLabel={t('radioPanel.meshcoreChannel.shareQrAria', { name: ch.name })}
+                      ariaLabel={t('radioPanel.meshcoreChannel.shareQrAria', { name: channelName })}
                     />
                   </div>
                 ) : null}

--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -3726,6 +3726,7 @@ function MeshcoreChannelSection({
   const [shareQrIdx, setShareQrIdx] = useState<number | null>(null);
   const detailsRef = useRef<HTMLDetailsElement>(null);
   const formRef = useRef<HTMLDivElement>(null);
+  const shareQrRef = useRef<HTMLDivElement>(null);
 
   const isValidHex = editKeyHex.length === 32 && /^[0-9a-fA-F]{32}$/.test(editKeyHex);
 
@@ -3775,6 +3776,12 @@ function MeshcoreChannelSection({
     }
   }, [editingIdx, addingNew]);
 
+  useEffect(() => {
+    if (shareQrIdx != null && shareQrRef.current) {
+      shareQrRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [shareQrIdx]);
+
   function openEdit(ch: { index: number; name: string; secret: Uint8Array }) {
     setEditingIdx(ch.index);
     setEditName(ch.name);
@@ -3819,6 +3826,7 @@ function MeshcoreChannelSection({
       await onDeleteChannel(idx);
       setConfirmDeleteIdx(null);
       if (editingIdx === idx) setEditingIdx(null);
+      if (shareQrIdx === idx) setShareQrIdx(null);
     } catch (e) {
       console.warn('[MeshcoreChannelSection] delete failed ' + errLikeToLogString(e));
     } finally {
@@ -3861,121 +3869,120 @@ function MeshcoreChannelSection({
           )}
           {channels.map((ch) => {
             const revealed = revealedIdx.has(ch.index);
-            return (
-              <div
-                key={`ch-${ch.index}-${ch.name}`}
-                className="bg-deep-black/60 flex items-center gap-2 rounded-lg border border-gray-700/50 px-3 py-2"
-              >
-                <span className="rounded bg-gray-700 px-1.5 py-0.5 font-mono text-xs font-bold text-gray-400">
-                  {ch.index}
-                </span>
-                <span className="flex-1 text-sm text-gray-200">
-                  {ch.name || t('radioPanel.meshcoreChannel.defaultName', { index: ch.index })}
-                </span>
-                <span className="text-muted font-mono text-xs">
-                  {revealed ? bytesToHex(ch.secret) : '••••••••••••••••'}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setRevealedIdx((prev) => {
-                      const next = new Set(prev);
-                      if (next.has(ch.index)) next.delete(ch.index);
-                      else next.add(ch.index);
-                      return next;
-                    });
-                  }}
-                  className="text-muted px-1 text-xs hover:text-gray-300"
-                  title={revealed ? t('radioPanel.hideKey') : t('radioPanel.revealKey')}
-                >
-                  {revealed ? t('common.hide') : t('common.show')}
-                </button>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openEdit(ch);
-                  }}
-                  disabled={disabled}
-                  className="px-1 text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50"
-                >
-                  {t('common.edit')}
-                </button>
-                {ch.secret?.length === 16 ? (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShareQrIdx((prev) => (prev === ch.index ? null : ch.index));
-                    }}
-                    aria-label={t('radioPanel.meshcoreChannel.shareQrAria', { name: ch.name })}
-                    className="px-1 text-xs text-amber-400 hover:text-amber-300"
-                  >
-                    {t('radioPanel.meshcoreChannel.shareQr')}
-                  </button>
-                ) : null}
-                {confirmDeleteIdx === ch.index ? (
-                  <span className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      onClick={() => handleDelete(ch.index)}
-                      disabled={disabled || saving}
-                      className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
-                    >
-                      {t('common.confirm')}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setConfirmDeleteIdx(null);
-                      }}
-                      className="text-muted text-xs hover:text-gray-300"
-                    >
-                      {t('common.cancel')}
-                    </button>
-                  </span>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setConfirmDeleteIdx(ch.index);
-                    }}
-                    disabled={disabled || saving}
-                    className="px-1 text-xs text-red-500 hover:text-red-400 disabled:opacity-50"
-                  >
-                    {t('common.delete')}
-                  </button>
-                )}
-              </div>
-            );
-          })}
-        </div>
-
-        {shareQrIdx != null
-          ? (() => {
-              const ch = channels.find((c) => c.index === shareQrIdx);
-              if (!ch || ch.secret?.length !== 16) return null;
-              let uri: string;
+            const showShareQr = shareQrIdx === ch.index && ch.secret?.length === 16;
+            let shareQrUri: string | null = null;
+            if (showShareQr) {
               try {
-                uri = buildMeshcoreChannelAddUri({
+                shareQrUri = buildMeshcoreChannelAddUri({
                   name: ch.name || t('radioPanel.meshcoreChannel.defaultName', { index: ch.index }),
                   secretHex: bytesToHex(ch.secret),
                 });
               } catch {
                 // catch-no-log-ok invalid channel secret hides QR
-                return null;
+                shareQrUri = null;
               }
-              return (
-                <div className="bg-deep-black/40 rounded-lg border border-gray-700/50 p-3">
-                  <QrCodeImage
-                    value={uri}
-                    size={160}
-                    ariaLabel={t('radioPanel.meshcoreChannel.shareQrAria', { name: ch.name })}
-                  />
+            }
+            return (
+              <div key={`ch-${ch.index}-${ch.name}`} className="space-y-1">
+                <div className="bg-deep-black/60 flex items-center gap-2 rounded-lg border border-gray-700/50 px-3 py-2">
+                  <span className="rounded bg-gray-700 px-1.5 py-0.5 font-mono text-xs font-bold text-gray-400">
+                    {ch.index}
+                  </span>
+                  <span className="flex-1 text-sm text-gray-200">
+                    {ch.name || t('radioPanel.meshcoreChannel.defaultName', { index: ch.index })}
+                  </span>
+                  <span className="text-muted font-mono text-xs">
+                    {revealed ? bytesToHex(ch.secret) : '••••••••••••••••'}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRevealedIdx((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(ch.index)) next.delete(ch.index);
+                        else next.add(ch.index);
+                        return next;
+                      });
+                    }}
+                    className="text-muted px-1 text-xs hover:text-gray-300"
+                    title={revealed ? t('radioPanel.hideKey') : t('radioPanel.revealKey')}
+                  >
+                    {revealed ? t('common.hide') : t('common.show')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      openEdit(ch);
+                    }}
+                    disabled={disabled}
+                    className="px-1 text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50"
+                  >
+                    {t('common.edit')}
+                  </button>
+                  {ch.secret?.length === 16 ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShareQrIdx((prev) => (prev === ch.index ? null : ch.index));
+                      }}
+                      aria-expanded={shareQrIdx === ch.index}
+                      aria-label={t('radioPanel.meshcoreChannel.shareQrAria', { name: ch.name })}
+                      className="px-1 text-xs text-amber-400 hover:text-amber-300"
+                    >
+                      {t('radioPanel.meshcoreChannel.shareQr')}
+                    </button>
+                  ) : null}
+                  {confirmDeleteIdx === ch.index ? (
+                    <span className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(ch.index)}
+                        disabled={disabled || saving}
+                        className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
+                      >
+                        {t('common.confirm')}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setConfirmDeleteIdx(null);
+                        }}
+                        className="text-muted text-xs hover:text-gray-300"
+                      >
+                        {t('common.cancel')}
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setConfirmDeleteIdx(ch.index);
+                      }}
+                      disabled={disabled || saving}
+                      className="px-1 text-xs text-red-500 hover:text-red-400 disabled:opacity-50"
+                    >
+                      {t('common.delete')}
+                    </button>
+                  )}
                 </div>
-              );
-            })()
-          : null}
+                {shareQrUri != null ? (
+                  <div
+                    ref={shareQrRef}
+                    className="bg-deep-black/40 rounded-lg border border-gray-700/50 p-3"
+                  >
+                    <QrCodeImage
+                      value={shareQrUri}
+                      size={160}
+                      ariaLabel={t('radioPanel.meshcoreChannel.shareQrAria', { name: ch.name })}
+                    />
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
 
         <div className="pt-1">
           <p className="text-muted mb-1 text-[11px]">{t('qrIngest.pasteImageHint')}</p>


### PR DESCRIPTION
## Summary
- MeshCore channel share QR now renders inline under the channel whose **QR** control was clicked, instead of after the full channel list (where it was easy to miss below the fold).
- Adds `aria-expanded`, scrolls the QR into view on open, and clears share state when that channel is deleted.
- Adds a RadioPanel regression test for under-row placement.

## Test plan
- [ ] Radio → Channels (MeshCore) with 2+ channels that have 16-byte secrets
- [ ] Click **QR** on a channel near the top; confirm the QR appears directly under that row
- [ ] Click **QR** again to collapse; click another channel’s **QR** and confirm only that row shows a QR
- [ ] Delete a channel while its QR is open; confirm the QR disappears
- [ ] `pnpm exec vitest run src/renderer/components/RadioPanel.test.tsx -t "share QR"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MeshCore channel QR codes now appear directly beneath the selected channel for easier sharing.
  - The interface automatically scrolls to newly opened QR codes.
  - Share controls indicate when QR content is expanded.

- **Bug Fixes**
  - QR selections are cleared when their channel is deleted.
  - Invalid channel secrets no longer generate QR codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->