### PR TITLE
fix(flatpak): auto-retry with --no-sandbox when user namespaces are blocked

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -431,7 +431,7 @@ flatpak run org.coloradomesh.MeshClient
 
 **Symptom**: `flatpak run org.coloradomesh.MeshClient` prints `Command failed` right after `Running 'bwrap … -- mesh-client'` with no window. Common on **Arch, CachyOS, KDE Plasma 6, and Hyprland** (pure Wayland). The AppImage from the same release often works.
 
-**Cause**: The Flatpak sandbox mounts an empty `/tmp/.X11-unix`, so Electron cannot fall back to X11 unless the wrapper passes Wayland/Ozone flags. Older bundles also omitted Chromium sandbox flags and `TMPDIR` setup that zypak expects.
+**Cause**: The Flatpak sandbox mounts an empty `/tmp/.X11-unix`, so Electron cannot fall back to X11 unless the wrapper passes Wayland/Ozone flags. Older bundles also omitted Chromium sandbox flags and `TMPDIR` setup that zypak expects. A different immediate exit with `No usable sandbox!` on hardened hosts is covered in [Flatpak: "No usable sandbox!" on Ubuntu 23.10+ / hardened Linux](#flatpak-no-usable-sandbox-on-ubuntu-2310--hardened-linux).
 
 The log line `F: /lib32 does not exist in runtime` is **harmless** on x86_64-only runtimes — not the failure cause.
 
@@ -464,6 +464,28 @@ flatpak uninstall --user org.coloradomesh.MeshClient
 flatpak install --user ./org.coloradomesh.MeshClient-x86_64.flatpak
 flatpak run org.coloradomesh.MeshClient
 ```
+
+### Flatpak: "No usable sandbox!" on Ubuntu 23.10+ / hardened Linux
+
+**Symptom**: `flatpak run org.coloradomesh.MeshClient` exits immediately with no window. The terminal may show `zypak-helper` lines (for example `Wait found events, but sd-event found none`) followed by:
+
+```text
+FATAL:content/browser/zygote_host/zygote_host_impl_linux.cc:129] No usable sandbox!
+```
+
+**Cause**: The host blocks **unprivileged user namespaces** (common on **Ubuntu 23.10+** with AppArmor `apparmor_restrict_unprivileged_userns`, and on some hardened **Fedora** / **Arch** setups). The Flatpak wrapper passes `--disable-setuid-sandbox` (zypak owns Chromium sandboxing), so when user namespaces are unavailable Chromium has no usable sandbox and aborts.
+
+**Fix in app**: Current releases auto-retry with `--no-sandbox` when this fatal is detected (same fallback as `pnpm start` via `scripts/start-electron.mjs`). Reinstall the latest `.flatpak` from [GitHub Releases](https://github.com/Colorado-Mesh/mesh-client/releases) if you are on an older bundle.
+
+**Workaround** (skip the probe, force `--no-sandbox` on first launch):
+
+```bash
+MESH_CLIENT_NO_SANDBOX=1 flatpak run org.coloradomesh.MeshClient
+```
+
+The **outer Flatpak bubblewrap sandbox** still isolates the app when Chromium runs with `--no-sandbox`; only the inner Chromium namespace sandbox is relaxed.
+
+**Host root-cause fix** (optional — restores the inner Chromium sandbox): allow unprivileged user namespaces on the host, or add an AppArmor profile exception. See the upstream Chromium guide: [AppArmor userns restrictions](https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md). On older kernels, `kernel.unprivileged_userns_clone=1` may also be required — see [Linux launch notes](development-environment.md#linux-launch-notes) in development-environment.md.
 
 ## Database and local data
 

--- a/flatpak/mesh-client-wrapper.sh
+++ b/flatpak/mesh-client-wrapper.sh
@@ -51,5 +51,30 @@ if [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
 fi
 
 cd "$APP_ROOT"
+
+retry_log="${TMPDIR}/mesh-client-sandbox.log"
+
+# Explicit opt-in: single attempt with --no-sandbox (outer bubblewrap sandbox still active).
+if [ "${MESH_CLIENT_NO_SANDBOX:-}" = "1" ]; then
+  # shellcheck disable=SC2086
+  exec zypak-wrapper "$ELECTRON" $gpu_args $electron_args --no-sandbox . "$@"
+fi
+
+# First attempt keeps the zypak/Chromium sandbox. On hosts blocking unprivileged user
+# namespaces (Ubuntu 23.10+ AppArmor, etc.) Chromium fatals with "No usable sandbox!";
+# retry once with --no-sandbox (same as scripts/start-electron.mjs fallback).
 # shellcheck disable=SC2086
-exec zypak-wrapper "$ELECTRON" $gpu_args $electron_args . "$@"
+if zypak-wrapper "$ELECTRON" $gpu_args $electron_args . "$@" 2> "$retry_log"; then
+  if [ -s "$retry_log" ]; then
+    cat "$retry_log" >&2
+  fi
+  exit 0
+fi
+retry_code=$?
+if grep -q 'No usable sandbox!' "$retry_log"; then
+  echo "mesh-client: host blocks user namespaces; retrying with --no-sandbox (outer Flatpak sandbox still active)" >&2
+  # shellcheck disable=SC2086
+  exec zypak-wrapper "$ELECTRON" $gpu_args $electron_args --no-sandbox . "$@"
+fi
+cat "$retry_log" >&2
+exit $retry_code

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -370,6 +370,22 @@ function checkWrapperLaunchPaths() {
     });
   }
 
+  if (!sh.includes('No usable sandbox!')) {
+    violations.push({
+      file: rel,
+      message:
+        'wrapper must detect Chromium "No usable sandbox!" fatal and retry with --no-sandbox on hardened hosts',
+    });
+  }
+
+  if (!/exec zypak-wrapper[^\n]*--no-sandbox[^\n]* \. "\$@"/.test(sh)) {
+    violations.push({
+      file: rel,
+      message:
+        'wrapper must exec zypak-wrapper with --no-sandbox fallback when user namespaces are blocked',
+    });
+  }
+
   if (sh.includes('dist-electron/main/index.js "$@"')) {
     violations.push({
       file: rel,


### PR DESCRIPTION
## Summary
- Add detect-and-retry logic to `flatpak/mesh-client-wrapper.sh` so hosts that block unprivileged user namespaces (Ubuntu 23.10+ AppArmor, hardened Fedora/Arch) no longer fatal with `No usable sandbox!` on launch.
- Mirror the existing `scripts/start-electron.mjs` fallback: first attempt keeps the Chromium sandbox; retry once with `--no-sandbox` when the fatal is detected (outer Flatpak bubblewrap sandbox still active).
- Add `MESH_CLIENT_NO_SANDBOX=1` opt-in to skip the probe, enforce the fallback in `check-flatpak.mjs`, and document symptoms/workarounds in `docs/troubleshooting.md`.

## Test plan
- [x] `pnpm run check:flatpak`
- [x] `pnpm run test:run -- scripts/check-flatpak.test.mjs`
- [ ] `flatpak run org.coloradomesh.MeshClient` on a userns-blocked host — window opens after one stderr retry line
- [ ] Same command on a normal host — no retry message; Chromium sandbox remains enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Flatpak launches now automatically retry with a compatible sandbox configuration when the host blocks Chromium’s user namespaces.
  - Added an optional `MESH_CLIENT_NO_SANDBOX=1` workaround for affected systems.

- **Documentation**
  - Added troubleshooting guidance for “No usable sandbox!” errors on Ubuntu 23.10+ and hardened Linux environments.
  - Documented application-level and host-level resolution options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->