### PR TITLE
fix(meshtastic): stop RAK4631 serial drop during configure handshake (#895)

### DIFF
--- a/patches/@jsr__meshtastic__core@2.6.6.patch
+++ b/patches/@jsr__meshtastic__core@2.6.6.patch
@@ -198,3 +198,70 @@ index 9c0d192d0a22c1a158e70f4dc3b74460ea7bd22b..7d63cb22ad5c6a8cde8823b9925e93b6
          }
        }
      } finally {
+diff --git a/src/utils/transform/decodePacket.js b/src/utils/transform/decodePacket.js
+index b1cb39a13ac3f7fb5a368b04755d73a5c2f32743..78a812eaca5079a599e81e618399a247688a7786 100755
+--- a/src/utils/transform/decodePacket.js
++++ b/src/utils/transform/decodePacket.js
+@@ -71,8 +71,11 @@ export const decodePacket = (device)=>new WritableStream({
+                 }
+               case "configCompleteId":
+                 {
++                  // mesh-client: ignore stale completes from an orphaned PhoneAPI
++                  // handshake (different nonce) — do not mark DeviceConfigured (#895).
+                   if (decodedMessage.payloadVariant.value !== device.configId) {
+                     device.log.error(Types.Emitter[Types.Emitter.HandleFromRadio], `❌ Invalid config id received from device, expected ${device.configId} but received ${decodedMessage.payloadVariant.value}`);
++                    break;
+                   }
+                   device.log.info(Types.Emitter[Types.Emitter.HandleFromRadio], `⚙️ Valid config id received from device: ${device.configId}`);
+                   device.updateDeviceStatus(Types.DeviceStatusEnum.DeviceConfigured);
+@@ -133,6 +136,15 @@ export const decodePacket = (device)=>new WritableStream({
+                 {
+                   break;
+                 }
++              // mesh-client: known FromRadio variants decoded by protobufs but unused
++              // by core — silence WARN spam (fileInfo is part of the config handshake).
++              case "fileInfo":
++              case "clientNotification":
++              case "deviceuiConfig":
++              case "lockdownStatus":
++                {
++                  break;
++                }
+               default:
+                 {
+                   device.log.warn(Types.Emitter[Types.Emitter.HandleFromRadio], `⚠️ Unhandled payload variant: ${decodedMessage.payloadVariant.case}`);
+diff --git a/src/utils/transform/decodePacket.ts b/src/utils/transform/decodePacket.ts
+index ff5ccb00f5b9b1f80f0126a0fb6e757fd19ddc6b..2597e6af6783de19390ece201bd678a02fc930e1 100755
+--- a/src/utils/transform/decodePacket.ts
++++ b/src/utils/transform/decodePacket.ts
+@@ -104,11 +104,14 @@ export const decodePacket = (device: MeshDevice) =>
+             }
+ 
+             case "configCompleteId": {
++              // mesh-client: ignore stale completes from an orphaned PhoneAPI
++              // handshake (different nonce) — do not mark DeviceConfigured (#895).
+               if (decodedMessage.payloadVariant.value !== device.configId) {
+                 device.log.error(
+                   Types.Emitter[Types.Emitter.HandleFromRadio],
+                   `❌ Invalid config id received from device, expected ${device.configId} but received ${decodedMessage.payloadVariant.value}`,
+                 );
++                break;
+               }
+ 
+               device.log.info(
+@@ -209,6 +212,15 @@ export const decodePacket = (device: MeshDevice) =>
+               break;
+             }
+ 
++            // mesh-client: known FromRadio variants decoded by protobufs but unused
++            // by core — silence WARN spam (fileInfo is part of the config handshake).
++            case "fileInfo":
++            case "clientNotification":
++            case "deviceuiConfig":
++            case "lockdownStatus": {
++              break;
++            }
++
+             default: {
+               device.log.warn(
+                 Types.Emitter[Types.Emitter.HandleFromRadio],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ overrides:
   ws: ^8.21.0
 
 patchedDependencies:
-  '@jsr/meshtastic__core@2.6.6': 93604a080fa754cbde3dc78ef46ee50c2996c34d6d85720acacecfd6ebd7c652
+  '@jsr/meshtastic__core@2.6.6': 1ab3dfdd14c435e2493243286e726cf0c874facbaad4aa692fe8ddf0bf5f5e5a
   '@jsr/meshtastic__transport-web-serial@0.2.5': 27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74
   '@liamcottle/meshcore.js@1.15.0': 25469f71b6cd7c5510b210ddb8846d541e9b47ebd08e1531a39267df33840b43
   debug@4.4.3: cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37
@@ -131,7 +131,7 @@ importers:
         version: 1.15.0(patch_hash=25469f71b6cd7c5510b210ddb8846d541e9b47ebd08e1531a39267df33840b43)(supports-color@8.1.1)
       '@meshtastic/core':
         specifier: npm:@jsr/meshtastic__core@^2.6.6
-        version: '@jsr/meshtastic__core@2.6.6(patch_hash=93604a080fa754cbde3dc78ef46ee50c2996c34d6d85720acacecfd6ebd7c652)(buffer@6.0.3)'
+        version: '@jsr/meshtastic__core@2.6.6(patch_hash=1ab3dfdd14c435e2493243286e726cf0c874facbaad4aa692fe8ddf0bf5f5e5a)(buffer@6.0.3)'
       '@meshtastic/transport-http':
         specifier: npm:@jsr/meshtastic__transport-http@^0.2.1
         version: '@jsr/meshtastic__transport-http@0.2.1(buffer@6.0.3)'
@@ -5062,7 +5062,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jsr/meshtastic__core@2.6.6(patch_hash=93604a080fa754cbde3dc78ef46ee50c2996c34d6d85720acacecfd6ebd7c652)(buffer@6.0.3)':
+  '@jsr/meshtastic__core@2.6.6(patch_hash=1ab3dfdd14c435e2493243286e726cf0c874facbaad4aa692fe8ddf0bf5f5e5a)(buffer@6.0.3)':
     dependencies:
       '@bufbuild/protobuf': 2.14.0
       '@jsr/meshtastic__protobufs': 2.7.26
@@ -5078,13 +5078,13 @@ snapshots:
 
   '@jsr/meshtastic__transport-http@0.2.1(buffer@6.0.3)':
     dependencies:
-      '@jsr/meshtastic__core': 2.6.6(patch_hash=93604a080fa754cbde3dc78ef46ee50c2996c34d6d85720acacecfd6ebd7c652)(buffer@6.0.3)
+      '@jsr/meshtastic__core': 2.6.6(patch_hash=1ab3dfdd14c435e2493243286e726cf0c874facbaad4aa692fe8ddf0bf5f5e5a)(buffer@6.0.3)
     transitivePeerDependencies:
       - buffer
 
   '@jsr/meshtastic__transport-web-serial@0.2.5(patch_hash=27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74)(buffer@6.0.3)':
     dependencies:
-      '@meshtastic/core': '@jsr/meshtastic__core@2.6.6(patch_hash=93604a080fa754cbde3dc78ef46ee50c2996c34d6d85720acacecfd6ebd7c652)(buffer@6.0.3)'
+      '@meshtastic/core': '@jsr/meshtastic__core@2.6.6(patch_hash=1ab3dfdd14c435e2493243286e726cf0c874facbaad4aa692fe8ddf0bf5f5e5a)(buffer@6.0.3)'
     transitivePeerDependencies:
       - buffer
 

--- a/src/renderer/lib/connection.serial-cleanup.test.ts
+++ b/src/renderer/lib/connection.serial-cleanup.test.ts
@@ -123,7 +123,7 @@ describe('connection serial cleanup', () => {
     const device = {
       disconnect: vi.fn().mockResolvedValue(undefined),
       complete: vi.fn(),
-      transport: { port, fromDevice },
+      transport: { port, fromDevice, toDevice: new WritableStream() },
     } as unknown as MeshDevice;
 
     await safeDisconnect(device);
@@ -134,12 +134,49 @@ describe('connection serial cleanup', () => {
     expect(device.complete).toHaveBeenCalledTimes(1);
   });
 
+  it('safeDisconnect sends ToRadio.disconnect before device.disconnect for serial', async () => {
+    const port = makeMockSerialPort();
+    const callOrder: string[] = [];
+    const toDevice = new WritableStream<Uint8Array>({
+      write() {
+        callOrder.push('toRadioDisconnect');
+      },
+    });
+    const device = {
+      disconnect: vi.fn().mockImplementation(() => {
+        callOrder.push('device.disconnect');
+        return Promise.resolve();
+      }),
+      complete: vi.fn(),
+      transport: { port, fromDevice: new ReadableStream(), toDevice },
+    } as unknown as MeshDevice;
+
+    await safeDisconnect(device);
+
+    expect(callOrder).toEqual(['toRadioDisconnect', 'device.disconnect']);
+  });
+
+  it('safeDisconnect skips ToRadio.disconnect when transport is not serial', async () => {
+    const write = vi.fn();
+    const toDevice = new WritableStream<Uint8Array>({ write });
+    const device = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      complete: vi.fn(),
+      transport: { toDevice, fromDevice: new ReadableStream() },
+    } as unknown as MeshDevice;
+
+    await safeDisconnect(device);
+
+    expect(write).not.toHaveBeenCalled();
+    expect(device.disconnect).toHaveBeenCalledTimes(1);
+  });
+
   it('safeDisconnect closes TransportWebSerial connection field', async () => {
     const port = makeMockSerialPort();
     const device = {
       disconnect: vi.fn().mockResolvedValue(undefined),
       complete: vi.fn(),
-      transport: { connection: port },
+      transport: { connection: port, toDevice: new WritableStream() },
     } as unknown as MeshDevice;
 
     await safeDisconnect(device);

--- a/src/renderer/lib/connection.ts
+++ b/src/renderer/lib/connection.ts
@@ -15,6 +15,7 @@ import {
 } from './connectionWebStreams';
 import { notifyNobleBlePrimaryRfLinkReady } from './meshcoreDualNobleBleInit';
 import { armMeshtasticLateConfigureRetryableSwallow } from './meshtastic/meshtasticConfigureRetry';
+import { sendMeshtasticPhoneApiDisconnect } from './meshtastic/meshtasticPhoneApiDisconnect';
 import { parseMeshtasticTcpAddress } from './parseMeshtasticTcpAddress';
 import {
   isBlePeripheralConflictErrorMessage,
@@ -575,6 +576,10 @@ export async function safeDisconnect(device: MeshDevice): Promise<void> {
   // in-flight sendPacket().wait() then rejects with "Packet does not exist". These are expected
   // teardown races and must not surface as unhandled-rejection error logs.
   armMeshtasticLateConfigureRetryableSwallow();
+  // Serial only: tell firmware PhoneAPI to reset before we drop the CDC streams (#895).
+  if (getSerialPortFromMeshTransport(device.transport)) {
+    await sendMeshtasticPhoneApiDisconnect(device);
+  }
   try {
     await device.disconnect();
   } catch (err) {

--- a/src/renderer/lib/meshtastic/meshtasticPhoneApiDisconnect.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticPhoneApiDisconnect.test.ts
@@ -1,0 +1,59 @@
+import { fromBinary } from '@bufbuild/protobuf';
+import type { MeshDevice } from '@meshtastic/core';
+import { Mesh } from '@meshtastic/protobufs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildToRadioDisconnectBytes,
+  sendMeshtasticPhoneApiDisconnect,
+} from './meshtasticPhoneApiDisconnect';
+
+describe('meshtasticPhoneApiDisconnect', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('encodes ToRadio.disconnect', () => {
+    const bytes = buildToRadioDisconnectBytes();
+    const decoded = fromBinary(Mesh.ToRadioSchema, bytes) as unknown as {
+      payloadVariant: { case: string; value: boolean };
+    };
+    expect(decoded.payloadVariant.case).toBe('disconnect');
+    expect(decoded.payloadVariant.value).toBe(true);
+  });
+
+  it('writes disconnect bytes via transport toDevice', async () => {
+    const written: Uint8Array[] = [];
+    const toDevice = new WritableStream<Uint8Array>({
+      write(chunk) {
+        written.push(chunk);
+      },
+    });
+    const device = {
+      transport: { toDevice },
+    } as unknown as MeshDevice;
+
+    await sendMeshtasticPhoneApiDisconnect(device);
+
+    expect(written).toHaveLength(1);
+    const decoded = fromBinary(Mesh.ToRadioSchema, written[0]) as unknown as {
+      payloadVariant: { case: string };
+    };
+    expect(decoded.payloadVariant.case).toBe('disconnect');
+  });
+
+  it('swallows write failures during teardown', async () => {
+    const toDevice = new WritableStream<Uint8Array>({
+      write() {
+        throw new DOMException('The device has been lost.', 'NetworkError');
+      },
+    });
+    const device = {
+      transport: { toDevice },
+    } as unknown as MeshDevice;
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    await expect(sendMeshtasticPhoneApiDisconnect(device)).resolves.toBeUndefined();
+    expect(debugSpy).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/lib/meshtastic/meshtasticPhoneApiDisconnect.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticPhoneApiDisconnect.test.ts
@@ -1,16 +1,21 @@
 import { fromBinary } from '@bufbuild/protobuf';
 import type { MeshDevice } from '@meshtastic/core';
 import { Mesh } from '@meshtastic/protobufs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildToRadioDisconnectBytes,
+  MESHTASTIC_PHONE_API_DISCONNECT_TIMEOUT_MS,
   sendMeshtasticPhoneApiDisconnect,
 } from './meshtasticPhoneApiDisconnect';
 
 describe('meshtasticPhoneApiDisconnect', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('encodes ToRadio.disconnect', () => {
@@ -55,5 +60,25 @@ describe('meshtasticPhoneApiDisconnect', () => {
 
     await expect(sendMeshtasticPhoneApiDisconnect(device)).resolves.toBeUndefined();
     expect(debugSpy).toHaveBeenCalled();
+  });
+
+  it('resolves when writer.write never settles so safeDisconnect can continue', async () => {
+    vi.useFakeTimers();
+    const toDevice = new WritableStream<Uint8Array>({
+      write() {
+        return new Promise(() => {
+          // never settles
+        });
+      },
+    });
+    const device = {
+      transport: { toDevice },
+    } as unknown as MeshDevice;
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    const pending = sendMeshtasticPhoneApiDisconnect(device);
+    await vi.advanceTimersByTimeAsync(MESHTASTIC_PHONE_API_DISCONNECT_TIMEOUT_MS);
+    await expect(pending).resolves.toBeUndefined();
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('ToRadio.disconnect timed out'));
   });
 });

--- a/src/renderer/lib/meshtastic/meshtasticPhoneApiDisconnect.ts
+++ b/src/renderer/lib/meshtastic/meshtasticPhoneApiDisconnect.ts
@@ -4,6 +4,10 @@ import { Mesh } from '@meshtastic/protobufs';
 
 import { errLikeToLogString } from '../errLikeToLogString';
 import { writeToRadioWithoutQueue } from '../meshtasticBacklogUtils';
+import { MS_PER_SECOND } from '../timeConstants';
+
+/** Cap for teardown ToRadio.disconnect (includes toRadioDirectWriteChain wait). */
+export const MESHTASTIC_PHONE_API_DISCONNECT_TIMEOUT_MS = 2 * MS_PER_SECOND;
 
 /** Encode PhoneAPI ToRadio.disconnect so firmware resets STATE_SEND_* (#895). */
 export function buildToRadioDisconnectBytes(): Uint8Array {
@@ -19,14 +23,24 @@ export function buildToRadioDisconnectBytes(): Uint8Array {
  * Best-effort ToRadio.disconnect before tearing down a MeshDevice.
  * Call only for serial (caller gates): without this, firmware PhoneAPI can keep
  * dumping an orphaned config handshake when the port reopens (#895).
+ * Bounded so a hung writer / write-chain cannot block safeDisconnect port close.
  */
 export async function sendMeshtasticPhoneApiDisconnect(device: MeshDevice): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    await writeToRadioWithoutQueue(device, buildToRadioDisconnectBytes());
+    const write = writeToRadioWithoutQueue(device, buildToRadioDisconnectBytes());
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error('ToRadio.disconnect timed out'));
+      }, MESHTASTIC_PHONE_API_DISCONNECT_TIMEOUT_MS);
+    });
+    await Promise.race([write, timeout]);
   } catch (e) {
-    // catch-no-log-ok teardown: port may already be gone
+    // catch-no-log-ok teardown: port may already be gone or write hung
     console.debug(
       '[meshtasticPhoneApiDisconnect] ToRadio.disconnect write failed ' + errLikeToLogString(e),
     );
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }

--- a/src/renderer/lib/meshtastic/meshtasticPhoneApiDisconnect.ts
+++ b/src/renderer/lib/meshtastic/meshtasticPhoneApiDisconnect.ts
@@ -1,0 +1,32 @@
+import { create, toBinary } from '@bufbuild/protobuf';
+import type { MeshDevice } from '@meshtastic/core';
+import { Mesh } from '@meshtastic/protobufs';
+
+import { errLikeToLogString } from '../errLikeToLogString';
+import { writeToRadioWithoutQueue } from '../meshtasticBacklogUtils';
+
+/** Encode PhoneAPI ToRadio.disconnect so firmware resets STATE_SEND_* (#895). */
+export function buildToRadioDisconnectBytes(): Uint8Array {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- External SDK value is validated by surrounding boundary logic.
+  const toRadio = create(Mesh.ToRadioSchema, {
+    payloadVariant: { case: 'disconnect', value: true },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- External SDK value is validated by surrounding boundary logic.
+  return toBinary(Mesh.ToRadioSchema, toRadio);
+}
+
+/**
+ * Best-effort ToRadio.disconnect before tearing down a MeshDevice.
+ * Call only for serial (caller gates): without this, firmware PhoneAPI can keep
+ * dumping an orphaned config handshake when the port reopens (#895).
+ */
+export async function sendMeshtasticPhoneApiDisconnect(device: MeshDevice): Promise<void> {
+  try {
+    await writeToRadioWithoutQueue(device, buildToRadioDisconnectBytes());
+  } catch (e) {
+    // catch-no-log-ok teardown: port may already be gone
+    console.debug(
+      '[meshtasticPhoneApiDisconnect] ToRadio.disconnect write failed ' + errLikeToLogString(e),
+    );
+  }
+}

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../lib/bleReconnectExhaustLatch';
 import {
   assertPowerResumeSkipsOnExplicitDisconnect,
+  extractBalancedBlock,
   extractUseCallbackBody,
   loadRendererLibSource,
   loadRuntimeSource,
@@ -345,17 +346,38 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     );
   });
 
-  it('attachRfSession configures before awaiting SQLite node hydrate (#895)', () => {
+  it('attachRfSession configures outside the node-hydrate IIFE (#895)', () => {
     const attachBody = extractUseCallbackBody(SOURCE, 'attachRfSession');
-    // wantConfigId must not wait on SQLite: hydrate runs in a void IIFE, configure is awaited
-    // on the attach path (same as reconnect).
-    expect(attachBody).toMatch(
-      /wireSubscriptions\([\s\S]*?isConfiguringRef\.current = true[\s\S]*?void \(async \(\) => \{[\s\S]*?loadMeshtasticNodeMapFromDb[\s\S]*?await configureMeshtasticDeviceWithRetry/,
+    const voidMarker = 'void (async () => {';
+    let hydrateIifeEnd = -1;
+    for (let searchFrom = 0; searchFrom < attachBody.length;) {
+      const voidIdx = attachBody.indexOf(voidMarker, searchFrom);
+      if (voidIdx === -1) break;
+      const braceIdx = attachBody.indexOf('{', voidIdx);
+      expect(braceIdx).toBeGreaterThan(voidIdx);
+      const body = extractBalancedBlock(attachBody, braceIdx);
+      if (body.includes('loadMeshtasticNodeMapFromDb')) {
+        // Closing `}` of the IIFE body, then `)();`
+        const afterBrace = braceIdx + 1 + body.length;
+        expect(attachBody.slice(afterBrace, afterBrace + 5)).toMatch(/^\}\)\(\);/);
+        hydrateIifeEnd = attachBody.indexOf(';', afterBrace) + 1;
+        break;
+      }
+      searchFrom = voidIdx + 1;
+    }
+    expect(hydrateIifeEnd).toBeGreaterThan(0);
+    const configureIdx = attachBody.indexOf(
+      'await configureMeshtasticDeviceWithRetry',
+      hydrateIifeEnd,
     );
-    const configureIdx = attachBody.indexOf('await configureMeshtasticDeviceWithRetry');
-    const wireIdx = attachBody.indexOf('wireSubscriptions');
-    expect(wireIdx).toBeGreaterThanOrEqual(0);
-    expect(configureIdx).toBeGreaterThan(wireIdx);
+    expect(configureIdx).toBeGreaterThan(hydrateIifeEnd);
+  });
+
+  it('attachRfSession drops delayed node hydrate after reconnect generation bump (#895)', () => {
+    const attachBody = extractUseCallbackBody(SOURCE, 'attachRfSession');
+    expect(attachBody).toMatch(
+      /loadMeshtasticNodeMapFromDb\(\)[\s\S]*?reconnectGenerationRef\.current !== generation[\s\S]*?applyMeshtasticNodesToUi/,
+    );
   });
 
   it('uses nodeStore as the merge base and synchronizes runtime patches immediately', () => {

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -345,6 +345,19 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
     );
   });
 
+  it('attachRfSession configures before awaiting SQLite node hydrate (#895)', () => {
+    const attachBody = extractUseCallbackBody(SOURCE, 'attachRfSession');
+    // wantConfigId must not wait on SQLite: hydrate runs in a void IIFE, configure is awaited
+    // on the attach path (same as reconnect).
+    expect(attachBody).toMatch(
+      /wireSubscriptions\([\s\S]*?isConfiguringRef\.current = true[\s\S]*?void \(async \(\) => \{[\s\S]*?loadMeshtasticNodeMapFromDb[\s\S]*?await configureMeshtasticDeviceWithRetry/,
+    );
+    const configureIdx = attachBody.indexOf('await configureMeshtasticDeviceWithRetry');
+    const wireIdx = attachBody.indexOf('wireSubscriptions');
+    expect(wireIdx).toBeGreaterThanOrEqual(0);
+    expect(configureIdx).toBeGreaterThan(wireIdx);
+  });
+
   it('uses nodeStore as the merge base and synchronizes runtime patches immediately', () => {
     const updateNodesBody = extractUseCallbackBody(SOURCE, 'updateNodes');
     expect(updateNodesBody).toContain('getIdentityNodeMap(identityId)');

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -2647,6 +2647,10 @@ export function useMeshtasticRuntime() {
         let dbCacheNodeCount = 0;
         try {
           const cachedNodes = await loadMeshtasticNodeMapFromDb();
+          // Superseded attach must not stamp a stale snapshot onto a newer session (#895).
+          if (reconnectGenerationRef.current !== generation) {
+            return;
+          }
           dbCacheNodeCount = cachedNodes.size;
           applyMeshtasticNodesToUi(driverIdentityId, cachedNodes);
         } catch (e) {
@@ -2654,6 +2658,9 @@ export function useMeshtasticRuntime() {
             '[useMeshtasticRuntime] attachRfSession db cache hydrate failed ' +
               errLikeToLogString(e),
           );
+        }
+        if (reconnectGenerationRef.current !== generation) {
+          return;
         }
         console.debug(
           `[useMeshtasticRuntime] attachRfSession dbCache→UI ${Math.round(performance.now() - dbCacheStart)}ms (${dbCacheNodeCount} nodes)`,

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -2634,21 +2634,31 @@ export function useMeshtasticRuntime() {
       }
       wireSubscriptions(activeDevice, type, { driverIdentityId });
 
-      // Show persisted nodes immediately while NodeDB configure replays over BLE/serial.
-      const dbCacheStart = performance.now();
-      let dbCacheNodeCount = 0;
-      try {
-        const cachedNodes = await loadMeshtasticNodeMapFromDb();
-        dbCacheNodeCount = cachedNodes.size;
-        applyMeshtasticNodesToUi(driverIdentityId, cachedNodes);
-      } catch (e) {
-        console.warn(
-          '[useMeshtasticRuntime] attachRfSession db cache hydrate failed ' + errLikeToLogString(e),
+      // Configure immediately (same as reconnect). Do not await SQLite hydrate first —
+      // a multi-hundred-ms gap before wantConfigId lets an orphaned PhoneAPI dump
+      // (nodeInfo/fileInfo) overlap a late configure and drop serial on some RAK4631s (#895).
+      isConfiguringRef.current = true;
+      setMeshtasticConfigurePhase(true);
+      meshtasticIngestSessionRef.current?.setConfiguring(true);
+
+      // Show persisted nodes/messages in parallel while NodeDB configure replays.
+      void (async () => {
+        const dbCacheStart = performance.now();
+        let dbCacheNodeCount = 0;
+        try {
+          const cachedNodes = await loadMeshtasticNodeMapFromDb();
+          dbCacheNodeCount = cachedNodes.size;
+          applyMeshtasticNodesToUi(driverIdentityId, cachedNodes);
+        } catch (e) {
+          console.warn(
+            '[useMeshtasticRuntime] attachRfSession db cache hydrate failed ' +
+              errLikeToLogString(e),
+          );
+        }
+        console.debug(
+          `[useMeshtasticRuntime] attachRfSession dbCache→UI ${Math.round(performance.now() - dbCacheStart)}ms (${dbCacheNodeCount} nodes)`,
         );
-      }
-      console.debug(
-        `[useMeshtasticRuntime] attachRfSession dbCache→UI ${Math.round(performance.now() - dbCacheStart)}ms (${dbCacheNodeCount} nodes)`,
-      );
+      })();
 
       void (async () => {
         try {
@@ -2668,9 +2678,6 @@ export function useMeshtasticRuntime() {
         }
       })();
 
-      isConfiguringRef.current = true;
-      setMeshtasticConfigurePhase(true);
-      meshtasticIngestSessionRef.current?.setConfiguring(true);
       await configureMeshtasticDeviceWithRetry(activeDevice, {
         logTag: 'useMeshtasticRuntime attachRfSession',
       });


### PR DESCRIPTION
## Summary
- Start Meshtastic `configure()` immediately in `attachRfSession` (do not await SQLite node hydrate first), matching the working reconnect path.
- Send PhoneAPI `ToRadio.disconnect` on serial `safeDisconnect` so firmware clears orphaned handshake state before the port closes.
- Patch `@meshtastic/core` `decodePacket` to ignore mismatched `configCompleteId` (no false `DeviceConfigured`) and silence known unused FromRadio variants (`fileInfo`, etc.).

Fixes #895 — the `fileInfo` WARN was cosmetic; the drop came from a delayed `wantConfigId` overlapping leftover PhoneAPI dump traffic on some RAK4631 USB CDC links.

## Test plan
- [x] Unit/source-contract: PhoneAPI disconnect helper, serial teardown order, attachRfSession configure-before-hydrate
- [x] Pre-commit Vitest related suite (passed)
- [ ] Manual: USB serial to RAK4631 (or large NodeDB node) — first connect reaches valid config without `Device decoding pipe failed: The device has been lost`
- [ ] Confirm `fileInfo` no longer spams WARN after patch
- [ ] Disconnect/reconnect serial and confirm next connect does not inherit mid-handshake NodeInfo/`fileInfo` dump before `Requesting device configuration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Serial devices now receive a proper disconnect command before teardown.
  - Disconnect cleanup continues safely if sending the command fails or times out.
  - Device configuration begins sooner during reconnection instead of waiting for node-map data to load.
  - Delayed node-map results no longer interfere with a newer reconnection attempt.
- **Tests**
  - Added coverage for disconnect behavior, failed writes, timeouts, and reconnection sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->