### PR TITLE
chore(deps): floor @xmldom/xmldom for GHSA-6gmq-8vp8-gcm6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   '@meshtastic/core': npm:@jsr/meshtastic__core@^2.6.6
   cacheable-request: ^10.0.0
   form-data: ^4.0.6
+  '@xmldom/xmldom': ^0.8.15
   app-builder-lib: ^26.15.0
   brace-expansion: ^5.0.9
   builder-util-runtime: ^9.7.0
@@ -1472,10 +1473,9 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -5802,7 +5802,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.15': {}
 
   '@xterm/addon-fit@0.11.0': {}
 
@@ -8270,7 +8270,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,7 @@ overrides:
   # GHSA-v3r7-h72x-cjcm / GHSA-jr45-8vmc-qm54 / GHSA-m8rv-5g2x-5cg5 /
   # GHSA-fxqj-rqcc-2cmp / GHSA-mwp4-54f8-5fhr / GHSA-9f4c-93c8-jc8g /
   # GHSA-v93f-fgjr-hjrj / GHSA-4f78-qhmw-8j8m / GHSA-ff2p-hmqr-hxm4 /
-  # GHSA-f2r8-jv7c-xqmp / GHSA-p2rr-rvmm-c5fp).
+  # GHSA-f2r8-jv7c-xqmp / GHSA-p2rr-rvmm-c5fp / GHSA-6gmq-8vp8-gcm6).
   # brace-expansion: keep a single 5.0.9 floor. GHSA-rgw5-rvv9-x895 is a
   # bypass of the CVE-2026-14257 mitigation and marks >=4.0.0 <5.0.9 vulnerable
   # (only >=5.0.9 counts as patched). CI audit is blocking.
@@ -60,7 +60,11 @@ overrides:
   # undici-types stays on 7.x to match @types/node.
   # postcss: GHSA-fxqj-rqcc-2cmp — floor >=8.5.23.
   # ip-address: GHSA-mwp4-54f8-5fhr (mqtt → socks) — floor >=10.3.1.
+  # @xmldom/xmldom: GHSA-6gmq-8vp8-gcm6 — floor >=0.8.15 (electron-builder →
+  # app-builder-lib → plist / @electron/osx-sign / @electron/universal still
+  # resolve 0.8.13 without an override).
   # electron: deliberate major pin — bump with Flatpak sync + native rebuild smoke.
+  '@xmldom/xmldom': ^0.8.15
   app-builder-lib: ^26.15.0
   brace-expansion: ^5.0.9
   builder-util-runtime: ^9.7.0


### PR DESCRIPTION
## Summary
- Add a pnpm override floor for `@xmldom/xmldom` at `^0.8.15` to clear Dependabot alert #107 (GHSA-6gmq-8vp8-gcm6 / XML fragment injection via invalid `EntityReference.nodeName`).
- Bump the transitive resolution from `0.8.13` → `0.8.15` (via `electron-builder` → `plist` / `@electron/osx-sign` / `@electron/universal`).
- Other open Dependabot alerts (`@humanfs/node`, `nanoid`, `browserslist`) already resolve to patched versions on `main` and need no further lockfile change.

## Test plan
- [x] `pnpm audit` reports no known vulnerabilities after the override
- [x] Pre-commit suite passed on commit
- [ ] Confirm Dependabot alert #107 auto-dismisses after merge