### PR TITLE
fix(radio): stop settings form clobbering edits; move apply status inline

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1800,6 +1800,35 @@ function AppContent() {
   const effectiveChannelConfigs = isRemoteConfigureTarget
     ? (meshtasticRuntime.remoteConfigSnapshot?.channelConfigs ?? [])
     : meshtasticRuntime.channelConfigs;
+  // Stable identity: RadioPanel syncs MeshCore LoRa form fields from this object, so a fresh
+  // object per render would overwrite in-progress user edits.
+  const meshcoreRadioFreq = meshcoreRuntime.selfInfo?.radioFreq;
+  const meshcoreRadioBw = meshcoreRuntime.selfInfo?.radioBw;
+  const meshcoreRadioSf = meshcoreRuntime.selfInfo?.radioSf;
+  const meshcoreRadioCr = meshcoreRuntime.selfInfo?.radioCr;
+  const meshcoreTxPower = meshcoreRuntime.selfInfo?.txPower;
+  const hasMeshcoreSelfInfo = meshcoreRuntime.selfInfo != null;
+  const meshcoreLoraConfig = useMemo(
+    () =>
+      capabilities.hasCompanionContactManagementConfig && hasMeshcoreSelfInfo
+        ? {
+            freq: meshcoreRadioFreq,
+            bw: meshcoreRadioBw,
+            sf: meshcoreRadioSf,
+            cr: meshcoreRadioCr,
+            txPower: meshcoreTxPower,
+          }
+        : undefined,
+    [
+      capabilities.hasCompanionContactManagementConfig,
+      hasMeshcoreSelfInfo,
+      meshcoreRadioFreq,
+      meshcoreRadioBw,
+      meshcoreRadioSf,
+      meshcoreRadioCr,
+      meshcoreTxPower,
+    ],
+  );
   const effectiveLoraConfig = isRemoteConfigureTarget
     ? (meshtasticRuntime.remoteConfigSnapshot?.loraConfig ?? null)
     : meshtasticRuntime.loraConfig;
@@ -3848,18 +3877,7 @@ function AppContent() {
                                       ? meshcorePanelActions.setRadioParams
                                       : undefined
                                   }
-                                  loraConfig={
-                                    capabilities.hasCompanionContactManagementConfig &&
-                                    meshcoreRuntime.selfInfo
-                                      ? {
-                                          freq: meshcoreRuntime.selfInfo.radioFreq,
-                                          bw: meshcoreRuntime.selfInfo.radioBw,
-                                          sf: meshcoreRuntime.selfInfo.radioSf,
-                                          cr: meshcoreRuntime.selfInfo.radioCr,
-                                          txPower: meshcoreRuntime.selfInfo.txPower,
-                                        }
-                                      : undefined
-                                  }
+                                  loraConfig={meshcoreLoraConfig}
                                   meshcoreSelfInfo={
                                     capabilities.hasCompanionContactManagementConfig
                                       ? meshcoreRuntime.selfInfo

--- a/src/renderer/components/RadioPanel.test.tsx
+++ b/src/renderer/components/RadioPanel.test.tsx
@@ -470,6 +470,90 @@ describe('RadioPanel MeshCore advert position synchronization', () => {
   });
 });
 
