### PR TITLE
fix(meshtastic): stop the Radio tab crashing on 64-bit config fields

### DIFF
--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -12,6 +12,7 @@ import { formatMeshtasticModuleApplyError } from '@/renderer/lib/meshtastic/mesh
 import { clearMeshtasticClientNotification } from '@/renderer/lib/meshtastic/meshtasticClientNotification';
 import {
   mergeMeshtasticConfigApplyValue,
+  meshtasticConfigSignature,
   meshtasticConfigSlice,
   meshtasticConfigSliceHydrated,
   stripMeshtasticProtobufMeta,
@@ -774,7 +775,7 @@ export default function RadioPanel({
 
   useEffect(() => {
     if (deviceOwner) {
-      const signature = JSON.stringify([
+      const signature = meshtasticConfigSignature([
         deviceOwner.longName,
         deviceOwner.shortName,
         deviceOwner.isLicensed,
@@ -1006,7 +1007,7 @@ export default function RadioPanel({
     if (Object.keys(lora).length === 0) return;
     // Skip unchanged re-pushes (the radio can resend an identical config) so a sync cannot
     // overwrite edits the user is still typing.
-    const signature = JSON.stringify(stripMeshtasticProtobufMeta(lora));
+    const signature = meshtasticConfigSignature(stripMeshtasticProtobufMeta(lora));
     if (syncedMeshtasticLoraRef.current === signature) return;
     syncedMeshtasticLoraRef.current = signature;
     if (typeof lora.region === 'number') setRegion(lora.region);

--- a/src/renderer/hooks/useSyncFormFromConfig.test.ts
+++ b/src/renderer/hooks/useSyncFormFromConfig.test.ts
@@ -18,6 +18,23 @@ describe('useSyncFormFromConfig', () => {
     expect(applyConfig.mock.calls[0][0]).not.toHaveProperty('$typeName');
   });
 
+  it('applies a slice holding a 64-bit protobuf field without throwing', () => {
+    const applyConfig = vi.fn();
+    // A fresh object each render: dedupe has to compare by value, and the 64-bit
+    // `powermon_enables` field decodes as a bigint.
+    const { rerender } = renderHook(() => {
+      useSyncFormFromConfig(
+        { $typeName: 'meshtastic.Config.PowerConfig', isPowerSaving: true, powermonEnables: 0n },
+        applyConfig,
+      );
+    });
+
+    expect(applyConfig).toHaveBeenCalledWith({ isPowerSaving: true, powermonEnables: 0n });
+
+    rerender();
+    expect(applyConfig).toHaveBeenCalledTimes(1);
+  });
+
   it('skips sync when config slice is empty', () => {
     const applyConfig = vi.fn();
 

--- a/src/renderer/hooks/useSyncFormFromConfig.ts
+++ b/src/renderer/hooks/useSyncFormFromConfig.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import {
+  meshtasticConfigSignature,
   meshtasticConfigSlice,
   stripMeshtasticProtobufMeta,
 } from '@/renderer/lib/meshtastic/meshtasticConfigApply';
@@ -15,7 +16,7 @@ export function useSyncFormFromConfig(
   useEffect(() => {
     const cfg = stripMeshtasticProtobufMeta(meshtasticConfigSlice(configSlice));
     if (Object.keys(cfg).length === 0) return;
-    const signature = JSON.stringify(cfg);
+    const signature = meshtasticConfigSignature(cfg);
     if (appliedSignatureRef.current === signature) return;
     appliedSignatureRef.current = signature;
     applyConfig(cfg);

--- a/src/renderer/lib/meshtastic/meshtasticConfigApply.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticConfigApply.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildMeshtasticModuleApplyValue,
   mergeMeshtasticConfigApplyValue,
+  meshtasticConfigSignature,
   meshtasticConfigSlice,
   meshtasticConfigSliceHydrated,
   stripMeshtasticProtobufMeta,
@@ -24,6 +25,20 @@ describe('meshtasticConfigApply', () => {
     expect(stripMeshtasticProtobufMeta({ $typeName: 'x', enabled: true })).toEqual({
       enabled: true,
     });
+  });
+
+  it('signature serializes 64-bit protobuf fields instead of throwing', () => {
+    expect(() => meshtasticConfigSignature({ powermonEnables: 0n })).not.toThrow();
+    expect(meshtasticConfigSignature({ powermonEnables: 12n })).toBe('{"powermonEnables":"12n"}');
+  });
+
+  it('signature distinguishes bigint values from their decimal strings', () => {
+    expect(meshtasticConfigSignature({ v: 1n })).not.toBe(meshtasticConfigSignature({ v: '1' }));
+  });
+
+  it('signature is stable for equal slices', () => {
+    const slice = { isPowerSaving: true, powermonEnables: 3n, sdsSecs: 0 };
+    expect(meshtasticConfigSignature({ ...slice })).toBe(meshtasticConfigSignature({ ...slice }));
   });
 
   it('merge preserves hidden device fields and overlays UI', () => {

--- a/src/renderer/lib/meshtastic/meshtasticConfigApply.ts
+++ b/src/renderer/lib/meshtastic/meshtasticConfigApply.ts
@@ -19,6 +19,18 @@ export function stripMeshtasticProtobufMeta(cfg: Record<string, unknown>): Recor
 }
 
 /**
+ * Stable signature for "did this device slice change?" comparisons.
+ *
+ * Protobufs 2.8.0 decodes 64-bit fields (e.g. `PowerConfig.powermon_enables`) as `bigint`,
+ * which plain `JSON.stringify` throws on.
+ */
+export function meshtasticConfigSignature(value: unknown): string {
+  return JSON.stringify(value, (_key, val: unknown) =>
+    typeof val === 'bigint' ? `${val.toString()}n` : val,
+  );
+}
+
+/**
  * Merge device-owned config with UI edits so hidden fields are not cleared on apply.
  * Firmware setConfig/setModuleConfig replaces the full protobuf struct.
  */


### PR DESCRIPTION
## Summary

- Opening the Meshtastic **Radio** tab after #922 threw `TypeError: Do not know how to serialize a BigInt` into the error boundary, blanking the panel.
- Cause: protobufs 2.8.0 decodes `Config.PowerConfig.powermon_enables` (uint64) as a `bigint`, and the form-sync dedupe signatures in `useSyncFormFromConfig` / `RadioPanel` ran the raw device slice through `JSON.stringify`.
- Added `meshtasticConfigSignature()` in `meshtasticConfigApply.ts`, which serializes bigints as `"<value>n"` so they round-trip into a comparable signature and still differ from the equivalent decimal string. All three affected signature sites now use it.

## Test plan

- [x] `meshtasticConfigApply.test.ts`: signature does not throw on a bigint, distinguishes `1n` from `'1'`, and is stable across equal slices.
- [x] `useSyncFormFromConfig.test.ts`: a power slice containing `powermonEnables: 0n` applies once and dedupes on re-render.
- [x] `pnpm run typecheck`
- [x] Pre-commit related suite (17 files, 163 tests) incl. `RadioPanel.test.tsx`
- [ ] Manual: connect a Meshtastic radio and open the Radio tab — no error boundary, no BigInt error in `mesh-client.log`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration synchronization for devices using 64-bit values.
  * Prevented synchronization errors when handling certain advanced Meshtastic settings.
  * Avoided redundant configuration updates when values remain unchanged.

* **Tests**
  * Added coverage for 64-bit configuration values, stable comparisons, and reliable synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->