### PR TITLE
fix(flatpak): vendor Electron 41.10.7 archives

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -140,10 +140,10 @@ In Electron dev: open the **Reticulum** protocol pill (amber) → **Connection**
 
 #### Keep Rust and the sidecar current
 
-`pnpm run update` updates Node dependencies **and**, when `cargo` is available:
+`pnpm run update` updates Node dependencies and:
 
-1. Runs `rustup update` (or `brew upgrade rust` if you use Homebrew rust without rustup)
-2. Rebuilds the sidecar with `cargo build` in `reticulum-sidecar/`
+1. Syncs Flatpak vendored Electron archives to match `package.json` (`scripts/sync-flatpak-electron.mjs`)
+2. When `cargo` is available: runs `rustup update` (or `brew upgrade rust` if you use Homebrew rust without rustup) and rebuilds the sidecar with `cargo build` in `reticulum-sidecar/`
 
 **Scope:** `pnpm update` / `pnpm-lock.yaml` changes are **repo-local** (commit the lockfile on your branch). The sidecar rebuild writes only to gitignored `reticulum-sidecar/target/`. **Rust toolchain updates are not repo-scoped** — `rustup update` refreshes the toolchain in your user profile (`~/.rustup`, `~/.cargo/bin`), shared by any Rust project on the machine. The committed [`rust-toolchain.toml`](../reticulum-sidecar/rust-toolchain.toml) selects `stable` and required components for this crate; rustup applies it when you build or lint inside `reticulum-sidecar/`.
 

--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -105,12 +105,12 @@ modules:
         strip-components: 0
         only-arches: [aarch64]
       - type: archive
-        url: https://github.com/electron/electron/releases/download/v41.10.6/electron-v41.10.6-linux-x64.zip
-        sha256: a27291d502b16170fe49d14beab68c4d9a1040192500e1643a9ab0b11274f075
+        url: https://github.com/electron/electron/releases/download/v41.10.7/electron-v41.10.7-linux-x64.zip
+        sha256: 21bf93906685c77f350f618d034f33202f0764aabbfc204e6b724f82196537f9
         dest: electron-prebuilt
         only-arches: [x86_64]
       - type: archive
-        url: https://github.com/electron/electron/releases/download/v41.10.6/electron-v41.10.6-linux-arm64.zip
-        sha256: 9dbb040d575c33f8b2d2ab944e429979b01b5261c0240cff4749892be1bc56ea
+        url: https://github.com/electron/electron/releases/download/v41.10.7/electron-v41.10.7-linux-arm64.zip
+        sha256: b2b6528212e1e832889ea1493050ff5be04525cc2b8cb10161dfce83dd502c1f
         dest: electron-prebuilt
         only-arches: [aarch64]

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -97,6 +97,21 @@ update_rust_toolchain() {
   return 0
 }
 
+# Keep Flatpak offline Electron archives aligned with package.json (CI check:flatpak).
+# Idempotent when already in sync; fetches SHASUMS256.txt when Electron moved.
+sync_flatpak_electron() {
+  if [ ! -f 'scripts/sync-flatpak-electron.mjs' ]; then
+    echo 'scripts/sync-flatpak-electron.mjs missing — skipping Flatpak Electron sync.' >&2
+    return 0
+  fi
+  if ! command -v node > /dev/null 2>&1; then
+    echo 'Error: node is required to sync Flatpak Electron archives.' >&2
+    return 1
+  fi
+  echo 'Syncing Flatpak Electron vendored archives...'
+  node scripts/sync-flatpak-electron.mjs
+}
+
 # Rebuild Reticulum sidecar after dependency/toolchain updates
 rebuild_reticulum_sidecar() {
   if [ ! -f 'reticulum-sidecar/Cargo.toml' ]; then
@@ -755,6 +770,9 @@ pnpm install
 echo ''
 echo 'Running pnpm prune...'
 pnpm prune
+
+echo ''
+sync_flatpak_electron
 
 HAS_WARNING=0
 

--- a/scripts/update.test.mjs
+++ b/scripts/update.test.mjs
@@ -127,6 +127,17 @@ describe('update.sh Reticulum stack functionality check', () => {
     expect(upstreamCall).toBeGreaterThan(patchesCall);
   });
 
+  it('syncs Flatpak Electron archives after pnpm prune', () => {
+    expect(updateScript).toContain('sync_flatpak_electron()');
+    expect(updateScript).toContain('node scripts/sync-flatpak-electron.mjs');
+    const pruneIdx = updateScript.lastIndexOf("echo 'Running pnpm prune...'");
+    const syncCallIdx = updateScript.lastIndexOf('\nsync_flatpak_electron\n');
+    const rustIdx = updateScript.lastIndexOf('\nupdate_rust_toolchain\n');
+    expect(pruneIdx).toBeGreaterThanOrEqual(0);
+    expect(syncCallIdx).toBeGreaterThan(pruneIdx);
+    expect(rustIdx).toBeGreaterThan(syncCallIdx);
+  });
+
   const LXMFACE_REVIEWED_SHA = '308a729d5bf951880633e5e174b3b7628203106b';
 
   /**


### PR DESCRIPTION
## Summary
- Sync Flatpak offline Electron `linux-{x64,arm64}` archive URLs and sha256s to **41.10.7** so they match `package.json` after #905.
- Unblocks `pnpm run check:flatpak` / CI Build & Test ([failed run](https://github.com/Colorado-Mesh/mesh-client/actions/runs/33032497048)).

## Test plan
- [x] `pnpm run sync:flatpak-electron` updated the manifest
- [x] `pnpm run check:flatpak` passes locally
- [ ] CI Build & Test / Check Flatpak green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Electron runtime to version 41.10.7.
  * Updated release checksums for x86_64 and aarch64 packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->