### PR TITLE
fix(radio): stop config signature check crashing on bigint fields

### DIFF
--- a/src/renderer/components/RadioPanel.tsx
+++ b/src/renderer/components/RadioPanel.tsx
@@ -12,6 +12,7 @@ import { formatMeshtasticModuleApplyError } from '@/renderer/lib/meshtastic/mesh
 import { clearMeshtasticClientNotification } from '@/renderer/lib/meshtastic/meshtasticClientNotification';
 import {
   mergeMeshtasticConfigApplyValue,
+  meshtasticConfigSignature,
   meshtasticConfigSlice,
   meshtasticConfigSliceHydrated,
   stripMeshtasticProtobufMeta,
@@ -1033,7 +1034,7 @@ export default function RadioPanel({
     if (Object.keys(lora).length === 0) return;
     // Skip unchanged re-pushes (the radio can resend an identical config) so a sync cannot
     // overwrite edits the user is still typing.
-    const signature = JSON.stringify(stripMeshtasticProtobufMeta(lora));
+    const signature = meshtasticConfigSignature(stripMeshtasticProtobufMeta(lora));
     if (syncedMeshtasticLoraRef.current === signature) return;
     syncedMeshtasticLoraRef.current = signature;
     if (typeof lora.region === 'number') setRegion(lora.region);

--- a/src/renderer/hooks/useSyncFormFromConfig.test.ts
+++ b/src/renderer/hooks/useSyncFormFromConfig.test.ts
@@ -18,6 +18,21 @@ describe('useSyncFormFromConfig', () => {
     expect(applyConfig.mock.calls[0][0]).not.toHaveProperty('$typeName');
   });
 
+  it('applies a config slice containing a bigint field without throwing', () => {
+    // Regression: Config.PowerConfig.powermon_enables decodes as native bigint, which
+    // JSON.stringify cannot serialize — the signature check must not crash on it.
+    const applyConfig = vi.fn();
+
+    renderHook(() => {
+      useSyncFormFromConfig(
+        { $typeName: 'meshtastic.Config.PowerConfig', powermonEnables: 7n, isPowerSaving: true },
+        applyConfig,
+      );
+    });
+
+    expect(applyConfig).toHaveBeenCalledWith({ powermonEnables: 7n, isPowerSaving: true });
+  });
+
   it('skips sync when config slice is empty', () => {
     const applyConfig = vi.fn();
 

--- a/src/renderer/hooks/useSyncFormFromConfig.ts
+++ b/src/renderer/hooks/useSyncFormFromConfig.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import {
+  meshtasticConfigSignature,
   meshtasticConfigSlice,
   stripMeshtasticProtobufMeta,
 } from '@/renderer/lib/meshtastic/meshtasticConfigApply';
@@ -15,7 +16,7 @@ export function useSyncFormFromConfig(
   useEffect(() => {
     const cfg = stripMeshtasticProtobufMeta(meshtasticConfigSlice(configSlice));
     if (Object.keys(cfg).length === 0) return;
-    const signature = JSON.stringify(cfg);
+    const signature = meshtasticConfigSignature(cfg);
     if (appliedSignatureRef.current === signature) return;
     appliedSignatureRef.current = signature;
     applyConfig(cfg);

--- a/src/renderer/lib/meshtastic/meshtasticConfigApply.test.ts
+++ b/src/renderer/lib/meshtastic/meshtasticConfigApply.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildMeshtasticModuleApplyValue,
   mergeMeshtasticConfigApplyValue,
+  meshtasticConfigSignature,
   meshtasticConfigSlice,
   meshtasticConfigSliceHydrated,
   stripMeshtasticProtobufMeta,
@@ -50,6 +51,22 @@ describe('meshtasticConfigApply', () => {
       enabled: true,
       baud: 115200,
     });
+  });
+
+  it('meshtasticConfigSignature stringifies bigint fields instead of throwing', () => {
+    // PowerConfig.powermon_enables / RemoteHardwareConfig.gpio_mask decode as native bigint —
+    // plain JSON.stringify throws "Do not know how to serialize a BigInt" on these.
+    expect(() =>
+      meshtasticConfigSignature({ powermonEnables: 42n, isPowerSaving: true }),
+    ).not.toThrow();
+    expect(meshtasticConfigSignature({ powermonEnables: 42n })).toBe(
+      JSON.stringify({ powermonEnables: '42' }),
+    );
+  });
+
+  it('meshtasticConfigSignature is stable across calls for unchanged input', () => {
+    const cfg = { gpioMask: 255n, gpioValue: 0n, enabled: true };
+    expect(meshtasticConfigSignature(cfg)).toBe(meshtasticConfigSignature({ ...cfg }));
   });
 
   it('buildMeshtasticModuleApplyValue delegates to merge', () => {

--- a/src/renderer/lib/meshtastic/meshtasticConfigApply.ts
+++ b/src/renderer/lib/meshtastic/meshtasticConfigApply.ts
@@ -19,6 +19,18 @@ export function stripMeshtasticProtobufMeta(cfg: Record<string, unknown>): Recor
 }
 
 /**
+ * Stable signature of a device config slice for change detection (skip re-applying an
+ * unchanged re-push). Some fields decode as native `bigint` (e.g. PowerConfig.powermon_enables,
+ * RemoteHardwareConfig.gpio_mask/gpio_value), which plain `JSON.stringify` cannot serialize —
+ * stringify those explicitly so the signature check itself cannot crash the panel.
+ */
+export function meshtasticConfigSignature(cfg: Record<string, unknown>): string {
+  return JSON.stringify(cfg, (_key: string, value: unknown) =>
+    typeof value === 'bigint' ? value.toString() : value,
+  );
+}
+
+/**
  * Merge device-owned config with UI edits so hidden fields are not cleared on apply.
  * Firmware setConfig/setModuleConfig replaces the full protobuf struct.
  */


### PR DESCRIPTION
## Summary

The Radio tab crashes to the ErrorBoundary ("Something went wrong" / "Do not know how to serialize a BigInt") whenever a Meshtastic `PowerConfig` (or, via `ModulePanel`'s shared hook, a `RemoteHardwareConfig`) slice is present. `Try Again` does nothing, since the same stale config re-triggers the identical crash on re-render.

## Root cause

`Config.PowerConfig.powermon_enables` (and `RemoteHardwareConfig.gpio_mask`/`gpio_value`) decode from the Meshtastic protobufs as native JS `bigint`. The change-detection signature added in #917 (skip re-applying an unchanged device config re-push, so it doesn't clobber in-progress edits) calls plain `JSON.stringify()` on the raw config slice — which has no built-in `BigInt` support and throws `TypeError: Do not know how to serialize a BigInt`.

## Fix

Add `meshtasticConfigSignature()` in `meshtasticConfigApply.ts` — a `JSON.stringify` wrapper whose replacer stringifies `bigint` values (lossless, unlike `Number(bigint)`) instead of leaving the native serializer to throw. Swap it in at both signature call sites:

- `useSyncFormFromConfig` (shared by RadioPanel's device/display/bluetooth/position/power/network sections and every ModulePanel section)
- `RadioPanel`'s Meshtastic LoRa sync effect

The config object passed to `applyConfig`/consumers is untouched — only the signature computation stringifies bigints, so downstream behavior for non-bigint fields is unchanged.

## Testing

- New regression tests in `meshtasticConfigApply.test.ts` (bigint field doesn't throw, signature is stable/deterministic) and `useSyncFormFromConfig.test.ts` (hook applies a bigint-bearing slice without throwing).
- `pnpm run typecheck`, targeted `eslint`, and full `pnpm vitest run` on `RadioPanel.test.tsx` / `ModulePanel.test.tsx` / the two files above — all pass.
- Pre-commit's staged-scoped Vitest run (162 tests) passed clean on commit.

https://claude.ai/code/session_01WMA8sffz7rFDmW6A7ZNdak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration synchronization for devices using large numeric values.
  * Prevented sync checks from failing when configurations contain native integer values.
  * Reduced unnecessary configuration re-application when settings have not changed.

* **Tests**
  * Added coverage confirming stable change detection and reliable form synchronization for these configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->