### PR TITLE
fix(reticulum): harden propagation sync establish on dual-TCP paths

### DIFF
--- a/reticulum-sidecar/patches/README.md
+++ b/reticulum-sidecar/patches/README.md
@@ -573,6 +573,29 @@ Listed in `scripts/lib/ratspeak-overlay-apply-list.sh` and `RATSPEAK_PATCH_ENTRI
 
 When upstream rsLXMF exposes equivalent abort / cancel mid-transfer cleanup, remove this patch and the apply step.
 
+## rsLXMF-propagation-client-lrproof-diagnostics.patch
+
+Adds sticky `last_establish_error` on `PropagationClient` so client `/get` Sync surfaces `LrproofIdentityMissing`, `LrproofInvalid`, and `LrproofInvalidKey` instead of a generic `NoLinkProof` (parity with peer `/offer` via `rsLXMF-propagation-sync-peering.patch`).
+
+| Field | Value |
+| ----- | ----- |
+| **Base commit** | floated rsLXMF `origin/main` at apply time |
+| **Upstream PR** | none yet (mesh-client-local; watch ratspeak/rsLXMF) |
+
+**Touches:** rsLXMF `PropagationClient` (`drain_events` / `handle_link_proof` establish diagnostics)
+
+### Apply locally
+
+```bash
+./scripts/apply-rsLXMF-propagation-client-lrproof-diagnostics.sh
+```
+
+Listed in `scripts/lib/ratspeak-overlay-apply-list.sh` and `RATSPEAK_PATCH_ENTRIES` in `scripts/update.sh`. Sidecar `PropagationBridge::poll_client_download` reads `client.last_establish_error()`.
+
+### Sunset
+
+When upstream rsLXMF exposes equivalent PropagationClient LRPROOF diagnostics, remove this patch and the apply step.
+
 ## Removed: rsLXMF-propagation-client-link-attached-tx.patch
 
 Sunset when floated rsLXMF `origin/main` pinned PropagationClient link-scoped TX with `SendLinkEndpoint` plus `attached_interface` (interface-pinned link TX). That superseded the local `OutboundAttached` / `queue_link_outbound` overlay for the same pathless-Link flood as [ratspeak/rsReticulum#22](https://github.com/ratspeak/rsReticulum/issues/22). Tracked entry removed from `RATSPEAK_PATCH_ENTRIES` in `scripts/update.sh` after sunset confirmation.

--- a/reticulum-sidecar/patches/rsLXMF-propagation-client-lrproof-diagnostics.patch
+++ b/reticulum-sidecar/patches/rsLXMF-propagation-client-lrproof-diagnostics.patch
@@ -1,0 +1,126 @@
+diff --git a/crates/lxmf-core/src/propagation_client.rs b/crates/lxmf-core/src/propagation_client.rs
+index 44a8882..6075e5a 100644
+--- a/crates/lxmf-core/src/propagation_client.rs
++++ b/crates/lxmf-core/src/propagation_client.rs
+@@ -145,6 +145,8 @@ pub struct PropagationClient {
+     started_at: Option<Instant>,
+     timeout: Duration,
+     identified: bool,
++    /// Sticky Establishing failure (LRPROOF identity miss / invalid proof).
++    last_establish_error: Option<&'static str>,
+ }
+ 
+ impl PropagationClient {
+@@ -187,9 +189,15 @@ impl PropagationClient {
+             started_at: None,
+             timeout: Duration::from_secs(120),
+             identified: false,
++            last_establish_error: None,
+         }
+     }
+ 
++    /// Sticky establish failure from the last LinkProof attempt (identity miss / invalid proof).
++    pub const fn last_establish_error(&self) -> Option<&'static str> {
++        self.last_establish_error
++    }
++
+     pub fn set_propagation_node(&mut self, dest_hash: [u8; 16]) {
+         self.outbound_propagation_node = Some(dest_hash);
+     }
+@@ -248,6 +256,25 @@ impl PropagationClient {
+         true
+     }
+ 
++    /// Abort an in-flight or terminal download and return to [`Idle`].
++    ///
++    /// Unlike [`Self::acknowledge_transfer`], this also tears down mid-transfer
++    /// states (`LinkEstablishing` … `PurgeRequested`) so a cancelled Sync cannot
++    /// leave the client permanently busy (`start_download` would keep failing).
++    pub fn abort_transfer(&mut self) {
++        if matches!(self.status.state, PropagationClientState::Idle) {
++            return;
++        }
++        self.cleanup();
++        self.available_messages.clear();
++        self.received_messages.clear();
++        self.received_ids.clear();
++        self.status = PropagationTransferStatus::default();
++        self.identified = false;
++        self.started_at = None;
++        self.last_establish_error = None;
++    }
++
+     pub fn start_download(&mut self) -> bool {
+         self.start_download_with_limit(None)
+     }
+@@ -277,6 +304,7 @@ impl PropagationClient {
+         if !self.pending_transport.is_empty() {
+             return false;
+         }
++        self.last_establish_error = None;
+ 
+         let (link, request_data) = Link::new_initiator(node_hash, 1);
+         let link_id = link.link_id;
+@@ -622,9 +650,18 @@ impl PropagationClient {
+                             let node_hex = self.outbound_propagation_node.map(|h| hex_encode(&h));
+                             if let Some(node_hex) = node_hex {
+                                 if let Some(pub_key) = known_identities.get(&node_hex) {
+-                                    let ed25519_bytes: [u8; 32] = pub_key[32..64]
+-                                        .try_into()
+-                                        .expect("known_identities values are [u8; 64]; slice [32..64] is always 32 bytes");
++                                    let ed25519_bytes: [u8; 32] = match pub_key[32..64].try_into() {
++                                        Ok(bytes) => bytes,
++                                        Err(_) => {
++                                            tracing::warn!(
++                                                node = %node_hex,
++                                                "propagation client LRPROOF: invalid ed25519 key bytes"
++                                            );
++                                            self.last_establish_error = Some("LrproofInvalidKey");
++                                            self.status.state = PropagationClientState::Failed;
++                                            continue;
++                                        }
++                                    };
+                                     if let Ok(verify_key) =
+                                         Ed25519PublicKey::from_bytes(&ed25519_bytes)
+                                     {
+@@ -634,7 +671,21 @@ impl PropagationClient {
+                                             &ed25519_bytes,
+                                             interface_id,
+                                         );
++                                    } else {
++                                        tracing::warn!(
++                                            node = %node_hex,
++                                            "propagation client LRPROOF: invalid ed25519 key bytes"
++                                        );
++                                        self.last_establish_error = Some("LrproofInvalidKey");
++                                        self.status.state = PropagationClientState::Failed;
+                                     }
++                                } else {
++                                    tracing::warn!(
++                                        node = %node_hex,
++                                        "propagation client LRPROOF ignored: destination identity unknown"
++                                    );
++                                    self.last_establish_error = Some("LrproofIdentityMissing");
++                                    // Stay LinkEstablishing so a later tick with identity can succeed.
+                                 }
+                             }
+                         }
+@@ -710,6 +761,7 @@ impl PropagationClient {
+         };
+ 
+         if let Ok(rtt_data) = link.validate_proof(proof_data, verify_key, ed25519_pub) {
++            self.last_establish_error = None;
+             if let Some(link_id) = self.link_id {
+                 let rtt_header = rns_wire::header::PacketHeader {
+                     flags: rns_wire::flags::PacketFlags {
+@@ -750,6 +802,10 @@ impl PropagationClient {
+                     result_rx,
+                 });
+             }
++        } else {
++            tracing::warn!("propagation client LRPROOF validate_proof failed");
++            self.last_establish_error = Some("LrproofInvalid");
++            self.status.state = PropagationClientState::Failed;
+         }
+     }
+ 

--- a/reticulum-sidecar/patches/rsLXMF-propagation-client-lrproof-diagnostics.patch
+++ b/reticulum-sidecar/patches/rsLXMF-propagation-client-lrproof-diagnostics.patch
@@ -1,5 +1,5 @@
 diff --git a/crates/lxmf-core/src/propagation_client.rs b/crates/lxmf-core/src/propagation_client.rs
-index 44a8882..6075e5a 100644
+index 8335336..6075e5a 100644
 --- a/crates/lxmf-core/src/propagation_client.rs
 +++ b/crates/lxmf-core/src/propagation_client.rs
 @@ -145,6 +145,8 @@ pub struct PropagationClient {
@@ -27,33 +27,15 @@ index 44a8882..6075e5a 100644
      pub fn set_propagation_node(&mut self, dest_hash: [u8; 16]) {
          self.outbound_propagation_node = Some(dest_hash);
      }
-@@ -248,6 +256,25 @@ impl PropagationClient {
-         true
+@@ -264,6 +272,7 @@ impl PropagationClient {
+         self.status = PropagationTransferStatus::default();
+         self.identified = false;
+         self.started_at = None;
++        self.last_establish_error = None;
      }
  
-+    /// Abort an in-flight or terminal download and return to [`Idle`].
-+    ///
-+    /// Unlike [`Self::acknowledge_transfer`], this also tears down mid-transfer
-+    /// states (`LinkEstablishing` … `PurgeRequested`) so a cancelled Sync cannot
-+    /// leave the client permanently busy (`start_download` would keep failing).
-+    pub fn abort_transfer(&mut self) {
-+        if matches!(self.status.state, PropagationClientState::Idle) {
-+            return;
-+        }
-+        self.cleanup();
-+        self.available_messages.clear();
-+        self.received_messages.clear();
-+        self.received_ids.clear();
-+        self.status = PropagationTransferStatus::default();
-+        self.identified = false;
-+        self.started_at = None;
-+        self.last_establish_error = None;
-+    }
-+
      pub fn start_download(&mut self) -> bool {
-         self.start_download_with_limit(None)
-     }
-@@ -277,6 +304,7 @@ impl PropagationClient {
+@@ -295,6 +304,7 @@ impl PropagationClient {
          if !self.pending_transport.is_empty() {
              return false;
          }
@@ -61,7 +43,7 @@ index 44a8882..6075e5a 100644
  
          let (link, request_data) = Link::new_initiator(node_hash, 1);
          let link_id = link.link_id;
-@@ -622,9 +650,18 @@ impl PropagationClient {
+@@ -640,9 +650,18 @@ impl PropagationClient {
                              let node_hex = self.outbound_propagation_node.map(|h| hex_encode(&h));
                              if let Some(node_hex) = node_hex {
                                  if let Some(pub_key) = known_identities.get(&node_hex) {
@@ -83,7 +65,7 @@ index 44a8882..6075e5a 100644
                                      if let Ok(verify_key) =
                                          Ed25519PublicKey::from_bytes(&ed25519_bytes)
                                      {
-@@ -634,7 +671,21 @@ impl PropagationClient {
+@@ -652,7 +671,21 @@ impl PropagationClient {
                                              &ed25519_bytes,
                                              interface_id,
                                          );
@@ -105,7 +87,7 @@ index 44a8882..6075e5a 100644
                                  }
                              }
                          }
-@@ -710,6 +761,7 @@ impl PropagationClient {
+@@ -728,6 +761,7 @@ impl PropagationClient {
          };
  
          if let Ok(rtt_data) = link.validate_proof(proof_data, verify_key, ed25519_pub) {
@@ -113,7 +95,7 @@ index 44a8882..6075e5a 100644
              if let Some(link_id) = self.link_id {
                  let rtt_header = rns_wire::header::PacketHeader {
                      flags: rns_wire::flags::PacketFlags {
-@@ -750,6 +802,10 @@ impl PropagationClient {
+@@ -768,6 +802,10 @@ impl PropagationClient {
                      result_rx,
                  });
              }

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -61,7 +61,7 @@ use super::packet_log::{
 use super::path_failover::{
     self, PathSlotCandidate, active_via_hash_from_slots, live_interface_names,
     record_path_failover_attempt, remaining_live_ifaces, select_unblocked_slot,
-    should_attempt_nomad_via_failover, via_prefix,
+    should_attempt_nomad_via_failover, should_attempt_propagation_via_failover, via_prefix,
 };
 use super::path_medium::{self, PathMediumPreferenceSetting, PathMediumSetting};
 use super::path_speed;
@@ -2427,6 +2427,24 @@ impl LiveBridge {
         hex::encode(self.identity.hash)
     }
 
+    /// Live path-table hops + interface name for a destination (propagation list enrichment).
+    pub fn live_path_fields_for_destination(
+        &self,
+        destination_hash_hex: &str,
+    ) -> (Option<u8>, Option<String>) {
+        let clean = destination_hash_hex.trim().to_lowercase();
+        self.path_peer_cache
+            .lock()
+            .ok()
+            .and_then(|cache| {
+                cache
+                    .iter()
+                    .find(|p| p.destination_hash == clean)
+                    .map(|p| (p.hops, p.interface.clone().filter(|name| !name.is_empty())))
+            })
+            .unwrap_or((None, None))
+    }
+
     /// rnsh/rncp gating decision for `destination_hash_hex`: resolves the
     /// path-table egress interface (if known) to a transport atom via
     /// [`super::via::classify_path_interface_name`] and buckets it with
@@ -2803,6 +2821,7 @@ impl LiveBridge {
                     // cancel_client_download()s so this poll loop exits on Idle/Failed.
                     let cancel = Arc::new(AtomicBool::new(false));
                     let started = spawn_client_download_driver_task(
+                        None,
                         Arc::clone(&propagation),
                         Arc::clone(&router),
                         Arc::clone(&outbound),
@@ -2993,8 +3012,12 @@ impl LiveBridge {
     }
 
     /// Shared path gate for offer probe + Sync (`PROPAGATION_PATH_UNKNOWN`).
-    async fn ensure_propagation_path_or_unknown(&self, dest_hex: &str) -> Result<(), String> {
-        if self.ensure_path_for_direct(dest_hex, true).await {
+    async fn ensure_propagation_path_or_unknown(
+        &self,
+        dest_hex: &str,
+        force: bool,
+    ) -> Result<(), String> {
+        if self.ensure_path_for_direct(dest_hex, force).await {
             Ok(())
         } else {
             Err("PROPAGATION_PATH_UNKNOWN".into())
@@ -3681,7 +3704,8 @@ impl LiveBridge {
         self.cancel_propagation_sync().await;
         self.rehydrate_propagation_identities_from_persisted();
         let identity_ok = self.ensure_identity_for_direct(&dest_hex).await;
-        self.ensure_propagation_path_or_unknown(&dest_hex).await?;
+        self.ensure_propagation_path_or_unknown(&dest_hex, true)
+            .await?;
         let identity_known_after = self
             .outbound
             .lock()
@@ -3785,7 +3809,10 @@ impl LiveBridge {
         )
     }
 
-    pub async fn start_propagation_sync(&self, destination_hash: &str) -> Result<(), String> {
+    pub async fn start_propagation_sync(
+        self: Arc<Self>,
+        destination_hash: &str,
+    ) -> Result<(), String> {
         let hash = parse_hash16(destination_hash)?;
         let dest_hex = destination_hash.to_lowercase();
         // Cancel any in-flight sync/emitter before starting a new one.
@@ -3861,7 +3888,10 @@ impl LiveBridge {
         // Do this before peering PoW — nonzero peering_cost stamps are expensive and useless
         // when there is no path (would previously burn CPU then stall into syncTimedOut).
         let hops = self.hops_to_destination(&dest_hex).await;
-        if let Err(err) = self.ensure_propagation_path_or_unknown(&dest_hex).await {
+        if let Err(err) = self
+            .ensure_propagation_path_or_unknown(&dest_hex, false)
+            .await
+        {
             // Path gate awaits; only clear if we still own this attempt's latch.
             if let Ok(mut driver) = self.outbound.lock() {
                 if driver.propagation_sync_target() == Some(hash) {
@@ -3936,6 +3966,7 @@ impl LiveBridge {
             }
         });
         if !self.spawn_client_download_driver(
+            Some(Arc::clone(&self)),
             hash,
             dest_hex.clone(),
             Arc::clone(&cancel),
@@ -3974,6 +4005,7 @@ impl LiveBridge {
     #[allow(clippy::too_many_arguments)] // shared /get driver args mirror spawn_client_download_driver_task
     fn spawn_client_download_driver(
         &self,
+        live: Option<Arc<LiveBridge>>,
         pn_hash: [u8; 16],
         pn_hex: String,
         cancel: Arc<AtomicBool>,
@@ -3983,6 +4015,7 @@ impl LiveBridge {
         emit_ui: bool,
     ) -> bool {
         spawn_client_download_driver_task(
+            live,
             Arc::clone(&self.propagation),
             Arc::clone(&self.router),
             Arc::clone(&self.outbound),
@@ -5974,10 +6007,61 @@ fn peer_route_fields_equal(a: &PeerRow, b: &PeerRow) -> bool {
         && a.public_key == b.public_key
 }
 
+/// After establish failure, suppress dead iface/via and retry client `/get` on another hub.
+#[allow(clippy::too_many_arguments)] // mirrors Nomad path failover state threaded through driver loop
+async fn propagation_download_attempt_failover(
+    live: Option<&Arc<LiveBridge>>,
+    bridge: &PropagationBridge,
+    pn_hash: [u8; 16],
+    pn_hex: &str,
+    failover_round: &mut u8,
+    tried_interfaces: &mut Vec<String>,
+    blocked_ifaces: &mut Vec<String>,
+    blocked_vias: &mut Vec<String>,
+    live_ifaces: &[String],
+    current_iface: &mut Option<String>,
+    current_via: &mut Option<String>,
+) -> bool {
+    if live.is_none() || !should_attempt_propagation_via_failover(*failover_round) {
+        return false;
+    }
+    bridge.cancel_client_download();
+    *failover_round = failover_round.saturating_add(1);
+    record_path_failover_attempt(
+        tried_interfaces,
+        blocked_ifaces,
+        blocked_vias,
+        current_iface.as_deref(),
+        current_via.as_deref(),
+    );
+    let Some(live_ref) = live else {
+        return false;
+    };
+    if let Some(found) = live_ref
+        .suppress_via_and_rediscover(pn_hex, blocked_ifaces, blocked_vias, live_ifaces)
+        .await
+    {
+        *current_iface = found.iface.clone();
+        *current_via = found.via.clone();
+    }
+    tracing::info!(
+        target: "propagation-sync",
+        pn_hash = %pn_hex,
+        failover_round = *failover_round,
+        iface = ?current_iface,
+        via_prefix = via_prefix(current_via.as_deref()),
+        establish_error = ?bridge.last_establish_error(),
+        tried_interfaces = ?tried_interfaces,
+        "propagation client /get establish failover"
+    );
+    bridge.start_client_download(pn_hash)
+}
+
 /// Shared client `/get` driver used by user Sync (`emit_ui: true`) and post-peer
 /// silent retrieve (`emit_ui: false`).
 #[allow(clippy::too_many_arguments)] // bridge + router + outbound + UI/callback wiring
 fn spawn_client_download_driver_task(
+    live: Option<Arc<LiveBridge>>,
     bridge: Arc<PropagationBridge>,
     router: Arc<tokio::sync::Mutex<LxmRouter>>,
     outbound: Arc<std::sync::Mutex<LxmfOutboundDriver>>,
@@ -6000,13 +6084,45 @@ fn spawn_client_download_driver_task(
         return false;
     }
     tokio::spawn(async move {
-        // Client tick cadence; the client's own 120s timeout bounds a stuck link.
         const POLL_INTERVAL: Duration = Duration::from_millis(500);
         const DOWNLOAD_WATCHDOG: Duration = Duration::from_secs(180);
         const ESTABLISH_STALL: Duration = Duration::from_secs(45);
         let mut interval = tokio::time::interval(POLL_INTERVAL);
-        let started = Instant::now();
-        let mut last_logged_progress = -1.0_f64;
+        let attempt_started = Instant::now();
+        let mut failover_round: u8 = 0;
+        let mut tried_interfaces: Vec<String> = Vec::new();
+        let mut blocked_ifaces: Vec<String> = Vec::new();
+        let mut blocked_vias: Vec<String> = Vec::new();
+        let mut live_ifaces: Vec<String> = Vec::new();
+        let mut current_iface: Option<String> = None;
+        let mut current_via: Option<String> = None;
+        if let Some(ref live_ref) = live {
+            if let Ok(ifaces) = live_ref.fetch_interfaces().await {
+                live_ifaces = super::auto_path_policy::order_live_ifaces_private_first(
+                    &live_interface_names(&ifaces),
+                    &ifaces,
+                );
+            }
+            if let Ok((slots, _)) = live_ref.path_slots(&pn_hex).await {
+                current_via = active_via_hash_from_slots(&slots);
+                current_iface = slots
+                    .iter()
+                    .find(|s| {
+                        s.get("active")
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(false)
+                    })
+                    .and_then(|s| s.get("interface").and_then(|v| v.as_str()))
+                    .map(str::to_string);
+            }
+            record_path_failover_attempt(
+                &mut tried_interfaces,
+                &mut blocked_ifaces,
+                &mut blocked_vias,
+                current_iface.as_deref(),
+                current_via.as_deref(),
+            );
+        }
         let emit_progress = |active: bool, progress: f64, message: Option<&str>| {
             if !emit_ui {
                 return;
@@ -6046,122 +6162,178 @@ fn spawn_client_download_driver_task(
                 f();
             }
         };
-        // Immediate Establishing frame so the renderer stall watchdog sees progress.
-        run_guarded(&|| {
-            emit_progress(true, 10.0, None);
-        });
-        loop {
-            interval.tick().await;
-            // Superseded by a newer sync run: that run now owns the client,
-            // so exit without touching shared client state.
-            if !still_current() {
-                break;
-            }
-            // This run was cancelled: cancel the client only while we are
-            // still the active run (lifecycle-lock guarded via run_if_current).
-            if cancel.load(Ordering::SeqCst) {
-                run_guarded(&|| {
-                    bridge.cancel_client_download();
-                });
-                break;
-            }
-            let progress = bridge.client_download_progress();
-            if progress <= 10.0
-                && bridge.client_download_active()
-                && started.elapsed() > ESTABLISH_STALL
-            {
+        let terminal_establish_failure =
+            |bridge: &PropagationBridge, round: u8, tried: &[String]| {
+                let message = bridge.propagation_establish_fail_message();
                 tracing::info!(
-                    target: "propagation-retrieve",
+                    target: "propagation-sync",
                     pn_hash = %pn_hex,
-                    "client /get stalled while establishing"
+                    failover_round = round,
+                    message = %message,
+                    tried_interfaces = ?tried,
+                    "propagation client /get establish failed"
                 );
-                run_guarded(&|| {
-                    bridge.cancel_client_download();
-                    emit_progress(
-                        false,
-                        0.0,
-                        Some("propagation establish failed: NoLinkProof"),
-                    );
-                });
-                break;
-            }
-            if started.elapsed() > DOWNLOAD_WATCHDOG {
-                tracing::info!(
-                    target: "propagation-retrieve",
-                    pn_hash = %pn_hex,
-                    "client /get download watchdog timeout"
-                );
-                run_guarded(&|| {
-                    bridge.cancel_client_download();
-                    emit_progress(
-                        false,
-                        0.0,
-                        Some("propagation establish failed: NoLinkProof"),
-                    );
-                });
-                break;
-            }
-            if (progress - last_logged_progress).abs() >= 0.5 {
-                last_logged_progress = progress;
-                run_guarded(&|| {
-                    emit_progress(true, progress, None);
-                });
-            }
-            let known = outbound
-                .lock()
-                .ok()
-                .map(|d| d.known_identities_for_propagation())
-                .unwrap_or_default();
-            match bridge.poll_client_download(&known) {
-                ClientDownloadPoll::Idle => break,
-                // Keep polling on the next interval tick.
-                ClientDownloadPoll::InProgress => {}
-                ClientDownloadPoll::Failed => {
-                    tracing::info!(
-                        target: "propagation-retrieve",
-                        pn_hash = %pn_hex,
-                        "client /get download failed"
-                    );
-                    // Consume the terminal failed state → Idle so a later
-                    // sync can start a fresh retrieval.
+                message
+            };
+        'attempt: loop {
+            let round_started = Instant::now();
+            let mut last_logged_progress = -1.0_f64;
+            run_guarded(&|| {
+                emit_progress(true, 10.0, None);
+            });
+            loop {
+                interval.tick().await;
+                if !still_current() {
+                    break 'attempt;
+                }
+                if cancel.load(Ordering::SeqCst) {
                     run_guarded(&|| {
                         bridge.cancel_client_download();
-                        emit_progress(
-                            false,
-                            0.0,
-                            Some("propagation establish failed: NoLinkProof"),
-                        );
                     });
-                    break;
+                    break 'attempt;
                 }
-                ClientDownloadPoll::Complete {
-                    messages,
-                    listed,
-                    downloaded,
-                } => {
-                    let delivered = messages.len();
-                    {
-                        let router = router.lock().await;
-                        if let Some(ref cb) = router.delivery_callback {
-                            for msg in &messages {
-                                cb(msg);
-                            }
-                        }
-                    }
-                    // Empty list is success (result=0), not failure.
+                let progress = bridge.client_download_progress();
+                if progress <= 10.0
+                    && bridge.client_download_active()
+                    && round_started.elapsed() > ESTABLISH_STALL
+                {
                     tracing::info!(
                         target: "propagation-retrieve",
                         pn_hash = %pn_hex,
+                        failover_round,
+                        establish_error = ?bridge.last_establish_error(),
+                        "client /get stalled while establishing"
+                    );
+                    if propagation_download_attempt_failover(
+                        live.as_ref(),
+                        &bridge,
+                        pn_hash,
+                        &pn_hex,
+                        &mut failover_round,
+                        &mut tried_interfaces,
+                        &mut blocked_ifaces,
+                        &mut blocked_vias,
+                        &live_ifaces,
+                        &mut current_iface,
+                        &mut current_via,
+                    )
+                    .await
+                    {
+                        continue 'attempt;
+                    }
+                    let message =
+                        terminal_establish_failure(&bridge, failover_round, &tried_interfaces);
+                    run_guarded(&|| {
+                        emit_progress(false, 0.0, Some(&message));
+                    });
+                    break 'attempt;
+                }
+                if attempt_started.elapsed() > DOWNLOAD_WATCHDOG {
+                    tracing::info!(
+                        target: "propagation-retrieve",
+                        pn_hash = %pn_hex,
+                        "client /get download watchdog timeout"
+                    );
+                    if propagation_download_attempt_failover(
+                        live.as_ref(),
+                        &bridge,
+                        pn_hash,
+                        &pn_hex,
+                        &mut failover_round,
+                        &mut tried_interfaces,
+                        &mut blocked_ifaces,
+                        &mut blocked_vias,
+                        &live_ifaces,
+                        &mut current_iface,
+                        &mut current_via,
+                    )
+                    .await
+                    {
+                        continue 'attempt;
+                    }
+                    let message =
+                        terminal_establish_failure(&bridge, failover_round, &tried_interfaces);
+                    run_guarded(&|| {
+                        emit_progress(false, 0.0, Some(&message));
+                    });
+                    break 'attempt;
+                }
+                if (progress - last_logged_progress).abs() >= 0.5 {
+                    last_logged_progress = progress;
+                    run_guarded(&|| {
+                        emit_progress(true, progress, None);
+                    });
+                }
+                let known = outbound
+                    .lock()
+                    .ok()
+                    .map(|d| d.known_identities_for_propagation())
+                    .unwrap_or_default();
+                match bridge.poll_client_download(&known) {
+                    ClientDownloadPoll::Idle => break 'attempt,
+                    ClientDownloadPoll::InProgress => {}
+                    ClientDownloadPoll::Failed => {
+                        tracing::info!(
+                            target: "propagation-retrieve",
+                            pn_hash = %pn_hex,
+                            progress,
+                            establish_error = ?bridge.last_establish_error(),
+                            "client /get download failed"
+                        );
+                        if progress <= 10.0
+                            && propagation_download_attempt_failover(
+                                live.as_ref(),
+                                &bridge,
+                                pn_hash,
+                                &pn_hex,
+                                &mut failover_round,
+                                &mut tried_interfaces,
+                                &mut blocked_ifaces,
+                                &mut blocked_vias,
+                                &live_ifaces,
+                                &mut current_iface,
+                                &mut current_via,
+                            )
+                            .await
+                        {
+                            continue 'attempt;
+                        }
+                        let message =
+                            terminal_establish_failure(&bridge, failover_round, &tried_interfaces);
+                        run_guarded(&|| {
+                            bridge.cancel_client_download();
+                            emit_progress(false, 0.0, Some(&message));
+                        });
+                        break 'attempt;
+                    }
+                    ClientDownloadPoll::Complete {
+                        messages,
                         listed,
                         downloaded,
-                        delivered,
-                        retrieve_mode,
-                        "client /get download Completes"
-                    );
-                    run_guarded(&|| {
-                        emit_progress(false, 100.0, None);
-                    });
-                    break;
+                    } => {
+                        let delivered = messages.len();
+                        {
+                            let router = router.lock().await;
+                            if let Some(ref cb) = router.delivery_callback {
+                                for msg in &messages {
+                                    cb(msg);
+                                }
+                            }
+                        }
+                        tracing::info!(
+                            target: "propagation-retrieve",
+                            pn_hash = %pn_hex,
+                            listed,
+                            downloaded,
+                            delivered,
+                            retrieve_mode,
+                            "client /get download Completes"
+                        );
+                        run_guarded(&|| {
+                            emit_progress(false, 100.0, None);
+                        });
+                        break 'attempt;
+                    }
                 }
             }
         }

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -420,11 +420,12 @@ impl LiveBridge {
                 .map(hex::encode)
                 .unwrap_or_default();
             if msg.method == DeliveryMethod::Propagated {
-                tracing::info!(
+                let from_prefix = sender_hex.get(..12).unwrap_or(&sender_hex);
+                tracing::debug!(
                     target: "propagation-retrieve",
                     message_hash = %message_hash,
                     transient_id = %transient_id_hex,
-                    from = %sender_hex,
+                    from_prefix = %from_prefix,
                     "inbound LXMF delivered via propagation"
                 );
             }

--- a/reticulum-sidecar/src/stack/mod.rs
+++ b/reticulum-sidecar/src/stack/mod.rs
@@ -1371,15 +1371,35 @@ impl StackHandle {
             .iter()
             .map(|p| {
                 let preferred = preferred_id.as_deref() == Some(p.id.as_str());
+                let mut hops = p.hops;
+                let mut path_interface: Option<String> = None;
+                #[cfg(feature = "rns-stack")]
+                if p.id != "local-prop" {
+                    if let Some(live) = self.live.get() {
+                        if let Some(dest) = p.destination_hash.as_deref() {
+                            let (live_hops, live_iface) =
+                                live.live_path_fields_for_destination(dest);
+                            if hops.is_none() {
+                                hops = live_hops;
+                            }
+                            path_interface = live_iface;
+                        }
+                    }
+                }
                 let mut row = serde_json::json!({
                     "id": p.id,
                     "name": p.name,
-                    "hops": p.hops,
+                    "hops": hops,
                     "enabled": p.enabled,
                     "status": p.status,
                     "preferred": preferred,
                     "destination_hash": p.destination_hash,
                 });
+                if let Some(iface) = path_interface {
+                    if let Some(obj) = row.as_object_mut() {
+                        obj.insert("interface".into(), serde_json::Value::String(iface));
+                    }
+                }
                 #[cfg(feature = "rns-stack")]
                 if p.id == "local-prop" {
                     if let Some(stats) = &local_stats {
@@ -1628,7 +1648,7 @@ impl StackHandle {
         #[cfg(feature = "rns-stack")]
         {
             if let Some(live) = self.live.get() {
-                live.start_propagation_sync(&prop_hash).await?;
+                live.clone().start_propagation_sync(&prop_hash).await?;
                 return Ok(());
             }
             // Never fall through to the persistence stub: it marks sync active at
@@ -1679,7 +1699,7 @@ impl StackHandle {
         }
         #[cfg(feature = "rns-stack")]
         if let Some(live) = self.live.get() {
-            live.start_propagation_sync(&prop_hash).await?;
+            live.clone().start_propagation_sync(&prop_hash).await?;
             return Ok(());
         }
         Err("PROPAGATION_STACK_NOT_LIVE".into())

--- a/reticulum-sidecar/src/stack/path_failover.rs
+++ b/reticulum-sidecar/src/stack/path_failover.rs
@@ -206,6 +206,11 @@ pub fn should_retry_direct_path_failover(rounds_already: u8) -> bool {
     rounds_already < MAX_VIA_FAILOVERS
 }
 
+/// True when propagation client `/get` should attempt another iface/via after establish failure.
+pub fn should_attempt_propagation_via_failover(failover_round: u8) -> bool {
+    failover_round < MAX_VIA_FAILOVERS
+}
+
 /// True when Nomad should enter another via-failover round after a link result.
 ///
 /// Only `link_timeout` triggers in-request failover; other errors surface immediately.
@@ -482,6 +487,14 @@ mod tests {
         ));
         assert!(!should_attempt_nomad_via_failover("path_not_found", 0));
         assert!(!should_attempt_nomad_via_failover("nomad_busy", 0));
+    }
+
+    #[test]
+    fn should_attempt_propagation_via_failover_within_cap() {
+        assert!(should_attempt_propagation_via_failover(0));
+        assert!(should_attempt_propagation_via_failover(1));
+        assert!(!should_attempt_propagation_via_failover(2));
+        assert!(!should_attempt_propagation_via_failover(MAX_VIA_FAILOVERS));
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/propagation_bridge.rs
+++ b/reticulum-sidecar/src/stack/propagation_bridge.rs
@@ -495,6 +495,9 @@ impl PropagationBridge {
     /// `lxmf.propagation.client` link. Returns false when a download is already
     /// in flight or the client refuses to start.
     pub fn start_client_download(&self, pn_hash: [u8; 16]) -> bool {
+        if let Ok(mut slot) = self.last_establish_error.lock() {
+            *slot = None;
+        }
         let Ok(mut client) = self.client.lock() else {
             return false;
         };
@@ -558,6 +561,11 @@ impl PropagationBridge {
             return ClientDownloadPoll::Idle;
         }
         client.drain_events(known_identities);
+        if let Some(err) = client.last_establish_error() {
+            if let Ok(mut slot) = self.last_establish_error.lock() {
+                *slot = Some(err);
+            }
+        }
         client.tick();
         match client.state() {
             PropagationClientState::Idle => ClientDownloadPoll::Idle,
@@ -862,6 +870,13 @@ impl PropagationBridge {
 
     pub fn last_establish_error(&self) -> Option<&'static str> {
         self.last_establish_error.lock().ok().and_then(|slot| *slot)
+    }
+
+    /// Terminal establish failure message for WS / UI (granular LRPROOF when available).
+    pub fn propagation_establish_fail_message(&self) -> String {
+        self.last_establish_error()
+            .map(|e| format!("propagation establish failed: {e}"))
+            .unwrap_or_else(|| "propagation establish failed: NoLinkProof".to_string())
     }
 
     /// Sticky success/failure after Complete/Failed collapses to Idle.
@@ -1629,6 +1644,60 @@ mod tests {
     }
 
     #[test]
+    fn propagation_establish_fail_message_prefers_sticky_error() {
+        let dir =
+            std::env::temp_dir().join(format!("mesh-prop-bridge-failmsg-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("tmpdir");
+        let (tx, _rx) = mpsc::channel(8);
+        let identity = rns_identity::identity::Identity::new();
+        let bridge = PropagationBridge::new(
+            tx,
+            [0xab; 16],
+            dir.clone(),
+            &identity,
+            &super::super::pn_hosting_policy::PnHostingPolicy::default(),
+        )
+        .expect("bridge");
+        assert_eq!(
+            bridge.propagation_establish_fail_message(),
+            "propagation establish failed: NoLinkProof"
+        );
+        if let Ok(mut slot) = bridge.last_establish_error.lock() {
+            *slot = Some("LrproofIdentityMissing");
+        }
+        assert_eq!(
+            bridge.propagation_establish_fail_message(),
+            "propagation establish failed: LrproofIdentityMissing"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn start_client_download_clears_sticky_establish_error() {
+        let dir =
+            std::env::temp_dir().join(format!("mesh-prop-bridge-clear-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("tmpdir");
+        let (tx, _rx) = mpsc::channel(8);
+        let identity = rns_identity::identity::Identity::new();
+        let bridge = PropagationBridge::new(
+            tx,
+            [0xab; 16],
+            dir.clone(),
+            &identity,
+            &super::super::pn_hosting_policy::PnHostingPolicy::default(),
+        )
+        .expect("bridge");
+        if let Ok(mut slot) = bridge.last_establish_error.lock() {
+            *slot = Some("LrproofInvalid");
+        }
+        let _started = bridge.start_client_download([0xcd; 16]);
+        assert_eq!(bridge.last_establish_error(), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn apply_peer_sync_terminal_complete_returns_idle_and_marks_generation() {
         use lxmf_core::constants::PeerState;
         use lxmf_core::peer::LxmPeer;
@@ -2076,6 +2145,23 @@ mod tests {
             .find("\n    pub ")
             .map_or(probe_fn.len(), |idx| idx + 1);
         let probe_body = &probe_fn[..probe_end];
+        assert!(
+            sync_body.contains("ensure_propagation_path_or_unknown(&dest_hex, false)"),
+            "start_propagation_sync must use cached path on first attempt"
+        );
+        assert!(
+            probe_body.contains("ensure_propagation_path_or_unknown(&dest_hex, true)"),
+            "offer probe must force-refresh path"
+        );
+        assert!(
+            live.contains("propagation_download_attempt_failover")
+                && live.contains("propagation_establish_fail_message"),
+            "client /get driver must failover and prefer granular establish errors"
+        );
+        assert!(
+            bridge.contains("client.last_establish_error()"),
+            "poll_client_download must read PropagationClient establish error"
+        );
         assert!(
             probe_body.contains("ensure_propagation_path_or_unknown"),
             "offer probe must use the same shared path gate as Sync"

--- a/scripts/apply-rsLXMF-propagation-client-lrproof-diagnostics.sh
+++ b/scripts/apply-rsLXMF-propagation-client-lrproof-diagnostics.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Apply mesh-client rsLXMF PropagationClient LRPROOF establish diagnostics overlay.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=lib/apply-ratspeak-overlay.sh
+source "${SCRIPT_DIR}/lib/apply-ratspeak-overlay.sh"
+PATCH_FILE="${REPO_ROOT}/reticulum-sidecar/patches/rsLXMF-propagation-client-lrproof-diagnostics.patch"
+LXMF_DIR="${RS_LXMF_DIR:-${REPO_ROOT}/.rsstack/rsLXMF}"
+CLIENT_RS="${LXMF_DIR}/crates/lxmf-core/src/propagation_client.rs"
+
+if [[ ! -d "${LXMF_DIR}/.git" ]]; then
+  echo "error: rsLXMF not found at ${LXMF_DIR}" >&2
+  echo "Clone: git clone https://github.com/ratspeak/rsLXMF.git ${LXMF_DIR}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${PATCH_FILE}" ]]; then
+  echo "error: patch not found at ${PATCH_FILE}" >&2
+  exit 1
+fi
+
+overlay_already_present() {
+  [[ -f "${CLIENT_RS}" ]] || return 1
+  grep -qE 'fn last_establish_error\(' "${CLIENT_RS}"
+}
+
+if overlay_already_present; then
+  echo "propagation-client LRPROOF diagnostics overlay already present on rsLXMF @ $(git -C "${LXMF_DIR}" rev-parse --short HEAD)"
+  exit 0
+fi
+
+if apply_ratspeak_overlay_or_die "${LXMF_DIR}" "${PATCH_FILE}" "propagation-client-lrproof-diagnostics"; then
+  exit 0
+fi
+exit 1

--- a/scripts/apply-rsLXMF-propagation-client-lrproof-diagnostics.test.mjs
+++ b/scripts/apply-rsLXMF-propagation-client-lrproof-diagnostics.test.mjs
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const APPLY_SCRIPT = path.join(
+  SCRIPT_DIR,
+  'apply-rsLXMF-propagation-client-lrproof-diagnostics.sh',
+);
+const PATCH_FILE = path.join(
+  REPO_ROOT,
+  'reticulum-sidecar/patches/rsLXMF-propagation-client-lrproof-diagnostics.patch',
+);
+
+describe('apply-rsLXMF-propagation-client-lrproof-diagnostics', () => {
+  it('patch adds PropagationClient last_establish_error diagnostics', () => {
+    const patch = readFileSync(PATCH_FILE, 'utf8');
+    expect(patch).toContain('last_establish_error');
+    expect(patch).toContain('LrproofIdentityMissing');
+    expect(patch).toContain('LrproofInvalid');
+    expect(patch).toContain('fn last_establish_error');
+  });
+
+  it('apply script checks for overlay marker', () => {
+    const script = readFileSync(APPLY_SCRIPT, 'utf8');
+    expect(script).toContain('last_establish_error');
+    expect(script).toContain('rsLXMF-propagation-client-lrproof-diagnostics.patch');
+  });
+});

--- a/scripts/lib/ratspeak-overlay-apply-list.sh
+++ b/scripts/lib/ratspeak-overlay-apply-list.sh
@@ -23,6 +23,7 @@ RS_LXMF_APPLY_SCRIPTS=(
   apply-rsLXMF-propagation-node-deferred-messagestore-load.sh
   apply-rsLXMF-link-delivery-has-pending-to.sh
   apply-rsLXMF-propagation-client-abort-transfer.sh
+  apply-rsLXMF-propagation-client-lrproof-diagnostics.sh
 )
 
 apply_ratspeak_rns_overlays() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -226,6 +226,7 @@ check_ratspeak_patches() {
     'rsLXMF-propagation-node-deferred-messagestore-load.patch|ratspeak/rsLXMF||rsLXMF PropagationNode deferred messagestore load|'
     'rsLXMF-link-delivery-has-pending-to.patch|ratspeak/rsLXMF||rsLXMF LinkDeliveryManager has_pending_to|'
     'rsLXMF-propagation-client-abort-transfer.patch|ratspeak/rsLXMF||rsLXMF PropagationClient abort_transfer for cancelled Sync|'
+    'rsLXMF-propagation-client-lrproof-diagnostics.patch|ratspeak/rsLXMF||rsLXMF PropagationClient LRPROOF establish diagnostics|'
   )
   local patches_dir='reticulum-sidecar/patches'
   local has_ratspeak_warning=0

--- a/src/main/reticulumSidecarStderrLog.test.ts
+++ b/src/main/reticulumSidecarStderrLog.test.ts
@@ -44,6 +44,11 @@ describe('shouldForwardReticulumSidecarStdout', () => {
     expect(
       shouldForwardReticulumSidecarStdout('INFO target=lxmf-outbound LXMF advancing PN cascade'),
     ).toBe(true);
+    expect(
+      shouldForwardReticulumSidecarStdout(
+        'INFO target=propagation-retrieve pn_hash=abc client /get stalled while establishing',
+      ),
+    ).toBe(true);
   });
 
   it('does not forward INFO when PN markers appear only in message text', () => {

--- a/src/main/reticulumSidecarStderrLog.ts
+++ b/src/main/reticulumSidecarStderrLog.ts
@@ -11,7 +11,7 @@ const BEACON_FAIL_WARN_INTERVAL_MS = 60 * MS_PER_SECOND;
 // propagation-retrieve at warn by default (inbound peer/message metadata); opt in
 // via MESH_CLIENT_RUST_LOG (e.g. add propagation-retrieve=info).
 export const SIDECAR_DEFAULT_RUST_LOG =
-  'warn,propagation-sync=info,propagation-deposit=info,lxmf-outbound=info';
+  'warn,propagation-sync=info,propagation-retrieve=info,propagation-deposit=info,lxmf-outbound=info';
 
 /**
  * Whether a sidecar stdout line should be written to the app log.
@@ -20,6 +20,7 @@ export const SIDECAR_DEFAULT_RUST_LOG =
  */
 const SIDECAR_STDOUT_INFO_FORWARD_MARKERS = [
   'propagation-sync',
+  'propagation-retrieve',
   'propagation-deposit',
   'lxmf-outbound',
 ] as const;

--- a/src/main/reticulumSidecarStderrLog.ts
+++ b/src/main/reticulumSidecarStderrLog.ts
@@ -8,8 +8,8 @@ const BEACON_FAIL_WARN_INTERVAL_MS = 60 * MS_PER_SECOND;
 
 /** Default tracing filter for sidecar child processes (overridable via env). */
 // PN connect triage: keep global warn; surface sync/deposit/outbound INFO. Keep
-// propagation-retrieve at warn by default (inbound peer/message metadata); opt in
-// via MESH_CLIENT_RUST_LOG (e.g. add propagation-retrieve=info).
+// propagation-retrieve at info for pn_hash / establish / failover lines; per-message
+// inbound delivery records stay debug-only with redacted from_prefix in live.rs.
 export const SIDECAR_DEFAULT_RUST_LOG =
   'warn,propagation-sync=info,propagation-retrieve=info,propagation-deposit=info,lxmf-outbound=info';
 

--- a/src/main/support-bundle.test.ts
+++ b/src/main/support-bundle.test.ts
@@ -111,6 +111,7 @@ describe('extractLxmfOutboundLogSlice', () => {
         'info target=propagation-retrieve sync transfer progress',
         'info target=propagation-sync propagation sync aborted — no path to PN',
         'warn propagation establish failed: NoLinkProof',
+        'warn propagation establish failed: LrproofIdentityMissing',
         'error PROPAGATION_PATH_UNKNOWN',
       ].join('\n'),
       'utf8',
@@ -122,6 +123,7 @@ describe('extractLxmfOutboundLogSlice', () => {
     expect(slice).toContain('propagation-retrieve');
     expect(slice).toContain('propagation-sync');
     expect(slice).toContain('propagation establish');
+    expect(slice).toContain('LrproofIdentityMissing');
     expect(slice).toContain('PROPAGATION_PATH_UNKNOWN');
     expect(slice).not.toContain('hello world');
     expect(slice).not.toContain('peer refresh ok');

--- a/src/renderer/lib/reticulum/reticulumPropagationSync.test.ts
+++ b/src/renderer/lib/reticulum/reticulumPropagationSync.test.ts
@@ -120,6 +120,9 @@ describe('reticulumPropagationSync', () => {
     expect(mapPropagationSyncError('propagation establish failed: LrproofInvalid')).toBe(
       'reticulumPropagation.syncEstablishInvalidProof',
     );
+    expect(mapPropagationSyncError('propagation establish failed: LrproofInvalidKey')).toBe(
+      'reticulumPropagation.syncEstablishInvalidProof',
+    );
     expect(mapPropagationSyncError('propagation establish failed: NoLinkProof')).toBe(
       'reticulumPropagation.syncEstablishNoLinkProof',
     );


### PR DESCRIPTION
## Summary

Fixes propagation **Sync** failing with generic `reticulumPropagation.syncEstablishNoLinkProof` when a preferred PN is reachable on the forward path but establish stalls due to client-local reverse-path / interface asymmetry — observed on Runr (developer bundle `mesh-client-developer-bundle-2026-08-24_09-43`, v5.30.0) with **dual enabled TCP backbones** (`RNS_Transport_US-East` + `Local Pi Transport`).

### Root cause (Runr bundle)

- Preferred PN `pn-66529cad` had a valid 2-hop forward path via `RNS_Transport_US-East`.
- Establish timed out on both RRC hub and Nomad interfaces with the same link-proof failure — not `PROPAGATION_PATH_UNKNOWN`.
- Dual TCP interfaces increased the chance of stale cached paths and asymmetric egress on establish.

PR #881 added recovery UI for this symptom class; this change adds **establish-time failover**, **softer first-attempt path policy**, **granular LRPROOF diagnostics**, and **better support-bundle visibility**.

### Changes

**1. Propagation sync interface failover (`live.rs`)**
- New `propagation_download_attempt_failover()` reuses Nomad-style `suppress_via_and_rediscover` (up to `MAX_VIA_FAILOVERS` = 2).
- Refactored `spawn_client_download_driver_task()` with an outer `'attempt` loop: on establish stall (45s), download watchdog (180s), or early `/get` failure, failover to another iface/via before surfacing a terminal error.
- User Sync passes `Some(Arc<LiveBridge>)`; silent host `/get` passes `None` (no UI failover).

