### PR TITLE
fix(meshcore): keep live advert Long Name after path-updated rebuild

### DIFF
--- a/src/renderer/hooks/meshcore/meshcoreConnSideEffects.test.ts
+++ b/src/renderer/hooks/meshcore/meshcoreConnSideEffects.test.ts
@@ -8,6 +8,7 @@ import type {
   RxPacketEntry,
 } from '@/renderer/lib/meshcore/meshcoreHookTypes';
 import * as meshcoreRepeaterRpcInFlight from '@/renderer/lib/meshcoreRepeaterRpcInFlight';
+import { meshcoreChatStubNodeIdFromDisplayName } from '@/renderer/lib/meshcoreUtils';
 import {
   beginMeshcoreSilentBulkAttempt,
   resetMeshcoreWaitingMessagesDrainState,
@@ -829,6 +830,100 @@ describe('attachMeshcoreConnSideEffects', () => {
       snr: 9,
       rssi: -40,
       lastHeardAt: 1_700_000_100,
+    });
+  });
+
+  it('preserves concurrent advert longName when flushing waiting-drain last_heard', async () => {
+    const prefix = new Uint8Array([0xaa, 0xbb]);
+    useNodeStore.setState({
+      nodes: {
+        [ID]: {
+          42: {
+            nodeId: 42,
+            longName: 'OldPeer',
+            shortName: 'P',
+            snr: 5,
+            rssi: -80,
+            lastHeardAt: 100,
+            source: 'rf',
+          },
+        },
+      },
+    });
+    const h = makeHarness();
+    h.ctx.pubKeyPrefixMapRef.current.set('aabb', 42);
+    vi.mocked(h.conn.getWaitingMessages).mockImplementation(() => {
+      // Concurrent on-air advert rename while drain still holds OldPeer in workingNodes.
+      useNodeStore.setState((s) => ({
+        nodes: {
+          ...s.nodes,
+          [ID]: {
+            ...s.nodes[ID],
+            42: {
+              ...s.nodes[ID]?.[42],
+              nodeId: 42,
+              longName: 'NewPeer',
+              snr: 9,
+              rssi: -40,
+            },
+          },
+        },
+      }));
+      return Promise.resolve([
+        {
+          contactMessage: {
+            pubKeyPrefix: prefix,
+            text: 'hello from queue',
+            senderTimestamp: 1_700_000_100,
+          },
+        },
+      ]);
+    });
+    detach = attachMeshcoreConnSideEffects(h.conn, h.ctx);
+
+    await h.ctx.processWaitingMessagesRef.current?.({ showSyncBanner: true });
+
+    expect(useNodeStore.getState().nodes[ID]?.[42]).toMatchObject({
+      longName: 'NewPeer',
+      snr: 9,
+      rssi: -40,
+      lastHeardAt: 1_700_000_100,
+    });
+  });
+
+  it('applies waiting-drain longName when live name is placeholder', async () => {
+    const nodeId = meshcoreChatStubNodeIdFromDisplayName('RealPeer');
+    const placeholder = `Node-${nodeId.toString(16).toUpperCase()}`;
+    useNodeStore.setState({
+      nodes: {
+        [ID]: {
+          [nodeId]: {
+            nodeId,
+            longName: placeholder,
+            shortName: '',
+            lastHeardAt: 100,
+            source: 'rf',
+          },
+        },
+      },
+    });
+    const h = makeHarness();
+    vi.mocked(h.conn.getWaitingMessages).mockResolvedValue([
+      {
+        channelMessage: {
+          channelIdx: 0,
+          text: 'RealPeer: queued channel message',
+          senderTimestamp: 1_700_000_200,
+        },
+      },
+    ]);
+    detach = attachMeshcoreConnSideEffects(h.conn, h.ctx);
+
+    await h.ctx.processWaitingMessagesRef.current?.({ showSyncBanner: true });
+
+    expect(useNodeStore.getState().nodes[ID]?.[nodeId]).toMatchObject({
+      longName: 'RealPeer',
+      lastHeardAt: 1_700_000_200,
     });
   });
 

--- a/src/renderer/hooks/meshcore/meshcoreConnSideEffects.ts
+++ b/src/renderer/hooks/meshcore/meshcoreConnSideEffects.ts
@@ -25,6 +25,7 @@ import { processMeshcoreWaitingMessageItem } from '../../lib/meshcoreProcessWait
 import { resetMeshcoreRepeaterRpcInFlightOnDisconnect } from '../../lib/meshcoreRepeaterRpcInFlight';
 import { meshcoreSortedStorePrior } from '../../lib/meshcoreStoreDedup';
 import { resetMeshcoreTracePathMultiplexOnDisconnect } from '../../lib/meshcoreTracePathMultiplex';
