### PR TITLE
fix(mac): patch app-builder-lib CSC_LINK keychain unlock

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -7,6 +7,7 @@ Local overlays applied via `pnpm-workspace.yaml` → `patchedDependencies`. When
 | `@liamcottle__meshcore.js@1.15.0.patch` | [meshcore-dev/meshcore.js](https://github.com/meshcore-dev/meshcore.js) | Open: [#30](https://github.com/meshcore-dev/meshcore.js/pull/30), [#31](https://github.com/meshcore-dev/meshcore.js/pull/31), [#33](https://github.com/meshcore-dev/meshcore.js/pull/33); [#29](https://github.com/meshcore-dev/meshcore.js/pull/29) closed (unnecessary); [#32](https://github.com/meshcore-dev/meshcore.js/pull/32) closed (not carried — firmware does not push LoginFail). Upstream `1.15.0` removes deprecated `pingRepeaterZeroHop` (use `tracePath`) and requires explicit `pathLen` for `sendCommandSendRawData` (multi-byte path hashes via `MeshCorePath.toPathLen()`); patch rebased onto that release. |
 | `@jsr__meshtastic__core@2.6.6.patch` | [meshtastic/web](https://github.com/meshtastic/web) (`packages/sdk`) | [#1312](https://github.com/meshtastic/web/pull/1312) |
 | `@jsr__meshtastic__transport-web-serial@0.2.5.patch` | [meshtastic/web](https://github.com/meshtastic/web) (`packages/transport-web-serial`) | Fixed on upstream `main` (per-instance `toDeviceStream` + abort); keep patch until npm/`@jsr` package bump includes it |
+| `app-builder-lib@26.15.3.patch` | [electron-userland/electron-builder](https://github.com/electron-userland/electron-builder) (`packages/app-builder-lib`) | Merged on master: [#10101](https://github.com/electron-userland/electron-builder/pull/10101) / [#10066](https://github.com/electron-userland/electron-builder/issues/10066); not yet in published `26.x` (only `27.0.0-alpha`) |
 | `usb@2.18.0.patch` | [node-usb/node-usb](https://github.com/node-usb/node-usb) | [#964](https://github.com/node-usb/node-usb/pull/964) |
 | `readable-stream@4.7.0.patch` | [nodejs/readable-stream](https://github.com/nodejs/readable-stream) | **Intentionally local** — upstream uses `require('process/')` for browser bundlers; Electron/Node needs bare `process` |
 | `debug@4.4.3.patch` | [debug-js/debug](https://github.com/debug-js/debug) | **Intentionally local** — inlines `ms`/`humanize` so electron-vite does not fail resolving the `ms` dependency |
@@ -52,6 +53,18 @@ Per-instance `toDeviceStream` (instead of shared `Utils.toDeviceStream`) and swa
 ### Sunset
 
 When the published `@jsr/meshtastic__transport-web-serial` (or successor package) includes per-instance framing + abort teardown, remove the patch and bump the dependency.
+
+## app-builder-lib@26.15.3
+
+Pass the temporary keychain unlock password (not the `.p12` import password) to `security set-key-partition-list -k` during `CSC_LINK` macOS signing. Without this, dual-arch `dist:mac` fails with `SecKeychainUnlock: The user name or passphrase you entered is not correct` (electron-builder [#10066](https://github.com/electron-userland/electron-builder/issues/10066)).
+
+| Field | Value |
+| ----- | ----- |
+| **Upstream PR** | https://github.com/electron-userland/electron-builder/pull/10101 (merged to master; shipped in `27.0.0-alpha`, not `26.16.0`) |
+
+### Sunset
+
+When a published `app-builder-lib` **26.x** (or the electron-builder line we pin) includes [#10101](https://github.com/electron-userland/electron-builder/pull/10101), remove the patch and bump the override / lockfile. Do not jump to `27.0.0-alpha` solely for this fix.
 
 ## usb@2.18.0
 

--- a/patches/app-builder-lib@26.15.3.patch
+++ b/patches/app-builder-lib@26.15.3.patch
@@ -1,0 +1,26 @@
+diff --git a/out/codeSign/macCodeSign.js b/out/codeSign/macCodeSign.js
+index 9a69042fd48f4759a1c697bf23fa5b44f2da2366..0fffd18844e7f4c0d24c49999ae62182374ecdbc 100644
+--- a/out/codeSign/macCodeSign.js
++++ b/out/codeSign/macCodeSign.js
+@@ -156,16 +156,18 @@ async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink, cscIK
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
+ }
+-async function importCerts(keychainFile, paths, keyPasswords) {
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        // set-key-partition-list -k unlocks the keychain itself (not the .p12 import password).
++        // Upstream: https://github.com/electron-userland/electron-builder/pull/10101
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ patchedDependencies:
   '@jsr/meshtastic__core@2.6.6': 337d32fca15262ad66ba99c9f5e089b431818060b6a380e17065bbde1cf2a72d
   '@jsr/meshtastic__transport-web-serial@0.2.5': 27a2418bae8605e0e5ab6f1fcfd391abd9dc3110433da5754e934f38475dab74
   '@liamcottle/meshcore.js@1.15.0': 4f2fe6ca8ebd7b4c5d63c5b19c95b90d00542a1424b239888d1f5414dd0ea29e
+  app-builder-lib@26.15.3: 31b6515261c0293b0461ee1fb6771aff53487406edc56e942bc7095b86ac42cf
   debug@4.4.3: cf37fa96f5df733456b16c82c9e1c9054a92f6216692aa33d5e2e1e208888e37
   readable-stream@4.7.0: 96023d9278085d7490d08bce1a5079dd202f7782a0daa66fa81c6b1424ef8ab1
   usb@2.18.0: 6b746e2d49b9b006a88aec5bed7a13c629d7f5ba7b40e9f1e039136754c32533
@@ -5850,7 +5851,7 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  app-builder-lib@26.15.3(dmg-builder@26.16.0)(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1):
+  app-builder-lib@26.15.3(patch_hash=31b6515261c0293b0461ee1fb6771aff53487406edc56e942bc7095b86ac42cf)(dmg-builder@26.16.0)(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1):
     dependencies:
       '@electron/asar': 4.2.1
       '@electron/fuses': 1.8.0
@@ -6393,7 +6394,7 @@ snapshots:
 
   dmg-builder@26.16.0(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.16.0)(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1)
+      app-builder-lib: 26.15.3(patch_hash=31b6515261c0293b0461ee1fb6771aff53487406edc56e942bc7095b86ac42cf)(dmg-builder@26.16.0)(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1)
       builder-util: 26.16.0(supports-color@8.1.1)
       fs-extra: 10.1.0
       js-yaml: 4.3.2
@@ -6435,7 +6436,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.16.0)(supports-color@8.1.1):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.16.0)(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1)
+      app-builder-lib: 26.15.3(patch_hash=31b6515261c0293b0461ee1fb6771aff53487406edc56e942bc7095b86ac42cf)(dmg-builder@26.16.0)(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1)
       builder-util: 26.15.3(supports-color@8.1.1)
       electron-winstaller: 5.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -6444,7 +6445,7 @@ snapshots:
 
   electron-builder@26.16.0(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.16.0)(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1)
+      app-builder-lib: 26.15.3(patch_hash=31b6515261c0293b0461ee1fb6771aff53487406edc56e942bc7095b86ac42cf)(dmg-builder@26.16.0)(electron-builder-squirrel-windows@26.15.3)(supports-color@8.1.1)
       builder-util: 26.16.0(supports-color@8.1.1)
       builder-util-runtime: 9.7.0(supports-color@8.1.1)
       chalk: 4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,6 +84,7 @@ patchedDependencies:
   '@jsr/meshtastic__core@2.6.6': patches/@jsr__meshtastic__core@2.6.6.patch
   '@jsr/meshtastic__transport-web-serial@0.2.5': patches/@jsr__meshtastic__transport-web-serial@0.2.5.patch
   '@liamcottle/meshcore.js@1.15.0': patches/@liamcottle__meshcore.js@1.15.0.patch
+  app-builder-lib@26.15.3: patches/app-builder-lib@26.15.3.patch
   debug@4.4.3: patches/debug@4.4.3.patch
   readable-stream@4.7.0: patches/readable-stream@4.7.0.patch
   usb@2.18.0: patches/usb@2.18.0.patch

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -754,6 +754,7 @@ WATCH_ENTRIES=(
   '@jsr/meshtastic__transport-http|@meshtastic/transport-http|https://www.npmjs.com/package/@jsr/meshtastic__transport-http|HTTP transport for Meshtastic; upstream may introduce breaking changes'
   '@liamcottle/meshcore.js|@liamcottle/meshcore.js|https://www.npmjs.com/package/@liamcottle/meshcore.js|Custom patch (protocol fixes) + upstream may introduce breaking changes'
   '@michaelhart/meshcore-decoder|@michaelhart/meshcore-decoder|https://www.npmjs.com/package/@michaelhart/meshcore-decoder|MeshCore packet decoding; wire-format changes affect Sniffer/diagnostics'
+  'app-builder-lib|app-builder-lib|https://www.npmjs.com/package/app-builder-lib|Custom patch (macOS CSC_LINK set-key-partition-list keychain password; electron-builder#10101)'
   'usb|usb|https://www.npmjs.com/package/usb|Custom patch (macOS C++17 std compat)'
   'readable-stream|readable-stream|https://www.npmjs.com/package/readable-stream|Custom patch (bundler process/ path compat)'
   'debug|debug|https://www.npmjs.com/package/debug|Custom patch (inlined ms/humanize for bundler compat)'

--- a/src/main/windows-packaging.contract.test.ts
+++ b/src/main/windows-packaging.contract.test.ts
@@ -362,4 +362,33 @@ describe('Windows packaging (contract)', () => {
     expect(releaseWorkflow).toContain('CSC_IDENTITY_AUTO_DISCOVERY');
     expect(releaseWorkflow).toContain('Validate macOS signing secrets');
   });
+
+  it('patches app-builder-lib so CSC_LINK signing uses the keychain password', () => {
+    const workspaceYaml = readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf-8');
+    const lockfile = readFileSync(join(REPO_ROOT, 'pnpm-lock.yaml'), 'utf-8');
+    const appBuilderLibLockRe = /^ {2}app-builder-lib@(26\.\d+\.\d+):$/m;
+    const resolvedMatch = appBuilderLibLockRe.exec(lockfile);
+    expect(resolvedMatch).not.toBeNull();
+    const resolvedVersion = resolvedMatch![1];
+    expect(workspaceYaml).toContain(
+      `app-builder-lib@${resolvedVersion}: patches/app-builder-lib@${resolvedVersion}.patch`,
+    );
+
+    const macCodeSign = readFileSync(
+      join(REPO_ROOT, 'node_modules', 'app-builder-lib', 'out', 'codeSign', 'macCodeSign.js'),
+      'utf-8',
+    );
+    expect(macCodeSign).toContain(
+      'importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)',
+    );
+    expect(macCodeSign).toContain(
+      '["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]',
+    );
+    expect(macCodeSign).not.toMatch(
+      /set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password,/,
+    );
+
+    const updateScript = readFileSync(join(REPO_ROOT, 'scripts', 'update.sh'), 'utf-8');
+    expect(updateScript).toMatch(/WATCH_ENTRIES=\([\s\S]*'app-builder-lib\|app-builder-lib\|/);
+  });
 });


### PR DESCRIPTION
## Summary
- Dual-arch `dist:mac` CI failed with `SecKeychainUnlock: The user name or passphrase you entered is not correct` while importing `CSC_LINK` ([run 33973652320](https://github.com/Colorado-Mesh/mesh-client/actions/runs/33973652320/job/101326619303)).
- Root cause is electron-builder [#10066](https://github.com/electron-userland/electron-builder/issues/10066): `set-key-partition-list -k` was given the `.p12` import password instead of the temporary keychain password.
- Backport upstream [#10101](https://github.com/electron-userland/electron-builder/pull/10101) via a pnpm patch on `app-builder-lib@26.15.3` (fix is on master/`27.0.0-alpha` only; not in published `26.16.0`).

## Test plan
- [x] `vitest` packaging contract asserts patch wiring + installed `macCodeSign.js` uses `keychainPassword`
- [ ] Re-run **Build Binaries (no release)** and confirm macOS `dist:mac` signs/notarizes for both x64 and arm64
- [ ] Confirm pre-commit / PR CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS application signing by ensuring keychain passwords are used correctly during packaging.
  - Resolved an issue that could prevent successful code signing when credentials are stored in the macOS keychain.

- **Maintenance**
  - Added automated tracking and validation for the packaging fix to help ensure it remains applied during future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->