### PR TITLE
fix(reticulum): keep LXMFace when MeshChat sends default person icon

### DIFF
--- a/src/renderer/components/ReticulumPeerDetailModal.test.tsx
+++ b/src/renderer/components/ReticulumPeerDetailModal.test.tsx
@@ -280,7 +280,7 @@ describe('ReticulumPeerDetailModal — avatar icon', () => {
     expect(select).toHaveValue('user');
   });
 
-  it('loads wire people icon into People select option', async () => {
+  it('treats wire people icon as unset so LXMFace shows (not People picker)', async () => {
     vi.mocked(window.electronAPI.db.getReticulumDestinations).mockResolvedValue([
       {
         destination_hash: PEER_HASH,
@@ -294,7 +294,7 @@ describe('ReticulumPeerDetailModal — avatar icon', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText('reticulumProfileIcon.iconNameAria')).toHaveValue('user');
+      expect(screen.getByLabelText('reticulumProfileIcon.iconNameAria')).toHaveValue('circle');
     });
   });
 

--- a/src/renderer/lib/reticulum/reticulumIconAppearance.test.ts
+++ b/src/renderer/lib/reticulum/reticulumIconAppearance.test.ts
@@ -39,11 +39,22 @@ describe('reticulumIconAppearance', () => {
 
   it('maps material symbols to lucide names; person/unknown stay unset for LXMFace', () => {
     expect(resolveReticulumProfileIconName('favorite')).toBe('heart');
+    expect(resolveReticulumProfileIconName('favorite_border')).toBe('heart');
     expect(resolveReticulumProfileIconName('star')).toBe('star');
+    expect(resolveReticulumProfileIconName('grade')).toBe('star');
+    expect(resolveReticulumProfileIconName('security')).toBe('shield');
     expect(resolveReticulumProfileIconName('user')).toBe('user');
     expect(resolveReticulumProfileIconName('hiking')).toBe('circle');
     expect(resolveReticulumProfileIconName('people')).toBe('circle');
     expect(resolveReticulumProfileIconName('person')).toBe('circle');
     expect(resolveReticulumProfileIconName('account_circle')).toBe('circle');
+  });
+
+  it('does not classify unknown wire names that merely contain a supported token', () => {
+    expect(resolveReticulumProfileIconName('custom_star')).toBe('circle');
+    expect(resolveReticulumProfileIconName('my_favorite_badge')).toBe('circle');
+    expect(resolveReticulumProfileIconName('super_security_cam')).toBe('circle');
+    expect(isDefaultReticulumProfileIcon('custom_star', 'amber')).toBe(true);
+    expect(hasCustomReticulumProfileIcon('custom_star', 'amber')).toBe(false);
   });
 });

--- a/src/renderer/lib/reticulum/reticulumIconAppearance.test.ts
+++ b/src/renderer/lib/reticulum/reticulumIconAppearance.test.ts
@@ -16,6 +16,11 @@ describe('reticulumIconAppearance', () => {
     expect(hasCustomReticulumProfileIcon('star', 'green')).toBe(true);
     expect(hasCustomReticulumProfileIcon('user', null)).toBe(true);
     expect(hasCustomReticulumProfileIcon('circle', 'amber')).toBe(false);
+    // MeshChat default person icons must not override LXMFace
+    expect(isDefaultReticulumProfileIcon('person', 'green')).toBe(true);
+    expect(isDefaultReticulumProfileIcon('people', 'purple')).toBe(true);
+    expect(hasCustomReticulumProfileIcon('person', 'green')).toBe(false);
+    expect(hasCustomReticulumProfileIcon('hiking', 'amber')).toBe(false);
   });
 
   it('maps foreground rgb to palette color', () => {
@@ -32,11 +37,13 @@ describe('reticulumIconAppearance', () => {
     expect(parsed).toEqual({ icon_name: 'hiking', icon_color: 'amber' });
   });
 
-  it('maps material symbols to lucide names', () => {
+  it('maps material symbols to lucide names; person/unknown stay unset for LXMFace', () => {
     expect(resolveReticulumProfileIconName('favorite')).toBe('heart');
-    expect(resolveReticulumProfileIconName('hiking')).toBe('user');
-    expect(resolveReticulumProfileIconName('people')).toBe('user');
-    expect(resolveReticulumProfileIconName('person')).toBe('user');
     expect(resolveReticulumProfileIconName('star')).toBe('star');
+    expect(resolveReticulumProfileIconName('user')).toBe('user');
+    expect(resolveReticulumProfileIconName('hiking')).toBe('circle');
+    expect(resolveReticulumProfileIconName('people')).toBe('circle');
+    expect(resolveReticulumProfileIconName('person')).toBe('circle');
+    expect(resolveReticulumProfileIconName('account_circle')).toBe('circle');
   });
 });

--- a/src/renderer/lib/reticulum/reticulumIconAppearance.ts
+++ b/src/renderer/lib/reticulum/reticulumIconAppearance.ts
@@ -66,7 +66,8 @@ export function mapRgbToReticulumIconColor(
 }
 
 /**
- * True when stored appearance is unset (missing or legacy `circle`).
+ * True when stored appearance is unset (missing, legacy `circle`, or MeshChat
+ * default / unknown Material icons that should not override LXMFace).
  * Color is ignored — Circle is no longer a real avatar choice.
  */
 export function isDefaultReticulumProfileIcon(
@@ -75,8 +76,7 @@ export function isDefaultReticulumProfileIcon(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- API compatibility
   iconColor?: string | null,
 ): boolean {
-  const name = iconName?.trim().toLowerCase() || 'circle';
-  return name === 'circle';
+  return resolveReticulumProfileIconName(iconName) === 'circle';
 }
 
 export function hasCustomReticulumProfileIcon(
@@ -86,7 +86,12 @@ export function hasCustomReticulumProfileIcon(
   return !isDefaultReticulumProfileIcon(iconName, iconColor);
 }
 
-/** Map Material symbol names (MeshChat / LXMF wire) to supported Lucide badges. */
+/**
+ * Map Material symbol names (MeshChat / LXMF wire) to supported Lucide badges.
+ * Only star / heart / shield / exact `user` (our People picker) override LXMFace.
+ * MeshChat’s default person/account icons and unknown symbols resolve to unset
+ * (`circle`) so the generated face stays the peer’s visual identity.
+ */
 export function resolveReticulumProfileIconName(
   iconName?: string | null,
 ): ReticulumProfileIconName {
@@ -96,17 +101,8 @@ export function resolveReticulumProfileIconName(
   if (wire.includes('star') || wire.includes('grade')) return 'star';
   if (wire.includes('heart') || wire.includes('favorite')) return 'heart';
   if (wire.includes('shield') || wire.includes('security')) return 'shield';
-  if (
-    wire === 'people' ||
-    wire === 'person' ||
-    wire.includes('person') ||
-    wire.includes('people') ||
-    wire.includes('account') ||
-    wire === 'user'
-  ) {
-    return 'user';
-  }
-  return 'user';
+  // person / people / account / hiking / anything else → LXMFace
+  return 'circle';
 }
 
 export function parseReticulumIconAppearanceWire(

--- a/src/renderer/lib/reticulum/reticulumIconAppearance.ts
+++ b/src/renderer/lib/reticulum/reticulumIconAppearance.ts
@@ -92,16 +92,20 @@ export function hasCustomReticulumProfileIcon(
  * MeshChat’s default person/account icons and unknown symbols resolve to unset
  * (`circle`) so the generated face stays the peer’s visual identity.
  */
+const STAR_WIRE_ALIASES = new Set(['star', 'grade', 'star_rate', 'star_outline', 'star_border']);
+const HEART_WIRE_ALIASES = new Set(['heart', 'favorite', 'favorite_border', 'favorite_outline']);
+const SHIELD_WIRE_ALIASES = new Set(['shield', 'security', 'verified_user', 'gpp_good']);
+
 export function resolveReticulumProfileIconName(
   iconName?: string | null,
 ): ReticulumProfileIconName {
   if (isReticulumProfileIconName(iconName)) return iconName;
   const wire = iconName?.trim().toLowerCase();
   if (!wire || wire === 'circle') return 'circle';
-  if (wire.includes('star') || wire.includes('grade')) return 'star';
-  if (wire.includes('heart') || wire.includes('favorite')) return 'heart';
-  if (wire.includes('shield') || wire.includes('security')) return 'shield';
-  // person / people / account / hiking / anything else → LXMFace
+  if (STAR_WIRE_ALIASES.has(wire)) return 'star';
+  if (HEART_WIRE_ALIASES.has(wire)) return 'heart';
+  if (SHIELD_WIRE_ALIASES.has(wire)) return 'shield';
+  // person / people / account / hiking / custom_* containing a token / anything else → LXMFace
   return 'circle';
 }
 


### PR DESCRIPTION
## Summary
- MeshChat often sends a default Material `person`/`people` icon in LXMF `icon_appearance`; we were treating that as a custom avatar and replacing the generated LXMFace with a Lucide People glyph.
- Treat MeshChat person/unknown Material icons as unset so LXMFace remains the peer identity; only star / heart / shield / explicit `user` (our People picker) override it.
- Updates Peer details load behavior so a persisted wire `people` icon shows as None (LXMFace) instead of the People picker option.

## Test plan
- [ ] Open a DM from a MeshChat peer that advertises a default person icon — tab and message header show LXMFace (not People outline)
- [ ] Selected DM still uses the purple active pill (unchanged)
- [ ] Peer details → set People / Star / Heart / Shield still overrides LXMFace
- [ ] Peer details → None restores LXMFace
- [ ] Vitest: `reticulumIconAppearance`, PeerDetailModal people-wire case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile icon handling so default or unrecognized icons no longer replace a peer’s generated identity face.
  * Default person, people, hiking, and amber icons are now treated as unset when appropriate.
  * Prevented wire-level `people` icons from incorrectly appearing as a selected custom user icon.
  * Preserved explicitly selected icons such as `star`, `heart`, and `shield`, while unsupported icons use the expected fallback appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->