### PR TITLE
fix(flatpak): stage vendored Electron before offline native rebuild

### DIFF
--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -63,6 +63,8 @@ modules:
           export MESH_CLIENT_BUILD_INFO="$(cat flatpak/ci-build-info.json)"
         fi
         pnpm run build
+      # pnpm --ignore-scripts skips electron postinstall; stage vendored zip offline
+      - node scripts/flatpak-stage-electron.mjs
       # Rebuild native addons (noble BLE, sqlite) against the bundled Electron ABI
       - pnpm run rebuild
       # Install app payload (Electron binary + app roots; zypak needs a real Chromium binary)

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -207,6 +207,33 @@ function checkFlatpakWorkflowStoreVersion(pkg) {
   return violations;
 }
 
+function checkManifestStagesElectronBeforeRebuild() {
+  const violations = [];
+  if (!fs.existsSync(MANIFEST)) return violations;
+
+  const yaml = fs.readFileSync(MANIFEST, 'utf8');
+  const rel = path.relative(ROOT, MANIFEST);
+
+  if (!yaml.includes('node scripts/flatpak-stage-electron.mjs')) {
+    violations.push({
+      file: rel,
+      message:
+        'manifest must run flatpak-stage-electron.mjs before rebuild (offline electron-prebuilt → node_modules/electron/dist)',
+    });
+  }
+
+  const stageIdx = yaml.indexOf('node scripts/flatpak-stage-electron.mjs');
+  const rebuildIdx = yaml.indexOf('pnpm run rebuild');
+  if (stageIdx !== -1 && rebuildIdx !== -1 && stageIdx > rebuildIdx) {
+    violations.push({
+      file: rel,
+      message: 'flatpak-stage-electron.mjs must run before pnpm run rebuild',
+    });
+  }
+
+  return violations;
+}
+
 function checkManifestBranchAndElectronPayload(pkg) {
   const violations = [];
   if (!fs.existsSync(MANIFEST)) return violations;
@@ -630,6 +657,7 @@ function main() {
     ...checkManifestAppId(),
     ...checkManifestPnpmVersion(PKG_JSON),
     ...checkFlatpakWorkflowStoreVersion(PKG_JSON),
+    ...checkManifestStagesElectronBeforeRebuild(),
     ...checkManifestBranchAndElectronPayload(PKG_JSON),
     ...checkManifestCiBuildInfoExport(),
     ...checkFlatpakWorkflowTestBuildContracts(),

--- a/scripts/flatpak-stage-electron.mjs
+++ b/scripts/flatpak-stage-electron.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Stage Flatpak-vendored Electron into node_modules/electron/dist before rebuild.
+ *
+ * Failure point: pnpm --ignore-scripts skips electron postinstall, and the
+ * flatpak-builder sandbox has no network for electron/install.js. The vendored
+ * electron-prebuilt archive must be copied into dist/ so rebuild-native can
+ * probe the binary and run install-app-deps offline.
+ */
+import { cpSync, existsSync, mkdirSync, rmSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { isElectronBinaryInstalled } from './electron-binary.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const projectRoot = path.resolve(__dirname, '..');
+export const FLATPAK_ELECTRON_PREBUILT = path.join(projectRoot, 'electron-prebuilt');
+
+/**
+ * @param {object} [opts]
+ * @param {string} [opts.root]
+ * @param {string} [opts.prebuiltDir]
+ */
+export function stageFlatpakElectron({
+  root = projectRoot,
+  prebuiltDir = FLATPAK_ELECTRON_PREBUILT,
+} = {}) {
+  if (!existsSync(prebuiltDir)) {
+    console.error(`[flatpak-electron] vendored prebuilt missing: ${prebuiltDir}`);
+    process.exit(1);
+  }
+
+  const distDir = path.join(root, 'node_modules', 'electron', 'dist');
+  mkdirSync(path.dirname(distDir), { recursive: true });
+  rmSync(distDir, { recursive: true, force: true });
+  cpSync(prebuiltDir, distDir, { recursive: true });
+
+  if (!isElectronBinaryInstalled(root, 'linux', existsSync)) {
+    console.error(`[flatpak-electron] staged binary missing under ${distDir}`);
+    process.exit(1);
+  }
+
+  console.log(`[flatpak-electron] staged ${prebuiltDir} -> ${distDir}`);
+}
+
+const isDirectRun =
+  process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  stageFlatpakElectron();
+}

--- a/scripts/flatpak-stage-electron.test.mjs
+++ b/scripts/flatpak-stage-electron.test.mjs
@@ -1,0 +1,21 @@
+// @vitest-environment node
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { isElectronBinaryInstalled } from './electron-binary.mjs';
+import { stageFlatpakElectron } from './flatpak-stage-electron.mjs';
+
+describe('stageFlatpakElectron', () => {
+  it('copies electron-prebuilt into node_modules/electron/dist', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'mesh-flatpak-electron-'));
+    const prebuiltDir = path.join(root, 'electron-prebuilt');
+    const electronBin = path.join(prebuiltDir, 'electron');
+    mkdirSync(prebuiltDir, { recursive: true });
+    writeFileSync(electronBin, '#!/bin/sh\n', { mode: 0o755 });
+
+    stageFlatpakElectron({ root, prebuiltDir });
+
+    expect(isElectronBinaryInstalled(root, 'linux')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes Flatpak x86_64/aarch64 CI failure after Electron 44 (#926): `pnpm run rebuild` tried to download the Electron binary via `electron/install.js`, which fails offline in the flatpak-builder sandbox (`TypeError: fetch failed`).
- Adds `scripts/flatpak-stage-electron.mjs` to copy the vendored `electron-prebuilt` archive into `node_modules/electron/dist` before rebuild, and extends `check:flatpak` to enforce build order.

## Test plan

- [x] `pnpm exec vitest run scripts/flatpak-stage-electron.test.mjs scripts/check-flatpak.test.mjs`
- [x] `pnpm run check:flatpak`
- [ ] Flatpak CI (`flatpak.yaml`) green on both x86_64 and aarch64