### PR TITLE
fix: refresh stale MeshCore reply parents

### DIFF
--- a/src/renderer/lib/meshcoreChannelText.ts
+++ b/src/renderer/lib/meshcoreChannelText.ts
@@ -932,22 +932,6 @@ function meshcoreWireHadExplicitReplyKey(msg: ChatMessage): boolean {
   return /#\d{4,}\]/u.test(raw);
 }
 
-function meshcoreWireReplyKeyFromMessage(msg: ChatMessage): number | undefined {
-  const normalized = normalizeMeshcoreIncomingText(msg.meshcoreDedupeKey ?? msg.payload);
-  return normalized.wireReplyKey;
-}
-
-/** Firmware seconds `#key` resolved a parent — keep it; do not upgrade to latest-from-sender. */
-function meshcoreTrustExplicitSecWireReplyKey(
-  msg: ChatMessage,
-  parent: ChatMessage | undefined,
-): boolean {
-  const wireReplyKey = meshcoreWireReplyKeyFromMessage(msg);
-  if (wireReplyKey == null || parent == null) return false;
-  if (wireReplyKey >= MESHCORE_REPLY_KEY_MS_THRESHOLD) return false;
-  return meshcoreMessageMatchesReplyKey(parent, wireReplyKey);
-}
-
 /** True when this row is a reply to someone else's message (not self-tapback / own outbound). */
 function meshcoreIsIncomingBracketReply(msg: ChatMessage, targetName: string | undefined): boolean {
   if (!targetName?.trim()) return false;
@@ -958,6 +942,7 @@ function meshcoreIsIncomingBracketReply(msg: ChatMessage, targetName: string | u
  * Fill / lightly repair reply previews.
  * - Own outbound rows: keep explicit composer `replyId` (never "latest from sender").
  * - Incoming `@[Name]` without `#key`: re-resolve latest target message once the full thread is loaded.
+ * - Incoming keyed rows: keep a corroborated parent, but refresh stale seconds/ms keys for generic replies.
  */
 function refreshMeshcoreReplyParent(msg: ChatMessage, prior: readonly ChatMessage[]): ChatMessage {
   if (msg.emoji != null && msg.replyId != null) return msg;
@@ -984,10 +969,7 @@ function refreshMeshcoreReplyParent(msg: ChatMessage, prior: readonly ChatMessag
     if (hintParent) {
       replyId = meshcoreCanonicalReplyKey(hintParent);
       parent = hintParent;
-    } else if (
-      !(explicitWireKey && !parent) &&
-      !meshcoreTrustExplicitSecWireReplyKey(msg, parent)
-    ) {
+    } else if (!(explicitWireKey && !parent)) {
       const upgraded = tryUpgradeMeshcoreReplyToLatestSameSender(
         msg,
         prior,

--- a/src/renderer/lib/meshcoreChannelText.ts
+++ b/src/renderer/lib/meshcoreChannelText.ts
@@ -682,8 +682,9 @@ const GENERIC_MESHCORE_REPLY_BODIES = new Set([
 ]);
 
 /**
- * True when a reply body substantively references `parentPayload` (keep an explicit wire `#key`
- * parent). Generic short replies and tapbacks return false so a stale keyed parent can upgrade.
+ * True when a reply body substantively references `parentPayload` so a persisted parent survives
+ * hydration even when its explicit wire-key provenance is unavailable. Generic short replies and
+ * tapbacks return false so a stale keyed parent can upgrade.
  */
 export function meshcoreReplyBodyReferencesParent(body: string, parentPayload: string): boolean {
   const bodyNorm = normalizePayloadMatchText(body);
@@ -750,7 +751,6 @@ function tryUpgradeMeshcoreReplyToLatestSameSender(
   targetName: string,
   lookupOpts: MeshcoreReplyLookupOptions,
   currentParent: ChatMessage | undefined,
-  explicitWireKey: boolean,
 ): { replyId: number; parent: ChatMessage } | null {
   const resolvedKey = resolveMeshcoreLatestBracketParentKey(msg, prior, targetName);
   if (resolvedKey == null) return null;
@@ -760,7 +760,7 @@ function tryUpgradeMeshcoreReplyToLatestSameSender(
     return { replyId: resolvedKey, parent: resolvedParent };
   }
   if (resolvedParent.timestamp <= currentParent.timestamp) return null;
-  if (explicitWireKey && meshcoreReplyBodyReferencesParent(msg.payload, currentParent.payload)) {
+  if (meshcoreReplyBodyReferencesParent(msg.payload, currentParent.payload)) {
     return null;
   }
   return { replyId: resolvedKey, parent: resolvedParent };
@@ -976,7 +976,6 @@ function refreshMeshcoreReplyParent(msg: ChatMessage, prior: readonly ChatMessag
         targetName,
         lookupOpts,
         parent,
-        explicitWireKey,
       );
       if (upgraded) {
         replyId = upgraded.replyId;
@@ -990,7 +989,6 @@ function refreshMeshcoreReplyParent(msg: ChatMessage, prior: readonly ChatMessag
       targetName,
       lookupOpts,
       parent,
-      false,
     );
     if (upgraded) {
       replyId = upgraded.replyId;

--- a/src/renderer/lib/meshcoreIncomingIngest.test.ts
+++ b/src/renderer/lib/meshcoreIncomingIngest.test.ts
@@ -187,6 +187,26 @@ describe('parseMeshcoreChannelIncomingFromThread (canonical live ingest)', () =>
     expect(parsed.replyId).toBe(1780240608140);
     expect(parsed.replyPreviewText).toContain('Message B');
   });
+
+  it('refreshes a stale firmware-seconds key to the latest targeted message', () => {
+    const staleTs = 1_788_442_372_706;
+    const latestTs = 1_788_526_257_000;
+    seedStore([
+      nv0n('reply previews should be fixed in the next release', staleTs),
+      nv0n('ugh i want my cool fall. tired of the heat', latestTs),
+    ]);
+    const prior = listChatMessagesFromStore(ID);
+    const parsed = parseMeshcoreChannelIncomingFromThread(prior, {
+      rawText: `Runr 01: @[${NV0N}#${Math.floor(staleTs / 1000)}] fall wx will be much appreciated this year!`,
+      senderId: 204,
+      displayName: 'Runr 01',
+      channel: CH,
+      timestamp: 1_788_528_196_000,
+      receivedVia: 'rf',
+    });
+    expect(parsed.replyId).toBe(latestTs);
+    expect(parsed.replyPreviewText).toBe('ugh i want my cool fall. tired of the heat');
+  });
 });
 
 describe('ingestMeshcoreChannelMessage + store persist', () => {
@@ -194,12 +214,12 @@ describe('ingestMeshcoreChannelMessage + store persist', () => {
     useMessageStore.setState({ messages: {} });
   });
 
-  it('persists reply parent matched by firmware seconds wire key', () => {
+  it('keeps a firmware-seconds parent when the reply body corroborates it', () => {
     const tsSec = 1_780_240_708;
     const tsMs = tsSec * 1000;
     seedStore([nv0n('message one', tsMs), nv0n('message two', tsMs + 60_000)]);
     const parsed = ingestMeshcoreChannelMessage(ID, {
-      rawText: `🆎 Alex: @[${NV0N}#${tsSec}] replying to first`,
+      rawText: `🆎 Alex: @[${NV0N}#${tsSec}] replying about message one`,
       senderId: 205,
       displayName: '🆎 Alex',
       channel: CH,
@@ -209,7 +229,9 @@ describe('ingestMeshcoreChannelMessage + store persist', () => {
     const result = upsertMeshcoreMessageWithDedup(ID, parsed);
     expect(result.message.replyId).toBe(tsMs);
     expect(result.message.replyPreviewText).toBe('message one');
-    const inStore = listChatMessagesFromStore(ID).find((m) => m.payload === 'replying to first');
+    const inStore = listChatMessagesFromStore(ID).find(
+      (m) => m.payload === 'replying about message one',
+    );
     expect(inStore?.replyId).toBe(tsMs);
     expect(inStore?.replyPreviewText).toBe('message one');
   });
@@ -320,6 +342,30 @@ describe('meshcoreChatMessagesForDisplay (historical backfill only)', () => {
     const out = meshcoreChatMessagesForDisplay(rows);
     const wherewolf = out.find((m) => m.payload === 'reply to b');
     expect(wherewolf?.replyId).toBe(1780240608140);
+  });
+
+  it('repairs a stale firmware-seconds parent saved during live ingest', () => {
+    const staleTs = 1_788_442_372_706;
+    const latestTs = 1_788_526_257_000;
+    const rows: ChatMessage[] = [
+      nv0n('reply previews should be fixed in the next release', staleTs),
+      nv0n('ugh i want my cool fall. tired of the heat', latestTs),
+      {
+        sender_id: 204,
+        sender_name: 'Runr 01',
+        payload: 'fall wx will be much appreciated this year!',
+        channel: CH,
+        timestamp: 1_788_528_196_000,
+        status: 'acked',
+        replyId: staleTs,
+        replyPreviewText: 'reply previews should be fixed in the next release',
+        replyPreviewSender: NV0N,
+      },
+    ];
+    const out = meshcoreChatMessagesForDisplay(rows);
+    const reply = out.find((m) => m.payload.startsWith('fall wx'));
+    expect(reply?.replyId).toBe(latestTs);
+    expect(reply?.replyPreviewText).toBe('ugh i want my cool fall. tired of the heat');
   });
 
   it('does not replace live-ingest-correct rows on display pass', () => {

--- a/src/renderer/lib/meshcoreIncomingIngest.test.ts
+++ b/src/renderer/lib/meshcoreIncomingIngest.test.ts
@@ -368,6 +368,30 @@ describe('meshcoreChatMessagesForDisplay (historical backfill only)', () => {
     expect(reply?.replyPreviewText).toBe('ugh i want my cool fall. tired of the heat');
   });
 
+  it('keeps a corroborated stale parent after explicit-key provenance is lost', () => {
+    const staleTs = 1_788_442_372_706;
+    const latestTs = 1_788_526_257_000;
+    const rows: ChatMessage[] = [
+      nv0n('message one about espresso machines', staleTs),
+      nv0n('message two about cooler weather', latestTs),
+      {
+        sender_id: 204,
+        sender_name: 'Runr 01',
+        payload: 'I agree about espresso machines',
+        channel: CH,
+        timestamp: 1_788_528_196_000,
+        status: 'acked',
+        replyId: staleTs,
+        replyPreviewText: 'message one about espresso machines',
+        replyPreviewSender: NV0N,
+      },
+    ];
+    const out = meshcoreChatMessagesForDisplay(rows);
+    const reply = out.find((m) => m.payload.startsWith('I agree'));
+    expect(reply?.replyId).toBe(staleTs);
+    expect(reply?.replyPreviewText).toBe('message one about espresso machines');
+  });
+
   it('does not replace live-ingest-correct rows on display pass', () => {
     seedStore([nv0n('Message B - reply to this please.', 1780240608140)]);
     const correct = wireReply(


### PR DESCRIPTION
## Summary

- refresh incoming MeshCore replies to the latest message from the targeted sender when a stale keyed parent conflicts with a generic reply
- apply the same repair to firmware-seconds and millisecond reply keys during live ingest
- preserve an explicitly keyed older parent when the reply body corroborates it
- cover live ingest and hydration with regression cases matching the reported stale-preview behavior

## Problem

Some incoming MeshCore replies carry a sender-timestamp key for an older message even though the reply is directed at the sender's newer message. Historical hydration already repaired this case, but live ingest had a special exception that always trusted firmware-seconds keys. That caused the old quote to be persisted and displayed immediately.

The live resolver now uses the existing evidence-based refresh behavior for both seconds and millisecond keys. Explicit older replies remain stable when their body refers to the keyed parent, and unmatched explicit keys still do not guess.

## Verification

- `pnpm run check:pr` — 10,330 passed, 5 skipped
- focused MeshCore reply suites — 100 passed
- pre-commit related suite — 2,859 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reply threading for MeshCore messages with stale firmware-second keys.
  * Incoming and historical messages now resolve generic replies to the latest applicable message when appropriate.
  * Corroborated parent messages are retained during display refresh, even when explicit key provenance is unavailable.

* **Tests**
  * Added regression coverage for live message ingestion, historical display backfill, persistence, and stale-parent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->