### PR TITLE
fix: replace ineffective games session dynamic import

### DIFF
--- a/src/renderer/components/ReticulumStackPanel.test.tsx
+++ b/src/renderer/components/ReticulumStackPanel.test.tsx
@@ -23,6 +23,10 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+vi.mock('@/renderer/lib/reticulum/reticulumGamesSession', () => ({
+  refreshGamesSessions: vi.fn(async () => {}),
+}));
+
 vi.mock('@/renderer/lib/sessions/reticulumSession', () => ({
   tryGetReticulumSession: () => ({
     restartStack: vi.fn().mockResolvedValue(undefined),

--- a/src/renderer/lib/reticulum/useReticulumSidecarApi.test.ts
+++ b/src/renderer/lib/reticulum/useReticulumSidecarApi.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/renderer/lib/sessions/reticulumSession', () => ({
 }));
 
 import { isReticulumAutostartEnabled } from '@/renderer/lib/appSettingsStorage';
+import { refreshGamesSessions } from '@/renderer/lib/reticulum/reticulumGamesSession';
 import {
   resetReticulumIdentityStoreForTests,
   useReticulumIdentityStore,
@@ -35,6 +36,7 @@ describe('useReticulumSidecarApi', () => {
     onStatus.mockReset();
     onEvent.mockReset();
     onStartStack.mockReset();
+    vi.mocked(refreshGamesSessions).mockClear();
     resetReticulumManualStackStopSuppressForTests();
     vi.mocked(isReticulumAutostartEnabled).mockReturnValue(false);
     resetReticulumIdentityStoreForTests();
@@ -79,6 +81,34 @@ describe('useReticulumSidecarApi', () => {
       expect(result.current.sidecarUiRunning).toBe(true);
     });
     expect(result.current.sidecarApiReady).toBe(false);
+  });
+
+  it('refreshes games sessions when sidecarApiReady becomes true', async () => {
+    getStatus.mockResolvedValue({ running: true, port: 59477, pid: 42 });
+
+    const { result, rerender } = renderHook(
+      ({ connecting }: { connecting: boolean }) =>
+        useReticulumSidecarApi({
+          connecting,
+          onStartStack,
+        }),
+      { initialProps: { connecting: true } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.sidecarUiRunning).toBe(true);
+    });
+    expect(result.current.sidecarApiReady).toBe(false);
+    expect(refreshGamesSessions).not.toHaveBeenCalled();
+
+    rerender({ connecting: false });
+
+    await waitFor(() => {
+      expect(result.current.sidecarApiReady).toBe(true);
+    });
+    await waitFor(() => {
+      expect(refreshGamesSessions).toHaveBeenCalled();
+    });
   });
 
   it('shares refreshed identity status across hook instances', async () => {

--- a/src/renderer/lib/reticulum/useReticulumSidecarApi.test.ts
+++ b/src/renderer/lib/reticulum/useReticulumSidecarApi.test.ts
@@ -12,6 +12,10 @@ vi.mock('@/renderer/lib/appSettingsStorage', () => ({
   setReticulumAutostartEnabled: vi.fn(),
 }));
 
+vi.mock('@/renderer/lib/reticulum/reticulumGamesSession', () => ({
+  refreshGamesSessions: vi.fn(async () => {}),
+}));
+
 vi.mock('@/renderer/lib/sessions/reticulumSession', () => ({
   tryGetReticulumSession: vi.fn(() => ({ connectAutomatic: vi.fn() })),
 }));

--- a/src/renderer/lib/reticulum/useReticulumSidecarApi.ts
+++ b/src/renderer/lib/reticulum/useReticulumSidecarApi.ts
@@ -8,6 +8,7 @@ import {
 } from '@/renderer/lib/appSettingsStorage';
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import { isBleScanBusyErrorMessage } from '@/renderer/lib/reticulum/reticulumBleAdapterLease';
+import { refreshGamesSessions } from '@/renderer/lib/reticulum/reticulumGamesSession';
 import {
   isReticulumManualStackStopSuppress,
   setReticulumManualStackStopSuppress,
@@ -292,11 +293,7 @@ export function useReticulumSidecarApi({
     void refreshIdentity();
     if (sidecarApiReady) {
       void refreshAppInfo();
-      void import('./reticulumGamesSession')
-        .then(({ refreshGamesSessions }) => refreshGamesSessions())
-        .catch((e: unknown) => {
-          console.debug('[useReticulumSidecarApi] refreshGamesSessions ' + String(e));
-        });
+      void refreshGamesSessions();
     }
   }, [sidecarStatus.running, sidecarApiReady, refreshIdentity, refreshAppInfo]);
 


### PR DESCRIPTION
## Summary
- Replace the `reticulumGamesSession` dynamic import in `useReticulumSidecarApi` with a static import, since App/runtime/Games UI already pull that module into the main chunk (`INEFFECTIVE_DYNAMIC_IMPORT`).
- Mock `refreshGamesSessions` in sidecar/stack panel tests so the static import does not force i18n into those suites.

## Test plan
- [x] `pnpm exec vitest run src/renderer/lib/reticulum/useReticulumSidecarApi.test.ts src/renderer/components/ReticulumStackPanel.test.tsx`
- [ ] Confirm Vite no longer warns `INEFFECTIVE_DYNAMIC_IMPORT` for `reticulumGamesSession.ts` on `pnpm run dev` / build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session refresh handling when the sidecar API becomes ready.
  * Prevented test environments from triggering real session-refresh logic.
* **Tests**
  * Updated coverage to reliably test sidecar API and stack panel behavior using isolated session-refresh handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->