### PR TITLE
fix(rrc): clear unread badges when caught up at bottom

### DIFF
--- a/src/renderer/components/RrcPanel.test.tsx
+++ b/src/renderer/components/RrcPanel.test.tsx
@@ -574,6 +574,60 @@ describe('RrcPanel', () => {
     expect(window.electronAPI.reticulum.rrc.disconnect).not.toHaveBeenCalled();
   });
 
+  it('clears unread when returning to pinned active room after traffic while away', async () => {
+    const store = useRrcSessionStore.getState();
+    store.applyStatus('active', hubA, 'Hub A');
+    store.roomJoined('#lobby');
+    store.setActiveRoom('#lobby');
+    store.addMessage(
+      {
+        id: 'seed',
+        room: '#lobby',
+        kind: 'msg',
+        body: 'seed',
+        sender_hash: 'cccccccccccccccccccccccccccccccc',
+        timestamp: 1,
+      },
+      { bumpUnread: false },
+    );
+
+    const { rerender } = render(<RrcPanel isActive />);
+    await waitFor(() => {
+      expect(screen.getByTestId('rrc-message-stream')).toBeInTheDocument();
+    });
+
+    const stream = screen.getByTestId('rrc-message-stream');
+    Object.defineProperty(stream, 'scrollHeight', { value: 400, configurable: true });
+    Object.defineProperty(stream, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(stream, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+
+    rerender(<RrcPanel isActive={false} />);
+
+    useRrcSessionStore.getState().setRrcPanelFocused(false);
+    useRrcSessionStore.getState().addMessage(
+      {
+        id: 'away-1',
+        room: '#lobby',
+        kind: 'msg',
+        body: 'while away',
+        sender_hash: 'dddddddddddddddddddddddddddddddd',
+        timestamp: 2,
+      },
+      { bumpUnread: true },
+    );
+    expect(useRrcSessionStore.getState().totalUnread()).toBe(1);
+
+    rerender(<RrcPanel isActive />);
+
+    await waitFor(() => {
+      expect(useRrcSessionStore.getState().totalUnread()).toBe(0);
+    });
+  });
+
   it('sends one hub-global /who for an empty joined roster', async () => {
     const store = useRrcSessionStore.getState();
     store.applyStatus('active', hubA, 'Hub A');

--- a/src/renderer/components/RrcPanel.test.tsx
+++ b/src/renderer/components/RrcPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
@@ -23,11 +23,16 @@ import {
 } from '@/renderer/lib/rrcHubDisconnectSuppress';
 import { saveRrcHubAutoJoin } from '@/renderer/lib/rrcHubPrefs';
 import { clearRrcOpenDms, loadRrcOpenDms, upsertRrcOpenDm } from '@/renderer/lib/rrcOpenDms';
-import { resetRrcRoomHistoryForTests } from '@/renderer/lib/rrcRoomHistory';
+import { hydrateRrcRoomMessages, resetRrcRoomHistoryForTests } from '@/renderer/lib/rrcRoomHistory';
 import { useRrcHubStore } from '@/renderer/stores/rrcHubStore';
-import { useRrcSessionStore } from '@/renderer/stores/rrcSessionStore';
+import { selectRrcActiveRoomMessages, useRrcSessionStore } from '@/renderer/stores/rrcSessionStore';
 
 import RrcPanel from './RrcPanel';
+
+function ActiveRoomMessageCountProbe() {
+  const count = useRrcSessionStore((s) => selectRrcActiveRoomMessages(s).length);
+  return <div data-testid="active-room-message-count">{count}</div>;
+}
 
 vi.mock('@/renderer/lib/reticulum/reticulumSidecarReads', () => ({
   isReticulumSidecarRunning: vi.fn(() => Promise.resolve(false)),
@@ -263,6 +268,53 @@ describe('RrcPanel', () => {
       expect(window.electronAPI.db.deleteRrcMessagesByRoom).toHaveBeenCalledWith(hubA, 'lobby');
     });
     expect(useRrcSessionStore.getState().messages.get(`${hubA}::lobby`)).toBeUndefined();
+  });
+
+  it('shows SQLite history merged by hydrateRrcRoomMessages after mount', async () => {
+    const store = useRrcSessionStore.getState();
+    store.applyStatus('active', hubA, 'Hub A');
+    store.roomJoined('#lobby');
+    store.setActiveRoom('#lobby');
+    store.addMessage({
+      id: 'live-1',
+      room: '#lobby',
+      kind: 'msg',
+      body: 'live only',
+      sender_hash: 'cccccccccccccccccccccccccccccccc',
+      timestamp: 200,
+    });
+
+    render(
+      <>
+        <ActiveRoomMessageCountProbe />
+        <RrcPanel isActive />
+      </>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /Message or \/command/i })).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('active-room-message-count')).toHaveTextContent('1');
+
+    vi.mocked(window.electronAPI.db.listRrcMessages).mockResolvedValueOnce([
+      {
+        message_id: 'hist-1',
+        hub_hash: hubA,
+        room: 'lobby',
+        sender_hash: null,
+        nickname: 'alice',
+        kind: 'msg',
+        body: 'from sqlite',
+        timestamp: 100,
+      },
+    ]);
+
+    await act(async () => {
+      await hydrateRrcRoomMessages(hubA, '#lobby', { force: true });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-room-message-count')).toHaveTextContent('2');
+    });
   });
 
   it('Disconnect with hub auto-join does not reconnect via rrc.connect', async () => {

--- a/src/renderer/components/RrcPanel.tsx
+++ b/src/renderer/components/RrcPanel.tsx
@@ -54,6 +54,7 @@ import {
   MAX_RRC_HUB_SESSIONS,
   RRC_HUB_STREAM_ROOM,
   RRC_NICKNAME_STORAGE_KEY,
+  selectRrcActiveRoomMessages,
   useRrcSessionStore,
 } from '@/renderer/stores/rrcSessionStore';
 import type { RrcHubInfo, RrcRoomMember } from '@/shared/rrc-types';
@@ -131,7 +132,6 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
   const clearUnread = useRrcSessionStore((s) => s.clearUnread);
   const clearActiveRoomMessages = useRrcSessionStore((s) => s.clearActiveRoomMessages);
   const addMessage = useRrcSessionStore((s) => s.addMessage);
-  const messagesForActiveRoom = useRrcSessionStore((s) => s.messagesForActiveRoom);
   const markPartIntent = useRrcSessionStore((s) => s.markPartIntent);
   const localIdentityHash = useRrcSessionStore((s) => s.localIdentityHash);
   const setDisconnectIntent = useRrcSessionStore((s) => s.setDisconnectIntent);
@@ -427,7 +427,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
     [recentRooms, joinedKeys, listedRooms],
   );
 
-  const activeMessages = messagesForActiveRoom();
+  const activeMessages = useRrcSessionStore(selectRrcActiveRoomMessages);
   const activeRoomInfo = activeRoom ? rooms.get(activeRoom) : undefined;
   const muteKey = hubDestHash && activeRoom ? `rrc:${hubDestHash}:${activeRoom}` : null;
   const isMuted = muteKey ? mutedViews.has(muteKey) : false;

--- a/src/renderer/components/RrcPanel.tsx
+++ b/src/renderer/components/RrcPanel.tsx
@@ -116,7 +116,6 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
   const nickname = useRrcSessionStore((s) => s.nickname);
   const rooms = useRrcSessionStore((s) => s.rooms);
   const listedRooms = useRrcSessionStore((s) => s.listedRooms);
-  const messages = useRrcSessionStore((s) => s.messages);
   const activeRoom = useRrcSessionStore((s) => s.activeRoom);
   const lastError = useRrcSessionStore((s) => s.lastError);
   const moderationBanner = useRrcSessionStore((s) => s.moderationBanner);
@@ -242,9 +241,10 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
     };
   }, [isActive, setRrcPanelFocused]);
 
