### PR TITLE
fix(ci): bump pnpm/action-setup for pnpm 12 on Windows

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yaml
+++ b/.github/actions/setup-node-pnpm/action.yaml
@@ -11,7 +11,8 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+      # pnpm/action-setup v6.1.0 (pnpm 12 native bootstrap; older pins break Windows store path)
+      uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
     - name: Setup Node
       # actions/setup-node v6.5.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/buttonmash.yaml
+++ b/.github/workflows/buttonmash.yaml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
       - name: Setup Node
         # actions/setup-node v6.5.0

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -72,7 +72,7 @@ jobs:
           persist-credentials: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/third-party-licenses.yaml
+++ b/.github/workflows/third-party-licenses.yaml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -7,6 +7,8 @@ import { describe, expect, it } from 'vitest';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CHECKOUT_SHA = 'd23441a48e516b6c34aea4fa41551a30e30af803';
 const SETUP_NODE_SHA = '249970729cb0ef3589644e2896645e5dc5ba9c38';
+/** pnpm/action-setup v6.1.0 — required for pnpm 12 native bootstrap (esp. Windows). */
+const PNPM_ACTION_SETUP_SHA = 'ea17c68df8912ef543352723c149a84f56e3d413';
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
@@ -51,7 +53,7 @@ describe('CI workflow contracts', () => {
     expect(testsWorkflow).toContain('cancel-in-progress: true');
     expect(ciWorkflow).toContain('uses: ./.github/actions/setup-node-pnpm');
     expect(testsWorkflow).toContain('uses: ./.github/actions/setup-node-pnpm');
-    expect(setupAction).toContain('pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271');
+    expect(setupAction).toContain(`pnpm/action-setup@${PNPM_ACTION_SETUP_SHA}`);
     expect(setupAction).toContain(`actions/setup-node@${SETUP_NODE_SHA}`);
     expect(setupAction).toContain("default: '22.23.2'");
     expect(setupAction).toContain('pnpm install --frozen-lockfile');


### PR DESCRIPTION
## Summary
- Windows build failed right after the pnpm 12 merge when `actions/setup-node` ran `pnpm store path` against a broken legacy `@pnpm/exe` shim path under `setup-pnpm` (`PNPM_HOME` v10 vs v11 layout warning + `"…\pnpm\pnpm" is not recognized`).
- Bump `pnpm/action-setup` to **v6.1.0** (`ea17c68…`), which adds native pnpm 12 bootstrap (see [pnpm/action-setup#288](https://github.com/pnpm/action-setup/pull/288)), across the composite action and workflows that still pin the action directly.
- Update the CI workflow contract test pin.

## Test plan
- [x] `pnpm exec vitest run scripts/ci-workflows.test.mjs`
- [ ] Re-run Build (or this PR’s CI) and confirm Windows `Install Node.js` / `Setup Node` succeeds with `cache: pnpm`
- [ ] Confirm macOS/Linux install steps still pass with the same pin