### PR TITLE
docs: update third-party licenses

### DIFF
--- a/docs/third-party-licenses.md
+++ b/docs/third-party-licenses.md
@@ -64,8 +64,8 @@ Bundled binaries, fonts, and vendored sources are attributed in [Credits](credit
 | @types/qrcode                         | MIT             | ^1.5.6          | 1.5.6             | https://github.com/DefinitelyTyped/DefinitelyTyped.git                               |
 | @types/react                          | MIT             | ^19.2.18        | 19.2.18           | https://github.com/DefinitelyTyped/DefinitelyTyped.git                               |
 | @types/react-dom                      | MIT             | ^19.2.4         | 19.2.4            | https://github.com/DefinitelyTyped/DefinitelyTyped.git                               |
-| @typescript-eslint/eslint-plugin      | MIT             | ^8.67.0         | 8.67.0            | git+https://github.com/typescript-eslint/typescript-eslint.git                       |
-| @typescript-eslint/parser             | MIT             | ^8.67.0         | 8.67.0            | git+https://github.com/typescript-eslint/typescript-eslint.git                       |
+| @typescript-eslint/eslint-plugin      | MIT             | ^8.67.0         | 8.67.0            | https://github.com/typescript-eslint/typescript-eslint.git                           |
+| @typescript-eslint/parser             | MIT             | ^8.67.0         | 8.67.0            | https://github.com/typescript-eslint/typescript-eslint.git                           |
 | @vitejs/plugin-react                  | MIT             | ^6.1.0          | 6.1.0             | git+https://github.com/vitejs/vite-plugin-react.git                                  |
 | @vitest/coverage-v8                   | MIT             | ^4.1.11         | 4.1.11            | git+https://github.com/vitest-dev/vitest.git                                         |
 | concurrently                          | MIT             | ^9.2.4          | 9.2.4             | git+https://github.com/open-cli-tools/concurrently.git                               |
@@ -97,7 +97,7 @@ Bundled binaries, fonts, and vendored sources are attributed in [Credits](credit
 | sort-package-json                     | MIT             | ^3.7.1          | 3.7.1             | git+ssh://git@github.com/keithamus/sort-package-json.git                             |
 | tailwindcss                           | MIT             | ^4.3.3          | 4.3.3             | https://github.com/tailwindlabs/tailwindcss.git                                      |
 | typescript                            | Apache-2.0      | ^6.0.3          | 6.0.3             | git+https://github.com/microsoft/TypeScript.git                                      |
-| typescript-eslint                     | MIT             | ^8.67.0         | 8.67.0            | git+https://github.com/typescript-eslint/typescript-eslint.git                       |
+| typescript-eslint                     | MIT             | ^8.67.0         | 8.67.0            | https://github.com/typescript-eslint/typescript-eslint.git                           |
 | vite                                  | MIT             | ^8.2.2          | 8.2.2             | git+https://github.com/vitejs/vite.git                                               |
 | vitest                                | MIT             | ^4.1.11         | 4.1.11            | git+https://github.com/vitest-dev/vitest.git                                         |
 | vitest-axe                            | MIT             | 1.0.0-pre.5     | 1.0.0-pre.5       | git+https://github.com/chaance/vitest-axe.git                                        |


### PR DESCRIPTION
Regenerated `docs/third-party-licenses.md` after dependency changes.

Opened automatically by `third-party-licenses.yaml` (direct pushes to
`main` are blocked by the merge-queue ruleset).