-  useEffect(() => {
-    if (isActive && activeRoom) clearUnread(activeRoom);
-  }, [isActive, activeRoom, clearUnread, messages]);
+  const handleCaughtUp = useCallback(() => {
+    if (!isActive || !activeRoom || !hubDestHash) return;
+    clearUnread(activeRoom, hubDestHash);
+  }, [isActive, activeRoom, hubDestHash, clearUnread]);
 
   const sendHubCommand = useCallback(
     async (body: string) => {
@@ -1230,6 +1230,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
             alwaysShowMessageActions={alwaysShowMessageActions}
             placeholder={whisperComposerPlaceholder}
             isActive={isActive}
+            onCaughtUp={handleCaughtUp}
           />
           {showNicklist && (
             <RrcNickList

--- a/src/renderer/components/rrc/RrcChatView.test.tsx
+++ b/src/renderer/components/rrc/RrcChatView.test.tsx
@@ -626,4 +626,49 @@ describe('RrcChatView stick-to-bottom', () => {
     expect(mockScrollToEnd).toHaveBeenCalled();
     expect((stream as HTMLDivElement).scrollTop).toBe(900);
   });
+
+  it('calls onCaughtUp after pinned tab re-entry when near bottom', async () => {
+    const onCaughtUp = vi.fn();
+    const { rerender } = render(
+      <RrcChatView
+        {...baseProps}
+        isActive
+        onCaughtUp={onCaughtUp}
+        messages={[makeMsg({ id: '1', body: 'one' })]}
+      />,
+    );
+    const stream = screen.getByTestId('rrc-message-stream');
+    Object.defineProperty(stream, 'scrollHeight', { value: 400, configurable: true });
+    Object.defineProperty(stream, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(stream, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+
+    rerender(
+      <RrcChatView
+        {...baseProps}
+        isActive={false}
+        onCaughtUp={onCaughtUp}
+        messages={[makeMsg({ id: '1', body: 'one' })]}
+      />,
+    );
+
+    mockScrollToEnd.mockClear();
+    onCaughtUp.mockClear();
+
+    rerender(
+      <RrcChatView
+        {...baseProps}
+        isActive
+        onCaughtUp={onCaughtUp}
+        messages={[makeMsg({ id: '1', body: 'one' }), makeMsg({ id: '2', body: 'two' })]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onCaughtUp).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/renderer/components/rrc/RrcChatView.tsx
+++ b/src/renderer/components/rrc/RrcChatView.tsx
@@ -174,6 +174,8 @@ export interface RrcChatViewProps {
   placeholder?: string;
   /** When false, skip follow-on-append and snapshot scroll for tab restore. */
   isActive?: boolean;
+  /** Called when the user has scrolled to (or restored) the latest messages. */
+  onCaughtUp?: () => void;
 }
 
 export function RrcChatView({
@@ -192,6 +194,7 @@ export function RrcChatView({
   alwaysShowMessageActions = false,
   placeholder,
   isActive = true,
+  onCaughtUp,
 }: RrcChatViewProps) {
   const { t } = useTranslation();
   const { inactive: appWindowInactive } = useAppWindowActivity();
@@ -340,16 +343,32 @@ export function RrcChatView({
     return getDistFromChatBottom(scrollContainerRef.current, messagesEndRef.current, null);
   }, [computeIsAtChatEnd]);
 
+  const applyNearBottomCaughtUp = useCallback(
+    (distFromBottom: number) => {
+      if (!isActive || appWindowInactive || distFromBottom >= 50) return;
+      onCaughtUp?.();
+    },
+    [appWindowInactive, isActive, onCaughtUp],
+  );
+
   const handleStreamScroll = useCallback(() => {
     streamPinRef.current = false;
-    updateScrollButtonVisibility();
-  }, [updateScrollButtonVisibility]);
+    const distFromBottom = updateScrollButtonVisibility();
+    if (distFromBottom != null) applyNearBottomCaughtUp(distFromBottom);
+  }, [applyNearBottomCaughtUp, updateScrollButtonVisibility]);
 
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
-    messageVirtualizerRef.current.scrollToEnd({ behavior });
-    isPinnedToBottomRef.current = true;
-    setShowScrollButton(false);
-  }, []);
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'auto') => {
+      messageVirtualizerRef.current.scrollToEnd({ behavior });
+      isPinnedToBottomRef.current = true;
+      setShowScrollButton(false);
+      requestAnimationFrame(() => {
+        const dist = updateScrollButtonVisibility();
+        if (dist != null) applyNearBottomCaughtUp(dist);
+      });
+    },
+    [applyNearBottomCaughtUp, updateScrollButtonVisibility],
+  );
 
   /** Last visible id — rooms at the 500-message cap grow without length change. */
   const latestVisibleMessageId =
@@ -362,7 +381,8 @@ export function RrcChatView({
       messageVirtualizerRef.current.scrollToEnd();
     }
     requestAnimationFrame(() => {
-      updateScrollButtonVisibility();
+      const dist = updateScrollButtonVisibility();
+      if (dist != null) applyNearBottomCaughtUp(dist);
     });
   }, [
     visibleMessages.length,
@@ -371,6 +391,7 @@ export function RrcChatView({
     activeRoom,
     appWindowInactive,
     updateScrollButtonVisibility,
+    applyNearBottomCaughtUp,
   ]);
 
   // Hub and/or room switch while active → pin + scroll to end.
@@ -413,6 +434,10 @@ export function RrcChatView({
           messageVirtualizerRef.current.scrollToEnd();
           isPinnedToBottomRef.current = true;
           setShowScrollButton(false);
+          requestAnimationFrame(() => {
+            const dist = updateScrollButtonVisibility();
+            if (dist != null) applyNearBottomCaughtUp(dist);
+          });
         } else if (el) {
           el.scrollTop = savedScrollTopRef.current;
         }
@@ -420,7 +445,21 @@ export function RrcChatView({
         savedWasPinnedToBottomRef.current = false;
       }
     }
-  }, [isActive]);
+  }, [applyNearBottomCaughtUp, isActive, updateScrollButtonVisibility]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const onFocus = () => {
+      requestAnimationFrame(() => {
+        const dist = updateScrollButtonVisibility();
+        if (dist != null) applyNearBottomCaughtUp(dist);
+      });
+    };
+    window.addEventListener('focus', onFocus);
+    return () => {
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [applyNearBottomCaughtUp, isActive, updateScrollButtonVisibility]);
 
   useLayoutEffect(() => {
     requestAnimationFrame(() => {

--- a/src/renderer/stores/rrcSessionStore.test.ts
+++ b/src/renderer/stores/rrcSessionStore.test.ts
@@ -207,6 +207,37 @@ describe('rrcSessionStore', () => {
     expect(useRrcSessionStore.getState().totalUnread()).toBe(1);
   });
 
+  it('clearUnread drops live room counts and stashed unreadByHub for the hub', () => {
+    const store = useRrcSessionStore.getState();
+    const hub = '28c7c1a68c735693aa8e6b8193ed44b2';
+    store.applyStatus('active', hub, 'Community');
+    store.roomJoined('#lobby');
+    store.setActiveRoom('#lobby');
+    store.setRrcPanelFocused(false);
+    store.addMessage(
+      {
+        id: '1',
+        room: '#lobby',
+        kind: 'msg',
+        body: 'hi',
+        sender_hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        timestamp: 1,
+      },
+      { bumpUnread: true },
+    );
+    useRrcSessionStore.setState({
+      unreadByHub: new Map([[hub, 17]]),
+    });
+    expect(useRrcSessionStore.getState().totalUnread()).toBe(18);
+
+    store.clearUnread('#lobby', hub);
+
+    expect(useRrcSessionStore.getState().unreadByRoom.get('lobby')).toBeUndefined();
+    expect(useRrcSessionStore.getState().unreadByHub.get(hub)).toBeUndefined();
+    expect(useRrcSessionStore.getState().unreadForHub(hub)).toBe(0);
+    expect(useRrcSessionStore.getState().totalUnread()).toBe(0);
+  });
+
   it('does not bump unread for self echo', () => {
     const store = useRrcSessionStore.getState();
     store.applyStatus('active', '28c7c1a68c735693aa8e6b8193ed44b2', 'Community');

--- a/src/renderer/stores/rrcSessionStore.test.ts
+++ b/src/renderer/stores/rrcSessionStore.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@/renderer/lib/rrcLegacyWhispersMigrate';
 import { clearRrcOpenDms, loadRrcOpenDms, saveRrcOpenDms } from '@/renderer/lib/rrcOpenDms';
 
-import { useRrcSessionStore } from './rrcSessionStore';
+import { selectRrcActiveRoomMessages, useRrcSessionStore } from './rrcSessionStore';
 
 describe('rrcSessionStore', () => {
   beforeEach(() => {
@@ -236,6 +236,40 @@ describe('rrcSessionStore', () => {
     expect(useRrcSessionStore.getState().unreadByHub.get(hub)).toBeUndefined();
     expect(useRrcSessionStore.getState().unreadForHub(hub)).toBe(0);
     expect(useRrcSessionStore.getState().totalUnread()).toBe(0);
+  });
+
+  it('selectRrcActiveRoomMessages tracks the focused hub active room bucket', () => {
+    const store = useRrcSessionStore.getState();
+    const hub = '28c7c1a68c735693aa8e6b8193ed44b2';
+    store.applyStatus('active', hub, 'Community');
+    store.roomJoined('#lobby');
+    store.setActiveRoom('#lobby');
+    expect(selectRrcActiveRoomMessages(useRrcSessionStore.getState())).toEqual([]);
+
+    store.addMessage({
+      id: '1',
+      room: '#lobby',
+      kind: 'msg',
+      body: 'live',
+      timestamp: 1,
+    });
+    expect(selectRrcActiveRoomMessages(useRrcSessionStore.getState()).map((m) => m.id)).toEqual([
+      '1',
+    ]);
+
+    store.mergeHistoryMessages(hub, '#lobby', [
+      {
+        id: 'hist',
+        room: 'lobby',
+        kind: 'msg',
+        body: 'sqlite',
+        timestamp: 0,
+      },
+    ]);
+    expect(selectRrcActiveRoomMessages(useRrcSessionStore.getState()).map((m) => m.id)).toEqual([
+      'hist',
+      '1',
+    ]);
   });
 
   it('does not bump unread for self echo', () => {

--- a/src/renderer/stores/rrcSessionStore.ts
+++ b/src/renderer/stores/rrcSessionStore.ts
@@ -911,15 +911,21 @@ export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
   },
 
   clearUnread: (room, hubHash) => {
-    set((s) =>
-      mutateHubSession(s, hubHash, (session) => {
+    set((s) => {
+      const hub = hubHash !== undefined ? normHub(hubHash) : s.focusedHubHash;
+      if (!hub) return {};
+      const sessionMut = mutateHubSession(s, hub, (session) => {
         const unreadByRoom = new Map(session.unreadByRoom);
         for (const [rk] of session.unreadByRoom) {
           if (rrcRoomsMatch(rk, room)) unreadByRoom.delete(rk);
         }
         return { ...session, unreadByRoom };
-      }),
-    );
+      });
+      if (Object.keys(sessionMut).length === 0) return {};
+      const unreadByHub = new Map(s.unreadByHub);
+      unreadByHub.delete(hub);
+      return { ...sessionMut, unreadByHub };
+    });
   },
 
   clearActiveRoomMessages: (hubHash) => {

--- a/src/renderer/stores/rrcSessionStore.ts
+++ b/src/renderer/stores/rrcSessionStore.ts
@@ -399,6 +399,20 @@ function loadInitialRrcNickname(): string {
   return 'mesh-client';
 }
 
+const EMPTY_ACTIVE_ROOM_MESSAGES: RrcChatMessage[] = [];
+
+/**
+ * Zustand selector for the focused hub's active-room transcript. Reads one Map
+ * bucket so components re-render when that room's array changes, not when
+ * subscribing to the stable `messagesForActiveRoom` action reference.
+ */
+export function selectRrcActiveRoomMessages(s: RrcSessionStoreState): RrcChatMessage[] {
+  const hub = s.focusedHubHash;
+  const room = s.activeRoom;
+  if (!hub || !room) return EMPTY_ACTIVE_ROOM_MESSAGES;
+  return s.messages.get(msgKey(hub, room)) ?? EMPTY_ACTIVE_ROOM_MESSAGES;
+}
+
 export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
   sessionsByHub: new Map(),
   focusedHubHash: null,


### PR DESCRIPTION
## Summary

Fixes RRC unread badges (sidebar RRC tab, Reticulum protocol-switcher pill, and hub-browser row) that stayed visible after returning to a room you were already pinned to the bottom of.

When new RRC traffic arrived while you were on another panel or protocol, the transcript correctly restored to the latest message, but unread counts never dropped — e.g. a **18** badge on both the sidebar and the Colorado Mesh hub row even though the chat was showing the newest line.

This aligns RRC with the Chat/Rooms **caught-up** contract: unread clears when you are near the bottom (<50px) of the active room, not merely when the panel becomes visible.

## Root cause

Two gaps compared to Chat/Rooms:

1. **No scroll-aware caught-up path.** `RrcPanel` called `clearUnread(activeRoom)` synchronously when `isActive` flipped true, before the virtualizer finished restoring pinned scroll. `RrcChatView` restored pin state on tab return but never signaled “caught up” after scroll settled.

2. **`clearUnread` only cleared `unreadByRoom`.** Hub badges use `unreadForHub()`, which falls back to stashed `unreadByHub` after disconnect/reconnect. Room-level clear could leave a stale hub stash (matching persistent hub-browser badges while the session was live).

## Changes

### `rrcSessionStore.ts`
- `clearUnread(room, hubHash?)` now also deletes the matching `unreadByHub` entry for the resolved hub.
- Hub is resolved explicitly (`hubHash ?? focusedHubHash`) before mutating.

### `RrcChatView.tsx`
- New optional `onCaughtUp` callback.
- `applyNearBottomCaughtUp` (same 50px threshold and window-focus gate as Chat/Rooms) fires on:
  - Scroll near bottom
  - Pinned tab return (after `scrollToEnd` + `requestAnimationFrame`)
  - New messages while pinned and active
  - Window refocus while near bottom
  - Jump to Latest click

### `RrcPanel.tsx`
- Replaced blunt `isActive` → `clearUnread` effect with `handleCaughtUp`, wired to `RrcChatView` and passing `hubDestHash`.
- Removed unused `messages` store subscription.

## Commits

- `14100353` fix(rrc): clear unread badges when caught up at bottom

## Out of scope

- In-thread “New messages” divider for RRC (badges only today).
- Clearing unread for **other rooms** on the same hub when only the active room is caught up (hub badge should still reflect other rooms until opened).
- LXMF Chat watermark behavior (separate system).

## Test plan

- [x] `pnpm exec vitest run src/renderer/stores/rrcSessionStore.test.ts -t "clearUnread drops"`
- [x] `pnpm exec vitest run src/renderer/components/rrc/RrcChatView.test.tsx -t "onCaughtUp"`
- [x] `pnpm exec vitest run src/renderer/components/RrcPanel.test.tsx -t "clears unread when returning"`
- [ ] Join a hub room on Reticulum RRC; pin to bottom (follow latest).
- [ ] Switch to Chat or another protocol; receive RRC room traffic.
- [ ] Return to RRC → same room shows latest line.
- [ ] Confirm sidebar RRC badge, protocol-switcher Reticulum pill, and hub-browser badge for that hub all drop to **0**.
- [ ] Scroll up in a room with unread → badge should **not** clear until Jump to Latest or scroll back within 50px of bottom.
- [ ] Repeat with app window blurred/unfocused, then refocus while pinned near bottom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unread message counts now clear reliably when returning to an active room after messages arrive while the panel is inactive or unfocused.
  * Counts are cleared when the chat is caught up near the bottom of the message stream.
  * Stale room and hub unread totals are removed together for accurate notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->