### PR TITLE
fix(release): rebase onto main before push when tip advanced

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -116,17 +116,55 @@ print_release_usage() {
   echo "       (Bare -- from \`pnpm run release -- …\` is ignored; pnpm 11 forwards it.)"
 }
 
+# Rebase the local release tip onto origin/main when main advanced during the long
+# pre-flight (Cut release ~20m). Recreate the annotated tag on the rebased tip each
+# attempt so the tag SHA matches what we push. Retries cover a second concurrent push.
+push_release_main_with_rebase() {
+  local new_version="$1"
+  local max_attempts="${2:-5}"
+  local attempt=1
+
+  while [ "$attempt" -le "$max_attempts" ]; do
+    git fetch origin main
+    if ! git merge-base --is-ancestor origin/main HEAD; then
+      print_warning "origin/main advanced during release; rebasing (attempt ${attempt}/${max_attempts})..."
+      if ! git rebase origin/main; then
+        git rebase --abort 2> /dev/null || true
+        print_error "Rebase onto origin/main failed (conflicts). Resolve, then: pnpm run release --finish"
+        return 1
+      fi
+    fi
+
+    # Point the release tag at HEAD after any rebase (drop a stale local tag first).
+    if git rev-parse "$new_version" > /dev/null 2>&1; then
+      git tag -d "$new_version"
+    fi
+    git tag -a "$new_version" -m "Release $new_version"
+
+    if git push origin main; then
+      return 0
+    fi
+    if [ "$attempt" -eq "$max_attempts" ]; then
+      print_error "Failed to push main after ${max_attempts} rebase/push attempts."
+      return 1
+    fi
+    print_warning "Push rejected; fetching and retrying..."
+    attempt=$((attempt + 1))
+    sleep "$attempt"
+  done
+  return 1
+}
+
 commit_tag_and_push_release() {
   local new_version="$1"
   git add package.json pnpm-lock.yaml org.coloradomesh.MeshClient.yml
   [ -f "$METAINFO_FILE" ] && git add "$METAINFO_FILE"
   git commit -m "chore: release $new_version"
 
-  print_header "Creating tag $new_version..."
-  git tag -a "$new_version" -m "Release $new_version"
-
-  print_header "Pushing to GitHub..."
-  git push origin main
+  print_header "Creating tag $new_version and pushing to GitHub..."
+  if ! push_release_main_with_rebase "$new_version" 5; then
+    exit 1
+  fi
   git push origin "$new_version"
 
   print_success "--------------------------------------------------------"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -129,7 +129,11 @@ push_release_main_with_rebase() {
     if ! git merge-base --is-ancestor origin/main HEAD; then
       print_warning "origin/main advanced during release; rebasing (attempt ${attempt}/${max_attempts})..."
       if ! git rebase origin/main; then
-        git rebase --abort 2> /dev/null || true
+        # Do not swallow abort stderr — a failed abort leaves the repo mid-rebase.
+        if ! git rebase --abort; then
+          print_error "Rebase onto origin/main failed, and git rebase --abort also failed (repo may be mid-rebase). Fix the working tree, then: pnpm run release --finish"
+          return 2
+        fi
         print_error "Rebase onto origin/main failed (conflicts). Resolve, then: pnpm run release --finish"
         return 1
       fi

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -85,6 +85,23 @@ describe('release.sh full-suite gate', () => {
     expect(finishBody).not.toMatch(/pnpm run test:run/);
   });
 
+  it('rebases onto origin/main before push when main advanced during preflight', () => {
+    // Cut release can take ~20m; concurrent main merges (e.g. licenses bot) reject a
+    // naive `git push origin main`. Rebase+retry, retagging the tip each attempt.
+    expect(script).toMatch(/push_release_main_with_rebase/);
+    expect(script).toMatch(/git fetch origin main/);
+    expect(script).toMatch(/git merge-base --is-ancestor origin\/main HEAD/);
+    expect(script).toMatch(/git rebase origin\/main/);
+    const helperFn = script.slice(script.indexOf('push_release_main_with_rebase()'));
+    const helperBody = helperFn.slice(0, helperFn.indexOf('\n}\n\n'));
+    const rebaseIdx = helperBody.indexOf('git rebase origin/main');
+    const tagIdx = helperBody.indexOf('git tag -a');
+    const pushIdx = helperBody.indexOf('git push origin main');
+    expect(rebaseIdx).toBeGreaterThanOrEqual(0);
+    expect(tagIdx).toBeGreaterThan(rebaseIdx);
+    expect(pushIdx).toBeGreaterThan(tagIdx);
+  });
+
   it('supports --yes / MESH_CLIENT_RELEASE_YES to skip confirmation prompts', () => {
     expect(script).toMatch(/confirm_or_yes/);
     expect(script).toMatch(/--yes \| -y\)/);

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -100,6 +100,10 @@ describe('release.sh full-suite gate', () => {
     expect(rebaseIdx).toBeGreaterThanOrEqual(0);
     expect(tagIdx).toBeGreaterThan(rebaseIdx);
     expect(pushIdx).toBeGreaterThan(tagIdx);
+    // Failed abort must surface Git stderr and use a distinct status (not `2>/dev/null || true`).
+    expect(helperBody).toMatch(/if ! git rebase --abort; then/);
+    expect(helperBody).toMatch(/return 2/);
+    expect(helperBody).not.toMatch(/git rebase --abort 2>\s*\/dev\/null/);
   });
 
   it('supports --yes / MESH_CLIENT_RELEASE_YES to skip confirmation prompts', () => {


### PR DESCRIPTION
## Summary
- Cut release failed when `main` advanced during the long preflight (`git push` rejected; tag never landed).
- Rebase the release commit onto `origin/main` (retag tip, retry up to 5 times) before pushing the tag.
- Adds a source contract test for the rebase → tag → push order.

## Test plan
- [x] `vitest run scripts/release.test.mjs` (43 passed; also via pre-commit)
- [ ] Merge, then re-run **Actions → Cut release** to land `v5.34.0` (previous attempt left no tag on remote)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release publishing now rebases onto the latest main branch before creating and pushing version tags.
  * Added retry handling for rejected main-branch pushes, with backoff between attempts.
* **Tests**
  * Added coverage verifying the rebase, tag creation, and push sequence during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->