### PR TITLE
fix(nodes): replace identity store after Clear All Nodes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   brace-expansion: ^5.0.9
   builder-util-runtime: ^9.7.0
   electron: ^44.1.0
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.6
   ip-address: ^10.3.1
   js-yaml: ^4.3.0
   markdown-it@<=14.1.1: '>=14.2.0 <15'
@@ -2346,8 +2346,8 @@ packages:
     resolution: {integrity: sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==}
     engines: {node: '>=18.2.0'}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastq@1.20.3:
     resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
@@ -5836,7 +5836,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6917,7 +6917,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       tslib: 2.8.1
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastq@1.20.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,8 +48,9 @@ overrides:
   # brace-expansion: keep a single 5.0.9 floor. GHSA-rgw5-rvv9-x895 is a
   # bypass of the CVE-2026-14257 mitigation and marks >=4.0.0 <5.0.9 vulnerable
   # (only >=5.0.9 counts as patched). CI audit is blocking.
-  # fast-uri: GHSA-7p8r-x3mc-p8w7 (host confusion via backslash authority);
-  # electron-builder → app-builder-lib → ajv still pulls 3.1.4.
+  # fast-uri: GHSA-7p8r-x3mc-p8w7 plus GHSA-5jgf-p345-68v8 / GHSA-f65p-4m7j-42xc /
+  # GHSA-fph4-wmhf-6fwf / GHSA-jqff-g426-hqxp — floor >=3.1.6 (electron-builder →
+  # app-builder-lib → ajv still pulls older 3.1.x without an override).
   # undici: GHSA-4cwx-7wf7-3272 (+ sibling undici GHSAs) — floor >=7.29.0, kept as
   # a scoped `undici@<7.29.0` override so transitive consumers (jsdom ^7.25.0,
   # node-gyp ^6.25.0) land on 7.29.0. package.json depends on undici ^8.10.0
@@ -64,7 +65,7 @@ overrides:
   brace-expansion: ^5.0.9
   builder-util-runtime: ^9.7.0
   electron: ^44.1.0
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.6
   ip-address: ^10.3.1
   js-yaml: ^4.3.0
   markdown-it@<=14.1.1: '>=14.2.0 <15'

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2282,10 +2282,7 @@ function AppContent() {
     setPendingDmTarget(null);
   }, []);
 
-  const {
-    refreshNodesFromDb: refreshMeshtasticNodesInStore,
-    refreshMessagesFromDb: refreshMeshtasticMessagesInStore,
-  } = meshtasticDbRefresh;
+  const { refreshMessagesFromDb: refreshMeshtasticMessagesInStore } = meshtasticDbRefresh;
   const {
     refreshNodesFromDb: refreshMeshcoreNodesInStore,
     refreshMessagesFromDb: refreshMeshcoreMessagesInStore,
@@ -2294,19 +2291,13 @@ function AppContent() {
   const refreshNodesFromDb = useCallback(() => {
     const actions = selectByProtocol(panelActionsByProtocol, protocol);
     if (capabilities.hasRemoteAdmin) {
+      // Meshtastic runtime refresh already replace-syncs the identity node store.
       void actions.refreshNodesFromDb();
-      void refreshMeshtasticNodesInStore({ nodesMode: 'replace' });
     } else {
       void actions.refreshNodesFromDb();
       void refreshMeshcoreNodesInStore({ nodesMode: 'replace' });
     }
-  }, [
-    protocol,
-    capabilities.hasRemoteAdmin,
-    panelActionsByProtocol,
-    refreshMeshtasticNodesInStore,
-    refreshMeshcoreNodesInStore,
-  ]);
+  }, [protocol, capabilities.hasRemoteAdmin, panelActionsByProtocol, refreshMeshcoreNodesInStore]);
 
   const refreshMessagesFromDb = useCallback(
     (opts?: MessageClearRefreshOptions) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2295,10 +2295,10 @@ function AppContent() {
     const actions = selectByProtocol(panelActionsByProtocol, protocol);
     if (capabilities.hasRemoteAdmin) {
       void actions.refreshNodesFromDb();
-      void refreshMeshtasticNodesInStore();
+      void refreshMeshtasticNodesInStore({ nodesMode: 'replace' });
     } else {
       void actions.refreshNodesFromDb();
-      void refreshMeshcoreNodesInStore();
+      void refreshMeshcoreNodesInStore({ nodesMode: 'replace' });
     }
   }, [
     protocol,

--- a/src/renderer/components/AppPanel.test.tsx
+++ b/src/renderer/components/AppPanel.test.tsx
@@ -514,3 +514,36 @@ describe('AppPanel: font size control', () => {
     expect(results).toHaveNoViolations();
   });
 });
