### PR TITLE
fix: MeshCore TCP MsgWaiting drain + false TX queue badge

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -806,11 +806,11 @@ When the Meshtastic SDK logs a routing / queue failure, mesh-client intercepts m
 
 **Symptoms**: After TCP connect to pyMC/OpenHop, the header shows **Fetching queued messages…** or **Message sync paused while the radio is busy…** for one to two minutes; Chat backlog arrives slowly; developer bundle may show `ui.waitingMessagesDrainDeferred: true` and log lines like `requestTelemetry error timeout` ~120s after connect.
 
-**Cause**: Post-connect self telemetry (optional altitude fetch) used to run before proactive MsgWaiting drain and could hold the companion RF lane for up to **120s**. Silent bulk `getWaitingMessages` on TCP also used a **45s** timeout before falling back to one-at-a-time `syncNextMessage`.
+**Cause**: Post-connect self telemetry (optional altitude fetch) used to run before proactive MsgWaiting drain and could hold the companion RF lane for up to **120s**. Silent bulk `getWaitingMessages` on TCP also used a **45s** timeout before falling back to one-at-a-time `syncNextMessage`. On busy meshes the companion queue can keep growing during init RPCs (contacts/channels dump, autoadd, MQTT export) before drain starts.
 
 **Fix**:
 
-1. Upgrade to a build that schedules MsgWaiting drain before post-connect telemetry and uses a **15s** silent bulk timeout on TCP (same as serial/BLE).
+1. Upgrade to a build that starts MsgWaiting drain right after the contacts/channels dump (not after all post-init side effects), runs post-connect telemetry only after drain, and uses **syncNextMessage-only** silent drain on TCP (pyMC/OpenHop often never answers bulk `getWaitingMessages`).
 2. On MeshCore tab, use **Sync now** if the header still shows a backlog after connect.
 3. In support bundles, check `ui.meshcoreDrain` for `meshcoreCompanionRepeaterRfBusy`, `meshcoreAdminRpcInFlightCount`, and `meshcoreSilentBulkTimeoutStreak` when triaging repeat reports.
 