+import { meshcoreIsPlaceholderNodeLongName } from '../../lib/meshcoreUtils';
 import {
   normalizeMeshcoreWaitingMessageBatch,
   normalizeMeshcoreWaitingMessageItem,
@@ -118,8 +119,9 @@ interface MeshcoreWaitingMessagesDrainState {
 
 /**
  * Waiting-drain mutations are last_heard (+ optional channel display-name). Rebuild patches
- * against the live store row so concurrent RF SNR/RSSI writes aren't overwritten by the
- * start-of-drain `workingNodes` snapshot.
+ * against the live store row so concurrent RF SNR/RSSI / advert-name writes aren't overwritten
+ * by the start-of-drain `workingNodes` snapshot. Only apply snapshot names when live is empty
+ * or a Node-HEX placeholder (channel enrichment upgrades placeholders only).
  */
 function collectDirtyWaitingNodeRecords(
   identityId: string,
@@ -140,10 +142,20 @@ function collectDirtyWaitingNodeRecords(
     const patch: NodeRecord = { nodeId, lastHeardAt: nextLastHeard };
     const workingLong = working.long_name?.trim();
     const workingShort = working.short_name?.trim();
-    if (workingLong && workingLong !== (live.longName ?? '').trim()) {
+    const liveLong = (live.longName ?? '').trim();
+    const liveShort = (live.shortName ?? '').trim();
+    if (
+      workingLong &&
+      workingLong !== liveLong &&
+      (!liveLong || meshcoreIsPlaceholderNodeLongName(liveLong, nodeId))
+    ) {
       patch.longName = workingLong;
     }
-    if (workingShort && workingShort !== (live.shortName ?? '').trim()) {
+    if (
+      workingShort &&
+      workingShort !== liveShort &&
+      (!liveShort || meshcoreIsPlaceholderNodeLongName(liveShort, nodeId))
+    ) {
       patch.shortName = workingShort;
     }
     if (

--- a/src/renderer/lib/meshcoreUtils.test.ts
+++ b/src/renderer/lib/meshcoreUtils.test.ts
@@ -594,13 +594,13 @@ describe('meshcoreMergeContactAdvNameFromPrevious', () => {
     ).toBe('Bob');
   });
 
-  it('takes radio name when radio lastAdvert is strictly newer', () => {
+  it('keeps live advert rename when radio lastAdvert is newer but advName is still old', () => {
     expect(
-      meshcoreMergeContactAdvNameFromPrevious('FirmwareRename', 'OldName', nodeId, {
+      meshcoreMergeContactAdvNameFromPrevious('OldRoom', 'NewRoom', nodeId, {
         prevLastHeard: 1_700_000_000,
         radioLastAdvert: 1_700_000_500,
       }),
-    ).toBe('FirmwareRename');
+    ).toBe('NewRoom');
   });
 
   it('keeps previous when radio lastAdvert is 0', () => {
@@ -650,6 +650,25 @@ describe('buildNodesFromContacts advert-name merge (path-updated rebuild)', () =
       type: 3,
       advName: 'OldRoom',
       lastAdvert: 1_700_000_100,
+      advLat: 0,
+      advLon: 0,
+    };
+    const radio = meshcoreContactToMeshNode(contact);
+    const merged = meshcoreMergeContactAdvNameFromPrevious(
+      radio.long_name,
+      'NewRoom',
+      radio.node_id,
+      { prevLastHeard: 1_700_000_100, radioLastAdvert: contact.lastAdvert },
+    );
+    expect(merged).toBe('NewRoom');
+  });
+
+  it('keeps live rename when getContacts bumps lastAdvert without updating advName', () => {
+    const contact = {
+      publicKey: key32,
+      type: 3,
+      advName: 'OldRoom',
+      lastAdvert: 1_700_000_500,
       advLat: 0,
       advLon: 0,
     };

--- a/src/renderer/lib/meshcoreUtils.ts
+++ b/src/renderer/lib/meshcoreUtils.ts
@@ -647,15 +647,17 @@ export function meshcorePreviousAdvertNameForRebuild(
 
 /**
  * When rebuilding from `getContacts`, companion firmware often keeps the name from when the
- * contact was first stored. Prefer a live advert name already in the UI unless the radio dump
- * is strictly newer (connect/refresh after firmware actually renamed the contact).
+ * contact was first stored and may bump `lastAdvert` without renaming. Prefer a live advert
+ * name already in the UI whenever both names are real and differ; on-air adverts / local
+ * setAdvertName are the authoritative rename paths (`opts` kept for call-site compat).
  */
 export function meshcoreMergeContactAdvNameFromPrevious(
   radioAdvName: string | undefined,
   prevLongName: string | undefined,
   nodeId: number,
-  opts?: MeshcoreMergeContactAdvNameOpts,
+  _opts?: MeshcoreMergeContactAdvNameOpts,
 ): string {
+  void _opts;
   const radioTrim = (radioAdvName ?? '').trim();
   const prevTrim = (prevLongName ?? '').trim();
   const radioReal = radioTrim.length > 0 && !meshcoreIsPlaceholderNodeLongName(radioTrim, nodeId);
@@ -665,20 +667,9 @@ export function meshcoreMergeContactAdvNameFromPrevious(
   if (!radioReal && prevReal) return prevTrim;
   if (!prevReal) return radioTrim || prevTrim || hexFallback;
   if (radioTrim === prevTrim) return radioTrim;
-
-  const radioAdvert =
-    opts?.radioLastAdvert != null &&
-    Number.isFinite(opts.radioLastAdvert) &&
-    opts.radioLastAdvert > 0
-      ? opts.radioLastAdvert
-      : 0;
-  const prevHeard =
-    opts?.prevLastHeard != null && Number.isFinite(opts.prevLastHeard) ? opts.prevLastHeard : 0;
-  // Tie or missing radio time: companion often updates lastAdvert without renaming.
-  if (radioAdvert === 0 || prevHeard >= radioAdvert) {
-    return prevTrim;
-  }
-  return radioTrim;
+  // Companion dump disagrees with a real live/previous name — keep the live name. lastAdvert
+  // is not a reliable name version (path hears often bump time without updating advName).
+  return prevTrim;
 }
 
 /** Result of mapping a heard RF advert (push 0x80) into UI + DB when the node is not yet a contact. */


### PR DESCRIPTION
## Summary

- **Bug (5.30.0):** MeshCore Contacts Long Name still flashed the new on-air advert name, then reverted to the old label ~2 seconds later (after #875 / #877).
- **Root cause:** Path-updated (event 129) debounces a full `getContacts` rebuild (~2s). Companion dumps often bump `lastAdvert` without updating `advName`. `meshcoreMergeContactAdvNameFromPrevious` treated “strictly newer `lastAdvert`” as a firmware rename and accepted the stale radio name, poisoning Zustand, the live-name remember map, and SQLite.
- **Secondary hole:** Waiting-message drain flush preferred the start-of-drain snapshot `long_name` whenever it differed from live, so a concurrent advert rename during MsgWaiting drain could also roll the name back.

### Fix

1. **Sticky live name on merge** — When both radio and previous names are real and disagree, always keep the previous/live name. Companion `lastAdvert` is not a reliable name version. Authoritative renames remain on-air advert / PacketRouter `upsertNode` and local `setAdvertName`.
2. **Waiting-drain name flush** — Only apply snapshot `longName` / `shortName` when live is empty or a Node-HEX placeholder (channel enrichment only upgrades placeholders). Prefer live when it already has a real name.

### Commits

- `eeef78a1` fix(meshcore): keep live advert Long Name after path-updated rebuild

## Test plan

- [x] `pnpm exec vitest run src/renderer/lib/meshcoreUtils.test.ts src/renderer/hooks/meshcore/meshcoreConnSideEffects.test.ts` (157 passed)
- [x] Pre-commit staged Vitest suite (3184 passed)
- [ ] Manual: MeshCore connected → peer/room renames and floods advert → Contacts Long Name stays on the new name past the ~2s path-updated rebuild
- [ ] Manual: Same rename while MsgWaiting / waiting-messages drain is active → Long Name does not snap back to the old label
- [ ] Manual: Channel message that upgrades a Node-HEX placeholder still applies the display name on drain flush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved current contact names when processing newer radio advertisements with stale names.
  * Replaced placeholder node names with real names from queued messages.
  * Prevented concurrent node advert updates from overwriting established live names.
  * Improved contact rebuilding to retain updated advert names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->