+
+describe('AppPanel: Clear All Nodes success toast', () => {
+  const defaultProps = {
+    protocol: 'meshtastic' as const,
+    nodeCount: 3,
+    messageCount: 0,
+    channels: [] as { index: number; name: string }[],
+    myNodeNum: null as number | null,
+    onLocationFilterChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.mocked(window.electronAPI.appSettings.getAll).mockResolvedValue({});
+    vi.mocked(window.electronAPI.db.clearNodes).mockResolvedValue(undefined);
+  });
+
+  it('shows the resolved node count in the success toast', async () => {
+    render(
+      <ToastProvider>
+        <AppPanel {...defaultProps} />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Destructive actions'));
+    fireEvent.click(screen.getByRole('button', { name: /Clear All Nodes \(3\)/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Clear 3 Nodes/i }));
+
+    expect(
+      await screen.findByText('Clear All Nodes (3) completed successfully.'),
+    ).toBeInTheDocument();
+    expect(window.electronAPI.db.clearNodes).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/AppPanel.tsx
+++ b/src/renderer/components/AppPanel.tsx
@@ -112,24 +112,6 @@ function readNodesMapForProtocol(protocol: MeshProtocol): Map<number, MeshNode> 
   return nodeRecordsToMeshNodeMap(Object.values(byId));
 }
 
-const DANGER_ACTION_LABEL_KEY: Record<DangerActionId, string> = {
-  resetDiagnostics: 'appPanel.resetDiagnostics',
-  clearGpsData: 'appPanel.clearGpsData',
-  clearPositionHistory: 'appPanel.clearPositionHistory',
-  deleteOldNodes: 'appPanel.deleteOldNodes',
-  pruneMqttOnlyNodes: 'appPanel.pruneMqttOnlyNodes',
-  pruneUnnamedNodes: 'appPanel.pruneUnnamedNodes',
-  pruneNoFixNodes: 'appPanel.pruneNoFixNodes',
-  pruneDistantNodes: 'appPanel.pruneDistantNodesTitle',
-  pruneOfflineNodes: 'appPanel.pruneOfflineNodesTitle',
-  clearNodes: 'appPanel.clearAllNodesButton',
-  deleteContactsNoPubkeys: 'appPanel.deleteContactsNoPubkeysTitle',
-  clearReticulumContacts: 'appPanel.clearReticulumContactsTitle',
-  clearMessages: 'appPanel.clearMessagesTitle',
-  clearAllRepeaters: 'appPanel.clearAllRepeaters',
-  clearAllData: 'appPanel.clearAllLocalData',
-};
-
 function gpsIntervalLabel(t: (key: string) => string, secs: number): string {
   switch (secs) {
     case 0:
@@ -719,7 +701,7 @@ export default function AppPanel({
 
   const handleConfirm = useCallback(async () => {
     if (!pendingAction) return;
-    const { actionId, action, messageClearMeta } = pendingAction;
+    const { actionId, action, messageClearMeta, title } = pendingAction;
     setPendingAction(null);
     try {
       await action();
@@ -730,7 +712,7 @@ export default function AppPanel({
       }
       addToast(
         t('appPanel.actionCompleted', {
-          name: t(DANGER_ACTION_LABEL_KEY[actionId]),
+          name: title,
         }),
         'success',
       );

--- a/src/renderer/hooks/useDbRefresh.test.ts
+++ b/src/renderer/hooks/useDbRefresh.test.ts
@@ -61,6 +61,24 @@ describe('useProtocolDbRefresh', () => {
     });
   });
 
+  it('refreshNodesFromDb replace mode clears nodes when DB is empty', async () => {
+    useNodeStore.setState({
+      nodes: {
+        [ID]: {
+          1: { nodeId: 1, longName: 'Stale' },
+        },
+      },
+    });
+    vi.spyOn(window.electronAPI.db, 'getNodes').mockResolvedValue([]);
+
+    const { result } = renderHook(() => useProtocolDbRefresh('meshtastic', ID));
+    await result.current.refreshNodesFromDb({ nodesMode: 'replace' });
+
+    await waitFor(() => {
+      expect(useNodeStore.getState().nodes[ID]).toEqual({});
+    });
+  });
+
   it('refreshMessagesFromDb loads MeshCore messages only', async () => {
     vi.spyOn(window.electronAPI.db, 'getMeshcoreContacts').mockResolvedValue([]);
     vi.spyOn(window.electronAPI.db, 'getNodes').mockResolvedValue([]);

--- a/src/renderer/hooks/useDbRefresh.ts
+++ b/src/renderer/hooks/useDbRefresh.ts
@@ -8,10 +8,17 @@ import type { IdentityId, MeshProtocol } from '../lib/types';
  * Requires `identityId` after connect (or from `identityStore` via `useActiveMeshIdentity`).
  */
 export function useProtocolDbRefresh(protocol: MeshProtocol, identityId: IdentityId | null) {
-  const refreshNodesFromDb = useCallback(async (): Promise<void> => {
-    if (!identityId) return;
-    await hydrateIdentityStoresFromDb(protocol, identityId, { nodes: true, messages: false });
-  }, [protocol, identityId]);
+  const refreshNodesFromDb = useCallback(
+    async (opts?: { nodesMode?: 'upsert' | 'replace' }): Promise<void> => {
+      if (!identityId) return;
+      await hydrateIdentityStoresFromDb(protocol, identityId, {
+        nodes: true,
+        messages: false,
+        nodesMode: opts?.nodesMode ?? 'upsert',
+      });
+    },
+    [protocol, identityId],
+  );
 
   const refreshMessagesFromDb = useCallback(
     async (opts?: { messagesMode?: 'upsert' | 'replace' }): Promise<void> => {

--- a/src/renderer/lib/hydrateIdentityStoresFromDb.test.ts
+++ b/src/renderer/lib/hydrateIdentityStoresFromDb.test.ts
@@ -138,6 +138,80 @@ describe('hydrateIdentityStoresFromDb', () => {
     expect(useNodeStore.getState().nodes[ID_MT][1].longName).toBe('Stale-A');
   });
 
+  it('hydrateMeshcoreNodesFromDb replace mode clears nodes when contacts are empty', async () => {
+    upsertNodeRecordsForIdentity(ID_MC, [{ nodeId: 0xabc, longName: 'Stale-MC' }]);
+    vi.spyOn(window.electronAPI.db, 'getMeshcoreContacts').mockResolvedValue([]);
+    vi.spyOn(window.electronAPI.db, 'getNodes').mockResolvedValue([]);
+    vi.spyOn(window.electronAPI.db, 'getAllMeshcoreHopHistory').mockResolvedValue([]);
+    vi.spyOn(window.electronAPI.db, 'getMeshcoreMessages').mockResolvedValue([]);
+
+    await hydrateMeshcoreNodesFromDb(ID_MC, 'replace');
+
+    expect(useNodeStore.getState().nodes[ID_MC]).toEqual({});
+  });
+
+  it('drops a stale empty node replace when a newer hydration finishes first', async () => {
+    upsertNodeRecordsForIdentity(ID_MT, [{ nodeId: 1, longName: 'Prior' }]);
+
+    let resolveStale!: (rows: never[]) => void;
+    const staleLoad = new Promise<never[]>((resolve) => {
+      resolveStale = resolve;
+    });
+    let getNodesCalls = 0;
+    vi.spyOn(window.electronAPI.db, 'getNodes').mockImplementation(() => {
+      getNodesCalls += 1;
+      if (getNodesCalls === 1) return staleLoad;
+      return Promise.resolve([
+        {
+          node_id: 9,
+          long_name: 'Fresh',
+          short_name: 'F9',
+          hw_model: 'Heltec',
+          battery: 50,
+          snr: 0,
+          rssi: -90,
+          last_heard: 1,
+          latitude: null,
+          longitude: null,
+          role: null,
+          hops_away: null,
+          via_mqtt: null,
+          voltage: null,
+          channel_utilization: null,
+          air_util_tx: null,
+          altitude: null,
+          favorited: 0,
+          source: 'rf',
+          num_packets_rx_bad: null,
+          num_rx_dupe: null,
+          num_packets_rx: null,
+          num_packets_tx: null,
+          hops: null,
+          path: null,
+        },
+      ]);
+    });
+
+    const stale = hydrateIdentityStoresFromDb('meshtastic', ID_MT, {
+      nodes: true,
+      messages: false,
+      nodesMode: 'replace',
+    });
+    const fresh = hydrateIdentityStoresFromDb('meshtastic', ID_MT, {
+      nodes: true,
+      messages: false,
+      nodesMode: 'replace',
+    });
+
+    await fresh;
+    expect(useNodeStore.getState().nodes[ID_MT][9].longName).toBe('Fresh');
+
+    resolveStale([]);
+    await stale;
+    expect(useNodeStore.getState().nodes[ID_MT][9].longName).toBe('Fresh');
+    expect(useNodeStore.getState().nodes[ID_MT][1]).toBeUndefined();
+  });
+
   it('hydrates MeshCore contacts and messages into identity-scoped stores', async () => {
     vi.spyOn(window.electronAPI.db, 'getMeshcoreContacts').mockResolvedValue([
       {

--- a/src/renderer/lib/hydrateIdentityStoresFromDb.test.ts
+++ b/src/renderer/lib/hydrateIdentityStoresFromDb.test.ts
@@ -212,6 +212,203 @@ describe('hydrateIdentityStoresFromDb', () => {
     expect(useNodeStore.getState().nodes[ID_MT][1]).toBeUndefined();
   });
 
+  it('drops a stale Meshtastic full hydration when a newer one finishes first', async () => {
+    upsertMessageRecordsForIdentity(ID_MT, [
+      {
+        id: 'prior',
+        from: 1,
+        to: 0xffffffff,
+        payload: 'prior',
+        channelIndex: 0,
+        timestamp: 1000,
+        senderName: 'Prior',
+      },
+    ]);
+    upsertNodeRecordsForIdentity(ID_MT, [{ nodeId: 1, longName: 'Prior' }]);
+
+    type SavedMsg = Awaited<ReturnType<typeof window.electronAPI.db.getMessages>>[number];
+    let resolveStaleMsgs!: (rows: SavedMsg[]) => void;
+    const staleMsgs = new Promise<SavedMsg[]>((resolve) => {
+      resolveStaleMsgs = resolve;
+    });
+    let getMessagesCalls = 0;
+    vi.spyOn(window.electronAPI.db, 'getMessages').mockImplementation(() => {
+      getMessagesCalls += 1;
+      if (getMessagesCalls === 1) return staleMsgs;
+      return Promise.resolve([
+        {
+          id: 20,
+          sender_id: 9,
+          sender_name: 'Fresh',
+          payload: 'fresh',
+          channel: 0,
+          timestamp: 3000,
+          packetId: null,
+          status: 'acked',
+          error: null,
+          emoji: null,
+          replyId: null,
+          to: undefined,
+          mqttStatus: null,
+          receivedVia: null,
+        },
+      ]);
+    });
+    vi.spyOn(window.electronAPI.db, 'getNodes').mockResolvedValue([
+      {
+        node_id: 9,
+        long_name: 'Fresh',
+        short_name: 'F9',
+        hw_model: 'Heltec',
+        battery: 50,
+        snr: 0,
+        rssi: -90,
+        last_heard: 1,
+        latitude: null,
+        longitude: null,
+        role: null,
+        hops_away: null,
+        via_mqtt: null,
+        voltage: null,
+        channel_utilization: null,
+        air_util_tx: null,
+        altitude: null,
+        favorited: 0,
+        source: 'rf',
+        num_packets_rx_bad: null,
+        num_rx_dupe: null,
+        num_packets_rx: null,
+        num_packets_tx: null,
+        hops: null,
+        path: null,
+      },
+    ]);
+
+    const stale = hydrateIdentityStoresFromDb('meshtastic', ID_MT, {
+      nodes: true,
+      messages: true,
+      nodesMode: 'replace',
+      messagesMode: 'replace',
+    });
+    const fresh = hydrateIdentityStoresFromDb('meshtastic', ID_MT, {
+      nodes: true,
+      messages: true,
+      nodesMode: 'replace',
+      messagesMode: 'replace',
+    });
+
+    await fresh;
+    const freshMsgIds = Object.keys(useMessageStore.getState().messages[ID_MT] ?? {});
+    expect(freshMsgIds).toHaveLength(1);
+    expect(freshMsgIds[0]).not.toBe('prior');
+    expect(useNodeStore.getState().nodes[ID_MT][9].longName).toBe('Fresh');
+
+    resolveStaleMsgs([
+      {
+        id: 99,
+        sender_id: 1,
+        sender_name: 'Stale',
+        payload: 'stale',
+        channel: 0,
+        timestamp: 1500,
+        packetId: null,
+        status: 'acked',
+        error: null,
+        emoji: null,
+        replyId: null,
+        to: undefined,
+        mqttStatus: null,
+        receivedVia: null,
+      },
+    ]);
+    await stale;
+    expect(Object.keys(useMessageStore.getState().messages[ID_MT] ?? {})).toEqual(freshMsgIds);
+    expect(useNodeStore.getState().nodes[ID_MT][9].longName).toBe('Fresh');
+    expect(useNodeStore.getState().nodes[ID_MT][1]).toBeUndefined();
+  });
+
+  it('drops a stale MeshCore full hydration when a newer one finishes first', async () => {
+    upsertMessageRecordsForIdentity(ID_MC, [
+      {
+        id: 'prior-mc',
+        from: 0xabc,
+        to: 0xffffffff,
+        payload: 'prior',
+        channelIndex: 0,
+        timestamp: 1000,
+        senderName: 'Prior',
+      },
+    ]);
+
+    type SavedMcMsg = Awaited<ReturnType<typeof window.electronAPI.db.getMeshcoreMessages>>[number];
+    let resolveStaleMsgs!: (rows: SavedMcMsg[]) => void;
+    const staleMsgs = new Promise<SavedMcMsg[]>((resolve) => {
+      resolveStaleMsgs = resolve;
+    });
+    let serveFreshMessages = false;
+    vi.spyOn(window.electronAPI.db, 'getMeshcoreMessages').mockImplementation(() => {
+      if (!serveFreshMessages) return staleMsgs;
+      return Promise.resolve([
+        {
+          id: 20,
+          sender_id: 0xdef,
+          sender_name: 'Fresh',
+          payload: 'fresh',
+          channel_idx: 0,
+          timestamp: 3000,
+          status: 'acked',
+          packet_id: null,
+          emoji: null,
+          reply_id: null,
+          to_node: null,
+        },
+      ]);
+    });
+    vi.spyOn(window.electronAPI.db, 'getMeshcoreContacts').mockResolvedValue([]);
+    vi.spyOn(window.electronAPI.db, 'getNodes').mockResolvedValue([]);
+    vi.spyOn(window.electronAPI.db, 'getAllMeshcoreHopHistory').mockResolvedValue([]);
+
+    const stale = hydrateIdentityStoresFromDb('meshcore', ID_MC, {
+      nodes: true,
+      messages: true,
+      nodesMode: 'replace',
+      messagesMode: 'replace',
+    });
+    // Let the stale hydrator's DB awaits park on the deferred message load.
+    await Promise.resolve();
+    await Promise.resolve();
+    serveFreshMessages = true;
+    const fresh = hydrateIdentityStoresFromDb('meshcore', ID_MC, {
+      nodes: true,
+      messages: true,
+      nodesMode: 'replace',
+      messagesMode: 'replace',
+    });
+
+    await fresh;
+    const freshMsgIds = Object.keys(useMessageStore.getState().messages[ID_MC] ?? {});
+    expect(freshMsgIds).toHaveLength(1);
+    expect(freshMsgIds[0]).not.toBe('prior-mc');
+
+    resolveStaleMsgs([
+      {
+        id: 99,
+        sender_id: 0xabc,
+        sender_name: 'Stale',
+        payload: 'stale',
+        channel_idx: 0,
+        timestamp: 1500,
+        status: 'acked',
+        packet_id: null,
+        emoji: null,
+        reply_id: null,
+        to_node: null,
+      },
+    ]);
+    await stale;
+    expect(Object.keys(useMessageStore.getState().messages[ID_MC] ?? {})).toEqual(freshMsgIds);
+  });
+
   it('hydrates MeshCore contacts and messages into identity-scoped stores', async () => {
     vi.spyOn(window.electronAPI.db, 'getMeshcoreContacts').mockResolvedValue([
       {

--- a/src/renderer/lib/hydrateIdentityStoresFromDb.test.ts
+++ b/src/renderer/lib/hydrateIdentityStoresFromDb.test.ts
@@ -12,6 +12,7 @@ import {
   hydrateMeshtasticNodesFromDb,
   mergeMeshcoreDbMessageRowsForHydration,
   MESHCORE_DB_ROOM_MESSAGE_LOAD_LIMIT,
+  replaceNodesMapInIdentityStore,
   syncNodesMapToIdentityStore,
 } from './hydrateIdentityStoresFromDb';
 import { resetIdentityHydrationCoordinatorForTests } from './identityHydrationCoordinator';
@@ -85,6 +86,56 @@ describe('hydrateIdentityStoresFromDb', () => {
 
     expect(useNodeStore.getState().nodes[ID_MT][1].longName).toBe('Alpha');
     expect(Object.keys(useMessageStore.getState().messages[ID_MT] ?? {})).toHaveLength(1);
+  });
+
+  it('hydrateMeshtasticNodesFromDb replace mode clears nodes absent from DB', async () => {
+    upsertNodeRecordsForIdentity(ID_MT, [
+      { nodeId: 1, longName: 'Stale-A' },
+      { nodeId: 2, longName: 'Stale-B' },
+    ]);
+    vi.spyOn(window.electronAPI.db, 'getNodes').mockResolvedValue([]);
+
+    await hydrateMeshtasticNodesFromDb(ID_MT, 'replace');
+
+    expect(useNodeStore.getState().nodes[ID_MT]).toEqual({});
+  });
+
+  it('replaceNodesMapInIdentityStore drops ids missing from the map', () => {
+    upsertNodeRecordsForIdentity(ID_MT, [
+      { nodeId: 1, longName: 'Keep' },
+      { nodeId: 2, longName: 'Drop' },
+    ]);
+    replaceNodesMapInIdentityStore(
+      ID_MT,
+      new Map([
+        [
+          1,
+          {
+            node_id: 1,
+            long_name: 'Keep-2',
+            short_name: '',
+            hw_model: '',
+            battery: 0,
+            snr: 0,
+            rssi: 0,
+            last_heard: 0,
+            latitude: null,
+            longitude: null,
+          },
+        ],
+      ]),
+    );
+    expect(useNodeStore.getState().nodes[ID_MT][1].longName).toBe('Keep-2');
+    expect(useNodeStore.getState().nodes[ID_MT][2]).toBeUndefined();
+  });
+
+  it('hydrateMeshtasticNodesFromDb upsert mode leaves prior nodes when DB is empty', async () => {
+    upsertNodeRecordsForIdentity(ID_MT, [{ nodeId: 1, longName: 'Stale-A' }]);
+    vi.spyOn(window.electronAPI.db, 'getNodes').mockResolvedValue([]);
+
+    await hydrateMeshtasticNodesFromDb(ID_MT, 'upsert');
+
+    expect(useNodeStore.getState().nodes[ID_MT][1].longName).toBe('Stale-A');
   });
 
   it('hydrates MeshCore contacts and messages into identity-scoped stores', async () => {

--- a/src/renderer/lib/hydrateIdentityStoresFromDb.ts
+++ b/src/renderer/lib/hydrateIdentityStoresFromDb.ts
@@ -111,8 +111,10 @@ export interface MessageClearRefreshOptions {
 export async function hydrateMeshtasticNodesFromDb(
   identityId: IdentityId,
   nodesMode: 'upsert' | 'replace' = 'upsert',
+  isCurrent?: () => boolean,
 ): Promise<void> {
   const nodeMap = await loadMeshtasticNodeMapFromDb();
+  if (isCurrent && !isCurrent()) return;
   if (nodesMode === 'replace') {
     replaceNodesMapInIdentityStore(identityId, nodeMap);
   } else {
@@ -182,6 +184,7 @@ export async function loadMeshcoreSavedHopRowsForHydration(): Promise<MeshcoreSa
 export async function hydrateMeshcoreNodesFromDb(
   identityId: IdentityId,
   nodesMode: 'upsert' | 'replace' = 'upsert',
+  isCurrent?: () => boolean,
 ): Promise<void> {
   const [rows, savedNodes] = await Promise.all([
     window.electronAPI.db.getMeshcoreContacts(),
@@ -190,6 +193,7 @@ export async function hydrateMeshcoreNodesFromDb(
   const dbMsgs = await loadMeshcoreMessagesForHydration();
   const mapped = mapMeshcoreDbRowsToChatMessages(dbMsgs);
   const nodeMap = buildMeshcoreNodeMapFromDb(rows as MeshcoreContactDbRow[], savedNodes, mapped);
+  if (isCurrent && !isCurrent()) return;
   if (nodesMode === 'replace') {
     replaceNodesMapInIdentityStore(identityId, nodeMap);
   } else {
@@ -255,11 +259,13 @@ export async function hydrateMeshcoreMessagesFromDb(
 type IdentityHydratorFn = (
   identityId: IdentityId,
   opts: HydrateIdentityStoresOptions,
+  isCurrent: () => boolean,
 ) => Promise<void>;
 
 async function hydrateMeshtasticIdentity(
   identityId: IdentityId,
   opts: HydrateIdentityStoresOptions,
+  isCurrent: () => boolean,
 ): Promise<void> {
   const loadNodes = opts.nodes !== false;
   const loadMessages = opts.messages !== false;
@@ -267,11 +273,11 @@ async function hydrateMeshtasticIdentity(
   const nodesMode = opts.nodesMode ?? 'upsert';
   if (loadNodes && loadMessages) {
     await Promise.all([
-      hydrateMeshtasticNodesFromDb(identityId, nodesMode),
+      hydrateMeshtasticNodesFromDb(identityId, nodesMode, isCurrent),
       hydrateMeshtasticMessagesFromDb(identityId, messagesMode),
     ]);
   } else if (loadNodes) {
-    await hydrateMeshtasticNodesFromDb(identityId, nodesMode);
+    await hydrateMeshtasticNodesFromDb(identityId, nodesMode, isCurrent);
   } else if (loadMessages) {
     await hydrateMeshtasticMessagesFromDb(identityId, messagesMode);
   }
@@ -280,6 +286,7 @@ async function hydrateMeshtasticIdentity(
 async function hydrateMeshcoreIdentity(
   identityId: IdentityId,
   opts: HydrateIdentityStoresOptions,
+  isCurrent: () => boolean,
 ): Promise<void> {
   const loadNodes = opts.nodes !== false;
   const loadMessages = opts.messages !== false;
@@ -287,11 +294,11 @@ async function hydrateMeshcoreIdentity(
   const nodesMode = opts.nodesMode ?? 'upsert';
   if (loadNodes && loadMessages) {
     await Promise.all([
-      hydrateMeshcoreNodesFromDb(identityId, nodesMode),
+      hydrateMeshcoreNodesFromDb(identityId, nodesMode, isCurrent),
       hydrateMeshcoreMessagesFromDb(identityId, messagesMode),
     ]);
   } else if (loadNodes) {
-    await hydrateMeshcoreNodesFromDb(identityId, nodesMode);
+    await hydrateMeshcoreNodesFromDb(identityId, nodesMode, isCurrent);
   } else if (loadMessages) {
     await hydrateMeshcoreMessagesFromDb(identityId, messagesMode);
   }
@@ -300,6 +307,7 @@ async function hydrateMeshcoreIdentity(
 function hydrateReticulumIdentity(
   identityId: IdentityId,
   opts: HydrateIdentityStoresOptions,
+  isCurrent: () => boolean,
 ): Promise<void> {
   const loadNodes = opts.nodes !== false;
   const loadMessages = opts.messages !== false;
@@ -312,6 +320,7 @@ function hydrateReticulumIdentity(
           last_heard?: number | null;
           favorited?: number | null;
         }[];
+        if (!isCurrent()) return;
         const { reticulumHashToNodeId, registerReticulumDestinationHash } =
           await import('./reticulum/destHash');
         const records: NodeRecord[] = [];
@@ -333,6 +342,7 @@ function hydrateReticulumIdentity(
             reticulumDestinationHash: destinationHash,
           });
         }
+        if (!isCurrent()) return;
         upsertNodeRecordsForIdentity(identityId, records);
       } catch (e) {
         console.warn('[hydrateReticulumIdentity] destinations ' + errLikeToLogString(e));
@@ -347,6 +357,7 @@ function hydrateReticulumIdentity(
           timestamp: number;
           to_hash?: string;
         }[];
+        if (!isCurrent()) return;
         replaceMessageRecordsForIdentity(
           identityId,
           rows.map((row) => reticulumDbRowToMessageRecord(row)),
@@ -383,7 +394,7 @@ export async function hydrateIdentityStoresFromDb(
 
   const isCurrent = beginIdentityHydration(protocol, identityId);
   try {
-    await hydrator(identityId, opts);
+    await hydrator(identityId, opts, isCurrent);
     if (!isCurrent()) return;
   } catch (e) {
     if (!isCurrent()) return;

--- a/src/renderer/lib/hydrateIdentityStoresFromDb.ts
+++ b/src/renderer/lib/hydrateIdentityStoresFromDb.ts
@@ -125,8 +125,10 @@ export async function hydrateMeshtasticNodesFromDb(
 export async function hydrateMeshtasticMessagesFromDb(
   identityId: IdentityId,
   messagesMode: 'upsert' | 'replace' = 'upsert',
+  isCurrent?: () => boolean,
 ): Promise<void> {
   const msgs = await window.electronAPI.db.getMessages(undefined, getMeshtasticMessageLoadLimit());
+  if (isCurrent && !isCurrent()) return;
   const sanitized = dedupeMeshtasticHydrationOrphanSends(msgs.map(savedMessageToChatMessage));
   const reversed = sanitized.toReversed();
   const trimmed = trimChatMessagesToMax(reversed, MAX_IN_MEMORY_CHAT_MESSAGES);
@@ -226,11 +228,13 @@ export function replaceNodesMapInIdentityStore(
 export async function hydrateMeshcoreMessagesFromDb(
   identityId: IdentityId,
   messagesMode: 'upsert' | 'replace' = 'upsert',
+  isCurrent?: () => boolean,
 ): Promise<void> {
   const [dbMsgs, contactRows] = await Promise.all([
     loadMeshcoreMessagesForHydration(),
     window.electronAPI.db.getMeshcoreContacts(),
   ]);
+  if (isCurrent && !isCurrent()) return;
   const rows = dbMsgs;
   const roomServerIds = meshcoreRoomServerIdsFromContacts(contactRows as MeshcoreContactDbRow[]);
   const mapped = repairMeshcoreHydratedMessages(
@@ -274,12 +278,12 @@ async function hydrateMeshtasticIdentity(
   if (loadNodes && loadMessages) {
     await Promise.all([
       hydrateMeshtasticNodesFromDb(identityId, nodesMode, isCurrent),
-      hydrateMeshtasticMessagesFromDb(identityId, messagesMode),
+      hydrateMeshtasticMessagesFromDb(identityId, messagesMode, isCurrent),
     ]);
   } else if (loadNodes) {
     await hydrateMeshtasticNodesFromDb(identityId, nodesMode, isCurrent);
   } else if (loadMessages) {
-    await hydrateMeshtasticMessagesFromDb(identityId, messagesMode);
+    await hydrateMeshtasticMessagesFromDb(identityId, messagesMode, isCurrent);
   }
 }
 
@@ -295,12 +299,12 @@ async function hydrateMeshcoreIdentity(
   if (loadNodes && loadMessages) {
     await Promise.all([
       hydrateMeshcoreNodesFromDb(identityId, nodesMode, isCurrent),
-      hydrateMeshcoreMessagesFromDb(identityId, messagesMode),
+      hydrateMeshcoreMessagesFromDb(identityId, messagesMode, isCurrent),
     ]);
   } else if (loadNodes) {
     await hydrateMeshcoreNodesFromDb(identityId, nodesMode, isCurrent);
   } else if (loadMessages) {
-    await hydrateMeshcoreMessagesFromDb(identityId, messagesMode);
+    await hydrateMeshcoreMessagesFromDb(identityId, messagesMode, isCurrent);
   }
 }
 

--- a/src/renderer/lib/hydrateIdentityStoresFromDb.ts
+++ b/src/renderer/lib/hydrateIdentityStoresFromDb.ts
@@ -12,7 +12,11 @@ import {
   replaceMessageRecordsForIdentity,
   upsertMessageRecordsForIdentity,
 } from '../stores/messageStore';
-import { type NodeRecord, upsertNodeRecordsForIdentity } from '../stores/nodeStore';
+import {
+  type NodeRecord,
+  replaceNodeRecordsForIdentity,
+  upsertNodeRecordsForIdentity,
+} from '../stores/nodeStore';
 import { MAX_IN_MEMORY_CHAT_MESSAGES, trimChatMessagesToMax } from './chatInMemoryBuffer';
 import { errLikeToLogString } from './errLikeToLogString';
 import { beginIdentityHydration } from './identityHydrationCoordinator';
@@ -92,6 +96,8 @@ export interface HydrateIdentityStoresOptions {
   messages?: boolean;
   /** `replace` reloads the store slice from SQLite (post-delete); default upserts only. */
   messagesMode?: 'upsert' | 'replace';
+  /** `replace` reloads the node bucket from SQLite (post-delete); default upserts only. */
+  nodesMode?: 'upsert' | 'replace';
 }
 
 /** Options for post-delete message refresh (runtime + store). */
@@ -102,9 +108,16 @@ export interface MessageClearRefreshOptions {
   clearedAll?: boolean;
 }
 
-export async function hydrateMeshtasticNodesFromDb(identityId: IdentityId): Promise<void> {
+export async function hydrateMeshtasticNodesFromDb(
+  identityId: IdentityId,
+  nodesMode: 'upsert' | 'replace' = 'upsert',
+): Promise<void> {
   const nodeMap = await loadMeshtasticNodeMapFromDb();
-  syncNodesMapToIdentityStore(identityId, nodeMap);
+  if (nodesMode === 'replace') {
+    replaceNodesMapInIdentityStore(identityId, nodeMap);
+  } else {
+    syncNodesMapToIdentityStore(identityId, nodeMap);
+  }
 }
 
 export async function hydrateMeshtasticMessagesFromDb(
@@ -166,7 +179,10 @@ export async function loadMeshcoreSavedHopRowsForHydration(): Promise<MeshcoreSa
   return mergeMeshcoreSavedHopRowsForHydration(hopRows, hopHistoryRows);
 }
 
-export async function hydrateMeshcoreNodesFromDb(identityId: IdentityId): Promise<void> {
+export async function hydrateMeshcoreNodesFromDb(
+  identityId: IdentityId,
+  nodesMode: 'upsert' | 'replace' = 'upsert',
+): Promise<void> {
   const [rows, savedNodes] = await Promise.all([
     window.electronAPI.db.getMeshcoreContacts(),
     loadMeshcoreSavedHopRowsForHydration(),
@@ -174,7 +190,11 @@ export async function hydrateMeshcoreNodesFromDb(identityId: IdentityId): Promis
   const dbMsgs = await loadMeshcoreMessagesForHydration();
   const mapped = mapMeshcoreDbRowsToChatMessages(dbMsgs);
   const nodeMap = buildMeshcoreNodeMapFromDb(rows as MeshcoreContactDbRow[], savedNodes, mapped);
-  syncNodesMapToIdentityStore(identityId, nodeMap);
+  if (nodesMode === 'replace') {
+    replaceNodesMapInIdentityStore(identityId, nodeMap);
+  } else {
+    syncNodesMapToIdentityStore(identityId, nodeMap);
+  }
 }
 
 /** Push an in-memory node map into identity-scoped Zustand (e.g. after radio contact sync). */
@@ -183,6 +203,17 @@ export function syncNodesMapToIdentityStore(
   nodes: Map<number, MeshNode>,
 ): void {
   upsertNodeRecordsForIdentity(
+    identityId,
+    Array.from(nodes.values(), (node) => meshNodeToNodeRecord(node)),
+  );
+}
+
+/** Replace identity node bucket from a full map (post-delete DB reload). */
+export function replaceNodesMapInIdentityStore(
+  identityId: IdentityId,
+  nodes: Map<number, MeshNode>,
+): void {
+  replaceNodeRecordsForIdentity(
     identityId,
     Array.from(nodes.values(), (node) => meshNodeToNodeRecord(node)),
   );
@@ -233,13 +264,14 @@ async function hydrateMeshtasticIdentity(
   const loadNodes = opts.nodes !== false;
   const loadMessages = opts.messages !== false;
   const messagesMode = opts.messagesMode ?? 'upsert';
+  const nodesMode = opts.nodesMode ?? 'upsert';
   if (loadNodes && loadMessages) {
     await Promise.all([
-      hydrateMeshtasticNodesFromDb(identityId),
+      hydrateMeshtasticNodesFromDb(identityId, nodesMode),
       hydrateMeshtasticMessagesFromDb(identityId, messagesMode),
     ]);
   } else if (loadNodes) {
-    await hydrateMeshtasticNodesFromDb(identityId);
+    await hydrateMeshtasticNodesFromDb(identityId, nodesMode);
   } else if (loadMessages) {
     await hydrateMeshtasticMessagesFromDb(identityId, messagesMode);
   }
@@ -252,13 +284,14 @@ async function hydrateMeshcoreIdentity(
   const loadNodes = opts.nodes !== false;
   const loadMessages = opts.messages !== false;
   const messagesMode = opts.messagesMode ?? 'upsert';
+  const nodesMode = opts.nodesMode ?? 'upsert';
   if (loadNodes && loadMessages) {
     await Promise.all([
-      hydrateMeshcoreNodesFromDb(identityId),
+      hydrateMeshcoreNodesFromDb(identityId, nodesMode),
       hydrateMeshcoreMessagesFromDb(identityId, messagesMode),
     ]);
   } else if (loadNodes) {
-    await hydrateMeshcoreNodesFromDb(identityId);
+    await hydrateMeshcoreNodesFromDb(identityId, nodesMode);
   } else if (loadMessages) {
     await hydrateMeshcoreMessagesFromDb(identityId, messagesMode);
   }

--- a/src/renderer/lib/identityHydrationCoordinator.test.ts
+++ b/src/renderer/lib/identityHydrationCoordinator.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   beginIdentityHydration,
   resetIdentityHydrationCoordinatorForTests,
+  sameIdentityRefreshSession,
 } from './identityHydrationCoordinator';
 
 const ID = 'id-hydrate-coord';
@@ -17,5 +18,26 @@ describe('identityHydrationCoordinator', () => {
     const second = beginIdentityHydration('meshtastic', ID);
     expect(first()).toBe(false);
     expect(second()).toBe(true);
+  });
+
+  it('sameIdentityRefreshSession requires matching identity and generation', () => {
+    expect(
+      sameIdentityRefreshSession(
+        { identityId: 'a', generation: 1 },
+        { identityId: 'a', generation: 1 },
+      ),
+    ).toBe(true);
+    expect(
+      sameIdentityRefreshSession(
+        { identityId: 'a', generation: 1 },
+        { identityId: 'b', generation: 1 },
+      ),
+    ).toBe(false);
+    expect(
+      sameIdentityRefreshSession(
+        { identityId: 'a', generation: 1 },
+        { identityId: 'a', generation: 2 },
+      ),
+    ).toBe(false);
   });
 });

--- a/src/renderer/lib/identityHydrationCoordinator.ts
+++ b/src/renderer/lib/identityHydrationCoordinator.ts
@@ -22,6 +22,14 @@ export function beginIdentityHydration(
   return () => hydrationGeneration.get(key) === next;
 }
 
+/** True when a deferred nodes DB refresh still belongs to the session that started it. */
+export function sameIdentityRefreshSession(
+  started: { identityId: IdentityId | null; generation: number },
+  current: { identityId: IdentityId | null; generation: number },
+): boolean {
+  return started.generation === current.generation && started.identityId === current.identityId;
+}
+
 /** Test-only reset. */
 export function resetIdentityHydrationCoordinatorForTests(): void {
   hydrationGeneration.clear();

--- a/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.reconnect-hardening.test.ts
@@ -391,6 +391,18 @@ describe('useMeshtasticRuntime reconnect hardening (regression)', () => {
       /useEffect\(\(\) => \{[\s\S]{0,250}syncNodesMapToIdentityStore\(storeId, nodes\)/,
     );
   });
+
+  it('refreshNodesFromDb guards identity and reconnect generation before applying', () => {
+    const refreshBody = extractUseCallbackBody(SOURCE, 'refreshNodesFromDb');
+    expect(refreshBody).toContain('storeIdAtStart');
+    expect(refreshBody).toContain('generationAtStart');
+    expect(refreshBody).toContain('sameIdentityRefreshSession');
+    expect(refreshBody).toContain('replaceNodesMapInIdentityStore');
+    const loadIdx = refreshBody.indexOf('loadMeshtasticNodeMapFromDb');
+    const guardIdx = refreshBody.indexOf('sameIdentityRefreshSession');
+    expect(loadIdx).toBeGreaterThanOrEqual(0);
+    expect(guardIdx).toBeGreaterThan(loadIdx);
+  });
 });
 
 describe('useMeshtasticRuntime manual disconnect must not auto-reconnect', () => {

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -123,6 +123,7 @@ import {
   syncNodesMapToIdentityStore,
 } from '../lib/hydrateIdentityStoresFromDb';
 import { getIdentityIdForProtocol } from '../lib/identityByProtocol';
+import { sameIdentityRefreshSession } from '../lib/identityHydrationCoordinator';
 import {
   getIdentityChatMessages,
   getIdentityNode,
@@ -4047,14 +4048,25 @@ export function useMeshtasticRuntime() {
   }, []);
 
   const refreshNodesFromDb = useCallback(() => {
+    const storeIdAtStart =
+      meshtasticIdentityIdRef.current ?? meshtasticPendingDriverIdentityRef.current;
+    const generationAtStart = reconnectGenerationRef.current;
     void loadMeshtasticNodeMapFromDb()
       .then((nodeMap) => {
-        console.debug(`[useMeshtasticRuntime] refreshNodesFromDb: loaded ${nodeMap.size} nodes`);
-        const storeId =
+        const storeIdNow =
           meshtasticIdentityIdRef.current ?? meshtasticPendingDriverIdentityRef.current;
+        if (
+          !sameIdentityRefreshSession(
+            { identityId: storeIdAtStart, generation: generationAtStart },
+            { identityId: storeIdNow, generation: reconnectGenerationRef.current },
+          )
+        ) {
+          return;
+        }
+        console.debug(`[useMeshtasticRuntime] refreshNodesFromDb: loaded ${nodeMap.size} nodes`);
         setNodes(nodeMap);
-        if (storeId) {
-          replaceNodesMapInIdentityStore(storeId, nodeMap);
+        if (storeIdNow) {
+          replaceNodesMapInIdentityStore(storeIdNow, nodeMap);
         }
       })
       .catch((err: unknown) => {

--- a/src/renderer/runtime/useMeshtasticRuntime.ts
+++ b/src/renderer/runtime/useMeshtasticRuntime.ts
@@ -119,6 +119,7 @@ import {
 } from '../lib/gpsSource';
 import {
   hydrateMeshtasticMessagesFromDb,
+  replaceNodesMapInIdentityStore,
   syncNodesMapToIdentityStore,
 } from '../lib/hydrateIdentityStoresFromDb';
 import { getIdentityIdForProtocol } from '../lib/identityByProtocol';
@@ -4051,10 +4052,9 @@ export function useMeshtasticRuntime() {
         console.debug(`[useMeshtasticRuntime] refreshNodesFromDb: loaded ${nodeMap.size} nodes`);
         const storeId =
           meshtasticIdentityIdRef.current ?? meshtasticPendingDriverIdentityRef.current;
+        setNodes(nodeMap);
         if (storeId) {
-          syncNodesMapToIdentityStore(storeId, nodeMap);
-        } else {
-          setNodes(nodeMap);
+          replaceNodesMapInIdentityStore(storeId, nodeMap);
         }
       })
       .catch((err: unknown) => {

--- a/src/renderer/stores/nodeStore.test.ts
+++ b/src/renderer/stores/nodeStore.test.ts
@@ -7,6 +7,7 @@ import {
   clearNodeIdentity,
   patchNodeFavorited,
   removeNode,
+  replaceNodeRecordsForIdentity,
   updateMeshcoreOp,
   updatePosition,
   updateTelemetry,
@@ -124,6 +125,51 @@ describe('removeNode', () => {
     upsertNode(ID, { nodeId: NODE, longName: 'Alpha' });
     removeNode(ID, 999);
     expect(useNodeStore.getState().nodes[ID]?.[NODE]?.longName).toBe('Alpha');
+  });
+});
+
+describe('replaceNodeRecordsForIdentity', () => {
+  afterEach(() => {
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+  });
+
+  it('clears prior nodes when given an empty snapshot', () => {
+    upsertNode(ID, { nodeId: NODE, longName: 'Alpha' });
+    upsertNode(ID, { nodeId: NODE + 1, longName: 'Beta' });
+    replaceNodeRecordsForIdentity(ID, []);
+    expect(useNodeStore.getState().nodes[ID]).toEqual({});
+  });
+
+  it('drops ids absent from the replacement snapshot', () => {
+    upsertNode(ID, { nodeId: NODE, longName: 'Alpha' });
+    upsertNode(ID, { nodeId: NODE + 1, longName: 'Beta' });
+    replaceNodeRecordsForIdentity(ID, [{ nodeId: NODE + 1, longName: 'Beta-2' }]);
+    expect(useNodeStore.getState().nodes[ID]?.[NODE]).toBeUndefined();
+    expect(useNodeStore.getState().nodes[ID]?.[NODE + 1]?.longName).toBe('Beta-2');
+  });
+
+  it('does not clear traceRoutes, waypoints, or neighborInfo', () => {
+    upsertNode(ID, { nodeId: NODE, longName: 'Alpha' });
+    addTraceRoute(ID, { from: NODE, to: 43, route: [7], timestamp: 1 });
+    upsertWaypoint(ID, {
+      id: 5,
+      from: NODE,
+      name: 'Point',
+      latitude: 1,
+      longitude: 2,
+      timestamp: 1,
+    });
+    upsertNeighborInfo(ID, {
+      nodeId: NODE,
+      neighbors: [{ nodeId: 43, snr: 4, lastRxTime: 99 }],
+      timestamp: 1,
+    });
+    replaceNodeRecordsForIdentity(ID, []);
+    const state = useNodeStore.getState();
+    expect(state.nodes[ID]).toEqual({});
+    expect(state.traceRoutes[ID]).toHaveLength(1);
+    expect(state.waypoints[ID][5].name).toBe('Point');
+    expect(state.neighborInfo[ID][NODE].neighbors[0].nodeId).toBe(43);
   });
 });
 

--- a/src/renderer/stores/nodeStore.test.ts
+++ b/src/renderer/stores/nodeStore.test.ts
@@ -148,6 +148,47 @@ describe('replaceNodeRecordsForIdentity', () => {
     expect(useNodeStore.getState().nodes[ID]?.[NODE + 1]?.longName).toBe('Beta-2');
   });
 
+  it('preserves session metadata on retained nodes', () => {
+    updateMeshcoreOp(ID, NODE, {
+      meshcoreNodeStatus: {
+        battMilliVolts: 4000,
+        noiseFloor: -120,
+        lastRssi: -90,
+        lastSnr: 8,
+        nPacketsRecv: 0,
+        nPacketsSent: 0,
+        totalAirTimeSecs: 0,
+        totalUpTimeSecs: 0,
+        nSentFlood: 0,
+        nSentDirect: 0,
+        nRecvFlood: 0,
+        nRecvDirect: 0,
+        errEvents: 0,
+        nDirectDups: 0,
+        nFloodDups: 0,
+        currTxQueueLen: 0,
+      },
+      meshcoreNeighbors: {
+        totalNeighboursCount: 1,
+        neighbours: [
+          {
+            publicKeyPrefix: new Uint8Array([0xab]),
+            prefixHex: 'ab',
+            resolvedNodeId: 7,
+            heardSecondsAgo: 1,
+            snr: 3,
+          },
+        ],
+        fetchedAt: 1000,
+      },
+    });
+    replaceNodeRecordsForIdentity(ID, [{ nodeId: NODE, longName: 'From-DB' }]);
+    const rec = useNodeStore.getState().nodes[ID][NODE];
+    expect(rec.longName).toBe('From-DB');
+    expect(rec.meshcoreNodeStatus?.battMilliVolts).toBe(4000);
+    expect(rec.meshcoreNeighbors?.neighbours[0]?.resolvedNodeId).toBe(7);
+  });
+
   it('does not clear traceRoutes, waypoints, or neighborInfo', () => {
     upsertNode(ID, { nodeId: NODE, longName: 'Alpha' });
     addTraceRoute(ID, { from: NODE, to: 43, route: [7], timestamp: 1 });

--- a/src/renderer/stores/nodeStore.ts
+++ b/src/renderer/stores/nodeStore.ts
@@ -285,6 +285,23 @@ export function upsertNodeRecordsForIdentity(identityId: IdentityId, records: No
   });
 }
 
+/** Replace the full node bucket for an identity (post-delete DB reload). Empty clears nodes only. */
+export function replaceNodeRecordsForIdentity(identityId: IdentityId, records: NodeRecord[]): void {
+  useNodeStore.setState((s) => {
+    const byId: Record<number, NodeRecord> = {};
+    for (const record of records) {
+      const { nodeId, ...patch } = record;
+      byId[nodeId] = mergeNode(undefined, nodeId, patch);
+    }
+    return {
+      nodes: {
+        ...s.nodes,
+        [identityId]: byId,
+      },
+    };
+  });
+}
+
 function meshtasticLastHeardPatch(
   identityId: IdentityId,
   packetTimestampMs: number,

--- a/src/renderer/stores/nodeStore.ts
+++ b/src/renderer/stores/nodeStore.ts
@@ -288,10 +288,11 @@ export function upsertNodeRecordsForIdentity(identityId: IdentityId, records: No
 /** Replace the full node bucket for an identity (post-delete DB reload). Empty clears nodes only. */
 export function replaceNodeRecordsForIdentity(identityId: IdentityId, records: NodeRecord[]): void {
   useNodeStore.setState((s) => {
+    const prior = s.nodes[identityId] ?? {};
     const byId: Record<number, NodeRecord> = {};
     for (const record of records) {
       const { nodeId, ...patch } = record;
-      byId[nodeId] = mergeNode(undefined, nodeId, patch);
+      byId[nodeId] = mergeNode(prior[nodeId], nodeId, patch);
     }
     return {
       nodes: {


### PR DESCRIPTION
## Summary
- Clear All Nodes / node prune actions deleted SQLite rows and reloaded an empty map, but `nodeStore` only upserted (and no-oped on an empty snapshot), so the Nodes UI stayed stale until restart.
- Post-prune refresh now uses `nodesMode: 'replace'` / `replaceNodeRecordsForIdentity` so the identity node bucket matches the DB (including empty).
- Success toast uses the already-interpolated confirmation title so `Clear All Nodes (N)` no longer shows literal `{{count}}`.

## Test plan
- [ ] Meshtastic (including MQTT-only): Clear All Nodes → toast shows real count; Nodes list empties without restart
- [ ] Prune offline/distant/no-fix nodes → removed nodes disappear from the list immediately
- [ ] After clear, MQTT/RF rediscovery can re-add nodes as expected
- [ ] Confirm related unit tests: `nodeStore`, `hydrateIdentityStoresFromDb`, `useDbRefresh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node refreshes now fully replace stored node data, removing stale nodes that are no longer present in the database.
  * Empty database results now correctly clear the corresponding node list without affecting other identities.
  * Outdated refresh results are prevented from overwriting data after identity changes or reconnects.
  * Confirmation success messages now display the correct action title.

* **Tests**
  * Added coverage for node replacement, stale-node removal, empty results, refresh concurrency, reconnect handling, and preservation of related node information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->