@@ -957,7 +957,7 @@ The client deduplicates overlapping RF and MQTT hears within **5 minutes** (cros
 **Queue badge stuck at `Q: 255/256`**:
 
 - Usually means the companion radio outbound queue is nearly full. Enable debug logging and export logs if the badge stays red for minutes with no traffic; look for `[useMeshcoreRuntime] high queue depth=`.
-- Some **HTTP/TCP** companions pad the legacy 7-byte STATS CORE frame to 9 bytes with `raw[7]=0` and `raw[8]=0xff` (padding sentinel). mesh-client treats that signature as 7-byte layout (`queue_len` at byte 6). If chat send/receive works but the badge is red with `rawHex` ending in `0000ff`, upgrade to a build that includes this fix ([#600](https://github.com/Colorado-Mesh/mesh-client/issues/600)).
+- Some **HTTP/TCP** companions pad the legacy 7-byte STATS CORE frame to 9 bytes with `raw[7]=0` and `raw[8]=0xff` (padding sentinel) or `raw[8]=0x18` (`RESP_CODE_STATS` framing leak). mesh-client treats those signatures as 7-byte layout (`queue_len` at byte 6). If chat send/receive works but the badge shows a stuck non-zero depth (e.g. `Q: 24/256` with `rawHex` ending in `000018`), upgrade to a build that includes this fix ([#600](https://github.com/Colorado-Mesh/mesh-client/issues/600)).
 - On older builds, CORE stats could also be mis-parsed (false `Q: 255/256` with normal traffic).
 
 **Windows packaged updater: `Cannot find module 'semver'`**:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -802,6 +802,18 @@ When the Meshtastic SDK logs a routing / queue failure, mesh-client intercepts m
 
 **Reconnect ownership:** TCP disconnect/reconnect is owned by `useMeshcoreRuntime` + `rfReconnectController` (single-owner scheduler). Conn side effects **skip** `handleConnectionLost` when `connectType === 'tcp'` so the runtime `meshcore:tcp-disconnected` listener does not double-enter the reconnect scheduler.
 
+### MeshCore TCP / pyMC: initial connect MsgWaiting drain slow or paused
+
+**Symptoms**: After TCP connect to pyMC/OpenHop, the header shows **Fetching queued messages…** or **Message sync paused while the radio is busy…** for one to two minutes; Chat backlog arrives slowly; developer bundle may show `ui.waitingMessagesDrainDeferred: true` and log lines like `requestTelemetry error timeout` ~120s after connect.
+
+**Cause**: Post-connect self telemetry (optional altitude fetch) used to run before proactive MsgWaiting drain and could hold the companion RF lane for up to **120s**. Silent bulk `getWaitingMessages` on TCP also used a **45s** timeout before falling back to one-at-a-time `syncNextMessage`.
+
+**Fix**:
+
+1. Upgrade to a build that schedules MsgWaiting drain before post-connect telemetry and uses a **15s** silent bulk timeout on TCP (same as serial/BLE).
+2. On MeshCore tab, use **Sync now** if the header still shows a backlog after connect.
+3. In support bundles, check `ui.meshcoreDrain` for `meshcoreCompanionRepeaterRfBusy`, `meshcoreAdminRpcInFlightCount`, and `meshcoreSilentBulkTimeoutStreak` when triaging repeat reports.
+
 ### MeshCore contact delete and sticky Rooms badge
 
 - Deleting a contact from Chat/Contacts removes the SQLite contact row **and** room BBS messages for that `room_server_id` (so Rooms unread cannot outlive the room server).

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -60,7 +60,9 @@ import {
 } from '@/renderer/lib/meshcoreConfiguredChatChannels';
 import { persistMeshcoreSelfNodeId } from '@/renderer/lib/meshcoreLastSelfNodeId';
 import { resolveMeshcoreOwnNodeIdSet } from '@/renderer/lib/meshcoreOwnNodeIds';
+import { getMeshcoreCompanionRepeaterRfBusySnapshot } from '@/renderer/lib/meshcoreRepeaterRpcInFlight';
 import { totalRoomsUnreadCount } from '@/renderer/lib/meshcoreRoomsUnread';
+import { getMeshcoreSilentBulkDrainSnapshot } from '@/renderer/lib/meshcoreWaitingMessagesDrain';
 import { meshcoreWaitingMessagesVisibleForProtocol } from '@/renderer/lib/meshcoreWaitingMessagesStatusText';
 import { meshtasticMqttOwnNodeIds } from '@/renderer/lib/meshtasticMqttIdentity';
 import { remoteConfigChannelRetryRoute } from '@/renderer/lib/meshtasticRemoteAdminSnapshot';
@@ -2068,6 +2070,8 @@ function AppContent() {
 
   useEffect(() => {
     const liveResolvedMessageCount = selectByProtocol(storeMessageCountByProtocol, protocol);
+    const rfBusy = getMeshcoreCompanionRepeaterRfBusySnapshot();
+    const silentBulk = getMeshcoreSilentBulkDrainSnapshot();
     setDebugSnapshotUiContext({
       activePanelIndex,
       chatTabVisited,
@@ -2077,6 +2081,15 @@ function AppContent() {
       activeProtocol: protocol,
       waitingMessagesSilentDrainActive: meshcoreRuntime.waitingMessagesSilentDrainActive,
       waitingMessagesDrainDeferred: meshcoreRuntime.waitingMessagesDrainDeferred,
+      meshcoreDrain: {
+        meshcoreCompanionRepeaterRfBusy: rfBusy.repeaterRfBusy,
+        meshcoreCliReplyHoldCount: rfBusy.cliReplyHoldCount,
+        meshcoreAdminRpcInFlightCount: rfBusy.adminRpcInFlightCount,
+        meshcoreTraceRpcInFlightCount: rfBusy.traceRpcInFlightCount,
+        meshcoreTraceResponsesInFlightCount: rfBusy.traceResponsesInFlightCount,
+        meshcoreSilentBulkSkipped: silentBulk.silentBulkSkipped,
+        meshcoreSilentBulkTimeoutStreak: silentBulk.silentBulkTimeoutStreak,
+      },
     });
   }, [
     activePanelIndex,

--- a/src/renderer/hooks/meshcore/meshcoreConnSideEffects.test.ts
+++ b/src/renderer/hooks/meshcore/meshcoreConnSideEffects.test.ts
@@ -17,7 +17,6 @@ import {
   MESHCORE_WAITING_MESSAGES_DRAIN_DEBOUNCE_MS,
   MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS,
   MESHCORE_WAITING_MESSAGES_SILENT_BULK_TIMEOUT_TRIP,
-  MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS,
 } from '@/renderer/lib/timeConstants';
 import type { ChatMessage, DeviceState, TelemetryPoint } from '@/renderer/lib/types';
 import { useMessageStore } from '@/renderer/stores/messageStore';
@@ -412,11 +411,7 @@ describe('attachMeshcoreConnSideEffects', () => {
       detach = attachMeshcoreConnSideEffects(h.conn, h.ctx);
 
       const drainPromise = h.ctx.processWaitingMessagesRef.current?.({ showSyncBanner: false });
-      await vi.advanceTimersByTimeAsync(
-        connectionType === 'serial'
-          ? MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS
-          : MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS,
-      );
+      await vi.advanceTimersByTimeAsync(MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS);
       await vi.runAllTimersAsync();
       await drainPromise;
 
@@ -429,6 +424,25 @@ describe('attachMeshcoreConnSideEffects', () => {
     },
   );
 
+  it('silent bulk timeout on tcp uses 15s not 45s', async () => {
+    vi.useFakeTimers();
+    const h = makeHarness();
+    h.ctx.meshcoreConnectTypeRef.current = 'tcp';
+    vi.mocked(h.conn.getWaitingMessages).mockImplementation(() => new Promise(() => undefined));
+    h.syncNextMessage.mockResolvedValueOnce(null);
+    detach = attachMeshcoreConnSideEffects(h.conn, h.ctx);
+
+    const drainPromise = h.ctx.processWaitingMessagesRef.current?.({ showSyncBanner: false });
+    await vi.advanceTimersByTimeAsync(MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS - 1);
+    expect(h.syncNextMessage).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.runAllTimersAsync();
+    await drainPromise;
+
+    expect(h.conn.getWaitingMessages).toHaveBeenCalled();
+    expect(h.syncNextMessage).toHaveBeenCalled();
+  });
+
   it('skips silent bulk after consecutive timeouts and drains incrementally', async () => {
     vi.useFakeTimers();
     const h = makeHarness();
@@ -440,7 +454,7 @@ describe('attachMeshcoreConnSideEffects', () => {
 
     for (let i = 0; i < MESHCORE_WAITING_MESSAGES_SILENT_BULK_TIMEOUT_TRIP; i += 1) {
       const drainPromise = h.ctx.processWaitingMessagesRef.current?.({ showSyncBanner: false });
-      await vi.advanceTimersByTimeAsync(MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS);
       await vi.runAllTimersAsync();
       await drainPromise;
     }
@@ -557,7 +571,7 @@ describe('attachMeshcoreConnSideEffects', () => {
     const drainPromise = h.ctx.processWaitingMessagesRef.current?.({ showSyncBanner: false });
     await Promise.resolve();
     resetMeshcoreWaitingMessagesDrainState(0);
-    await vi.advanceTimersByTimeAsync(MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS);
     await vi.runAllTimersAsync();
     await drainPromise;
 

--- a/src/renderer/hooks/meshcore/meshcoreConnSideEffects.test.ts
+++ b/src/renderer/hooks/meshcore/meshcoreConnSideEffects.test.ts
@@ -359,7 +359,7 @@ describe('attachMeshcoreConnSideEffects', () => {
     expect(publish.mock.calls.length).toBeGreaterThan(0);
   });
 
-  it.each(['ble', 'serial', 'tcp'] as const)(
+  it.each(['ble', 'serial'] as const)(
     'silent drain prefers bulk getWaitingMessages on %s',
     async (connectionType) => {
       vi.useFakeTimers();
@@ -390,7 +390,32 @@ describe('attachMeshcoreConnSideEffects', () => {
     },
   );
 
-  it.each(['ble', 'serial', 'tcp'] as const)(
+  it('silent drain on tcp uses syncNextMessage without bulk getWaitingMessages', async () => {
+    vi.useFakeTimers();
+    const h = makeHarness();
+    h.ctx.meshcoreConnectTypeRef.current = 'tcp';
+    h.syncNextMessage
+      .mockResolvedValueOnce({
+        channelMessage: {
+          channelIdx: 0,
+          text: 'TcpPeer: queued',
+          senderTimestamp: 1_700_000_000,
+        },
+      })
+      .mockResolvedValueOnce(null);
+    detach = attachMeshcoreConnSideEffects(h.conn, h.ctx);
+
+    dispatch({ type: 'meshcore_waiting_messages', payload: {} });
+    await vi.advanceTimersByTimeAsync(MESHCORE_WAITING_MESSAGES_DRAIN_DEBOUNCE_MS + 50);
+    await vi.runAllTimersAsync();
+
+    expect(h.conn.getWaitingMessages).not.toHaveBeenCalled();
+    expect(h.syncNextMessage).toHaveBeenCalled();
+    expect(h.ctx.addMessagesBatch).toHaveBeenCalled();
+    expect(h.handleConnectionLost).not.toHaveBeenCalled();
+  });
+
+  it.each(['ble', 'serial'] as const)(
     'silent bulk timeout falls back to syncNextMessage on %s without disconnect',
     async (connectionType) => {
       vi.useFakeTimers();
@@ -424,7 +449,7 @@ describe('attachMeshcoreConnSideEffects', () => {
     },
   );
 
-  it('silent bulk timeout on tcp uses 15s not 45s', async () => {
+  it('TCP silent drain starts syncNextMessage immediately without bulk timeout wait', async () => {
     vi.useFakeTimers();
     const h = makeHarness();
     h.ctx.meshcoreConnectTypeRef.current = 'tcp';
@@ -433,13 +458,10 @@ describe('attachMeshcoreConnSideEffects', () => {
     detach = attachMeshcoreConnSideEffects(h.conn, h.ctx);
 
     const drainPromise = h.ctx.processWaitingMessagesRef.current?.({ showSyncBanner: false });
-    await vi.advanceTimersByTimeAsync(MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS - 1);
-    expect(h.syncNextMessage).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
     await vi.runAllTimersAsync();
     await drainPromise;
 
-    expect(h.conn.getWaitingMessages).toHaveBeenCalled();
+    expect(h.conn.getWaitingMessages).not.toHaveBeenCalled();
     expect(h.syncNextMessage).toHaveBeenCalled();
   });
 
@@ -688,6 +710,17 @@ describe('attachMeshcoreConnSideEffects', () => {
       force: true,
       incrementalOnly: true,
     });
+
+    expect(h.conn.getWaitingMessages).not.toHaveBeenCalled();
+    expect(h.syncNextMessage).toHaveBeenCalled();
+  });
+
+  it('TCP silent auto-drain skips bulk getWaitingMessages', async () => {
+    const h = makeHarness();
+    h.ctx.meshcoreConnectTypeRef.current = 'tcp';
+    detach = attachMeshcoreConnSideEffects(h.conn, h.ctx);
+
+    await h.ctx.processWaitingMessagesRef.current?.({ showSyncBanner: false, force: true });
 
     expect(h.conn.getWaitingMessages).not.toHaveBeenCalled();
     expect(h.syncNextMessage).toHaveBeenCalled();

--- a/src/renderer/hooks/meshcore/meshcoreConnSideEffects.ts
+++ b/src/renderer/hooks/meshcore/meshcoreConnSideEffects.ts
@@ -45,7 +45,7 @@ import {
   resetMeshcoreWaitingMessagesDrainSchedule,
   scheduleMeshcoreWaitingMessagesDrain,
   shouldActivateWaitingMessagesBanner,
-  shouldSkipMeshcoreSilentBulkGetWaitingMessages,
+  shouldPreferMeshcoreSilentIncrementalDrain,
   waitingMessagesDrainTimeoutMs,
 } from '../../lib/meshcoreWaitingMessagesDrain';
 import type { DomainEvent } from '../../lib/protocols/Protocol';
@@ -317,7 +317,9 @@ async function drainWaitingMessagesSilent(
   opts?: { incrementalOnly?: boolean; syncNextTimeoutMs?: number },
 ): Promise<void> {
   const syncNextTimeoutMs = opts?.syncNextTimeoutMs ?? MESHCORE_SYNC_NEXT_MESSAGE_TIMEOUT_MS;
-  if (opts?.incrementalOnly || shouldSkipMeshcoreSilentBulkGetWaitingMessages()) {
+  const preferIncremental =
+    opts?.incrementalOnly || shouldPreferMeshcoreSilentIncrementalDrain(deps.connectionType);
+  if (preferIncremental) {
     const retrieved = await drainWaitingMessagesIncremental(conn, state, deps, syncNextTimeoutMs);
     if (retrieved) noteMeshcoreSilentBulkSuccess();
     return;

--- a/src/renderer/lib/debugSnapshot.test.ts
+++ b/src/renderer/lib/debugSnapshot.test.ts
@@ -501,6 +501,25 @@ describe('analyzeDebugSnapshot', () => {
     expect(snap.warnings.map((w) => w.code)).toContain('staleResolvedBucket');
   });
 
+  it('includes meshcore drain congestion fields from ui context', () => {
+    setDebugSnapshotUiContext({
+      meshcoreDrain: {
+        meshcoreCompanionRepeaterRfBusy: true,
+        meshcoreCliReplyHoldCount: 1,
+        meshcoreAdminRpcInFlightCount: 2,
+        meshcoreTraceRpcInFlightCount: 0,
+        meshcoreTraceResponsesInFlightCount: 0,
+        meshcoreSilentBulkSkipped: true,
+        meshcoreSilentBulkTimeoutStreak: 2,
+      },
+    });
+    expect(getDebugSnapshotUiContext().meshcoreDrain).toMatchObject({
+      meshcoreCompanionRepeaterRfBusy: true,
+      meshcoreSilentBulkSkipped: true,
+      meshcoreSilentBulkTimeoutStreak: 2,
+    });
+  });
+
   it('flags chatPanelFrozen when frozen count lags live store', () => {
     const snap = makeSyntheticSnapshot({
       ui: {

--- a/src/renderer/lib/debugSnapshotUiContext.ts
+++ b/src/renderer/lib/debugSnapshotUiContext.ts
@@ -1,5 +1,15 @@
 import type { MeshProtocol } from './types';
 
+export interface DebugSnapshotMeshcoreDrainContext {
+  meshcoreCompanionRepeaterRfBusy: boolean;
+  meshcoreCliReplyHoldCount: number;
+  meshcoreAdminRpcInFlightCount: number;
+  meshcoreTraceRpcInFlightCount: number;
+  meshcoreTraceResponsesInFlightCount: number;
+  meshcoreSilentBulkSkipped: boolean;
+  meshcoreSilentBulkTimeoutStreak: number;
+}
+
 export interface DebugSnapshotUiContext {
   activePanelIndex: number;
   chatTabVisited: boolean;
@@ -9,7 +19,18 @@ export interface DebugSnapshotUiContext {
   activeProtocol: MeshProtocol;
   waitingMessagesSilentDrainActive: boolean;
   waitingMessagesDrainDeferred: boolean;
+  meshcoreDrain?: DebugSnapshotMeshcoreDrainContext;
 }
+
+const defaultMeshcoreDrainContext: DebugSnapshotMeshcoreDrainContext = {
+  meshcoreCompanionRepeaterRfBusy: false,
+  meshcoreCliReplyHoldCount: 0,
+  meshcoreAdminRpcInFlightCount: 0,
+  meshcoreTraceRpcInFlightCount: 0,
+  meshcoreTraceResponsesInFlightCount: 0,
+  meshcoreSilentBulkSkipped: false,
+  meshcoreSilentBulkTimeoutStreak: 0,
+};
 
 const defaultUiContext: DebugSnapshotUiContext = {
   activePanelIndex: 0,
@@ -20,6 +41,7 @@ const defaultUiContext: DebugSnapshotUiContext = {
   activeProtocol: 'meshtastic',
   waitingMessagesSilentDrainActive: false,
   waitingMessagesDrainDeferred: false,
+  meshcoreDrain: defaultMeshcoreDrainContext,
 };
 
 let uiContext: DebugSnapshotUiContext = { ...defaultUiContext };

--- a/src/renderer/lib/meshcoreCoreStatsQueue.test.ts
+++ b/src/renderer/lib/meshcoreCoreStatsQueue.test.ts
@@ -16,6 +16,12 @@ describe('queueLenFromMeshCoreCoreStatsRaw', () => {
     expect(queueLenFromMeshCoreCoreStatsRaw(raw, 0)).toBe(0);
   });
 
+  it('ignores RESP_CODE_STATS (0x18) byte-8 framing leak on TCP-padded CORE stats', () => {
+    // pyMC/OpenHop: …000018 with meshcore.js reading legacy queue at byte 6 (=0)
+    const raw = Uint8Array.from([0, 0, 0x33, 0x32, 0x02, 0, 0, 0, 0x18]);
+    expect(queueLenFromMeshCoreCoreStatsRaw(raw, 0)).toBe(0);
+  });
+
   it('does not treat byte 8 as padding when byte 7 is non-zero', () => {
     const raw = new Uint8Array(9);
     raw[6] = 0x05;

--- a/src/renderer/lib/meshcoreCoreStatsQueue.test.ts
+++ b/src/renderer/lib/meshcoreCoreStatsQueue.test.ts
@@ -22,6 +22,14 @@ describe('queueLenFromMeshCoreCoreStatsRaw', () => {
     expect(queueLenFromMeshCoreCoreStatsRaw(raw, 0)).toBe(0);
   });
 
+  it('treats 0x18 as real queue_len when err_flags high byte is non-zero', () => {
+    const raw = new Uint8Array(9);
+    raw[6] = 0x05;
+    raw[7] = 0x01;
+    raw[8] = 0x18;
+    expect(queueLenFromMeshCoreCoreStatsRaw(raw, 5)).toBe(0x18);
+  });
+
   it('does not treat byte 8 as padding when byte 7 is non-zero', () => {
     const raw = new Uint8Array(9);
     raw[6] = 0x05;

--- a/src/renderer/lib/meshcoreCoreStatsQueue.ts
+++ b/src/renderer/lib/meshcoreCoreStatsQueue.ts
@@ -3,7 +3,14 @@
  * battery_mv (2) + uptime_secs (4) + err_flags (2) + queue_len (1) => 9 bytes.
  * Legacy layout omitted `err_flags` (7 bytes total). @liamcottle/meshcore.js still parses the
  * 7-byte shape, so when firmware sends 9 bytes `.data.queueLen` is the low byte of `err_flags`.
+ *
+ * Full on-wire RESP_CODE_STATS frame is 11 bytes (response_code + stats_type + 9-byte payload).
+ * Some HTTP/TCP companions pad a legacy 7-byte payload to 9 bytes; byte 8 may be `0xff` or the
+ * next-frame `RESP_CODE_STATS` (`0x18`) rather than `queue_len`.
  */
+/** RESP_CODE_STATS — seen as TCP padding / framing leak at payload byte 8. */
+export const MESHCORE_STATS_RESP_CODE = 0x18;
+
 export function queueLenFromMeshCoreCoreStatsRaw(
   raw: Uint8Array | undefined,
   meshcoreJsParsedQueueLen: number,
@@ -12,8 +19,13 @@ export function queueLenFromMeshCoreCoreStatsRaw(
     return meshcoreJsParsedQueueLen;
   }
   if (raw.length >= 9) {
-    // HTTP/TCP companions may pad 7-byte CORE stats; byte 8 is 0xff sentinel, queue at byte 6.
-    if (raw[8] === 0xff && raw[7] === 0 && raw[6] === meshcoreJsParsedQueueLen) {
+    // HTTP/TCP companions may pad 7-byte CORE stats; treat known byte-8 sentinels as padding.
+    const byte8 = raw[8];
+    if (
+      (byte8 === 0xff || byte8 === MESHCORE_STATS_RESP_CODE) &&
+      raw[7] === 0 &&
+      raw[6] === meshcoreJsParsedQueueLen
+    ) {
       return raw[6];
     }
     return raw[8];

--- a/src/renderer/lib/meshcoreRepeaterRpcInFlight.ts
+++ b/src/renderer/lib/meshcoreRepeaterRpcInFlight.ts
@@ -155,6 +155,23 @@ export function resetMeshcoreRepeaterRpcInFlightForTests(): void {
   cliReplyHoldCount = 0;
 }
 
+/** Test / support-bundle snapshot of repeater RF congestion gates. */
+export function getMeshcoreCompanionRepeaterRfBusySnapshot(): {
+  repeaterRfBusy: boolean;
+  cliReplyHoldCount: number;
+  adminRpcInFlightCount: number;
+  traceRpcInFlightCount: number;
+  traceResponsesInFlightCount: number;
+} {
+  return {
+    repeaterRfBusy: meshcoreCompanionRepeaterRfBusy(),
+    cliReplyHoldCount,
+    adminRpcInFlightCount: inFlightByKey.size,
+    traceRpcInFlightCount: traceInFlightByKey.size,
+    traceResponsesInFlightCount: meshcoreTraceResponsesInFlightCount(),
+  };
+}
+
 /** Reset in-flight admin/trace queues when the radio disconnects. */
 export const resetMeshcoreRepeaterRpcInFlightOnDisconnect =
   resetMeshcoreRepeaterRpcInFlightForTests;

--- a/src/renderer/lib/meshcoreWaitingMessagesDrain.test.ts
+++ b/src/renderer/lib/meshcoreWaitingMessagesDrain.test.ts
@@ -55,6 +55,12 @@ describe('waitingMessagesDrainTimeoutMs', () => {
     );
   });
 
+  it('uses the shorter silent timeout for TCP auto-drains', () => {
+    expect(waitingMessagesDrainTimeoutMs(false, 'tcp')).toBe(
+      MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS,
+    );
+  });
+
   it('uses the manual sync timeout for Chat Sync now', () => {
     expect(waitingMessagesDrainTimeoutMs(true)).toBe(MESHCORE_WAITING_MESSAGES_SYNC_TIMEOUT_MS);
   });

--- a/src/renderer/lib/meshcoreWaitingMessagesDrain.test.ts
+++ b/src/renderer/lib/meshcoreWaitingMessagesDrain.test.ts
@@ -23,6 +23,7 @@ import {
   resetMeshcoreWaitingMessagesDrainState,
   scheduleMeshcoreWaitingMessagesDrain,
   shouldActivateWaitingMessagesBanner,
+  shouldPreferMeshcoreSilentIncrementalDrain,
   shouldRunMeshcoreWaitingMessagesPeriodicPoll,
   shouldSkipMeshcoreSilentBulkGetWaitingMessages,
   waitingMessagesDrainTimeoutMs,
@@ -427,6 +428,24 @@ describe('silent bulk timeout circuit breaker', () => {
       noteMeshcoreSilentBulkTimeout();
     }
     expect(shouldSkipMeshcoreSilentBulkGetWaitingMessages()).toBe(true);
+  });
+});
+
+describe('shouldPreferMeshcoreSilentIncrementalDrain', () => {
+  afterEach(() => {
+    resetMeshcoreSilentBulkBreaker();
+  });
+
+  it('prefers incremental on TCP even when the bulk circuit is closed', () => {
+    expect(shouldPreferMeshcoreSilentIncrementalDrain('tcp')).toBe(true);
+    expect(shouldPreferMeshcoreSilentIncrementalDrain('ble')).toBe(false);
+  });
+
+  it('prefers incremental when the silent bulk circuit is open', () => {
+    for (let i = 0; i < MESHCORE_WAITING_MESSAGES_SILENT_BULK_TIMEOUT_TRIP; i += 1) {
+      noteMeshcoreSilentBulkTimeout();
+    }
+    expect(shouldPreferMeshcoreSilentIncrementalDrain('ble')).toBe(true);
   });
 });
 

--- a/src/renderer/lib/meshcoreWaitingMessagesDrain.ts
+++ b/src/renderer/lib/meshcoreWaitingMessagesDrain.ts
@@ -137,6 +137,16 @@ export function shouldSkipMeshcoreSilentBulkGetWaitingMessages(): boolean {
   return silentBulkSkipped || silentBulkCliPreempt;
 }
 
+/**
+ * Silent auto-drain path: pyMC/OpenHop TCP often never answers bulk getWaitingMessages, so
+ * prefer syncNextMessage immediately instead of paying a silent bulk timeout every connect.
+ */
+export function shouldPreferMeshcoreSilentIncrementalDrain(
+  connectionType?: MeshcoreCompanionTransport,
+): boolean {
+  return connectionType === 'tcp' || shouldSkipMeshcoreSilentBulkGetWaitingMessages();
+}
+
 /** Record a successful silent bulk drain (including empty queue). */
 export function noteMeshcoreSilentBulkSuccess(): void {
   silentBulkTimeoutStreak = 0;

--- a/src/renderer/lib/meshcoreWaitingMessagesDrain.ts
+++ b/src/renderer/lib/meshcoreWaitingMessagesDrain.ts
@@ -164,6 +164,17 @@ export function resetMeshcoreSilentBulkBreaker(): void {
   silentBulkCliPreempt = false;
 }
 
+/** Test / support-bundle snapshot of silent-bulk circuit state. */
+export function getMeshcoreSilentBulkDrainSnapshot(): {
+  silentBulkSkipped: boolean;
+  silentBulkTimeoutStreak: number;
+} {
+  return {
+    silentBulkSkipped: silentBulkSkipped,
+    silentBulkTimeoutStreak: silentBulkTimeoutStreak,
+  };
+}
+
 export type MeshcoreCompanionTransport = 'ble' | 'serial' | 'tcp' | null | undefined;
 
 export function waitingMessagesDrainTimeoutMs(
@@ -173,8 +184,8 @@ export function waitingMessagesDrainTimeoutMs(
   if (showSyncBanner) {
     return MESHCORE_WAITING_MESSAGES_SYNC_TIMEOUT_MS;
   }
-  // BLE and USB serial both starve companion TX when bulk hangs — keep silent bulk short.
-  if (connectionType === 'serial' || connectionType === 'ble') {
+  // BLE, USB serial, and TCP/pyMC starve companion TX when bulk hangs — keep silent bulk short.
+  if (connectionType === 'serial' || connectionType === 'ble' || connectionType === 'tcp') {
     return MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS;
   }
   return MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS;

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -183,7 +183,7 @@ export const MESHCORE_WAITING_MESSAGES_SYNC_TIMEOUT_MS = 60_000;
 export const MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS = 45 * MS_PER_SECOND;
 /** Consecutive silent-bulk getWaitingMessages timeouts before skipping bulk until reconnect. */
 export const MESHCORE_WAITING_MESSAGES_SILENT_BULK_TIMEOUT_TRIP = 2;
-/** Shorter silent timeout on USB serial (single companion RPC lane). */
+/** Shorter silent bulk timeout on USB serial, BLE, and TCP/pyMC (single companion RPC lane). */
 export const MESHCORE_WAITING_MESSAGES_SERIAL_SILENT_TIMEOUT_MS = 15 * MS_PER_SECOND;
 /** Per-item timeout for silent syncNextMessage incremental drain. */
 export const MESHCORE_SYNC_NEXT_MESSAGE_TIMEOUT_MS = 12 * MS_PER_SECOND;
@@ -217,6 +217,13 @@ export const MESHCORE_ROOM_SYNC_MIN_INTERVAL_MINUTES = 60;
 
 /** Max wait for scheduler background route resolve (contacts only, no trace). */
 export const MESHCORE_ROOM_SYNC_ROUTE_RESOLVE_FAST_MS = 15_000;
+
+/** Optional post-connect self telemetry on TCP — altitude only; must not block MsgWaiting drain. */
+export const MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS =
+  MESHCORE_ROOM_SYNC_ROUTE_RESOLVE_FAST_MS;
+
+/** Max wait for proactive MsgWaiting drain before post-connect self telemetry runs. */
+export const MESHCORE_POST_CONNECT_SELF_TELEMETRY_DRAIN_WAIT_MS = 30 * MS_PER_SECOND;
 
 /** Defer first getMetadata after configure (NodeDB flood can starve the admin packet). */
 export const MESHTASTIC_GET_METADATA_AFTER_CONFIGURE_DEFER_MS = 12 * MS_PER_SECOND;

--- a/src/renderer/lib/timeConstants.ts
+++ b/src/renderer/lib/timeConstants.ts
@@ -219,8 +219,7 @@ export const MESHCORE_ROOM_SYNC_MIN_INTERVAL_MINUTES = 60;
 export const MESHCORE_ROOM_SYNC_ROUTE_RESOLVE_FAST_MS = 15_000;
 
 /** Optional post-connect self telemetry on TCP — altitude only; must not block MsgWaiting drain. */
-export const MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS =
-  MESHCORE_ROOM_SYNC_ROUTE_RESOLVE_FAST_MS;
+export const MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS = 15 * MS_PER_SECOND;
 
 /** Max wait for proactive MsgWaiting drain before post-connect self telemetry runs. */
 export const MESHCORE_POST_CONNECT_SELF_TELEMETRY_DRAIN_WAIT_MS = 30 * MS_PER_SECOND;

--- a/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
@@ -676,19 +676,36 @@ describe('useMeshcoreRuntime manual disconnect must not auto-reconnect', () => {
     );
   });
 
-  it('defers post-connect self telemetry once when waiting-message drain is busy', () => {
-    expect(RUNTIME_SOURCE).toContain('schedulePostConnectSelfTelemetry');
-    expect(RUNTIME_SOURCE).toContain(
-      'post-connect self telemetry deferred (waiting-message drain busy)',
+  it('schedules post-connect self telemetry after proactive MsgWaiting drain', () => {
+    const initConnBody = extractUseCallbackBody(RUNTIME_SOURCE, 'initConn');
+    const drainIdx = initConnBody.indexOf('scheduleMeshcoreWaitingMessagesDrain');
+    const telemetryIdx = initConnBody.indexOf('schedulePostConnectSelfTelemetryAfterDrain');
+    expect(drainIdx).toBeGreaterThan(-1);
+    expect(telemetryIdx).toBeGreaterThan(drainIdx);
+  });
+
+  it('does not schedule post-connect self telemetry from initConn requestAnimationFrame', () => {
+    expect(RUNTIME_SOURCE).not.toMatch(
+      /requestAnimationFrame\(\(\) => \{[\s\S]{0,1500}schedulePostConnectSelfTelemetry/,
     );
+  });
+
+  it('gates post-connect self telemetry on waiting-message drain idle', () => {
+    expect(RUNTIME_SOURCE).toContain('schedulePostConnectSelfTelemetryAfterDrain');
     expect(RUNTIME_SOURCE).toContain(
       'post-connect self telemetry skipped (waiting-message drain still busy)',
     );
     expect(RUNTIME_SOURCE).toMatch(
-      /schedulePostConnectSelfTelemetry = \(allowReschedule: boolean\)[\s\S]*?waitingMessagesDrainBusyRef\.current[\s\S]*?schedulePostConnectSelfTelemetry\(false\)/,
+      /schedulePostConnectSelfTelemetryAfterDrain[\s\S]*?awaitMeshcoreWaitingMessagesDrainIdle[\s\S]*?waitingMessagesDrainBusyRef\.current/,
     );
+  });
+
+  it('uses short TCP timeout for post-connect self telemetry', () => {
     expect(RUNTIME_SOURCE).toMatch(
-      /if \(waitingMessagesDrainBusyRef\.current\) \{[\s\S]*?schedulePostConnectSelfTelemetry\(false\);[\s\S]*?\} else \{[\s\S]*?schedulePostConnectSelfTelemetry\(true\);/,
+      /transportType === 'tcp'[\s\S]*?MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS/,
+    );
+    expect(RUNTIME_SOURCE).not.toMatch(
+      /schedulePostConnectSelfTelemetryAfterDrain[\s\S]{0,800}MESHCORE_TELEMETRY_TIMEOUT_MS/,
     );
   });
 

--- a/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
@@ -678,25 +678,25 @@ describe('useMeshcoreRuntime manual disconnect must not auto-reconnect', () => {
 
   it('schedules post-connect self telemetry after proactive MsgWaiting drain', () => {
     const initConnBody = extractUseCallbackBody(RUNTIME_SOURCE, 'initConn');
-    const drainIdx = initConnBody.indexOf('scheduleMeshcoreWaitingMessagesDrain');
-    const telemetryIdx = initConnBody.indexOf('schedulePostConnectSelfTelemetryAfterDrain');
-    expect(drainIdx).toBeGreaterThan(-1);
-    expect(telemetryIdx).toBeGreaterThan(drainIdx);
+    expect(initConnBody).toContain('runPostConnectSelfTelemetryIfReady');
+    expect(initConnBody).toMatch(
+      /scheduleMeshcoreWaitingMessagesDrain\([\s\S]*?await runPostConnectSelfTelemetryIfReady\(\)/,
+    );
   });
 
   it('does not schedule post-connect self telemetry from initConn requestAnimationFrame', () => {
     expect(RUNTIME_SOURCE).not.toMatch(
-      /requestAnimationFrame\(\(\) => \{[\s\S]{0,1500}schedulePostConnectSelfTelemetry/,
+      /requestAnimationFrame\(\(\) => \{[\s\S]{0,1500}runPostConnectSelfTelemetryIfReady/,
     );
   });
 
   it('gates post-connect self telemetry on waiting-message drain idle', () => {
-    expect(RUNTIME_SOURCE).toContain('schedulePostConnectSelfTelemetryAfterDrain');
+    expect(RUNTIME_SOURCE).toContain('runPostConnectSelfTelemetryIfReady');
     expect(RUNTIME_SOURCE).toContain(
       'post-connect self telemetry skipped (waiting-message drain still busy)',
     );
     expect(RUNTIME_SOURCE).toMatch(
-      /schedulePostConnectSelfTelemetryAfterDrain[\s\S]*?awaitMeshcoreWaitingMessagesDrainIdle[\s\S]*?waitingMessagesDrainBusyRef\.current/,
+      /runPostConnectSelfTelemetryIfReady[\s\S]*?awaitMeshcoreWaitingMessagesDrainIdle[\s\S]*?waitingMessagesDrainBusyRef\.current/,
     );
   });
 
@@ -705,7 +705,7 @@ describe('useMeshcoreRuntime manual disconnect must not auto-reconnect', () => {
       /transportType === 'tcp'[\s\S]*?MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS/,
     );
     expect(RUNTIME_SOURCE).not.toMatch(
-      /schedulePostConnectSelfTelemetryAfterDrain[\s\S]{0,800}MESHCORE_TELEMETRY_TIMEOUT_MS/,
+      /runPostConnectSelfTelemetryIfReady[\s\S]{0,800}MESHCORE_TELEMETRY_TIMEOUT_MS/,
     );
   });
 

--- a/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts
@@ -676,12 +676,24 @@ describe('useMeshcoreRuntime manual disconnect must not auto-reconnect', () => {
     );
   });
 
-  it('schedules post-connect self telemetry after proactive MsgWaiting drain', () => {
+  it('awaits proactive MsgWaiting drain before post-init side effects and telemetry', () => {
     const initConnBody = extractUseCallbackBody(RUNTIME_SOURCE, 'initConn');
     expect(initConnBody).toContain('runPostConnectSelfTelemetryIfReady');
     expect(initConnBody).toMatch(
-      /scheduleMeshcoreWaitingMessagesDrain\([\s\S]*?await runPostConnectSelfTelemetryIfReady\(\)/,
+      /await processWaitingMessagesRef\.current\?\.\(\{ showSyncBanner: false \}\)[\s\S]*?void runPostConnectSelfTelemetryIfReady\(\)/,
     );
+    const drainIdx = initConnBody.indexOf(
+      'await processWaitingMessagesRef.current?.({ showSyncBanner: false })',
+    );
+    const sideEffectsIdx = initConnBody.indexOf('conn.syncDeviceTime()');
+    expect(drainIdx).toBeGreaterThan(-1);
+    expect(sideEffectsIdx).toBeGreaterThan(-1);
+    expect(drainIdx).toBeLessThan(sideEffectsIdx);
+    const telemetryIdx = initConnBody.indexOf('void runPostConnectSelfTelemetryIfReady()');
+    expect(telemetryIdx).toBeGreaterThan(drainIdx);
+    expect(telemetryIdx).toBeLessThan(sideEffectsIdx);
+    const followUpIdx = initConnBody.indexOf('post-init follow-up getWaitingMessages failed');
+    expect(followUpIdx).toBeGreaterThan(sideEffectsIdx);
   });
 
   it('does not schedule post-connect self telemetry from initConn requestAnimationFrame', () => {

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -2853,6 +2853,57 @@ export function useMeshcoreRuntime() {
           }
         }
 
+        // Await MsgWaiting drain before post-init side effects so syncDeviceTime / autoadd /
+        // MQTT export cannot contend with syncNextMessage on the companion TCP/RF lane.
+        const runPostConnectSelfTelemetryIfReady = async (): Promise<void> => {
+          await awaitMeshcoreWaitingMessagesDrainIdle(
+            () => waitingMessagesDrainBusyRef.current,
+            MESHCORE_POST_CONNECT_SELF_TELEMETRY_DRAIN_WAIT_MS,
+          );
+          if (meshcoreSetupGenerationRef.current !== setupGen || connRef.current !== conn) {
+            return;
+          }
+          if (
+            waitingMessagesCountRef.current > 0 ||
+            shouldRunMeshcoreWaitingMessagesPeriodicPoll(waitingMessagesCountRef.current)
+          ) {
+            console.debug(
+              '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting messages pending)',
+            );
+            return;
+          }
+          if (waitingMessagesDrainBusyRef.current) {
+            console.debug(
+              '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting-message drain still busy)',
+            );
+            return;
+          }
+          const telemetryTimeoutMs =
+            transportType === 'tcp' ? MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS : undefined;
+          await requestTelemetryMeshCoreRef
+            .current(myNodeId, { timeoutMs: telemetryTimeoutMs })
+            .catch((e: unknown) => {
+              if (isMeshcoreTcpTransportDeadError(e) || isMeshcoreSetupAbortError(e)) return;
+              console.debug(
+                '[useMeshcoreRuntime] post-connect self telemetry (altitude) ' +
+                  errLikeToLogString(e),
+              );
+            });
+        };
+
+        try {
+          await processWaitingMessagesRef.current?.({ showSyncBanner: false });
+        } catch (e: unknown) {
+          // catch-no-log-ok logMeshcoreWaitingMessagesDrainError handles logging
+          logMeshcoreWaitingMessagesDrainError(
+            'initConn: proactive getWaitingMessages failed',
+            e,
+            false,
+          );
+        }
+        // After drain: kick telemetry without blocking post-init companion RPCs (autoadd/time sync).
+        void runPostConnectSelfTelemetryIfReady();
+
         const skipTcpSocketWork = isMeshcoreTcpBurstDeadBridge({
           transportType,
           burstCaptured: meshcoreTcpInitBurstCapturedRef.current,
@@ -3015,43 +3066,8 @@ export function useMeshcoreRuntime() {
           assertInitConnStillLive();
           maybeAutoLaunchMeshcoreMqttAfterIdentity();
 
-          // Proactively fetch any messages that queued while disconnected (no Chat banner).
-          const runPostConnectSelfTelemetryIfReady = async (): Promise<void> => {
-            await awaitMeshcoreWaitingMessagesDrainIdle(
-              () => waitingMessagesDrainBusyRef.current,
-              MESHCORE_POST_CONNECT_SELF_TELEMETRY_DRAIN_WAIT_MS,
-            );
-            if (meshcoreSetupGenerationRef.current !== setupGen || connRef.current !== conn) {
-              return;
-            }
-            if (
-              waitingMessagesCountRef.current > 0 ||
-              shouldRunMeshcoreWaitingMessagesPeriodicPoll(waitingMessagesCountRef.current)
-            ) {
-              console.debug(
-                '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting messages pending)',
-              );
-              return;
-            }
-            if (waitingMessagesDrainBusyRef.current) {
-              console.debug(
-                '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting-message drain still busy)',
-              );
-              return;
-            }
-            const telemetryTimeoutMs =
-              transportType === 'tcp' ? MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS : undefined;
-            await requestTelemetryMeshCoreRef
-              .current(myNodeId, { timeoutMs: telemetryTimeoutMs })
-              .catch((e: unknown) => {
-                if (isMeshcoreTcpTransportDeadError(e) || isMeshcoreSetupAbortError(e)) return;
-                console.debug(
-                  '[useMeshcoreRuntime] post-connect self telemetry (altitude) ' +
-                    errLikeToLogString(e),
-                );
-              });
-          };
-
+          // Messages often land during post-init (autoadd / time sync). pyMC TCP may not push
+          // event 131, so run one follow-up silent drain after the companion lane is free.
           scheduleMeshcoreWaitingMessagesDrain(
             async () => {
               try {
@@ -3059,12 +3075,11 @@ export function useMeshcoreRuntime() {
               } catch (e: unknown) {
                 // catch-no-log-ok logMeshcoreWaitingMessagesDrainError handles logging
                 logMeshcoreWaitingMessagesDrainError(
-                  'initConn: proactive getWaitingMessages failed',
+                  'initConn: post-init follow-up getWaitingMessages failed',
                   e,
                   false,
                 );
               }
-              await runPostConnectSelfTelemetryIfReady();
             },
             {
               isMounted: () => meshcoreHookMountedRef.current,

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -3016,6 +3016,42 @@ export function useMeshcoreRuntime() {
           maybeAutoLaunchMeshcoreMqttAfterIdentity();
 
           // Proactively fetch any messages that queued while disconnected (no Chat banner).
+          const runPostConnectSelfTelemetryIfReady = async (): Promise<void> => {
+            await awaitMeshcoreWaitingMessagesDrainIdle(
+              () => waitingMessagesDrainBusyRef.current,
+              MESHCORE_POST_CONNECT_SELF_TELEMETRY_DRAIN_WAIT_MS,
+            );
+            if (meshcoreSetupGenerationRef.current !== setupGen || connRef.current !== conn) {
+              return;
+            }
+            if (
+              waitingMessagesCountRef.current > 0 ||
+              shouldRunMeshcoreWaitingMessagesPeriodicPoll(waitingMessagesCountRef.current)
+            ) {
+              console.debug(
+                '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting messages pending)',
+              );
+              return;
+            }
+            if (waitingMessagesDrainBusyRef.current) {
+              console.debug(
+                '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting-message drain still busy)',
+              );
+              return;
+            }
+            const telemetryTimeoutMs =
+              transportType === 'tcp' ? MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS : undefined;
+            await requestTelemetryMeshCoreRef
+              .current(myNodeId, { timeoutMs: telemetryTimeoutMs })
+              .catch((e: unknown) => {
+                if (isMeshcoreTcpTransportDeadError(e) || isMeshcoreSetupAbortError(e)) return;
+                console.debug(
+                  '[useMeshcoreRuntime] post-connect self telemetry (altitude) ' +
+                    errLikeToLogString(e),
+                );
+              });
+          };
+
           scheduleMeshcoreWaitingMessagesDrain(
             async () => {
               try {
@@ -3028,6 +3064,7 @@ export function useMeshcoreRuntime() {
                   false,
                 );
               }
+              await runPostConnectSelfTelemetryIfReady();
             },
             {
               isMounted: () => meshcoreHookMountedRef.current,
@@ -3062,47 +3099,6 @@ export function useMeshcoreRuntime() {
               },
             );
           }, MESHCORE_WAITING_MESSAGES_POLL_MS);
-
-          const schedulePostConnectSelfTelemetryAfterDrain = (): void => {
-            void (async () => {
-              const idle = await awaitMeshcoreWaitingMessagesDrainIdle(
-                () => waitingMessagesDrainBusyRef.current,
-                MESHCORE_POST_CONNECT_SELF_TELEMETRY_DRAIN_WAIT_MS,
-              );
-              if (meshcoreSetupGenerationRef.current !== setupGen || connRef.current !== conn) {
-                return;
-              }
-              if (
-                waitingMessagesCountRef.current > 0 ||
-                shouldRunMeshcoreWaitingMessagesPeriodicPoll(waitingMessagesCountRef.current)
-              ) {
-                console.debug(
-                  '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting messages pending)',
-                );
-                return;
-              }
-              if (!idle && waitingMessagesDrainBusyRef.current) {
-                console.debug(
-                  '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting-message drain still busy)',
-                );
-                return;
-              }
-              const telemetryTimeoutMs =
-                transportType === 'tcp'
-                  ? MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS
-                  : undefined;
-              void requestTelemetryMeshCoreRef
-                .current(myNodeId, { timeoutMs: telemetryTimeoutMs })
-                .catch((e: unknown) => {
-                  if (isMeshcoreTcpTransportDeadError(e) || isMeshcoreSetupAbortError(e)) return;
-                  console.debug(
-                    '[useMeshcoreRuntime] post-connect self telemetry (altitude) ' +
-                      errLikeToLogString(e),
-                  );
-                });
-            })();
-          };
-          schedulePostConnectSelfTelemetryAfterDrain();
 
           meshcoreRoomReconnectSyncRef.current();
         } else {

--- a/src/renderer/runtime/useMeshcoreRuntime.ts
+++ b/src/renderer/runtime/useMeshcoreRuntime.ts
@@ -477,6 +477,8 @@ import { messageRecordsToChatMessages, nodeRecordsToMeshNodeMap } from '../lib/s
 import {
   computeRoomPostTotalTimeoutMs,
   MESHCORE_MAX_RECONNECT_DELAY_MS,
+  MESHCORE_POST_CONNECT_SELF_TELEMETRY_DRAIN_WAIT_MS,
+  MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS,
   MESHCORE_REPEATER_PING_SETTLE_MAX_MS,
   MESHCORE_ROOM_AUTO_LOGIN_DEBOUNCE_MS,
   MESHCORE_ROOM_LOGIN_HOP_BASE_MS,
@@ -488,8 +490,6 @@ import {
   MESHCORE_ROOM_SYNC_TICK_MS,
   MESHCORE_STATS_POLL_MS,
   MESHCORE_TRACE_PING_TOTAL_TIMEOUT_MS,
-  MESHCORE_WAITING_MESSAGES_AFTER_TX_DEFER_MS,
-  MESHCORE_WAITING_MESSAGES_DRAIN_DEBOUNCE_MS,
   MESHCORE_WAITING_MESSAGES_POLL_MS,
   MESHCORE_WAITING_MESSAGES_SILENT_TIMEOUT_MS,
   POWER_RESUME_MESHCORE_MESHTASTIC_SETTLE_MS,
@@ -817,7 +817,9 @@ export function useMeshcoreRuntime() {
     Promise.resolve(null),
   );
   /** Post-connect self telemetry (altitude); assigned to {@link requestTelemetry} below. */
-  const requestTelemetryMeshCoreRef = useRef<(nodeId: number) => Promise<void>>(async () => {});
+  const requestTelemetryMeshCoreRef = useRef<
+    (nodeId: number, opts?: { timeoutMs?: number }) => Promise<void>
+  >(async () => {});
   /** Rate-limit debug logs when optional packet-logger IPC publish fails. */
   const lastPacketLogPublishFailureLogAtRef = useRef(0);
   const meshcoreHookMountedRef = useRef(true);
@@ -2870,46 +2872,6 @@ export function useMeshcoreRuntime() {
                   '[useMeshcoreRuntime] post-connect refreshOurPosition ' + errLikeToLogString(e),
                 );
               });
-              // Give MsgWaiting drain a head start; if the lane is still busy, defer once
-              // more after the same window (do not drop telemetry on first busy sighting).
-              const postConnectTelemetryDelayMs =
-                MESHCORE_WAITING_MESSAGES_DRAIN_DEBOUNCE_MS +
-                MESHCORE_WAITING_MESSAGES_AFTER_TX_DEFER_MS;
-              const schedulePostConnectSelfTelemetry = (allowReschedule: boolean): void => {
-                window.setTimeout(() => {
-                  if (meshcoreSetupGenerationRef.current !== setupGen || connRef.current !== conn) {
-                    return;
-                  }
-                  if (waitingMessagesDrainBusyRef.current) {
-                    if (allowReschedule) {
-                      console.debug(
-                        '[useMeshcoreRuntime] post-connect self telemetry deferred (waiting-message drain busy)',
-                      );
-                      schedulePostConnectSelfTelemetry(false);
-                      return;
-                    }
-                    console.debug(
-                      '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting-message drain still busy)',
-                    );
-                    return;
-                  }
-                  void requestTelemetryMeshCoreRef.current(myNodeId).catch((e: unknown) => {
-                    if (isMeshcoreTcpTransportDeadError(e) || isMeshcoreSetupAbortError(e)) return;
-                    console.debug(
-                      '[useMeshcoreRuntime] post-connect self telemetry (altitude) ' +
-                        errLikeToLogString(e),
-                    );
-                  });
-                }, postConnectTelemetryDelayMs);
-              };
-              if (waitingMessagesDrainBusyRef.current) {
-                console.debug(
-                  '[useMeshcoreRuntime] post-connect self telemetry deferred (waiting-message drain busy)',
-                );
-                schedulePostConnectSelfTelemetry(false);
-              } else {
-                schedulePostConnectSelfTelemetry(true);
-              }
             });
           });
 
@@ -3100,6 +3062,47 @@ export function useMeshcoreRuntime() {
               },
             );
           }, MESHCORE_WAITING_MESSAGES_POLL_MS);
+
+          const schedulePostConnectSelfTelemetryAfterDrain = (): void => {
+            void (async () => {
+              const idle = await awaitMeshcoreWaitingMessagesDrainIdle(
+                () => waitingMessagesDrainBusyRef.current,
+                MESHCORE_POST_CONNECT_SELF_TELEMETRY_DRAIN_WAIT_MS,
+              );
+              if (meshcoreSetupGenerationRef.current !== setupGen || connRef.current !== conn) {
+                return;
+              }
+              if (
+                waitingMessagesCountRef.current > 0 ||
+                shouldRunMeshcoreWaitingMessagesPeriodicPoll(waitingMessagesCountRef.current)
+              ) {
+                console.debug(
+                  '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting messages pending)',
+                );
+                return;
+              }
+              if (!idle && waitingMessagesDrainBusyRef.current) {
+                console.debug(
+                  '[useMeshcoreRuntime] post-connect self telemetry skipped (waiting-message drain still busy)',
+                );
+                return;
+              }
+              const telemetryTimeoutMs =
+                transportType === 'tcp'
+                  ? MESHCORE_POST_CONNECT_SELF_TELEMETRY_TIMEOUT_MS
+                  : undefined;
+              void requestTelemetryMeshCoreRef
+                .current(myNodeId, { timeoutMs: telemetryTimeoutMs })
+                .catch((e: unknown) => {
+                  if (isMeshcoreTcpTransportDeadError(e) || isMeshcoreSetupAbortError(e)) return;
+                  console.debug(
+                    '[useMeshcoreRuntime] post-connect self telemetry (altitude) ' +
+                      errLikeToLogString(e),
+                  );
+                });
+            })();
+          };
+          schedulePostConnectSelfTelemetryAfterDrain();
 
           meshcoreRoomReconnectSyncRef.current();
         } else {
@@ -5659,7 +5662,7 @@ export function useMeshcoreRuntime() {
   );
 
   const requestTelemetry = useCallback(
-    async (nodeId: number) => {
+    async (nodeId: number, opts?: { timeoutMs?: number }) => {
       setMeshcoreRepeaterRpcPending((prev) =>
         setRepeaterAdminRpcPending(prev, nodeId, 'telemetry', true),
       );
@@ -5688,7 +5691,7 @@ export function useMeshcoreRuntime() {
             });
             throw new Error(MESHCORE_ERR_NOT_CONNECTED);
           }
-          const timeoutMs = MESHCORE_TELEMETRY_TIMEOUT_MS;
+          const timeoutMs = opts?.timeoutMs ?? MESHCORE_TELEMETRY_TIMEOUT_MS;
           try {
             const conn = resolveMeshcoreConn();
             if (!conn) {


### PR DESCRIPTION
## Summary

Fixes slow/stuck MeshCore TCP (pyMC/OpenHop) connect when the header shows **Fetching queued messages…** or a sticky **Q: 24/256** badge after drain.

### MsgWaiting drain ordering & TCP path
- **Await** proactive MsgWaiting drain after the contacts/channels dump and **before** post-init companion RPCs (`syncDeviceTime`, autoadd, MQTT export) so those RPCs cannot contend with `syncNextMessage`.
- Schedule a **follow-up silent drain** after post-init (pyMC often does not push event 131).
- On TCP, silent auto-drain **skips bulk** `getWaitingMessages` (often hangs) and goes straight to `syncNextMessage`.
- Shorten TCP silent bulk timeout to **15s** when bulk is still used (serial/BLE path); TCP post-connect self telemetry uses a **15s** timeout and only runs after drain (non-blocking so init is not stalled).
- Remove early `requestAnimationFrame` post-connect telemetry that raced ahead of drain.

### False TX queue badge (`Q: 24/256`)
- HTTP/TCP companions may pad a legacy 7-byte CORE stats payload to 9 bytes with `raw[8]=0x18` (`RESP_CODE_STATS`), same class as the existing `0xff` sentinel (#600).
- Parser now treats `0x18` like `0xff` when `raw[7]===0` and byte 6 matches meshcore.js — badge stays **Q: 0/256** instead of a sticky false bubble refreshed every 30s.

### Support / docs
- Debug snapshot exposes MeshCore drain / RF-busy fields (`ui.meshcoreDrain`).
- Troubleshooting updated for pyMC TCP slow drain and the `000018` CORE padding case.

## Commits
- `f2e7cd59` — prioritize MsgWaiting drain over post-connect telemetry on MeshCore TCP
- `b730cff3` — run post-connect telemetry only after MsgWaiting drain completes
- `5b844c6c` — drain MsgWaiting before post-init and fix false TCP TX queue badge

## Test plan
- [ ] Connect MeshCore TCP to pyMC/OpenHop (e.g. busy mesh companion).
- [ ] Confirm MsgWaiting header clears after connect; chat backlog arrives without multi-minute stall.
- [ ] Confirm header **Q: 0/256** after drain / first stats poll (not stuck at `Q: 24/256`).
- [ ] Serial/BLE: silent drain still prefers bulk `getWaitingMessages`; manual **Sync now** still uses bulk.
- [ ] `pnpm exec vitest run src/renderer/lib/meshcoreCoreStatsQueue.test.ts src/renderer/lib/meshcoreWaitingMessagesDrain.test.ts src/renderer/hooks/meshcore/meshcoreConnSideEffects.test.ts src/renderer/runtime/useMeshcoreRuntime.reconnect.test.ts src/renderer/hooks/useMeshcoreRuntime.waiting-messages-drain.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MeshCore message draining across TCP, BLE, and serial connections.
  * Reduced delays and improved fallback behavior when queued messages are slow or stalled.
  * Improved post-connection telemetry timing to avoid interference from pending messages.
  * Fixed queue detection for padded statistics responses.
* **Diagnostics**
  * Added debug information for repeater RF activity, RPC activity, drain skips, and timeout streaks.
* **Documentation**
  * Expanded troubleshooting guidance for queued-message draining and queue indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->