### PR TITLE
refactor(reticulum): align RRC and Games panels with standard theme

### DIFF
--- a/docs/reticulum.md
+++ b/docs/reticulum.md
@@ -359,7 +359,7 @@ When multiple enabled local RNode interfaces are connected, the interface list s
 
 ## RRC (Reticulum Relay Chat)
 
-IRC-style multi-pane client (`RrcPanel` + `rrcHubStore` / `rrcSessionStore`):
+IRC-style multi-pane client (`RrcPanel` + `rrcHubStore` / `rrcSessionStore`). Panel chrome uses the standard app slate/green theme (same as Nomad, Peers, and LXMF Chat); IRC mono transcript layout is unchanged.
 
 - Discover hubs from announces, connect by hash, or favourite hubs (Nomad-style). Soft cap **8** concurrent hub sessions.
 - Headless hub **auto-connect** (`useRrcStartupAutoConnect`, mounted from App): polls ~**500 ms** while any preferred hub is still pending (waiting for live attach / first link), then ~**4 s** steady; also wakes immediately on `RETICULUM_CONFIGURED_EVENT`.

--- a/src/renderer/components/GamesPanel.tsx
+++ b/src/renderer/components/GamesPanel.tsx
@@ -240,17 +240,19 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
   }
 
   return (
-    <div className="bg-primary-dark flex h-full w-full min-w-0 text-amber-50">
-      <aside className="flex w-72 shrink-0 flex-col border-r border-amber-800/40">
-        <div className="border-b border-amber-800/40 p-3">
-          <h2 className="text-sm font-semibold text-amber-100">{t('gamesPanel.title')}</h2>
+    <div className="flex h-full min-h-0 w-full min-w-0 text-gray-100">
+      <aside className="bg-secondary-dark flex w-72 shrink-0 flex-col border-r border-gray-700">
+        <div className="border-b border-gray-700 p-3">
+          <h2 className="text-sm font-semibold text-gray-100">{t('gamesPanel.title')}</h2>
           <div className="mt-2 flex flex-wrap gap-1">
             {GAMES_FILTERS.map((f) => (
               <button
                 key={f}
                 type="button"
                 className={`rounded px-2 py-1 text-xs ${
-                  filter === f ? 'bg-amber-800 text-amber-50' : 'bg-amber-950/40 text-amber-200/70'
+                  filter === f
+                    ? 'bg-readable-green text-white'
+                    : 'border border-gray-600 text-gray-300 hover:bg-gray-800/60'
                 }`}
                 aria-label={t(`gamesPanel.filters.${f}`)}
                 onClick={() => {
@@ -264,15 +266,17 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto">
           {filteredSessions.length === 0 ? (
-            <div className="p-3 text-xs text-amber-200/50">{t('gamesPanel.noSessions')}</div>
+            <div className="p-3 text-xs text-gray-400">{t('gamesPanel.noSessions')}</div>
           ) : (
             <ul>
               {filteredSessions.map((session) => (
                 <li key={session.session_id}>
                   <button
                     type="button"
-                    className={`flex w-full items-center gap-2 border-b border-amber-900/30 px-3 py-2 text-left text-xs hover:bg-amber-950/40 ${
-                      selectedSessionId === session.session_id ? 'bg-amber-950/60' : ''
+                    className={`flex w-full items-center gap-2 border-b border-gray-800 px-3 py-2 text-left text-xs hover:bg-gray-800/60 ${
+                      selectedSessionId === session.session_id
+                        ? 'border-bright-green bg-sidebar-active-bg border-l-2'
+                        : ''
                     }`}
                     aria-label={t('gamesPanel.sessionRowAria', {
                       app: t(`gamesPanel.apps.${session.app_id}`, {
@@ -285,14 +289,14 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
                     }}
                   >
                     <span className="min-w-0 flex-1 truncate">
-                      <span className="font-medium text-amber-100">
+                      <span className="font-medium text-gray-100">
                         {t(`gamesPanel.apps.${session.app_id}`, {
                           defaultValue: session.app_id,
                         })}
                       </span>
-                      <span className="ml-1 text-amber-200/50">{sessionPeerLabel(session)}</span>
+                      <span className="ml-1 text-gray-400">{sessionPeerLabel(session)}</span>
                     </span>
-                    <span className="text-amber-200/50">
+                    <span className="text-gray-400">
                       {t(`gamesPanel.status.${session.status}`, {
                         defaultValue: session.status,
                       })}
@@ -311,13 +315,13 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
             </ul>
           )}
         </div>
-        <div className="border-t border-amber-800/40 p-3">
-          <h3 className="mb-1 text-xs font-semibold text-amber-200">
+        <div className="border-t border-gray-700 p-3">
+          <h3 className="mb-1 text-xs font-semibold text-gray-200">
             {t('gamesPanel.newChallenge')}
           </h3>
           <input
             type="text"
-            className="w-full rounded border border-amber-800/50 bg-amber-950/40 px-2 py-1 text-xs text-amber-100"
+            className="bg-deep-black w-full rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
             placeholder={t('gamesPanel.peerHashPlaceholder')}
             aria-label={t('gamesPanel.peerHashAria')}
             value={challengeHash}
@@ -327,7 +331,7 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
           />
           <div className="mt-2 flex items-center gap-2">
             <select
-              className="rounded border border-amber-800/50 bg-amber-950/40 px-2 py-1 text-xs text-amber-100"
+              className="bg-deep-black rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
               aria-label={t('gamesPanel.selectAppAria')}
               value={challengeApp}
               onChange={(e) => {
@@ -342,7 +346,7 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
             </select>
             <button
               type="button"
-              className="flex-1 rounded bg-amber-800 px-2 py-1 text-xs font-medium text-amber-50 disabled:opacity-50"
+              className="bg-readable-green flex-1 rounded px-2 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
               aria-label={t('gamesPanel.sendChallengeAria')}
               disabled={actionBusy || !challengeHash.trim()}
               onClick={() => void handleSendChallenge()}
@@ -350,17 +354,17 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
               {t('gamesPanel.sendChallenge')}
             </button>
           </div>
-          <p className="mt-2 text-[11px] leading-snug text-amber-200/60">
+          <p className="mt-2 text-[11px] leading-snug text-gray-400">
             {t('gamesPanel.idleExpiryNotice')}
           </p>
         </div>
       </aside>
       <main className="flex min-w-0 flex-1 flex-col items-center justify-center gap-4 overflow-y-auto p-6">
         {!selectedSession ? (
-          <div className="text-sm text-amber-200/50">{t('gamesPanel.selectSessionPrompt')}</div>
+          <div className="text-sm text-gray-400">{t('gamesPanel.selectSessionPrompt')}</div>
         ) : (
           <>
-            <div className="text-xs text-amber-200/60">
+            <div className="text-xs text-gray-400">
               {t('gamesPanel.opponentLabel', { peer: sessionPeerLabel(selectedSession) })}
             </div>
             {(() => {
@@ -438,7 +442,7 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
                     <>
                       <button
                         type="button"
-                        className="rounded bg-amber-800 px-3 py-1 text-xs font-medium text-amber-50 disabled:opacity-50"
+                        className="bg-readable-green rounded px-3 py-1 text-xs font-medium text-white disabled:opacity-50"
                         aria-label={t('gamesPanel.acceptDrawAria')}
                         disabled={actionBusy}
                         onClick={() => {
@@ -449,7 +453,7 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
                       </button>
                       <button
                         type="button"
-                        className="rounded bg-amber-950/60 px-3 py-1 text-xs font-medium text-amber-200 disabled:opacity-50"
+                        className="rounded border border-gray-600 px-3 py-1 text-xs font-medium text-gray-300 hover:bg-gray-800/60 disabled:opacity-50"
                         aria-label={t('gamesPanel.declineDrawAria')}
                         disabled={actionBusy}
                         onClick={() => {
@@ -462,7 +466,7 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
                   ) : drawPending ? null : drawClaimReason === GAMES_DRAW_CLAIM.THREEFOLD ? (
                     <button
                       type="button"
-                      className="rounded bg-amber-950/60 px-3 py-1 text-xs font-medium text-amber-200 disabled:opacity-50"
+                      className="rounded border border-gray-600 px-3 py-1 text-xs font-medium text-gray-300 hover:bg-gray-800/60 disabled:opacity-50"
                       aria-label={t('gamesPanel.claimThreefoldAria')}
                       disabled={actionBusy}
                       onClick={() => {
@@ -474,7 +478,7 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
                   ) : drawClaimReason === GAMES_DRAW_CLAIM.FIFTY_MOVE ? (
                     <button
                       type="button"
-                      className="rounded bg-amber-950/60 px-3 py-1 text-xs font-medium text-amber-200 disabled:opacity-50"
+                      className="rounded border border-gray-600 px-3 py-1 text-xs font-medium text-gray-300 hover:bg-gray-800/60 disabled:opacity-50"
                       aria-label={t('gamesPanel.claimFiftyMoveAria')}
                       disabled={actionBusy}
                       onClick={() => {
@@ -486,7 +490,7 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
                   ) : (
                     <button
                       type="button"
-                      className="rounded bg-amber-950/60 px-3 py-1 text-xs font-medium text-amber-200 disabled:opacity-50"
+                      className="rounded border border-gray-600 px-3 py-1 text-xs font-medium text-gray-300 hover:bg-gray-800/60 disabled:opacity-50"
                       aria-label={t('gamesPanel.offerDrawAria')}
                       disabled={actionBusy}
                       onClick={() => {
@@ -511,7 +515,7 @@ export default function GamesPanel({ isActive }: GamesPanelProps) {
               )}
               <button
                 type="button"
-                className="rounded bg-amber-950/60 px-3 py-1 text-xs font-medium text-amber-200/70 disabled:opacity-50"
+                className="rounded border border-gray-600 px-3 py-1 text-xs font-medium text-gray-400 hover:bg-gray-800/60 disabled:opacity-50"
                 aria-label={t('gamesPanel.deleteSessionAria')}
                 disabled={actionBusy}
                 onClick={() => {

--- a/src/renderer/components/RrcPanel.test.tsx
+++ b/src/renderer/components/RrcPanel.test.tsx
@@ -117,10 +117,10 @@ describe('RrcPanel', () => {
     clearRrcHubAutoJoinBackoff(hubA);
   });
 
-  it('renders amber hub chrome and select-hub prompt', async () => {
+  it('renders standard hub chrome and select-hub prompt', async () => {
     const { container } = render(<RrcPanel isActive />);
     expect(screen.getAllByText(/Select an RRC hub/i).length).toBeGreaterThan(0);
-    expect(container.querySelector('[class*="border-amber"]')).toBeTruthy();
+    expect(container.querySelector('[class*="border-gray-700"]')).toBeTruthy();
     expect(await axe(container)).toHaveNoViolations();
   });
 

--- a/src/renderer/components/RrcPanel.tsx
+++ b/src/renderer/components/RrcPanel.tsx
@@ -1006,7 +1006,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
     : null;
 
   return (
-    <div className="bg-primary-dark flex h-full w-full min-w-0 text-amber-50">
+    <div className="flex h-full min-h-0 w-full min-w-0 text-gray-100">
       <RrcHubBrowser
         collapsed={collapsed}
         onToggleCollapsed={() => {
@@ -1103,12 +1103,12 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
       )}
 
       <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-        <header className="flex flex-wrap items-center gap-2 border-b border-amber-800/40 px-3 py-2">
+        <header className="flex flex-wrap items-center gap-2 border-b border-gray-700 px-3 py-2">
           <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-semibold text-amber-100">
+            <div className="truncate text-sm font-semibold text-gray-100">
               {hubName ?? hubDestHash ?? t('rrc.selectHubPrompt')}
             </div>
-            <div className="text-xs text-amber-200/50">
+            <div className="text-xs text-gray-400">
               {t(`rrc.status.${status}`)}
               {activeRoomHeaderLabel ? ` · ${activeRoomHeaderLabel}` : ''}
               {capabilities.direct_notice ? ` · ${t('rrc.capDirectNotice')}` : ''}
@@ -1118,7 +1118,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
             <>
               <button
                 type="button"
-                className={`rounded p-1.5 hover:bg-amber-950/50 ${showTimestamps ? 'text-amber-400' : 'text-amber-200/60'}`}
+                className={`rounded p-1.5 hover:bg-gray-800/60 ${showTimestamps ? 'text-bright-green' : 'text-gray-400'}`}
                 aria-label={t('rrc.toggleTimestamps')}
                 title={t('rrc.toggleTimestamps')}
                 onClick={() => {
@@ -1129,7 +1129,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
               </button>
               <button
                 type="button"
-                className={`rounded p-1.5 hover:bg-amber-950/50 ${isMuted ? 'text-amber-400' : 'text-amber-200/60'}`}
+                className={`rounded p-1.5 hover:bg-gray-800/60 ${isMuted ? 'text-bright-green' : 'text-gray-400'}`}
                 aria-label={isMuted ? t('rrc.unmuteRoom') : t('rrc.muteRoom')}
                 title={isMuted ? t('rrc.unmuteRoom') : t('rrc.muteRoom')}
                 disabled={!muteKey}
@@ -1140,7 +1140,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
               {activeRoom && (
                 <button
                   type="button"
-                  className="rounded p-1.5 text-amber-200/60 hover:bg-amber-950/50"
+                  className="rounded p-1.5 text-gray-400 hover:bg-gray-800/60"
                   aria-label={t('rrc.clearHistory')}
                   title={t('rrc.clearHistory')}
                   disabled={actionBusy}
@@ -1154,7 +1154,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
               {activeRoom && (!activeRoom.startsWith('[') || isRrcDmRoom(activeRoom)) && (
                 <button
                   type="button"
-                  className="rounded p-1.5 text-amber-200/60 hover:bg-amber-950/50"
+                  className="rounded p-1.5 text-gray-400 hover:bg-gray-800/60"
                   aria-label={t('rrc.leaveRoom')}
                   title={t('rrc.leaveRoom')}
                   disabled={actionBusy}
@@ -1168,7 +1168,7 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
           {canCancelSession && (
             <button
               type="button"
-              className="rounded bg-amber-900/60 px-2 py-1 text-xs text-amber-100"
+              className="rounded border border-gray-600 px-2 py-1 text-xs text-gray-200 hover:bg-gray-800/60"
               aria-label={cancelSessionLabel ? t('rrc.cancelConnect') : t('rrc.disconnect')}
               title={cancelSessionLabel ? t('rrc.cancelConnect') : t('rrc.disconnect')}
               disabled={actionBusy}
@@ -1179,11 +1179,11 @@ export default function RrcPanel({ isActive, alwaysShowMessageActions = false }:
           )}
         </header>
         {bannerText && (
-          <div className="flex items-start gap-2 border-b border-amber-700/60 bg-amber-900/40 px-3 py-1.5 text-xs text-amber-100">
+          <div className="flex items-start gap-2 border-b border-gray-700 bg-slate-800/80 px-3 py-1.5 text-xs text-gray-200">
             <span className="min-w-0 flex-1">{bannerText}</span>
             <button
               type="button"
-              className="shrink-0 p-0.5 text-amber-200/70 hover:text-amber-50"
+              className="shrink-0 p-0.5 text-gray-400 hover:text-gray-100"
               aria-label={t('rrc.dismissBanner')}
               onClick={() => {
                 setModerationBanner(null);

--- a/src/renderer/components/games/ChessBoard.tsx
+++ b/src/renderer/components/games/ChessBoard.tsx
@@ -166,9 +166,9 @@ export function ChessBoard({ session, onMove, disabled = false }: ChessBoardProp
 
   return (
     <div className="relative flex flex-col items-center gap-3">
-      <div className="text-sm text-amber-100">{statusText}</div>
+      <div className="text-sm text-gray-100">{statusText}</div>
       <div
-        className="relative grid grid-cols-8 border border-amber-800/60"
+        className="relative grid grid-cols-8 border border-gray-600"
         role="group"
         aria-label={t('gamesPanel.chess.boardAria')}
       >
@@ -184,7 +184,7 @@ export function ChessBoard({ session, onMove, disabled = false }: ChessBoardProp
                 key={square}
                 type="button"
                 className={`flex h-10 w-10 items-center justify-center text-xl ${
-                  dark ? 'bg-amber-900/70' : 'bg-amber-100/10'
+                  dark ? 'bg-slate-700' : 'bg-slate-600'
                 } ${isSelected ? 'ring-2 ring-cyan-400' : ''} enabled:hover:brightness-125 disabled:cursor-default`}
                 aria-label={t('gamesPanel.chess.squareAria', {
                   square,
@@ -218,7 +218,7 @@ export function ChessBoard({ session, onMove, disabled = false }: ChessBoardProp
             />
             <div
               role="group"
-              className="relative z-20 flex flex-col gap-1 rounded border border-amber-700 bg-amber-950 p-2"
+              className="bg-deep-black relative z-20 flex flex-col gap-1 rounded border border-gray-600 p-2"
             >
               {promoOptions.map((p) => {
                 const glyphKey = myColor === 'b' ? p : p.toUpperCase();
@@ -226,7 +226,7 @@ export function ChessBoard({ session, onMove, disabled = false }: ChessBoardProp
                   <button
                     key={p}
                     type="button"
-                    className="flex h-10 w-10 items-center justify-center rounded text-2xl text-amber-100 hover:bg-amber-900/80 disabled:cursor-default disabled:opacity-40"
+                    className="flex h-10 w-10 items-center justify-center rounded text-2xl text-gray-100 hover:bg-gray-800 disabled:cursor-default disabled:opacity-40"
                     aria-label={t(`gamesPanel.chess.promoteTo.${p}`)}
                     disabled={disabled || !isMyTurn}
                     onClick={() => {
@@ -247,7 +247,7 @@ export function ChessBoard({ session, onMove, disabled = false }: ChessBoardProp
             <button
               key={move}
               type="button"
-              className="rounded border border-amber-800/50 bg-amber-950/40 px-1.5 py-0.5 text-xs text-amber-200 enabled:hover:bg-amber-900/60"
+              className="rounded border border-gray-600 bg-slate-800/80 px-1.5 py-0.5 text-xs text-gray-300 enabled:hover:bg-gray-700"
               aria-label={t('gamesPanel.chess.legalMoveAria', { move })}
               disabled={disabled || !isMyTurn}
               onClick={() => {

--- a/src/renderer/components/games/TicTacToeBoard.tsx
+++ b/src/renderer/components/games/TicTacToeBoard.tsx
@@ -51,9 +51,9 @@ export function TicTacToeBoard({ session, onMove, disabled = false }: TicTacToeB
 
   return (
     <div className="flex flex-col items-center gap-3">
-      <div className="text-sm text-amber-100">{statusText}</div>
+      <div className="text-sm text-gray-100">{statusText}</div>
       {myMarker && (
-        <div className="text-xs text-amber-200/60">
+        <div className="text-xs text-gray-400">
           {t('gamesPanel.ttt.yourMarker', { marker: myMarker })}
           {moveCount > 0 ? ` · ${t('gamesPanel.ttt.moveCount', { count: moveCount })}` : ''}
         </div>
@@ -70,7 +70,7 @@ export function TicTacToeBoard({ session, onMove, disabled = false }: TicTacToeB
             <button
               key={index}
               type="button"
-              className="flex h-14 w-14 items-center justify-center rounded border border-amber-800/50 bg-amber-950/40 text-2xl font-bold text-amber-100 enabled:hover:bg-amber-900/60 disabled:cursor-default disabled:opacity-70"
+              className="flex h-14 w-14 items-center justify-center rounded border border-gray-600 bg-slate-800/80 text-2xl font-bold text-gray-100 enabled:hover:bg-gray-700 disabled:cursor-default disabled:opacity-70"
               aria-label={
                 isEmpty
                   ? t('gamesPanel.ttt.cellEmptyAria', { index: index + 1 })

--- a/src/renderer/components/reticulum/ReticulumGameChallengeButton.tsx
+++ b/src/renderer/components/reticulum/ReticulumGameChallengeButton.tsx
@@ -70,12 +70,12 @@ export function ReticulumGameChallengeButton({
         <span>{t('gamesPanel.challenge')}</span>
       </button>
       {showMenu && (
-        <div className="absolute top-full right-0 z-10 mt-1 w-36 rounded border border-amber-800/60 bg-slate-900 shadow-lg">
+        <div className="bg-deep-black absolute top-full right-0 z-10 mt-1 w-36 rounded border border-gray-600 shadow-lg">
           {CHALLENGE_APPS.map((appId) => (
             <button
               key={appId}
               type="button"
-              className="block w-full px-3 py-1.5 text-left text-xs text-amber-100 hover:bg-amber-900/60 disabled:opacity-50"
+              className="block w-full px-3 py-1.5 text-left text-xs text-gray-100 hover:bg-gray-800 disabled:opacity-50"
               disabled={disabled}
               aria-label={t('gamesPanel.challengeAppAria', {
                 app: t(`gamesPanel.apps.${appId}`, { defaultValue: appId }),

--- a/src/renderer/components/rrc/RrcChatView.test.tsx
+++ b/src/renderer/components/rrc/RrcChatView.test.tsx
@@ -128,7 +128,7 @@ describe('RrcChatView IRC layout', () => {
     expect(line.textContent).toMatch(/<Zeva>\s*psst/);
     expect(line.textContent).not.toMatch(/-Zeva-/);
     expect(line.innerHTML).toContain(rrcNickColorClass('Zeva'));
-    expect(line.className).toContain('text-amber-50/90');
+    expect(line.className).toContain('text-gray-100');
   });
 
   it('hides empty system/notice rows', () => {
@@ -166,7 +166,7 @@ describe('RrcChatView IRC layout', () => {
     const line = screen.getByTestId('rrc-chat-line');
     expect(line.textContent).toMatch(/<nv0n>\s*hi there/);
     expect(line.textContent).not.toContain('→');
-    expect(line.className).toContain('text-amber-50/90');
+    expect(line.className).toContain('text-gray-100');
     expect(line.innerHTML).toContain(rrcNickColorClass('nv0n'));
   });
 

--- a/src/renderer/components/rrc/RrcChatView.tsx
+++ b/src/renderer/components/rrc/RrcChatView.tsx
@@ -560,7 +560,7 @@ export function RrcChatView({
 
   if (!connected) {
     return (
-      <div className="flex flex-1 items-center justify-center p-6 text-sm text-amber-200/50">
+      <div className="flex flex-1 items-center justify-center p-6 text-sm text-gray-400">
         {t('rrc.selectHubPrompt')}
       </div>
     );
@@ -576,9 +576,9 @@ export function RrcChatView({
           className="h-full min-h-0 overflow-y-auto overscroll-contain px-3 py-2 [overflow-anchor:none]"
         >
           {!activeRoom && (
-            <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-amber-200/50">
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-gray-400">
               <p>{t('rrc.joinRoomPrompt')}</p>
-              <p className="max-w-md text-xs text-amber-200/40">{t('rrc.joinRoomHelp')}</p>
+              <p className="text-muted max-w-md text-xs">{t('rrc.joinRoomHelp')}</p>
             </div>
           )}
           {activeRoom && (
@@ -609,14 +609,14 @@ export function RrcChatView({
                     (msg.kind === 'notice' || msg.kind === 'msg') &&
                     Boolean(nick));
                 const lineClass = whisperAsRoomMsg
-                  ? 'text-amber-50/90'
+                  ? 'text-gray-100'
                   : msg.kind === 'notice' || msg.kind === 'system'
-                    ? 'text-amber-300/90'
+                    ? 'text-gray-400'
                     : msg.kind === 'action'
                       ? 'text-cyan-200/90 italic'
                       : msg.kind === 'error'
                         ? 'text-red-300'
-                        : 'text-amber-50/90';
+                        : 'text-gray-100';
                 const body = highlightRrcSelfMentions(
                   whisperEcho ? whisperEcho.text : msg.body,
                   nickname,
@@ -632,9 +632,7 @@ export function RrcChatView({
                     style={{ transform: `translateY(${vi.start}px)` }}
                   >
                     <div className="group flex items-start gap-1 leading-snug">
-                      {time && (
-                        <span className="shrink-0 text-[10px] text-amber-200/35">[{time}]</span>
-                      )}
+                      {time && <span className="text-muted shrink-0 text-[10px]">[{time}]</span>}
                       <div className="min-w-0 flex-1 break-words whitespace-pre-wrap">
                         {msg.kind === 'action' ? (
                           <>
@@ -654,7 +652,7 @@ export function RrcChatView({
                             {msg.kind === 'notice' && nick ? (
                               <span className={rrcNickColorClass(nick)}>-{nick}- </span>
                             ) : (
-                              <span className="text-amber-500/70">* </span>
+                              <span className="text-gray-500">* </span>
                             )}
                             {body}
                           </>
@@ -662,7 +660,7 @@ export function RrcChatView({
                       </div>
                       <button
                         type="button"
-                        className={`shrink-0 p-0.5 text-amber-200/20 hover:text-amber-100 ${
+                        className={`message-action shrink-0 rounded p-0.5 text-xs text-gray-600 ${
                           alwaysShowMessageActions
                             ? 'opacity-100'
                             : 'opacity-0 group-focus-within:opacity-100 group-hover:opacity-100'
@@ -691,7 +689,7 @@ export function RrcChatView({
             onClick={() => {
               scrollToBottom('smooth');
             }}
-            className="absolute bottom-2 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-amber-800/60 bg-slate-900/95 px-3 py-1.5 text-xs font-medium text-amber-100 shadow-lg transition-all hover:bg-slate-800"
+            className="bg-deep-black/95 absolute bottom-2 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-100 shadow-lg transition-all hover:bg-gray-800"
             aria-label={t('rrc.jumpToLatest')}
           >
             <ArrowDown aria-hidden className="h-3.5 w-3.5" size={14} />
@@ -699,7 +697,7 @@ export function RrcChatView({
           </button>
         )}
       </div>
-      <div className="relative flex gap-2 border-t border-amber-800/40 p-2">
+      <div className="relative flex gap-2 border-t border-gray-700 p-2">
         {mentionQuery != null && mentionCandidates.length > 0 && (
           <MentionAutocomplete
             listboxId={RRC_MENTION_LISTBOX_ID}
@@ -745,12 +743,12 @@ export function RrcChatView({
             aria-label={composerPlaceholder}
             aria-autocomplete="list"
             rows={2}
-            className="w-full resize-none rounded border border-amber-800/50 bg-slate-900/80 px-2 py-1.5 font-sans text-sm text-amber-50 disabled:opacity-50"
+            className="bg-deep-black w-full resize-none rounded border border-gray-600 px-2 py-1.5 font-sans text-sm text-gray-100 disabled:opacity-50"
           />
         </div>
         <button
           type="button"
-          className="self-end rounded bg-amber-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+          className="bg-readable-green self-end rounded px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
           aria-label={t('rrc.send')}
           disabled={!canSend || isMuted || !draft.trim()}
           onClick={() => {

--- a/src/renderer/components/rrc/RrcHubBrowser.tsx
+++ b/src/renderer/components/rrc/RrcHubBrowser.tsx
@@ -73,7 +73,7 @@ function HubRow({
     <li>
       <div
         className={`flex items-center gap-1 rounded px-2 py-1.5 text-sm ${
-          selected ? 'border-l-2 border-amber-400 bg-amber-950/40' : 'hover:bg-amber-950/25'
+          selected ? 'border-bright-green bg-sidebar-active-bg border-l-2' : 'hover:bg-gray-800/60'
         }`}
       >
         <span className={`shrink-0 text-xs ${marker.colorClass}`} title={markerTitle} aria-hidden>
@@ -98,28 +98,28 @@ function HubRow({
           disabled={!sidecarRunning && marker.kind !== 'connected' && marker.kind !== 'connecting'}
         >
           <div className="flex items-center justify-between gap-1">
-            <div className="truncate font-medium text-amber-50">{label}</div>
+            <div className="truncate font-medium text-gray-100">{label}</div>
             {unread > 0 && (
               <span className="shrink-0 rounded-full bg-red-600 px-1.5 text-[10px] text-white">
                 {unread > 99 ? '99+' : unread}
               </span>
             )}
           </div>
-          <div className="truncate text-xs text-amber-200/50">
+          <div className="truncate text-xs text-gray-400">
             {secondary ?? formatHash(hub.destination_hash)}
             {hub.hops != null ? ` · ${t('rrc.hopsAway', { count: hub.hops })}` : ''}
             {hub.user_count != null ? ` · ${t('rrc.userCount', { count: hub.user_count })}` : ''}
           </div>
           {hub.description ? (
-            <div className="truncate text-[10px] text-amber-200/40">{hub.description}</div>
+            <div className="text-muted truncate text-[10px]">{hub.description}</div>
           ) : null}
         </button>
         <button
           type="button"
           className={
             autoJoin
-              ? 'shrink-0 rounded border border-amber-400 bg-amber-800/80 px-1.5 py-0.5 text-[10px] font-bold text-amber-50'
-              : 'shrink-0 rounded border border-dashed border-amber-700/60 px-1.5 py-0.5 text-[10px] font-semibold text-amber-200/45 hover:border-amber-500 hover:text-amber-200'
+              ? 'border-bright-green bg-readable-green shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-bold text-white'
+              : 'text-muted shrink-0 rounded border border-dashed border-gray-600 px-1.5 py-0.5 text-[10px] font-semibold hover:border-gray-500 hover:text-gray-300'
           }
           aria-label={autoJoin ? t('rrc.disableHubAutoJoin') : t('rrc.enableHubAutoJoin')}
           aria-pressed={autoJoin}
@@ -132,7 +132,7 @@ function HubRow({
         </button>
         <button
           type="button"
-          className="shrink-0 p-1 text-amber-400"
+          className={`shrink-0 p-1 ${hub.favorited ? 'text-bright-green' : 'text-gray-500'}`}
           aria-label={hub.favorited ? t('rrc.unfavoriteHub') : t('rrc.favoriteHub')}
           title={hub.favorited ? t('rrc.unfavoriteHub') : t('rrc.favoriteHub')}
           onClick={() => {
@@ -223,20 +223,20 @@ export function RrcHubBrowser({
 
   return (
     <aside
-      className={`bg-secondary-dark flex shrink-0 flex-col border-r border-amber-800/40 ${
+      className={`bg-secondary-dark flex shrink-0 flex-col border-r border-gray-700 ${
         collapsed ? 'w-16' : 'w-64'
       }`}
     >
-      <div className="flex items-center justify-between gap-1 border-b border-amber-800/40 p-2">
+      <div className="flex items-center justify-between gap-1 border-b border-gray-700 p-2">
         {!collapsed && (
-          <span className="text-xs font-semibold tracking-wide text-amber-400/80 uppercase">
+          <span className="text-xs font-semibold tracking-wide text-gray-200 uppercase">
             {t('rrc.hubsTitle')}
           </span>
         )}
         <div className="flex items-center gap-1">
           <button
             type="button"
-            className="rounded p-1 text-amber-200/80 hover:bg-amber-950/50"
+            className="rounded p-1 text-gray-400 hover:bg-gray-800/60"
             aria-label={t('rrc.refreshHubs')}
             title={t('rrc.refreshHubs')}
             disabled={!sidecarRunning}
@@ -246,7 +246,7 @@ export function RrcHubBrowser({
           </button>
           <button
             type="button"
-            className="rounded p-1 text-amber-200/80 hover:bg-amber-950/50"
+            className="rounded p-1 text-gray-400 hover:bg-gray-800/60"
             aria-label={collapsed ? t('rrc.expandSidebar') : t('rrc.collapseSidebar')}
             title={collapsed ? t('rrc.expandSidebar') : t('rrc.collapseSidebar')}
             onClick={onToggleCollapsed}
@@ -258,18 +258,18 @@ export function RrcHubBrowser({
       {!collapsed && (
         <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
           {!sidecarRunning && (
-            <div className="rounded border border-amber-600/50 bg-amber-900/30 p-2 text-xs text-amber-200">
+            <div className="rounded-lg border border-amber-600/40 bg-amber-950/20 p-2 text-xs text-amber-200">
               {t('connectionPanel.reticulumIdentity.startStackFirst')}
             </div>
           )}
-          <p className="px-1 text-[10px] leading-snug text-amber-200/45">{t('rrc.hubLegend')}</p>
-          <div className="flex gap-1 rounded border border-amber-800/40 p-0.5 text-[10px]">
+          <p className="text-muted px-1 text-[10px] leading-snug">{t('rrc.hubLegend')}</p>
+          <div className="flex gap-1 rounded border border-gray-700 p-0.5 text-[10px]">
             <button
               type="button"
               className={`flex-1 rounded px-1 py-1 ${
                 hubTab === 'favourites'
-                  ? 'bg-amber-800/60 text-amber-50'
-                  : 'text-amber-200/60 hover:bg-amber-950/40'
+                  ? 'bg-readable-green text-white'
+                  : 'border border-gray-600 text-gray-300 hover:bg-gray-800/60'
               }`}
               aria-label={t('rrc.hubs.favourites')}
               onClick={() => {
@@ -282,8 +282,8 @@ export function RrcHubBrowser({
               type="button"
               className={`flex-1 rounded px-1 py-1 ${
                 hubTab === 'discovered'
-                  ? 'bg-amber-800/60 text-amber-50'
-                  : 'text-amber-200/60 hover:bg-amber-950/40'
+                  ? 'bg-readable-green text-white'
+                  : 'border border-gray-600 text-gray-300 hover:bg-gray-800/60'
               }`}
               aria-label={t('rrc.hubs.discovered')}
               onClick={() => {
@@ -301,9 +301,9 @@ export function RrcHubBrowser({
             }}
             placeholder={t('rrc.searchHubs')}
             aria-label={t('rrc.searchHubs')}
-            className="w-full rounded border border-amber-800/50 bg-slate-900/80 px-2 py-1 text-xs text-amber-50"
+            className="bg-deep-black w-full rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
           />
-          <label className="block text-xs text-amber-200/60">
+          <label className="block text-xs text-gray-400">
             {t('rrc.nickname')}
             <input
               type="text"
@@ -312,7 +312,7 @@ export function RrcHubBrowser({
                 onNicknameChange(e.target.value);
               }}
               aria-label={t('rrc.nickname')}
-              className="mt-0.5 w-full rounded border border-amber-800/50 bg-slate-900/80 px-2 py-1 text-xs text-amber-50"
+              className="bg-deep-black mt-0.5 w-full rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
             />
           </label>
           {rows.length > 0 ? (
@@ -328,11 +328,11 @@ export function RrcHubBrowser({
               onToggleAutoJoin={onToggleAutoJoin}
             />
           ) : (
-            <p className="px-2 text-xs text-amber-200/40">
+            <p className="text-muted px-2 text-xs">
               {hubTab === 'favourites' ? t('rrc.noFavouriteHubs') : t('rrc.noDiscoveredHubs')}
             </p>
           )}
-          <div className="mt-auto space-y-1 border-t border-amber-800/40 pt-2">
+          <div className="mt-auto space-y-1 border-t border-gray-700 pt-2">
             <input
               type="text"
               value={manualHash}
@@ -341,11 +341,11 @@ export function RrcHubBrowser({
               }}
               placeholder={t('rrc.manualHashPlaceholder')}
               aria-label={t('rrc.manualHashPlaceholder')}
-              className="w-full rounded border border-amber-800/50 bg-slate-900/80 px-2 py-1 font-mono text-xs text-amber-50"
+              className="bg-deep-black w-full rounded border border-gray-600 px-2 py-1 font-mono text-xs text-gray-100"
             />
             <button
               type="button"
-              className="w-full rounded bg-amber-700 px-2 py-1 text-xs font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+              className="bg-readable-green w-full rounded px-2 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
               aria-label={t('rrc.connectManual')}
               disabled={!sidecarRunning || !manualHash.trim()}
               onClick={onManualConnect}

--- a/src/renderer/components/rrc/RrcNickList.tsx
+++ b/src/renderer/components/rrc/RrcNickList.tsx
@@ -29,17 +29,17 @@ export function RrcNickList({
   const { t } = useTranslation();
   return (
     <aside
-      className={`bg-secondary-dark/60 flex shrink-0 flex-col overflow-hidden border-l border-amber-800/40 ${
+      className={`bg-secondary-dark/60 flex shrink-0 flex-col overflow-hidden border-l border-gray-700 ${
         collapsed ? 'w-16' : 'w-44'
       }`}
     >
       <div
-        className={`flex items-center gap-1 border-b border-amber-800/40 px-2 py-1.5 ${
+        className={`flex items-center gap-1 border-b border-gray-700 px-2 py-1.5 ${
           collapsed ? 'justify-center' : 'justify-between'
         }`}
       >
         {!collapsed && (
-          <span className="min-w-0 flex-1 truncate text-xs font-semibold tracking-wide text-amber-400/80 uppercase">
+          <span className="min-w-0 flex-1 truncate text-xs font-semibold tracking-wide text-gray-200 uppercase">
             {t('rrc.members')}
           </span>
         )}
@@ -47,7 +47,7 @@ export function RrcNickList({
           {!collapsed && (
             <button
               type="button"
-              className="rounded p-1 text-amber-200/70 hover:bg-amber-950/50"
+              className="rounded p-1 text-gray-400 hover:bg-gray-800/60"
               aria-label={t('rrc.refreshWho')}
               title={t('rrc.refreshWho')}
               disabled={busy}
@@ -58,7 +58,7 @@ export function RrcNickList({
           )}
           <button
             type="button"
-            className="rounded p-1 text-amber-200/80 hover:bg-amber-950/50"
+            className="rounded p-1 text-gray-400 hover:bg-gray-800/60"
             aria-label={collapsed ? t('rrc.expandMembers') : t('rrc.collapseMembers')}
             title={collapsed ? t('rrc.expandMembers') : t('rrc.collapseMembers')}
             aria-expanded={!collapsed}
@@ -72,14 +72,14 @@ export function RrcNickList({
       {collapsed ? (
         <div className="flex flex-1 flex-col items-center gap-2 py-2">
           <span
-            className="text-[10px] font-semibold tracking-wide text-amber-400/70 uppercase"
+            className="text-[10px] font-semibold tracking-wide text-gray-400 uppercase"
             title={t('rrc.members')}
           >
             {members.length}
           </span>
           <button
             type="button"
-            className="rounded p-1 text-amber-200/70 hover:bg-amber-950/50"
+            className="rounded p-1 text-gray-400 hover:bg-gray-800/60"
             aria-label={t('rrc.refreshWho')}
             title={t('rrc.refreshWho')}
             disabled={busy}
@@ -96,7 +96,7 @@ export function RrcNickList({
               <li key={m.identity_hash}>
                 <button
                   type="button"
-                  className={`w-full truncate rounded px-1.5 py-1 text-left hover:bg-amber-950/40 ${rrcNickColorClass(label)}`}
+                  className={`w-full truncate rounded px-1.5 py-1 text-left hover:bg-gray-800/60 ${rrcNickColorClass(label)}`}
                   aria-label={t('rrc.msgNick', { name: label })}
                   title={t('rrc.msgNick', { name: label })}
                   onClick={() => {
@@ -108,7 +108,7 @@ export function RrcNickList({
               </li>
             );
           })}
-          {members.length === 0 && <li className="text-amber-200/40">{t('rrc.noMembers')}</li>}
+          {members.length === 0 && <li className="text-muted">{t('rrc.noMembers')}</li>}
         </ul>
       )}
     </aside>

--- a/src/renderer/components/rrc/RrcRoomSidebar.tsx
+++ b/src/renderer/components/rrc/RrcRoomSidebar.tsx
@@ -139,7 +139,9 @@ export function RrcRoomSidebar({
           <button
             type="button"
             className={`relative flex w-full flex-col items-center gap-0.5 rounded px-1 py-1.5 ${
-              selected ? 'border-l-2 border-amber-400 bg-amber-950/40' : 'hover:bg-amber-950/25'
+              selected
+                ? 'border-bright-green bg-sidebar-active-bg border-l-2'
+                : 'hover:bg-gray-800/60'
             }`}
             title={label}
             aria-label={t('rrc.selectRoom', { name: label })}
@@ -147,7 +149,7 @@ export function RrcRoomSidebar({
               onSelectRoom(name, { join: opts?.joined === false });
             }}
           >
-            <span className="flex h-7 w-7 items-center justify-center rounded-md bg-amber-950/60 text-[10px] font-semibold text-amber-100">
+            <span className="flex h-7 w-7 items-center justify-center rounded-md bg-slate-800/80 text-[10px] font-semibold text-gray-100">
               {roomCollapsedLabel(label)}
             </span>
             {unread > 0 && !selected && (
@@ -162,7 +164,9 @@ export function RrcRoomSidebar({
       <li key={key}>
         <div
           className={`flex items-center gap-0.5 rounded ${
-            selected ? 'bg-amber-950/50 text-amber-50' : 'hover:bg-amber-950/25'
+            selected
+              ? 'border-bright-green bg-sidebar-active-bg border-l-2 text-gray-100'
+              : 'hover:bg-gray-800/60'
           }`}
         >
           <button
@@ -182,14 +186,14 @@ export function RrcRoomSidebar({
               )}
             </div>
             {opts?.topic ? (
-              <div className="truncate text-[10px] text-amber-200/40">{opts.topic}</div>
+              <div className="text-muted truncate text-[10px]">{opts.topic}</div>
             ) : null}
           </button>
           {!isWhisper && (
             <>
               <button
                 type="button"
-                className={`shrink-0 p-1 ${isFav ? 'text-amber-400' : 'text-amber-200/30'}`}
+                className={`shrink-0 p-1 ${isFav ? 'text-bright-green' : 'text-gray-500'}`}
                 aria-label={isFav ? t('rrc.unfavoriteRoom') : t('rrc.favoriteRoom')}
                 title={isFav ? t('rrc.unfavoriteRoom') : t('rrc.favoriteRoom')}
                 onClick={() => {
@@ -202,8 +206,8 @@ export function RrcRoomSidebar({
                 type="button"
                 className={
                   isAuto
-                    ? 'shrink-0 rounded border border-amber-400 bg-amber-800/80 px-1.5 py-0.5 text-[9px] font-bold text-amber-50'
-                    : 'shrink-0 rounded border border-dashed border-amber-700/60 px-1.5 py-0.5 text-[9px] font-semibold text-amber-200/45 hover:border-amber-500 hover:text-amber-200'
+                    ? 'border-bright-green bg-readable-green shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-bold text-white'
+                    : 'text-muted shrink-0 rounded border border-dashed border-gray-600 px-1.5 py-0.5 text-[9px] font-semibold hover:border-gray-500 hover:text-gray-300'
                 }
                 aria-label={isAuto ? t('rrc.disableAutoJoin') : t('rrc.enableAutoJoin')}
                 aria-pressed={isAuto}
@@ -245,19 +249,19 @@ export function RrcRoomSidebar({
 
   return (
     <aside
-      className={`bg-secondary-dark/80 flex shrink-0 flex-col border-r border-amber-800/40 ${
+      className={`bg-secondary-dark/80 flex shrink-0 flex-col border-r border-gray-700 ${
         collapsed ? 'w-16' : 'w-52'
       }`}
     >
-      <div className="flex items-center justify-between gap-1 border-b border-amber-800/40 p-2">
+      <div className="flex items-center justify-between gap-1 border-b border-gray-700 p-2">
         {!collapsed && (
-          <span className="text-xs font-semibold tracking-wide text-amber-400/80 uppercase">
+          <span className="text-xs font-semibold tracking-wide text-gray-200 uppercase">
             {t('rrc.rooms')}
           </span>
         )}
         <button
           type="button"
-          className="rounded p-1 text-amber-200/80 hover:bg-amber-950/50"
+          className="rounded p-1 text-gray-400 hover:bg-gray-800/60"
           aria-label={collapsed ? t('rrc.expandRooms') : t('rrc.collapseRooms')}
           title={collapsed ? t('rrc.expandRooms') : t('rrc.collapseRooms')}
           aria-expanded={!collapsed}
@@ -276,9 +280,9 @@ export function RrcRoomSidebar({
             }}
             placeholder={t('rrc.searchRooms')}
             aria-label={t('rrc.searchRooms')}
-            className="w-full rounded border border-amber-800/50 bg-slate-900/80 px-2 py-1 text-xs text-amber-50"
+            className="bg-deep-black w-full rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
           />
-          <p className="px-1 text-[10px] leading-snug text-amber-200/45">{t('rrc.roomLegend')}</p>
+          <p className="text-muted px-1 text-[10px] leading-snug">{t('rrc.roomLegend')}</p>
           <div className="flex gap-1">
             <input
               type="text"
@@ -287,11 +291,11 @@ export function RrcRoomSidebar({
                 onJoinRoomNameChange(e.target.value);
               }}
               aria-label={t('rrc.joinRoom')}
-              className="min-w-0 flex-1 rounded border border-amber-800/50 bg-slate-900/80 px-2 py-1 text-xs text-amber-50"
+              className="bg-deep-black min-w-0 flex-1 rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
             />
             <button
               type="button"
-              className="rounded bg-amber-800/80 px-2 py-1 text-xs text-amber-50"
+              className="bg-readable-green rounded px-2 py-1 text-xs text-white hover:opacity-90"
               aria-label={t('rrc.join')}
               disabled={busy}
               onClick={onJoin}
@@ -307,23 +311,23 @@ export function RrcRoomSidebar({
             }}
             placeholder={t('rrc.roomKeyOptional')}
             aria-label={t('rrc.roomKeyOptional')}
-            className="w-full rounded border border-amber-800/50 bg-slate-900/80 px-2 py-1 text-xs text-amber-50"
+            className="bg-deep-black w-full rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
           />
           <button
             type="button"
-            className="w-full rounded border border-amber-800/40 px-2 py-1 text-[10px] text-amber-200/70 hover:bg-amber-950/40"
+            className="w-full rounded border border-gray-600 px-2 py-1 text-[10px] text-gray-400 hover:bg-gray-800/60"
             aria-label={t('rrc.refreshRoomList')}
             disabled={busy}
             onClick={onRefreshList}
           >
             {t('rrc.refreshRoomList')}
           </button>
-          <p className="text-[10px] leading-snug text-amber-200/40">{t('rrc.listHint')}</p>
+          <p className="text-muted text-[10px] leading-snug">{t('rrc.listHint')}</p>
         </div>
       )}
       <ul className="min-h-0 flex-1 overflow-y-auto px-1 pb-2">
         {!collapsed && joinedDeduped.some((r) => filterName(r.name)) && (
-          <li className="px-2 py-1 text-[10px] tracking-wide text-amber-500/70 uppercase">
+          <li className="text-muted px-2 py-1 text-[10px] tracking-wide uppercase">
             {t('rrc.joinedRooms')}
           </li>
         )}
@@ -337,7 +341,7 @@ export function RrcRoomSidebar({
             }),
           )}
         {!collapsed && (listedNotJoined.length > 0 || favNotJoined.length > 0) && (
-          <li className="mt-2 px-2 py-1 text-[10px] tracking-wide text-amber-500/70 uppercase">
+          <li className="text-muted mt-2 px-2 py-1 text-[10px] tracking-wide uppercase">
             {t('rrc.listedRooms')}
           </li>
         )}
@@ -354,7 +358,7 @@ export function RrcRoomSidebar({
             renderRoomButton(name, { unread: unreadFor(name), joined: false }),
           )}
         {!collapsed && recentVisible.length > 0 && (
-          <li className="mt-2 px-2 py-1 text-[10px] tracking-wide text-amber-500/70 uppercase">
+          <li className="text-muted mt-2 px-2 py-1 text-[10px] tracking-wide uppercase">
             {t('rrc.recentRooms')}
           </li>
         )}
@@ -363,7 +367,7 @@ export function RrcRoomSidebar({
             renderRoomButton(name, { unread: unreadFor(name), joined: false }),
           )}
         {joinedDeduped.length === 0 && !collapsed && (
-          <li className="px-2 text-xs text-amber-200/40">{t('rrc.noRoomsJoined')}</li>
+          <li className="text-muted px-2 text-xs">{t('rrc.noRoomsJoined')}</li>
         )}
       </ul>
     </aside>

--- a/src/renderer/components/rrc/RrcTopicBar.tsx
+++ b/src/renderer/components/rrc/RrcTopicBar.tsx
@@ -10,14 +10,14 @@ export function RrcTopicBar({ room, topic, memberCount }: RrcTopicBarProps) {
   const { t } = useTranslation();
   if (!room || room.startsWith('[') || room.startsWith('@')) return null;
   return (
-    <div className="flex items-center gap-2 border-b border-amber-800/40 bg-amber-950/20 px-3 py-1.5 text-xs text-amber-100/80">
-      <span className="font-semibold text-amber-200">{room}</span>
-      <span className="text-amber-500/50">|</span>
-      <span className="min-w-0 flex-1 truncate text-amber-200/60 italic">
+    <div className="flex items-center gap-2 border-b border-gray-700 bg-slate-800/50 px-3 py-1.5 text-xs text-gray-200">
+      <span className="font-semibold text-gray-100">{room}</span>
+      <span className="text-gray-600">|</span>
+      <span className="min-w-0 flex-1 truncate text-gray-400 italic">
         {topic?.trim() ? topic : t('rrc.noTopic')}
       </span>
       {memberCount != null && memberCount > 0 && (
-        <span className="shrink-0 text-amber-200/50">
+        <span className="shrink-0 text-gray-400">
           {t('rrc.memberCount', { count: memberCount })}
         </span>
       )}

--- a/src/renderer/lib/rrcNickColor.ts
+++ b/src/renderer/lib/rrcNickColor.ts
@@ -1,6 +1,6 @@
 /**
  * Classic IRC-style stable nick colors for RRC transcript + nicklist.
- * Fixed Tailwind palette — avoids amber chrome and low-contrast greys.
+ * Fixed Tailwind palette — avoids low-contrast greys and panel text colors.
  */
 
 export const RRC_NICK_COLOR_CLASSES = [


### PR DESCRIPTION
## Summary
- Replace RRC and Games full-panel amber chrome with the standard Reticulum slate/green tokens used by Nomad, Peers, and LXMF Chat (`border-gray-700`, `bg-secondary-dark`, `border-bright-green`, `bg-readable-green`, etc.)
- Wire RRC transcript copy button to `.message-action` CSS vars so it respects App → Colors message-action settings like ChatPanel
- IRC mono transcript layout, nick color hashing, and game logic are unchanged; semantic accents (draw banners, delivery chips, stack-not-running banner) stay as-is

## Test plan
- [x] `pnpm exec vitest run src/renderer/components/RrcPanel.test.tsx src/renderer/components/rrc/RrcChatView.test.tsx src/renderer/components/GamesPanel.test.tsx src/renderer/components/games/ChessBoard.test.tsx` (106 tests, axe included)
- [ ] Reticulum → RRC: hub/room sidebars, transcript, composer, copy button
- [ ] Reticulum → Games: session list, chess/TTT boards, challenge dropdown from Peers/Chat DM
- [ ] App → Colors: confirm RRC copy button hover follows message-action theme tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Games and RRC interfaces with a consistent slate-gray and green visual theme.
  * Restyled game boards, chat views, hub and room navigation, member lists, topic bars, controls, and menus.
  * Improved consistency and readability across panel borders, text, buttons, inputs, and status messages.

* **Documentation**
  * Clarified the RRC panel’s standard application theme while preserving the existing IRC transcript layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->