**2. Softer path gate**
- New `ensure_propagation_path_or_unknown(dest, force)` — Sync uses `force: false` (prefer cached path on first attempt); offer/probe paths use `force: true`.

**3. Granular LRPROOF establish errors**
- New rsLXMF overlay: `reticulum-sidecar/patches/rsLXMF-propagation-client-lrproof-diagnostics.patch` + apply script registered in overlay list / `update.sh`.
- `PropagationClient` exposes `last_establish_error()`; bridge maps to user-facing messages instead of blanket `NoLinkProof`.
- Renderer test covers `LrproofInvalidKey` mapping.

**4. Support-bundle logging**
- Forward `propagation-retrieve` sidecar stderr lines into `mesh-client.log` and support-bundle slices (alongside existing `propagation-sync` markers).

**5. Propagation API hops enrichment**
- `list_propagation` merges live hops + interface from `LiveBridge::live_path_fields_for_destination()` so UI/diagnostics reflect current path state.

## Operational guidance (Runr / dual-TCP users)

Until this build is deployed:
1. Disable one TCP backbone under **Connection → Interfaces**.
2. **Network → Announce now**, wait ~10s.
3. Retry **Sync** on the preferred PN.

After this fix, support bundles should include `propagation-sync` / `propagation-retrieve` establish + failover lines; the UI may show granular establish errors (e.g. invalid key) instead of generic `NoLinkProof`.

## Test plan

- [x] `pnpm run check:reticulum-sidecar` (fmt + clippy + sidecar tests — 586 passed in pre-commit)
- [x] Staged Vitest via pre-commit (`reticulumSidecarStderrLog`, `support-bundle`, `reticulumPropagationSync`, overlay apply script)
- [ ] Manual: dual-TCP Reticulum node with preferred PN sync — confirm failover log lines and successful sync or specific establish error
- [ ] Manual: export support bundle during failed establish — confirm `propagation-retrieve` lines present
- [ ] Manual: single-TCP baseline — confirm no regression on normal sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Propagation listings now show current route hop counts and interface details when available.
  - Propagation downloads can automatically retry through alternate routes when a path fails.

- **Bug Fixes**
  - Failed interfaces and routes are suppressed during retries to improve recovery.
  - Propagation establishment errors now report the specific failure instead of a generic message.
  - Stale connection errors are cleared when starting a new download.

- **Diagnostics**
  - Added improved logging and reporting for propagation retrieval attempts, failover activity, and proof-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->