+describe('RadioPanel MeshCore LoRa form synchronization', () => {
+  it('keeps in-progress edits when an unchanged loraConfig object is re-supplied', async () => {
+    const user = userEvent.setup();
+    const renderPanel = (loraConfig: {
+      freq: number;
+      bw: number;
+      sf: number;
+      cr: number;
+      txPower: number;
+    }) => (
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          capabilities={MESHCORE_CAPABILITIES}
+          onApplyLoraParams={vi.fn().mockResolvedValue(undefined)}
+          loraConfig={loraConfig}
+        />
+      </ToastProvider>
+    );
+    const deviceParams = { freq: 869_618_000, bw: 62_500, sf: 8, cr: 5, txPower: 10 };
+    const { rerender } = render(renderPanel(deviceParams));
+    const loraDetails = [...document.querySelectorAll('details')].find((details) =>
+      details.textContent?.includes('LoRa / Radio'),
+    );
+    expect(loraDetails).toBeDefined();
+    await user.click(loraDetails!.querySelector('summary')!);
+
+    const frequency = screen.getByLabelText('Frequency (MHz)');
+    await waitFor(() => {
+      expect(frequency).toHaveValue(869.618);
+    });
+
+    fireEvent.change(frequency, { target: { value: '910.525' } });
+    expect(frequency).toHaveValue(910.525);
+
+    // New object identity, identical device values (e.g. an unrelated parent re-render).
+    rerender(renderPanel({ ...deviceParams }));
+    expect(frequency).toHaveValue(910.525);
+
+    // A genuine device change still hydrates the form.
+    rerender(renderPanel({ ...deviceParams, freq: 906_875_000 }));
+    await waitFor(() => {
+      expect(frequency).toHaveValue(906.875);
+    });
+  });
+
+  it('keeps an in-progress name edit when an unchanged deviceOwner object is re-supplied', async () => {
+    const user = userEvent.setup();
+    const renderPanel = (deviceOwner: {
+      longName: string;
+      shortName: string;
+      isLicensed: boolean;
+    }) => (
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          capabilities={MESHCORE_CAPABILITIES}
+          deviceOwner={deviceOwner}
+        />
+      </ToastProvider>
+    );
+    const owner = { longName: 'Device Name', shortName: '', isLicensed: false };
+    const { rerender } = render(renderPanel(owner));
+
+    const nameInput = screen.getByLabelText('Name');
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('Device Name');
+    });
+
+    await user.clear(nameInput);
+    await user.type(nameInput, 'My New Name');
+
+    rerender(renderPanel({ ...owner }));
+    expect(nameInput).toHaveValue('My New Name');
+
+    rerender(renderPanel({ ...owner, longName: 'Renamed On Device' }));
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('Renamed On Device');
+    });
+  });
+});
+
 describe('RadioPanel Bluetooth fixed PIN display', () => {
   it('shows leading zeros when syncing fixedPin from device config', async () => {
     const user = userEvent.setup();

--- a/src/renderer/components/RadioPanel.test.tsx
+++ b/src/renderer/components/RadioPanel.test.tsx
@@ -499,6 +499,51 @@ describe('RadioPanel apply status placement', () => {
     expect(userDetails!.contains(statusEl)).toBe(true);
   });
 
+  it('reports a Meshtastic applyConfig result inside its own section', async () => {
+    const user = userEvent.setup();
+    const onSetConfig = vi.fn().mockResolvedValue(undefined);
+    const onCommit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          onSetConfig={onSetConfig}
+          onCommit={onCommit}
+          meshtasticConfigSlices={{
+            device: { role: 0 },
+            bluetooth: { enabled: true, mode: 1, fixedPin: 123456 },
+          }}
+        />
+      </ToastProvider>,
+    );
+
+    const findSection = (title: string) =>
+      [...document.querySelectorAll('details')].find((d) => {
+        const span = d.querySelector(':scope > summary > span');
+        return span?.textContent?.trim() === title;
+      });
+    const deviceDetails = findSection('Device Role');
+    const bluetoothDetails = findSection('Bluetooth');
+    expect(deviceDetails).toBeDefined();
+    expect(bluetoothDetails).toBeDefined();
+    await user.click(deviceDetails!.querySelector('summary')!);
+    await user.click(bluetoothDetails!.querySelector('summary')!);
+
+    await user.click(screen.getByRole('button', { name: 'Apply Device Role' }));
+
+    await waitFor(() => {
+      expect(onCommit).toHaveBeenCalled();
+    });
+    const statusEl = await screen.findByRole('status');
+    expect(deviceDetails!.contains(statusEl)).toBe(true);
+    expect(bluetoothDetails!.contains(statusEl)).toBe(false);
+    // Styling comes from the reported outcome, not from matching English message text.
+    await waitFor(() => {
+      expect(statusEl.className).toContain('bg-brand-green/10');
+    });
+  });
+
   it('keeps a section status out of other sections', async () => {
     const user = userEvent.setup();
     const onSetOwner = vi.fn().mockResolvedValue(undefined);

--- a/src/renderer/components/RadioPanel.test.tsx
+++ b/src/renderer/components/RadioPanel.test.tsx
@@ -470,6 +470,111 @@ describe('RadioPanel MeshCore advert position synchronization', () => {
   });
 });
 
+describe('RadioPanel apply status placement', () => {
+  it('reports the apply result inside the applied section, not at the panel bottom', async () => {
+    const user = userEvent.setup();
+    const onSetOwner = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          capabilities={MESHCORE_CAPABILITIES}
+          onSetOwner={onSetOwner}
+          deviceOwner={{ longName: 'Node', shortName: '', isLicensed: false }}
+        />
+      </ToastProvider>,
+    );
+
+    const userDetails = [...document.querySelectorAll('details')].find((d) => {
+      const span = d.querySelector(':scope > summary > span');
+      return span?.textContent?.trim() === 'Device User / Identity';
+    });
+    expect(userDetails).toBeDefined();
+    await user.click(userDetails!.querySelector('summary')!);
+
+    await user.click(screen.getByRole('button', { name: 'Apply Device User / Identity' }));
+
+    const statusEl = await screen.findByRole('status');
+    expect(userDetails!.contains(statusEl)).toBe(true);
+  });
+
+  it('keeps a section status out of other sections', async () => {
+    const user = userEvent.setup();
+    const onSetOwner = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ToastProvider>
+        <RadioPanel
+          {...defaultProps}
+          isConnected
+          capabilities={MESHCORE_CAPABILITIES}
+          onApplyLoraParams={vi.fn().mockResolvedValue(undefined)}
+          loraConfig={{ freq: 915_000_000, bw: 125_000, sf: 12, cr: 5, txPower: 20 }}
+          onSetOwner={onSetOwner}
+          deviceOwner={{ longName: 'Node', shortName: '', isLicensed: false }}
+        />
+      </ToastProvider>,
+    );
+
+    const findSection = (title: string) =>
+      [...document.querySelectorAll('details')].find((d) => {
+        const span = d.querySelector(':scope > summary > span');
+        return span?.textContent?.trim() === title;
+      });
+    const userDetails = findSection('Device User / Identity');
+    const loraDetails = findSection('LoRa / Radio');
+    expect(userDetails).toBeDefined();
+    expect(loraDetails).toBeDefined();
+    await user.click(userDetails!.querySelector('summary')!);
+    await user.click(loraDetails!.querySelector('summary')!);
+
+    await user.click(screen.getByRole('button', { name: 'Apply Device User / Identity' }));
+
+    const statusEl = await screen.findByRole('status');
+    expect(userDetails!.contains(statusEl)).toBe(true);
+    expect(loraDetails!.contains(statusEl)).toBe(false);
+  });
+});
+
+describe('RadioPanel Meshtastic LoRa form synchronization', () => {
+  it('keeps in-progress edits when the device re-pushes an unchanged config slice', async () => {
+    const user = userEvent.setup();
+    const renderPanel = (lora: Record<string, unknown>) => (
+      <ToastProvider>
+        <RadioPanel {...defaultProps} isConnected meshtasticConfigSlices={{ lora }} />
+      </ToastProvider>
+    );
+    const deviceLora = { region: 1, modemPreset: 0, channelNum: 20, hopLimit: 3 };
+    const { rerender } = render(renderPanel(deviceLora));
+    const loraDetails = [...document.querySelectorAll('details')].find((d) => {
+      const span = d.querySelector(':scope > summary > span');
+      return span?.textContent?.trim() === 'LoRa / Radio';
+    });
+    expect(loraDetails).toBeDefined();
+    await user.click(loraDetails!.querySelector('summary')!);
+
+    // ConfigNumber renders its label as plain text beside the input.
+    const channelNumberField = screen.getByText('Channel Number').closest('div')!.parentElement!;
+    const frequencySlot = channelNumberField.querySelector('input')!;
+    await waitFor(() => {
+      expect(frequencySlot).toHaveValue(20);
+    });
+
+    fireEvent.change(frequencySlot, { target: { value: '5' } });
+    expect(frequencySlot).toHaveValue(5);
+
+    // Radio re-sends the same config (new object, identical content).
+    rerender(renderPanel({ ...deviceLora }));
+    expect(frequencySlot).toHaveValue(5);
+
+    // A genuine device change still hydrates the form.
+    rerender(renderPanel({ ...deviceLora, channelNum: 31 }));
+    await waitFor(() => {
+      expect(frequencySlot).toHaveValue(31);
+    });
+  });
+});
+
 describe('RadioPanel MeshCore LoRa form synchronization', () => {
   it('keeps in-progress edits when an unchanged loraConfig object is re-supplied', async () => {
     const user = userEvent.setup();

--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -575,20 +575,28 @@ export function ConfigBluetoothPin({
 
 /** Collapsible section wrapper */
 /** Apply result / progress text. Rendered inline under a section's Apply button. */
-function StatusMessage({ message }: { message: string | null }) {
-  if (!message) return null;
+/** Outcome of a reported status. Drives styling — never infer this from message text. */
+type StatusKind = 'success' | 'error' | 'neutral';
+
+interface PanelStatus {
+  message: string;
+  kind: StatusKind;
+}
+
+const STATUS_KIND_CLASSES: Record<StatusKind, string> = {
+  error: 'border border-red-700 bg-red-900/50 text-red-300',
+  success: 'bg-brand-green/10 border-brand-green text-bright-green border',
+  neutral: 'bg-deep-black text-muted',
+};
+
+function StatusMessage({ status }: { status: PanelStatus | null }) {
+  if (!status) return null;
   return (
     <div
       role="status"
-      className={`rounded-lg px-4 py-2 text-sm ${
-        message.includes('Failed')
-          ? 'border border-red-700 bg-red-900/50 text-red-300'
-          : message.includes('success')
-            ? 'bg-brand-green/10 border-brand-green text-bright-green border'
-            : 'bg-deep-black text-muted'
-      }`}
+      className={`rounded-lg px-4 py-2 text-sm ${STATUS_KIND_CLASSES[status.kind]}`}
     >
-      {message}
+      {status.message}
     </div>
   );
 }
@@ -609,7 +617,7 @@ function ConfigSection({
   disabled: boolean;
   hideApply?: boolean;
   /** Status for this section's own Apply action, shown directly under the button. */
-  status?: string | null;
+  status?: PanelStatus | null;
 }) {
   const { t } = useTranslation();
   return (
@@ -632,7 +640,7 @@ function ConfigSection({
               : t('modulePanel.applySection', { section: title })}
           </button>
         )}
-        <StatusMessage message={status} />
+        <StatusMessage status={status} />
       </div>
     </details>
   );
@@ -1079,22 +1087,19 @@ export default function RadioPanel({
   ]);
 
   // ─── Shared state ─────────────────────────────────────────────
-  const [status, setStatus] = useState<string | null>(null);
   const [applyingSection, setApplyingSection] = useState<string | null>(null);
-  /** Section key the current `status` belongs to; null means panel-level status. */
-  const [statusSection, setStatusSection] = useState<string | null>(null);
+  /** Current status plus the section it belongs to; a null section means panel-level. */
+  const [status, setStatus] = useState<(PanelStatus & { section: string | null }) | null>(null);
   /** Report an apply result inline under the given section's Apply button. */
-  const showSectionStatus = (section: string, message: string): void => {
-    setStatusSection(section);
-    setStatus(message);
+  const showSectionStatus = (section: string, message: string, kind: StatusKind): void => {
+    setStatus({ section, message, kind });
   };
-  /** Status text for a section, so unrelated sections stay quiet. */
-  const sectionStatus = (section: string): string | null =>
-    statusSection === section ? status : null;
+  /** Status for a section, so unrelated sections stay quiet. */
+  const sectionStatus = (section: string): PanelStatus | null =>
+    status?.section === section ? status : null;
   /** Report a status not tied to a section's Apply button (channel URL, channel list edits). */
-  const showPanelStatus = (message: string): void => {
-    setStatusSection(null);
-    setStatus(message);
+  const showPanelStatus = (message: string, kind: StatusKind): void => {
+    setStatus({ section: null, message, kind });
   };
 
   const { addToast } = useToast();
@@ -1251,7 +1256,11 @@ export default function RadioPanel({
     if (!isConnected) return false;
     clearMeshtasticClientNotification();
     setApplyingSection(configCase);
-    showSectionStatus(configCase, t('radioPanel.applyStatusApplying', { section: sectionLabel }));
+    showSectionStatus(
+      configCase,
+      t('radioPanel.applyStatusApplying', { section: sectionLabel }),
+      'neutral',
+    );
     const deviceSlice =
       configCase === 'lora' && meshtasticLoraConfig
         ? meshtasticLoraConfig
@@ -1269,6 +1278,7 @@ export default function RadioPanel({
         showSectionStatus(
           configCase,
           t('radioPanel.applyStatusSuccess', { section: sectionLabel }),
+          'success',
         );
         return true;
       } catch (err: unknown) {
@@ -1279,6 +1289,7 @@ export default function RadioPanel({
             section: sectionLabel,
             message: formatMeshtasticModuleApplyError(err, t),
           }),
+          'error',
         );
         return false;
       }
@@ -1289,6 +1300,7 @@ export default function RadioPanel({
         t('radioPanel.applyStatusFailed', {
           message: formatMeshtasticModuleApplyError(err, t),
         }),
+        'error',
       );
       return false;
     } finally {
@@ -1562,14 +1574,15 @@ export default function RadioPanel({
               t('radioPanel.applyStatusFailed', {
                 message: t(shortNameValidationError!),
               }),
+              'error',
             );
             return;
           }
           setApplyingSection('user');
-          showSectionStatus('user', t('radioPanel.applyUserApplying'));
+          showSectionStatus('user', t('radioPanel.applyUserApplying'), 'neutral');
           try {
             await onSetOwner({ longName, shortName, isLicensed });
-            showSectionStatus('user', t('radioPanel.applyUserSuccess'));
+            showSectionStatus('user', t('radioPanel.applyUserSuccess'), 'success');
           } catch (err) {
             console.warn('[RadioPanel] setOwner failed:', err instanceof Error ? err.message : err);
             showSectionStatus(
@@ -1577,6 +1590,7 @@ export default function RadioPanel({
               t('radioPanel.applyStatusFailed', {
                 message: setOwnerApplyErrorMessage(err, t),
               }),
+              'error',
             );
           } finally {
             setApplyingSection(null);
@@ -1663,6 +1677,7 @@ export default function RadioPanel({
               showSectionStatus(
                 'lora',
                 t('radioPanel.applyStatusApplying', { section: t('radioPanel.sectionLora') }),
+                'neutral',
               );
               try {
                 const clampedTxPower = Math.min(Math.max(1, txPower), meshcoreTxPowerMax);
@@ -1673,7 +1688,7 @@ export default function RadioPanel({
                   cr: codingRate,
                   txPower: clampedTxPower,
                 });
-                showSectionStatus('lora', t('radioPanel.applyLoraSuccess'));
+                showSectionStatus('lora', t('radioPanel.applyLoraSuccess'), 'success');
               } catch (err) {
                 console.warn(
                   '[RadioPanel] setLoRaConfig failed:',
@@ -1684,6 +1699,7 @@ export default function RadioPanel({
                   t('radioPanel.applyStatusFailed', {
                     message: err instanceof Error ? err.message : t('common.unknown'),
                   }),
+                  'error',
                 );
               } finally {
                 setApplyingSection(null);
@@ -1762,6 +1778,7 @@ export default function RadioPanel({
               showSectionStatus(
                 'txPower',
                 t('radioPanel.applyStatusApplying', { section: t('radioPanel.sectionTxPower') }),
+                'neutral',
               );
               try {
                 const clampedTxPower = Math.min(Math.max(1, txPower), meshcoreTxPowerMax);
@@ -1772,7 +1789,7 @@ export default function RadioPanel({
                   cr: codingRate,
                   txPower: clampedTxPower,
                 });
-                showSectionStatus('txPower', t('radioPanel.applyTxPowerSuccess'));
+                showSectionStatus('txPower', t('radioPanel.applyTxPowerSuccess'), 'success');
               } catch (err) {
                 console.warn(
                   '[RadioPanel] setTxPower failed:',
@@ -1783,6 +1800,7 @@ export default function RadioPanel({
                   t('radioPanel.applyStatusFailed', {
                     message: err instanceof Error ? err.message : t('common.unknown'),
                   }),
+                  'error',
                 );
               } finally {
                 setApplyingSection(null);
@@ -1824,10 +1842,15 @@ export default function RadioPanel({
                 showSectionStatus(
                   'floodScope',
                   t('radioPanel.applyStatusApplying', { section: t('radioPanel.floodScopeTitle') }),
+                  'neutral',
                 );
                 try {
                   await floodScopeRef.current?.apply();
-                  showSectionStatus('floodScope', t('radioPanel.floodScopeApplySuccess'));
+                  showSectionStatus(
+                    'floodScope',
+                    t('radioPanel.floodScopeApplySuccess'),
+                    'success',
+                  );
                 } catch (err) {
                   // catch-no-log-ok MeshcoreFloodScopeSection logs; inline status shown below
                   showSectionStatus(
@@ -1835,6 +1858,7 @@ export default function RadioPanel({
                     t('radioPanel.applyStatusFailed', {
                       message: err instanceof Error ? err.message : t('common.unknown'),
                     }),
+                    'error',
                   );
                 } finally {
                   setApplyingSection(null);
@@ -2156,7 +2180,7 @@ export default function RadioPanel({
                 clearMeshtasticClientNotification();
                 setApplyingSection('clientMuteGps');
                 await applyClientMuteGpsSuppression();
-                showSectionStatus('device', t('radioPanel.clientMuteGpsSuppressed'));
+                showSectionStatus('device', t('radioPanel.clientMuteGpsSuppressed'), 'success');
               } catch (err) {
                 console.warn(
                   '[RadioPanel] Client Mute GPS suppression failed ' + errLikeToLogString(err),
@@ -2166,6 +2190,7 @@ export default function RadioPanel({
                   t('radioPanel.applyStatusFailed', {
                     message: formatMeshtasticModuleApplyError(err, t),
                   }),
+                  'error',
                 );
               } finally {
                 setApplyingSection(null);
@@ -2860,7 +2885,7 @@ export default function RadioPanel({
       )}
 
       {/* Status for actions outside a section's Apply button (section results render inline) */}
-      {statusSection === null && <StatusMessage message={status} />}
+      {status?.section === null && <StatusMessage status={status} />}
 
       {/* Device Actions (MeshCore) — non-destructive commands */}
       {(onSendAdvert ||
@@ -3082,7 +3107,7 @@ function ChannelUrlImportExport({
     options?: { applyLora?: boolean },
   ) => Promise<ApplyChannelSetResult>;
   disabled: boolean;
-  setStatus: (s: string) => void;
+  setStatus: (message: string, kind: StatusKind) => void;
 }) {
   const { t } = useTranslation();
   const [includeSecondary, setIncludeSecondary] = useState(true);
@@ -3119,10 +3144,10 @@ function ChannelUrlImportExport({
     } catch (e) {
       console.debug('[RadioPanel] channel URL export failed ' + errLikeToLogString(e));
       if (e instanceof MeshtasticUrlError && e.message.includes('No channels selected')) {
-        setStatus(t('radioPanel.channelUrl.noChannelsToExport'));
+        setStatus(t('radioPanel.channelUrl.noChannelsToExport'), 'error');
       } else {
         const msg = e instanceof Error ? e.message : t('common.unknown');
-        setStatus(t('radioPanel.channelUrl.exportFailed', { message: msg }));
+        setStatus(t('radioPanel.channelUrl.exportFailed', { message: msg }), 'error');
       }
     }
   };
@@ -3131,10 +3156,10 @@ function ChannelUrlImportExport({
     if (!text) return;
     try {
       await writeClipboardText(text);
-      setStatus(t('radioPanel.channelUrl.copied'));
+      setStatus(t('radioPanel.channelUrl.copied'), 'success');
     } catch (e) {
       console.warn('[RadioPanel] channel URL copy failed ' + errLikeToLogString(e));
-      setStatus(t('radioPanel.channelUrl.copyFailed'));
+      setStatus(t('radioPanel.channelUrl.copyFailed'), 'error');
     }
   };
 
@@ -3190,9 +3215,10 @@ function ChannelUrlImportExport({
             applied: result.appliedCount,
             skipped: result.skipped.length,
           }),
+          'success',
         );
       } else {
-        setStatus(t('radioPanel.channelUrl.applySuccess'));
+        setStatus(t('radioPanel.channelUrl.applySuccess'), 'success');
       }
       setImportUrl('');
       setConfirmApply(null);
@@ -3202,6 +3228,7 @@ function ChannelUrlImportExport({
         t('radioPanel.channelUrl.applyFailed', {
           message: e instanceof Error ? e.message : t('common.unknown'),
         }),
+        'error',
       );
     } finally {
       setApplying(false);
@@ -3443,7 +3470,7 @@ function ChannelSection({
   onClearChannel: Props['onClearChannel'];
   onCommit: Props['onCommit'];
   disabled: boolean;
-  setStatus: (s: string) => void;
+  setStatus: (message: string, kind: StatusKind) => void;
   meshtasticLoraConfig?: MeshtasticLoraConfig | null;
   onApplyChannelSet?: (
     parsed: ParsedChannelSet,
@@ -3528,13 +3555,14 @@ function ChannelSection({
         },
       });
       await onCommit();
-      setStatus(t('radioPanel.channelSavedStatus', { index: selectedIndex }));
+      setStatus(t('radioPanel.channelSavedStatus', { index: selectedIndex }), 'success');
     } catch (err) {
       console.warn('[RadioPanel] save channel failed ' + errLikeToLogString(err));
       setStatus(
         t('radioPanel.channelSaveFailed', {
           message: err instanceof Error ? err.message : t('common.unknown'),
         }),
+        'error',
       );
     } finally {
       setSaving(false);
@@ -3561,13 +3589,14 @@ function ChannelSection({
         await onClearChannel(selectedIndex);
       }
       await onCommit();
-      setStatus(t('radioPanel.channelResetStatus', { index: selectedIndex }));
+      setStatus(t('radioPanel.channelResetStatus', { index: selectedIndex }), 'success');
     } catch (err) {
       console.warn('[RadioPanel] reset channel failed ' + errLikeToLogString(err));
       setStatus(
         t('radioPanel.channelSaveFailed', {
           message: err instanceof Error ? err.message : t('common.unknown'),
         }),
+        'error',
       );
     } finally {
       setSaving(false);

--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -760,9 +760,20 @@ export default function RadioPanel({
   const [longName, setLongName] = useState('');
   const [shortName, setShortName] = useState('');
   const [isLicensed, setIsLicensed] = useState(false);
+  /** Last device-reported owner applied to the form (skip redundant overwrites while editing). */
+  const syncedDeviceOwnerRef = useRef<string | null>(null);
+  /** Last device-reported MeshCore LoRa params applied to the form. */
+  const syncedMeshcoreLoraRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (deviceOwner) {
+      const signature = JSON.stringify([
+        deviceOwner.longName,
+        deviceOwner.shortName,
+        deviceOwner.isLicensed,
+      ]);
+      if (syncedDeviceOwnerRef.current === signature) return;
+      syncedDeviceOwnerRef.current = signature;
       setLongName(deviceOwner.longName);
       setShortName(truncateMeshtasticShortName(deviceOwner.shortName));
       setIsLicensed(deviceOwner.isLicensed);
@@ -807,6 +818,18 @@ export default function RadioPanel({
   // Sync LoRa state from loraConfig prop (MeshCore device info)
   useEffect(() => {
     if (!loraConfig) return;
+    // Only apply when the device-reported values actually changed, so a repeated sync does not
+    // overwrite edits the user is still typing.
+    const signature = JSON.stringify([
+      loraConfig.freq,
+      loraConfig.bw,
+      loraConfig.sf,
+      loraConfig.cr,
+      loraConfig.txPower,
+      meshcoreTxPowerMax,
+    ]);
+    if (syncedMeshcoreLoraRef.current === signature) return;
+    syncedMeshcoreLoraRef.current = signature;
     if (loraConfig.freq != null) setRadioFreqHz(meshcoreSelfInfoFreqToDisplayHz(loraConfig.freq));
     if (loraConfig.bw != null) setBandwidth(meshcoreSelfInfoBwToDisplayKhz(loraConfig.bw));
     if (loraConfig.sf != null) setSpreadFactor(loraConfig.sf);

--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -14,6 +14,7 @@ import {
   mergeMeshtasticConfigApplyValue,
   meshtasticConfigSlice,
   meshtasticConfigSliceHydrated,
+  stripMeshtasticProtobufMeta,
 } from '@/renderer/lib/meshtastic/meshtasticConfigApply';
 import { writeClipboardText } from '@/renderer/lib/writeClipboardText';
 import { bytesToHex, hexToBytesExactOrThrow } from '@/shared/hexBytes';
@@ -573,6 +574,25 @@ export function ConfigBluetoothPin({
 }
 
 /** Collapsible section wrapper */
+/** Apply result / progress text. Rendered inline under a section's Apply button. */
+function StatusMessage({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <div
+      role="status"
+      className={`rounded-lg px-4 py-2 text-sm ${
+        message.includes('Failed')
+          ? 'border border-red-700 bg-red-900/50 text-red-300'
+          : message.includes('success')
+            ? 'bg-brand-green/10 border-brand-green text-bright-green border'
+            : 'bg-deep-black text-muted'
+      }`}
+    >
+      {message}
+    </div>
+  );
+}
+
 function ConfigSection({
   title,
   children,
@@ -580,6 +600,7 @@ function ConfigSection({
   applying,
   disabled,
   hideApply = false,
+  status = null,
 }: {
   title: string;
   children: React.ReactNode;
@@ -587,6 +608,8 @@ function ConfigSection({
   applying: boolean;
   disabled: boolean;
   hideApply?: boolean;
+  /** Status for this section's own Apply action, shown directly under the button. */
+  status?: string | null;
 }) {
   const { t } = useTranslation();
   return (
@@ -609,6 +632,7 @@ function ConfigSection({
               : t('modulePanel.applySection', { section: title })}
           </button>
         )}
+        <StatusMessage message={status} />
       </div>
     </details>
   );
@@ -764,6 +788,8 @@ export default function RadioPanel({
   const syncedDeviceOwnerRef = useRef<string | null>(null);
   /** Last device-reported MeshCore LoRa params applied to the form. */
   const syncedMeshcoreLoraRef = useRef<string | null>(null);
+  /** Last device-reported Meshtastic LoRa slice applied to the form. */
+  const syncedMeshtasticLoraRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (deviceOwner) {
@@ -997,6 +1023,11 @@ export default function RadioPanel({
     const loraRaw = meshtasticLoraConfig ?? meshtasticConfigSlices?.lora;
     const lora = meshtasticConfigSlice(loraRaw);
     if (Object.keys(lora).length === 0) return;
+    // Skip unchanged re-pushes (the radio can resend an identical config) so a sync cannot
+    // overwrite edits the user is still typing.
+    const signature = JSON.stringify(stripMeshtasticProtobufMeta(lora));
+    if (syncedMeshtasticLoraRef.current === signature) return;
+    syncedMeshtasticLoraRef.current = signature;
     if (typeof lora.region === 'number') setRegion(lora.region);
     if (typeof lora.modemPreset === 'number') setModemPreset(lora.modemPreset);
     if (typeof lora.usePreset === 'boolean') setUsePreset(lora.usePreset);
@@ -1050,6 +1081,21 @@ export default function RadioPanel({
   // ─── Shared state ─────────────────────────────────────────────
   const [status, setStatus] = useState<string | null>(null);
   const [applyingSection, setApplyingSection] = useState<string | null>(null);
+  /** Section key the current `status` belongs to; null means panel-level status. */
+  const [statusSection, setStatusSection] = useState<string | null>(null);
+  /** Report an apply result inline under the given section's Apply button. */
+  const showSectionStatus = (section: string, message: string): void => {
+    setStatusSection(section);
+    setStatus(message);
+  };
+  /** Status text for a section, so unrelated sections stay quiet. */
+  const sectionStatus = (section: string): string | null =>
+    statusSection === section ? status : null;
+  /** Report a status not tied to a section's Apply button (channel URL, channel list edits). */
+  const showPanelStatus = (message: string): void => {
+    setStatusSection(null);
+    setStatus(message);
+  };
 
   const { addToast } = useToast();
   const { t } = useTranslation();
@@ -1205,7 +1251,7 @@ export default function RadioPanel({
     if (!isConnected) return false;
     clearMeshtasticClientNotification();
     setApplyingSection(configCase);
-    setStatus(t('radioPanel.applyStatusApplying', { section: sectionLabel }));
+    showSectionStatus(configCase, t('radioPanel.applyStatusApplying', { section: sectionLabel }));
     const deviceSlice =
       configCase === 'lora' && meshtasticLoraConfig
         ? meshtasticLoraConfig
@@ -1220,11 +1266,15 @@ export default function RadioPanel({
       });
       try {
         await onCommit();
-        setStatus(t('radioPanel.applyStatusSuccess', { section: sectionLabel }));
+        showSectionStatus(
+          configCase,
+          t('radioPanel.applyStatusSuccess', { section: sectionLabel }),
+        );
         return true;
       } catch (err: unknown) {
         // catch-no-log-ok commit failure surfaced in panel status text
-        setStatus(
+        showSectionStatus(
+          configCase,
           t('radioPanel.applyStatusCommitFailed', {
             section: sectionLabel,
             message: formatMeshtasticModuleApplyError(err, t),
@@ -1234,7 +1284,8 @@ export default function RadioPanel({
       }
     } catch (err) {
       console.warn('[RadioPanel] apply section failed ' + errLikeToLogString(err));
-      setStatus(
+      showSectionStatus(
+        configCase,
         t('radioPanel.applyStatusFailed', {
           message: formatMeshtasticModuleApplyError(err, t),
         }),
@@ -1506,7 +1557,8 @@ export default function RadioPanel({
         onApply={async () => {
           if (!onSetOwner) return;
           if (shortNameValidationIssue) {
-            setStatus(
+            showSectionStatus(
+              'user',
               t('radioPanel.applyStatusFailed', {
                 message: t(shortNameValidationError!),
               }),
@@ -1514,13 +1566,14 @@ export default function RadioPanel({
             return;
           }
           setApplyingSection('user');
-          setStatus(t('radioPanel.applyUserApplying'));
+          showSectionStatus('user', t('radioPanel.applyUserApplying'));
           try {
             await onSetOwner({ longName, shortName, isLicensed });
-            setStatus(t('radioPanel.applyUserSuccess'));
+            showSectionStatus('user', t('radioPanel.applyUserSuccess'));
           } catch (err) {
             console.warn('[RadioPanel] setOwner failed:', err instanceof Error ? err.message : err);
-            setStatus(
+            showSectionStatus(
+              'user',
               t('radioPanel.applyStatusFailed', {
                 message: setOwnerApplyErrorMessage(err, t),
               }),
@@ -1530,6 +1583,7 @@ export default function RadioPanel({
           }
         }}
         applying={applyingSection === 'user'}
+        status={sectionStatus('user')}
         disabled={disabled || !onSetOwner || !!shortNameValidationIssue}
       >
         <div className="space-y-1">
@@ -1606,7 +1660,8 @@ export default function RadioPanel({
             onApply={async () => {
               if (!onApplyLoraParams) return;
               setApplyingSection('lora');
-              setStatus(
+              showSectionStatus(
+                'lora',
                 t('radioPanel.applyStatusApplying', { section: t('radioPanel.sectionLora') }),
               );
               try {
@@ -1618,13 +1673,14 @@ export default function RadioPanel({
                   cr: codingRate,
                   txPower: clampedTxPower,
                 });
-                setStatus(t('radioPanel.applyLoraSuccess'));
+                showSectionStatus('lora', t('radioPanel.applyLoraSuccess'));
               } catch (err) {
                 console.warn(
                   '[RadioPanel] setLoRaConfig failed:',
                   err instanceof Error ? err.message : err,
                 );
-                setStatus(
+                showSectionStatus(
+                  'lora',
                   t('radioPanel.applyStatusFailed', {
                     message: err instanceof Error ? err.message : t('common.unknown'),
                   }),
@@ -1634,6 +1690,7 @@ export default function RadioPanel({
               }
             }}
             applying={applyingSection === 'lora'}
+            status={sectionStatus('lora')}
             disabled={loraDisabled}
           >
             <div className="space-y-1">
@@ -1702,7 +1759,8 @@ export default function RadioPanel({
             onApply={async () => {
               if (!onApplyLoraParams) return;
               setApplyingSection('txPower');
-              setStatus(
+              showSectionStatus(
+                'txPower',
                 t('radioPanel.applyStatusApplying', { section: t('radioPanel.sectionTxPower') }),
               );
               try {
@@ -1714,13 +1772,14 @@ export default function RadioPanel({
                   cr: codingRate,
                   txPower: clampedTxPower,
                 });
-                setStatus(t('radioPanel.applyTxPowerSuccess'));
+                showSectionStatus('txPower', t('radioPanel.applyTxPowerSuccess'));
               } catch (err) {
                 console.warn(
                   '[RadioPanel] setTxPower failed:',
                   err instanceof Error ? err.message : err,
                 );
-                setStatus(
+                showSectionStatus(
+                  'txPower',
                   t('radioPanel.applyStatusFailed', {
                     message: err instanceof Error ? err.message : t('common.unknown'),
                   }),
@@ -1730,6 +1789,7 @@ export default function RadioPanel({
               }
             }}
             applying={applyingSection === 'txPower'}
+            status={sectionStatus('txPower')}
             disabled={loraDisabled}
           >
             <ConfigNumber
@@ -1761,15 +1821,17 @@ export default function RadioPanel({
               title={t('radioPanel.floodScopeTitle')}
               onApply={async () => {
                 setApplyingSection('floodScope');
-                setStatus(
+                showSectionStatus(
+                  'floodScope',
                   t('radioPanel.applyStatusApplying', { section: t('radioPanel.floodScopeTitle') }),
                 );
                 try {
                   await floodScopeRef.current?.apply();
-                  setStatus(t('radioPanel.floodScopeApplySuccess'));
+                  showSectionStatus('floodScope', t('radioPanel.floodScopeApplySuccess'));
                 } catch (err) {
                   // catch-no-log-ok MeshcoreFloodScopeSection logs; inline status shown below
-                  setStatus(
+                  showSectionStatus(
+                    'floodScope',
                     t('radioPanel.applyStatusFailed', {
                       message: err instanceof Error ? err.message : t('common.unknown'),
                     }),
@@ -1779,6 +1841,7 @@ export default function RadioPanel({
                 }
               }}
               applying={applyingSection === 'floodScope'}
+              status={sectionStatus('floodScope')}
               disabled={loraDisabled}
             >
               <MeshcoreFloodScopeSection
@@ -1824,6 +1887,7 @@ export default function RadioPanel({
             })
           }
           applying={applyingSection === 'lora'}
+          status={sectionStatus('lora')}
           disabled={loraDisabled}
         >
           <ConfigSelect
@@ -1993,7 +2057,7 @@ export default function RadioPanel({
           onClearChannel={onClearChannel}
           onCommit={onCommit}
           disabled={disabled}
-          setStatus={setStatus}
+          setStatus={showPanelStatus}
           meshtasticLoraConfig={meshtasticLoraConfig}
           onApplyChannelSet={onApplyChannelSet}
           remoteChannelFailedIndices={remoteChannelFailedIndices}
@@ -2092,12 +2156,13 @@ export default function RadioPanel({
                 clearMeshtasticClientNotification();
                 setApplyingSection('clientMuteGps');
                 await applyClientMuteGpsSuppression();
-                setStatus(t('radioPanel.clientMuteGpsSuppressed'));
+                showSectionStatus('device', t('radioPanel.clientMuteGpsSuppressed'));
               } catch (err) {
                 console.warn(
                   '[RadioPanel] Client Mute GPS suppression failed ' + errLikeToLogString(err),
                 );
-                setStatus(
+                showSectionStatus(
+                  'device',
                   t('radioPanel.applyStatusFailed', {
                     message: formatMeshtasticModuleApplyError(err, t),
                   }),
@@ -2108,6 +2173,7 @@ export default function RadioPanel({
             }
           }}
           applying={applyingSection === 'device'}
+          status={sectionStatus('device')}
           disabled={deviceApplyDisabled}
         >
           {!deviceConfigReady && isConnected && (
@@ -2217,6 +2283,7 @@ export default function RadioPanel({
                 })
         }
         applying={applyingSection === 'position'}
+        status={sectionStatus('position')}
         disabled={positionApplyDisabled}
       >
         {capabilities?.hasFullPositionConfig !== false && !positionConfigReady && isConnected && (
@@ -2462,6 +2529,7 @@ export default function RadioPanel({
             })
           }
           applying={applyingSection === 'power'}
+          status={sectionStatus('power')}
           disabled={powerApplyDisabled}
         >
           {!powerConfigReady && isConnected && (
@@ -2567,6 +2635,7 @@ export default function RadioPanel({
             })
           }
           applying={applyingSection === 'network'}
+          status={sectionStatus('network')}
           disabled={networkApplyDisabled}
         >
           {!networkConfigReady && isConnected && (
@@ -2650,6 +2719,7 @@ export default function RadioPanel({
             })
           }
           applying={applyingSection === 'display'}
+          status={sectionStatus('display')}
           disabled={displayApplyDisabled}
         >
           {!displayConfigReady && isConnected && (
@@ -2755,6 +2825,7 @@ export default function RadioPanel({
             });
           }}
           applying={applyingSection === 'bluetooth'}
+          status={sectionStatus('bluetooth')}
           disabled={bluetoothApplyDisabled}
         >
           {!bluetoothConfigReady && isConnected && (
@@ -2788,20 +2859,8 @@ export default function RadioPanel({
         </ConfigSection>
       )}
 
-      {/* Status */}
-      {status && (
-        <div
-          className={`rounded-lg px-4 py-2 text-sm ${
-            status.includes('Failed')
-              ? 'border border-red-700 bg-red-900/50 text-red-300'
-              : status.includes('success')
-                ? 'bg-brand-green/10 border-brand-green text-bright-green border'
-                : 'bg-deep-black text-muted'
-          }`}
-        >
-          {status}
-        </div>
-      )}
+      {/* Status for actions outside a section's Apply button (section results render inline) */}
+      {statusSection === null && <StatusMessage message={status} />}
 
       {/* Device Actions (MeshCore) — non-destructive commands */}
       {(onSendAdvert ||

--- a/src/renderer/hooks/useSyncFormFromConfig.ts
+++ b/src/renderer/hooks/useSyncFormFromConfig.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import {
   meshtasticConfigSlice,
@@ -10,9 +10,14 @@ export function useSyncFormFromConfig(
   configSlice: unknown,
   applyConfig: (cfg: Record<string, unknown>) => void,
 ): void {
+  /** Signature of the last slice applied, so an unchanged re-push cannot clobber user edits. */
+  const appliedSignatureRef = useRef<string | null>(null);
   useEffect(() => {
     const cfg = stripMeshtasticProtobufMeta(meshtasticConfigSlice(configSlice));
     if (Object.keys(cfg).length === 0) return;
+    const signature = JSON.stringify(cfg);
+    if (appliedSignatureRef.current === signature) return;
+    appliedSignatureRef.current = signature;
     applyConfig(cfg);
     // applyConfig is intentionally omitted — callers pass inline setters that change each render.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sync only when device slice changes


### PR DESCRIPTION
## Summary

Two related fixes to the radio settings panel (`RadioPanel`), which is shared by Meshtastic and MeshCore.

**1. Form fields overwrote in-progress edits (`c4a2e6a8`, extended in `26fa79e7`)**

Typing a frequency, name, or other value in MeshCore radio settings was reverted to the device's value about once per second. Root cause: `App.tsx` built the `loraConfig` prop as a fresh object literal inside JSX, so its identity changed on every render, and `RadioPanel`'s sync effect depends only on that identity with no guard — it re-applied device values over the user's typing.

Confirmed with runtime logging before and after: the sync effect fired every ~1s with identical incoming content, and a typed `9000100` was replaced by the device's `869618000` one second later. After the fix, ~14s of continuous typing produced zero sync fires, while initial hydration and genuine device changes still populate the form.

- Memoize the MeshCore `loraConfig` prop on its primitive values instead of rebuilding it per render.
- Record the last device-reported owner and LoRa params applied to the form and skip unchanged re-syncs, matching the guard pattern already used for MeshCore advert lat/lon.
- The same unguarded sync existed on the Meshtastic path, where the radio can re-send an identical config slice as a new object (observed during connect). Added the guard to the shared `useSyncFormFromConfig` hook (device, position, power, network, bluetooth, display) and to the Meshtastic LoRa effect.

**2. Apply confirmations were far from the button (`26fa79e7`)**

Apply results rendered in a single banner at the bottom of the panel. Moved the status into `ConfigSection` so each result appears directly under its own Apply button, tracking which section a status belongs to so unrelated sections stay quiet. Covers every section for both protocols: Device User / Identity, LoRa / Radio, TX Power, Flood Scope, Device Role (including the Client Mute GPS follow-up), Position / GPS, Power, WiFi / Network, Display, Bluetooth. Statuses not tied to a section's Apply button (channel URL export/copy/import, channel save/reset) keep the panel-level banner.

## Test plan

- [x] `RadioPanel.test.tsx` passes (39 tests), including new coverage for: MeshCore LoRa and owner sync preserving edits across an unchanged prop; Meshtastic LoRa sync preserving edits across an unchanged config slice; apply status rendering inside the applied section and not in other sections.
- [x] New Meshtastic guard test verified to fail without the fix (typed value reverts to the device value).
- [x] Typecheck, ESLint, Prettier clean; pre-commit gate green (100 tests across `RadioPanel`, `ModulePanel`, `App`, `useSyncFormFromConfig`, `sourcePolicy`).
- [x] Manually verified on hardware: MeshCore frequency and name edits survive; values still hydrate on panel open and after applying.
- [ ] `pnpm run check:pr` (full lint + typecheck + full suite) before marking ready for review.
- [ ] Spot-check inline apply status on a Meshtastic radio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unchanged device configuration updates from overwriting in-progress edits to radio settings and device names.
  * Ensured genuine device configuration changes still update the corresponding forms.
  * Improved apply-status messages so they appear within the relevant settings section and do not affect neighboring sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->