### PR TITLE
feat(reticulum): show identity hash in Network identity panel

### DIFF
--- a/src/renderer/components/ReticulumNetworkPanel.test.tsx
+++ b/src/renderer/components/ReticulumNetworkPanel.test.tsx
@@ -171,6 +171,30 @@ describe('ReticulumNetworkPanel', () => {
     expect(img.getAttribute('data-value')).toBe(expected);
   });
 
+  it('renders identity hash label when identity is configured', async () => {
+    render(<ReticulumNetworkPanel connecting={false} onStartStack={async () => {}} />);
+
+    expect(
+      await screen.findByText('connectionPanel.reticulumIdentity.identityHashLabel'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('abc…')).toBeInTheDocument();
+  });
+
+  it('writes full identity hash to clipboard via electronAPI', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.mocked(window.electronAPI.clipboard.writeText);
+    writeText.mockClear();
+
+    render(<ReticulumNetworkPanel connecting={false} onStartStack={async () => {}} />);
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'connectionPanel.reticulumIdentity.copyIdentityHash',
+      }),
+    );
+    expect(writeText).toHaveBeenCalledWith('abc');
+  });
+
   it('writes full LXMF hash to clipboard via electronAPI', async () => {
     const user = userEvent.setup();
     const writeText = vi.mocked(window.electronAPI.clipboard.writeText);

--- a/src/renderer/components/ReticulumNetworkPanel.test.tsx
+++ b/src/renderer/components/ReticulumNetworkPanel.test.tsx
@@ -11,13 +11,19 @@ vi.mock('react-i18next', () => ({
 
 const refreshIdentity = vi.fn();
 
-const identityState = vi.hoisted(() => ({
-  configured: true,
-  identity_hash: 'abc',
-  lxmf_hash: 'def0123456789abcdef0123456789abc',
-  display_name: 'Existing Name',
-  public_key: null as string | null,
-}));
+const { TEST_IDENTITY_HASH, identityState } = vi.hoisted(() => {
+  const TEST_IDENTITY_HASH = 'aabbccddeeff00112233445566778899';
+  return {
+    TEST_IDENTITY_HASH,
+    identityState: {
+      configured: true,
+      identity_hash: TEST_IDENTITY_HASH,
+      lxmf_hash: 'def0123456789abcdef0123456789abc',
+      display_name: 'Existing Name',
+      public_key: null as string | null,
+    },
+  };
+});
 
 vi.mock('@/renderer/lib/reticulum/useReticulumSidecarApi', () => ({
   useReticulumSidecarApi: () => ({
@@ -50,7 +56,7 @@ describe('ReticulumNetworkPanel', () => {
     refreshIdentity.mockReset();
     identityState.public_key = null;
     identityState.lxmf_hash = 'def0123456789abcdef0123456789abc';
-    identityState.identity_hash = 'abc';
+    identityState.identity_hash = TEST_IDENTITY_HASH;
     identityState.display_name = 'Existing Name';
     window.electronAPI.reticulum.proxyGet = vi.fn().mockImplementation((path: string) => {
       if (path === '/api/v1/stack/settings') {
@@ -177,7 +183,7 @@ describe('ReticulumNetworkPanel', () => {
     expect(
       await screen.findByText('connectionPanel.reticulumIdentity.identityHashLabel'),
     ).toBeInTheDocument();
-    expect(screen.getByText('abc…')).toBeInTheDocument();
+    expect(screen.getByText(`${TEST_IDENTITY_HASH.slice(0, 24)}…`)).toBeInTheDocument();
   });
 
   it('writes full identity hash to clipboard via electronAPI', async () => {
@@ -192,7 +198,7 @@ describe('ReticulumNetworkPanel', () => {
         name: 'connectionPanel.reticulumIdentity.copyIdentityHash',
       }),
     );
-    expect(writeText).toHaveBeenCalledWith('abc');
+    expect(writeText).toHaveBeenCalledWith(TEST_IDENTITY_HASH);
   });
 
   it('writes full LXMF hash to clipboard via electronAPI', async () => {

--- a/src/renderer/components/ReticulumNetworkPanel.tsx
+++ b/src/renderer/components/ReticulumNetworkPanel.tsx
@@ -1416,6 +1416,7 @@ function IdentityConfiguredView({
     setNameDraft(identity?.display_name?.trim() ?? '');
   }, [identity?.display_name]);
 
+  const identityHash = identity?.identity_hash?.trim() ?? '';
   const lxmfHash = identity?.lxmf_hash?.trim() ?? '';
   const [showIdentityQr, setShowIdentityQr] = useState(false);
   const identityQrUri = useMemo(() => {
@@ -1441,6 +1442,15 @@ function IdentityConfiguredView({
     }
   }, [identity, lxmfHash]);
 
+  const copyIdentityHash = useCallback(async () => {
+    if (!identityHash) return;
+    try {
+      await writeClipboardText(identityHash);
+    } catch (e) {
+      console.warn('[ReticulumNetworkPanel] copy identity hash ' + errLikeToLogString(e));
+    }
+  }, [identityHash]);
+
   const copyLxmfHash = useCallback(async () => {
     if (!lxmfHash) return;
     try {
@@ -1465,6 +1475,26 @@ function IdentityConfiguredView({
 
   return (
     <div className="mt-3 space-y-1 text-sm text-gray-300">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-muted">
+          {t('connectionPanel.reticulumIdentity.identityHashLabel')}
+        </span>
+        <code className="text-gray-200" title={identityHash || undefined}>
+          {identityHash ? `${identityHash.slice(0, 24)}…` : '—'}
+        </code>
+        {identityHash ? (
+          <button
+            type="button"
+            className="shrink-0 text-gray-400 hover:text-gray-300"
+            aria-label={t('connectionPanel.reticulumIdentity.copyIdentityHash')}
+            onClick={() => {
+              void copyIdentityHash();
+            }}
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
+      </div>
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-muted">{t('connectionPanel.reticulumIdentity.hashLabel')}</span>
         <code className="text-amber-300" title={lxmfHash || undefined}>

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -1050,7 +1050,9 @@
       "importBackupAria": "Importovat zálohu Ratspeak .rsi z vloženého JSON",
       "importBackupFromFileAria": "Vyberte záložní soubor Ratspeak .rsi, který chcete importovat",
       "exportAria": "Exportovat zálohu identity Ratspeak .rsi šifrovanou pomocí kódu PIN",
-      "exportRawAria": "Exportovat nešifrovaný soubor identity RAW Reticulum"
+      "exportRawAria": "Exportovat nešifrovaný soubor identity RAW Reticulum",
+      "identityHashLabel": "Hash identity:",
+      "copyIdentityHash": "Kopírovat hash identity"
     },
     "reticulumInterfaces": {
       "title": "Rozhraní",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -1047,7 +1047,9 @@
       "importBackupAria": "Ratspeak .rsi-Backup aus eingefügtem json importieren",
       "importBackupFromFileAria": "Wählen Sie eine Ratspeak .rsi Backup-Datei zum Importieren",
       "exportAria": "PIN-verschlüsselte Ratspeak .rsi-Identitätssicherung exportieren",
-      "exportRawAria": "Unverschlüsselte RAW-Reticulum-Identitätsdatei exportieren"
+      "exportRawAria": "Unverschlüsselte RAW-Reticulum-Identitätsdatei exportieren",
+      "identityHashLabel": "Identitäts-Hash:",
+      "copyIdentityHash": "Identitäts-Hash kopieren"
     },
     "reticulumInterfaces": {
       "title": "Schnittstellen",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -1018,6 +1018,8 @@
       "replaceIdentityConfirmAction": "Replace identity",
       "mnemonic": "Write down this phrase and store it safely.",
       "confirmSaved": "I have saved my recovery phrase",
+      "identityHashLabel": "Identity hash:",
+      "copyIdentityHash": "Copy identity hash",
       "hashLabel": "LXMF hash:",
       "copyLxmfHash": "Copy LXMF hash",
       "saveDisplayName": "Save display name",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -1049,7 +1049,9 @@
       "importBackupAria": "Importar copia de seguridad de Ratspeak .rsi desde JSON pegado",
       "importBackupFromFileAria": "Elija un archivo de copia de seguridad .rsi de Ratspeak para importar",
       "exportAria": "Exportar copia de seguridad de identidad Ratspeak .rsi cifrada con PIN",
-      "exportRawAria": "Exportar archivo de identidad de Reticulum sin cifrar"
+      "exportRawAria": "Exportar archivo de identidad de Reticulum sin cifrar",
+      "identityHashLabel": "Hash de identidad:",
+      "copyIdentityHash": "Copiar hash de identidad"
     },
     "reticulumInterfaces": {
       "title": "Interfaces",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -1048,7 +1048,9 @@
       "importBackupAria": "Importer la sauvegarde Ratspeak .rsi à partir de JSON collé",
       "importBackupFromFileAria": "Choisissez un fichier de sauvegarde Ratspeak .rsi à importer",
       "exportAria": "Exporter la sauvegarde d'identité Ratspeak .rsi chiffrée par code PIN",
-      "exportRawAria": "Exporter le fichier d'identité RAW Reticulum non chiffré"
+      "exportRawAria": "Exporter le fichier d'identité RAW Reticulum non chiffré",
+      "identityHashLabel": "Hachage d'identité :",
+      "copyIdentityHash": "Copier le hachage d'identité"
     },
     "reticulumInterfaces": {
       "title": "Interfaces",

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -1049,7 +1049,9 @@
       "importBackupAria": "Impor cadangan Ratspeak .rsi dari JSON yang ditempelkan",
       "importBackupFromFileAria": "Pilih file cadangan Ratspeak .rsi untuk diimpor",
       "exportAria": "Ekspor cadangan identitas Ratspeak .rsi terenkripsi PIN",
-      "exportRawAria": "Ekspor file identitas Reticulum mentah yang tidak terenkripsi"
+      "exportRawAria": "Ekspor file identitas Reticulum mentah yang tidak terenkripsi",
+      "identityHashLabel": "Hash identitas:",
+      "copyIdentityHash": "Salin hash identitas"
     },
     "reticulumInterfaces": {
       "title": "Interface",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -1047,7 +1047,9 @@
       "importBackupAria": "Importa il backup Ratspeak .rsi da JSON incollato",
       "importBackupFromFileAria": "Scegli un file di backup Ratspeak .rsi da importare",
       "exportAria": "Esporta il backup dell'identità Ratspeak .rsi crittografato con PIN",
-      "exportRawAria": "Esporta file di identità RAW Reticulum non crittografato"
+      "exportRawAria": "Esporta file di identità RAW Reticulum non crittografato",
+      "identityHashLabel": "Hash identità:",
+      "copyIdentityHash": "Copia hash dell'identità"
     },
     "reticulumInterfaces": {
       "title": "interfacce",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -1049,7 +1049,9 @@
       "importBackupAria": "貼り付けられたJSONからRatspeak .rsiバックアップをインポートする",
       "importBackupFromFileAria": "インポートするRatspeak .rsiバックアップファイルを選択してください",
       "exportAria": "PIN暗号化されたRatspeak .rsi IDバックアップをエクスポート",
-      "exportRawAria": "暗号化されていないRAW Reticulum IDファイルをエクスポート"
+      "exportRawAria": "暗号化されていないRAW Reticulum IDファイルをエクスポート",
+      "identityHashLabel": "IDハッシュ：",
+      "copyIdentityHash": "IDハッシュをコピー"
     },
     "reticulumInterfaces": {
       "title": "インターフェース",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -1049,7 +1049,9 @@
       "importBackupAria": "붙여넣은 JSON에서 Ratspeak .rsi 백업 가져오기",
       "importBackupFromFileAria": "가져올 Ratspeak .rsi 백업 파일 선택",
       "exportAria": "PIN 암호화 Ratspeak .rsi ID 백업 내보내기",
-      "exportRawAria": "암호화되지 않은 원시 Reticulum ID 파일 내보내기"
+      "exportRawAria": "암호화되지 않은 원시 Reticulum ID 파일 내보내기",
+      "identityHashLabel": "ID 해시:",
+      "copyIdentityHash": "ID 해시 복사"
     },
     "reticulumInterfaces": {
       "title": "연계 문서",

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -1048,7 +1048,9 @@
       "importBackupAria": "Importeer Ratspeak .rsi back-up van geplakte JSON",
       "importBackupFromFileAria": "Kies een Ratspeak .rsi back-upbestand om te importeren",
       "exportAria": "Export PIN-gecodeerde Ratspeak .rsi identiteitsback-up",
-      "exportRawAria": "Exporteer niet-versleuteld RAW Reticulum-identiteitsbestand"
+      "exportRawAria": "Exporteer niet-versleuteld RAW Reticulum-identiteitsbestand",
+      "identityHashLabel": "Identiteitshash:",
+      "copyIdentityHash": "Identiteitshash kopiëren"
     },
     "reticulumInterfaces": {
       "title": "Raakvlakken",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -1051,7 +1051,9 @@
       "importBackupAria": "Importuj kopię zapasową Ratspeak .rsi z wklejonego JSON",
       "importBackupFromFileAria": "Wybierz plik kopii zapasowej Ratspeak .rsi do zaimportowania",
       "exportAria": "Eksportuj zaszyfrowaną kodem PIN kopię zapasową tożsamości Ratspeak .rsi",
-      "exportRawAria": "Eksportuj niezaszyfrowany surowy plik tożsamości Reticulum"
+      "exportRawAria": "Eksportuj niezaszyfrowany surowy plik tożsamości Reticulum",
+      "identityHashLabel": "Skrót tożsamości:",
+      "copyIdentityHash": "Skopiuj skrót tożsamości"
     },
     "reticulumInterfaces": {
       "title": "Interfejsy",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -1049,7 +1049,9 @@
       "importBackupAria": "Importar backup do Ratspeak .rsi do JSON colado",
       "importBackupFromFileAria": "Escolha um arquivo de backup Ratspeak .rsi para importar",
       "exportAria": "Exportar backup de identidade Ratspeak .rsi criptografado por PIN",
-      "exportRawAria": "Exportar arquivo de identidade Reticulum bruto não criptografado"
+      "exportRawAria": "Exportar arquivo de identidade Reticulum bruto não criptografado",
+      "identityHashLabel": "Hash de identidade:",
+      "copyIdentityHash": "Copiar hash de identidade"
     },
     "reticulumInterfaces": {
       "title": "Interfaces",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -1051,7 +1051,9 @@
       "importBackupAria": "Импорт резервной копии Ratspeak .rsi из вставленного JSON",
       "importBackupFromFileAria": "Выберите файл резервной копии Ratspeak .rsi для импорта",
       "exportAria": "Экспорт зашифрованной PIN-кодом резервной копии удостоверения Ratspeak .rsi",
-      "exportRawAria": "Экспорт незашифрованного файла идентификации Reticulum"
+      "exportRawAria": "Экспорт незашифрованного файла идентификации Reticulum",
+      "identityHashLabel": "Хэш удостоверения:",
+      "copyIdentityHash": "Копировать хэш удостоверения"
     },
     "reticulumInterfaces": {
       "title": "Интерфейсы",

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -1049,7 +1049,9 @@
       "importBackupAria": "Yapıştırılan JSON'dan Ratspeak .rsi yedeklemesini içe aktar",
       "importBackupFromFileAria": "İçe aktarmak için bir Ratspeak .rsi yedek dosyası seçin",
       "exportAria": "PIN şifreli Ratspeak .rsi kimlik yedeklemesini dışa aktarın",
-      "exportRawAria": "Şifrelenmemiş ham Reticulum kimlik dosyasını dışa aktar"
+      "exportRawAria": "Şifrelenmemiş ham Reticulum kimlik dosyasını dışa aktar",
+      "identityHashLabel": "Kimlik hash'i:",
+      "copyIdentityHash": "Kimlik karmasını kopyala"
     },
     "reticulumInterfaces": {
       "title": "Ara birimler",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -1051,7 +1051,9 @@
       "importBackupAria": "Імпортувати резервну копію Ratspeak .rsi зі вставленого JSON",
       "importBackupFromFileAria": "Виберіть файл резервної копії Ratspeak .rsi для імпорту",
       "exportAria": "Експортувати резервну копію ідентифікатора Ratspeak .rsi, зашифровану PIN-кодом",
-      "exportRawAria": "Експортувати незашифрований файл ідентифікації Reticulum"
+      "exportRawAria": "Експортувати незашифрований файл ідентифікації Reticulum",
+      "identityHashLabel": "Хеш посвідчення особи:",
+      "copyIdentityHash": "Скопіювати хеш посвідчення особи"
     },
     "reticulumInterfaces": {
       "title": "Інтерфейси",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -1049,7 +1049,9 @@
       "importBackupAria": "从粘贴的JSON导入Ratspeak .rsi备份",
       "importBackupFromFileAria": "选择要导入的Ratspeak .rsi备份文件",
       "exportAria": "导出PIN加密的Ratspeak .rsi身份备份",
-      "exportRawAria": "导出未加密的原始 Reticulum 身份文件"
+      "exportRawAria": "导出未加密的原始 Reticulum 身份文件",
+      "identityHashLabel": "标识哈希：",
+      "copyIdentityHash": "复制标识哈希"
     },
     "reticulumInterfaces": {
       "title": "接口",


### PR DESCRIPTION
## Summary
- Add core Reticulum **identity hash** display and copy button to Network > Reticulum Identity (above the existing LXMF hash row)
- Uses `identity_hash` already returned by `/api/v1/identity/status` — no sidecar or store changes
- Clarifies labeling: identity hash (core) vs LXMF hash (derived for messaging)

Fixes #900

## Test plan
- [x] `pnpm run test:run -- ReticulumNetworkPanel.test.tsx` (23 tests pass)
- [ ] Manual: Network tab → Reticulum Identity → confirm both identity hash and LXMF hash show when configured
- [ ] Manual: Copy buttons write full hash values to clipboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added display of the configured identity hash in the Reticulum network panel.
  * Added a copy button to copy the full identity hash to the clipboard.
  * Identity hashes are shortened for easier viewing while preserving the full value when copied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->