### PR TITLE
chore: speed up CI with parallel lint and UI test shards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,8 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
-          # paths-filter also handles push-like merge_group events from this checkout.
-          fetch-depth: 0
+          # PR filtering uses the API; push-like events still need history.
+          fetch-depth: ${{ github.event_name == 'pull_request' && 1 || 0 }}
       # dorny/paths-filter v4.0.0
       - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c
         id: filter
@@ -71,9 +71,6 @@ jobs:
       - name: Markdown lint
         run: pnpm run lint:md
 
-      - name: Lint
-        run: pnpm run lint
-
       - name: Audit Open Source Licenses
         run: pnpm run check:licenses
 
@@ -93,6 +90,18 @@ jobs:
 
       - name: YAML Lint
         run: yamllint -f github -s .
+
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-pnpm
+      # Bound worker count because each type-aware worker loads TypeScript programs.
+      - run: pnpm run lint --concurrency 2
 
   typecheck:
     name: Typecheck
@@ -155,12 +164,13 @@ jobs:
 
   build:
     name: Build & Test
-    needs: [changes, quality, typecheck, app-build, flatpak]
+    needs: [changes, quality, lint, typecheck, app-build, flatpak]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     env:
       CHANGES_RESULT: ${{ needs.changes.result }}
       QUALITY_RESULT: ${{ needs.quality.result }}
+      LINT_RESULT: ${{ needs.lint.result }}
       TYPECHECK_RESULT: ${{ needs.typecheck.result }}
       BUILD_RESULT: ${{ needs.app-build.result }}
       FLATPAK_RESULT: ${{ needs.flatpak.result }}
@@ -169,7 +179,7 @@ jobs:
         shell: bash
         run: |
           required_ok=true
-          for result in "$CHANGES_RESULT" "$QUALITY_RESULT" "$TYPECHECK_RESULT" "$BUILD_RESULT"; do
+          for result in "$CHANGES_RESULT" "$QUALITY_RESULT" "$LINT_RESULT" "$TYPECHECK_RESULT" "$BUILD_RESULT"; do
             [[ "$result" == 'success' ]] || required_ok=false
           done
           flatpak_ok=false
@@ -180,6 +190,7 @@ jobs:
             echo
             echo "- Changes: $CHANGES_RESULT"
             echo "- Code quality: $QUALITY_RESULT"
+            echo "- ESLint: $LINT_RESULT"
             echo "- Typecheck: $TYPECHECK_RESULT"
             echo "- Application build: $BUILD_RESULT"
             echo "- Flatpak checks: $FLATPAK_RESULT"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,8 +57,8 @@ jobs:
           CI_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/ci-test-scope.mjs
 
-  tests:
-    name: Coverage (${{ matrix.project }})
+  test-shards:
+    name: Vitest (${{ matrix.project }}, ${{ matrix.shard }}/${{ matrix.shards }})
     needs: changes
     permissions:
       contents: read
@@ -66,7 +66,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [renderer-ui, renderer-logic, main]
+        include:
+          - project: renderer-ui
+            shard: 1
+            shards: 3
+          - project: renderer-ui
+            shard: 2
+            shards: 3
+          - project: renderer-ui
+            shard: 3
+            shards: 3
+          - project: renderer-logic
+            shard: 1
+            shards: 1
+          - project: main
+            shard: 1
+            shards: 1
     env:
       VITEST_COVERAGE_SHARD: '1'
     steps:
@@ -85,13 +100,14 @@ jobs:
           VITEST_MODE: ${{ needs.changes.outputs.vitest_mode }}
           VITEST_PATHS_JSON: ${{ needs.changes.outputs.vitest_paths }}
           VITEST_PROJECT: ${{ matrix.project }}
+          VITEST_SHARD: ${{ matrix.shard }}/${{ matrix.shards }}
         run: node scripts/ci-run-vitest.mjs
 
       - name: Upload blob report
         if: always() && contains(fromJSON(needs.changes.outputs.vitest_projects), matrix.project)
         uses: actions/upload-artifact@v7
         with:
-          name: vitest-blob-${{ matrix.project }}
+          name: vitest-blob-${{ matrix.project }}-${{ matrix.shard }}
           path: .vitest-reports/*
           include-hidden-files: true
           retention-days: 1
@@ -100,6 +116,25 @@ jobs:
       - name: Record skipped project
         if: ${{ !contains(fromJSON(needs.changes.outputs.vitest_projects), matrix.project) }}
         run: echo 'No tests selected for ${{ matrix.project }}.' >> "$GITHUB_STEP_SUMMARY"
+
+  # Keep the required check names stable while the execution matrix changes.
+  tests:
+    name: Coverage (${{ matrix.project }})
+    needs: [changes, test-shards]
+    if: always() && !cancelled()
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [renderer-ui, renderer-logic, main]
+    steps:
+      - name: Verify test shards
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          SHARDS_RESULT: ${{ needs.test-shards.result }}
+        run: |
+          [[ "$CHANGES_RESULT" == 'success' && "$SHARDS_RESULT" == 'success' ]]
 
   reticulum-sidecar-coverage:
     name: Reticulum sidecar coverage

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -24,9 +24,10 @@ Mesh-Client uses GitHub Actions for continuous integration and deployment.
 
 ## CI Build (`ci.yaml`)
 
-Runs on every push, pull request, and merge-queue `merge_group` for `main` (and `workflow_dispatch`). After one change-detection job, independent lanes run concurrently:
+Runs on every push, pull request, and merge-queue `merge_group` for `main` (and `workflow_dispatch`). Independent lanes start concurrently; only Flatpak waits for change detection:
 
-- **Code quality:** format, markdownlint, ESLint, license allowlist, actionlint, dependency audit, and yamllint
+- **Code quality:** format, markdownlint, license allowlist, actionlint, dependency audit, and yamllint
+- **ESLint:** full repository lint with two workers, in parallel with formatting; all type-aware rules and the zero-warning gate remain enabled
 - **Typecheck:** `pnpm run typecheck`
 - **Application build:** `pnpm run build`
 - **Flatpak checks:** only when Flatpak inputs change; runs `check:flatpak`, `check:flatpak-offline-pnpm`, `desktop-file-validate`, and `appstreamcli validate`
@@ -59,9 +60,10 @@ Runs on every push, pull request, and merge-queue `merge_group` for `main`:
 2. **Pull requests:** run `vitest related` without coverage for the affected project lanes. Docs-only changes skip Vitest. Shared contracts select all projects.
 3. **Safe fallback:** test infrastructure, dependency manifests, deleted/renamed paths, oversized output, or detector failures run the full matrix.
 4. **Protected events:** `merge_group`, pushes to `main`, and manual runs always run full coverage across `renderer-ui`, `renderer-logic`, and `main`.
-5. **Merge job:** combine scoped blob reports for PR feedback, or run `pnpm run test:coverage:merge` on protected events to enforce global thresholds.
-6. **`reticulum-sidecar-coverage`:** when sidecar paths change, clone the `.rsstack/` workspace, run `cargo llvm-cov --fail-under-lines 45`, and upload `lcov.info`.
-7. Upload merged test results (retained 7 days).
+5. **Sharding:** `renderer-ui` runs in three shards; `renderer-logic` and `main` each run once. This applies to both related tests and full coverage. Each shard uploads a uniquely named blob report. The existing `Coverage (...)` required checks verify that detection and every shard succeeded.
+6. **Merge job:** combine scoped blob reports for PR feedback, or run `pnpm run test:coverage:merge` on protected events to enforce global thresholds.
+7. **`reticulum-sidecar-coverage`:** when sidecar paths change, clone the `.rsstack/` workspace, run `cargo llvm-cov --fail-under-lines 45`, and upload `lcov.info`.
+8. Upload merged test results (retained 7 days).
 
 The three `Coverage (...)` job names and `Merge coverage` remain stable for the repository ruleset, including when a project or the whole test matrix has no relevant PR work. Superseded runs for the same pull request or ref are cancelled.
 

--- a/scripts/ci-run-vitest.mjs
+++ b/scripts/ci-run-vitest.mjs
@@ -21,15 +21,23 @@ export function normalizeRelatedPathForVitest(filePath) {
   return filePath.startsWith('-') ? `./${filePath}` : filePath;
 }
 
-export function buildCiVitestArgs({ mode, project, relatedPaths = [] }) {
+export function buildCiVitestArgs({ mode, project, relatedPaths = [], shard = '' }) {
   if (!PROJECTS.has(project)) throw new Error(`Unknown Vitest project: ${project}`);
+  if (shard) {
+    const match = /^([1-9]\d*)\/([1-9]\d*)$/.exec(shard);
+    if (!match || !Number.isSafeInteger(Number(match[2])) || Number(match[1]) > Number(match[2])) {
+      throw new Error(`Invalid Vitest shard: ${shard}`);
+    }
+  }
 
+  const reportSuffix = shard ? `-${shard.replace('/', '-')}` : '';
   const reportArgs = [
     '--project',
     project,
     '--reporter=blob',
-    `--outputFile.blob=.vitest-reports/blob-${project}.json`,
+    `--outputFile.blob=.vitest-reports/blob-${project}${reportSuffix}.json`,
     '--passWithNoTests',
+    ...(shard ? [`--shard=${shard}`] : []),
   ];
   if (mode === 'full') {
     return ['run', '--coverage', '--coverage.clean=false', ...reportArgs];
@@ -52,6 +60,7 @@ export function runCiVitest(selection, opts = {}) {
 function main() {
   const mode = process.env.VITEST_MODE ?? '';
   const project = process.env.VITEST_PROJECT ?? '';
+  const shard = process.env.VITEST_SHARD ?? '';
   let relatedPaths = [];
   try {
     relatedPaths = parseRelatedPaths(process.env.VITEST_PATHS_JSON);
@@ -61,7 +70,7 @@ function main() {
   }
 
   console.error(`ci-run-vitest: ${mode} (${project}; ${relatedPaths.length} related path(s))`);
-  process.exit(runCiVitest({ mode, project, relatedPaths }));
+  process.exit(runCiVitest({ mode, project, relatedPaths, shard }));
 }
 
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);

--- a/scripts/ci-run-vitest.test.mjs
+++ b/scripts/ci-run-vitest.test.mjs
@@ -22,6 +22,43 @@ describe('ci-run-vitest', () => {
     ]);
   });
 
+  it.each(['full', 'related'])('shards %s runs without colliding blob reports', (mode) => {
+    const outputs = [1, 2, 3].map((index) => {
+      const args = buildCiVitestArgs({
+        mode,
+        project: 'renderer-ui',
+        shard: `${index}/3`,
+        relatedPaths: ['src/renderer/App.tsx'],
+      });
+      expect(args).toContain(`--shard=${index}/3`);
+      expect(args.includes('--coverage')).toBe(mode === 'full');
+      if (mode === 'related') expect(args).toContain('src/renderer/App.tsx');
+      return args.find((arg) => arg.startsWith('--outputFile.blob='));
+    });
+    expect(new Set(outputs).size).toBe(3);
+    expect(outputs[0]).toBe('--outputFile.blob=.vitest-reports/blob-renderer-ui-1-3.json');
+  });
+
+  it.each(['0/3', '4/3', '1/0', '-1/3', '1.5/3', '1/3/4', 'invalid', '1/9007199254740992'])(
+    'rejects invalid shard %s before invoking Vitest',
+    (shard) => {
+      const runVitestArgvFn = vi.fn();
+      expect(() =>
+        runCiVitest({ mode: 'full', project: 'main', shard }, { runVitestArgvFn }),
+      ).toThrow('Invalid Vitest shard');
+      expect(runVitestArgvFn).not.toHaveBeenCalled();
+    },
+  );
+
+  it('propagates a failing shard exit code', () => {
+    expect(
+      runCiVitest(
+        { mode: 'full', project: 'renderer-ui', shard: '2/3' },
+        { runVitestArgvFn: () => 1 },
+      ),
+    ).toBe(1);
+  });
+
   it('passes related paths as literal argv entries', () => {
     const relatedPath = 'src/main/a file & more.ts';
     const runVitestArgvFn = vi.fn(() => 0);

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -29,14 +30,66 @@ describe('CI workflow contracts', () => {
   });
 
   it('fans CI out behind one aggregate required check', () => {
-    for (const job of ['changes:', 'quality:', 'typecheck:', 'app-build:', 'flatpak:', 'build:']) {
+    for (const job of [
+      'changes:',
+      'quality:',
+      'lint:',
+      'typecheck:',
+      'app-build:',
+      'flatpak:',
+      'build:',
+    ]) {
       expect(ciWorkflow).toContain(`  ${job}`);
     }
-    expect(ciWorkflow).toContain('needs: [changes, quality, typecheck, app-build, flatpak]');
+    expect(ciWorkflow).toContain('needs: [changes, quality, lint, typecheck, app-build, flatpak]');
     expect(ciWorkflow).toContain('FLATPAK_RESULT: ${{ needs.flatpak.result }}');
     expect(ciWorkflow).toContain(
       '[[ "$FLATPAK_RESULT" == \'success\' || "$FLATPAK_RESULT" == \'skipped\' ]]',
     );
+  });
+
+  it('blocks required coverage checks when detection or any shard fails', () => {
+    const gate = testsWorkflow
+      .split('      - name: Verify test shards')[1]
+      .split('  reticulum-sidecar-coverage:')[0]
+      .split('        run: |\n')[1];
+    expect(testsWorkflow).toContain('needs: [changes, test-shards]');
+    for (const changes of ['success', 'failure', 'cancelled', 'skipped']) {
+      for (const shards of ['success', 'failure', 'cancelled', 'skipped']) {
+        const result = spawnSync('bash', ['-c', gate], {
+          env: { ...process.env, CHANGES_RESULT: changes, SHARDS_RESULT: shards },
+        });
+        expect(result.status === 0).toBe(changes === 'success' && shards === 'success');
+      }
+    }
+  });
+
+  it('includes ESLint failure in the required build gate', () => {
+    const gate = ciWorkflow
+      .split('      - name: Verify CI fan-out')[1]
+      .split('        run: |\n')[1];
+    const success = {
+      ...process.env,
+      CHANGES_RESULT: 'success',
+      QUALITY_RESULT: 'success',
+      LINT_RESULT: 'success',
+      TYPECHECK_RESULT: 'success',
+      BUILD_RESULT: 'success',
+      FLATPAK_RESULT: 'skipped',
+      GITHUB_STEP_SUMMARY: '/dev/null',
+    };
+    for (const lint of ['success', 'failure', 'cancelled', 'skipped']) {
+      const result = spawnSync('bash', ['-c', gate], {
+        env: { ...success, LINT_RESULT: lint },
+      });
+      expect(result.status === 0).toBe(lint === 'success');
+    }
+  });
+
+  it('uses distinct artifact names for shards and bounds lint concurrency', () => {
+    expect(testsWorkflow).toContain('name: vitest-blob-${{ matrix.project }}-${{ matrix.shard }}');
+    expect(testsWorkflow).toContain('VITEST_SHARD: ${{ matrix.shard }}/${{ matrix.shards }}');
+    expect(ciWorkflow).toContain('pnpm run lint --concurrency 2');
   });
 
   it('scopes pull request tests and keeps protected events on full coverage', () => {
@@ -60,11 +113,11 @@ describe('CI workflow contracts', () => {
   });
 
   it('pins checkout and removes persisted credentials before running repository code', () => {
-    expect(ciWorkflow.match(new RegExp(`actions/checkout@${CHECKOUT_SHA}`, 'g'))).toHaveLength(5);
+    expect(ciWorkflow.match(new RegExp(`actions/checkout@${CHECKOUT_SHA}`, 'g'))).toHaveLength(6);
     expect(testsWorkflow.match(new RegExp(`actions/checkout@${CHECKOUT_SHA}`, 'g'))).toHaveLength(
       4,
     );
-    expect(ciWorkflow.match(/persist-credentials: false/g)).toHaveLength(5);
+    expect(ciWorkflow.match(/persist-credentials: false/g)).toHaveLength(6);
     expect(testsWorkflow.match(/persist-credentials: false/g)).toHaveLength(4);
   });
 });


### PR DESCRIPTION
## Changes

Developer CI currently waits on serial formatting + ESLint and a single renderer UI test runner. In [the recent CI Build run](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34227536487), formatting took 45 seconds and ESLint took 4m18s. In [the matching Tests run](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34227536432), renderer UI tests took 6m04s while the other projects took about a minute or less.

- Run full-repository ESLint in its own job with two workers, alongside formatting and the other quality checks. Keep all rules and the zero-warning gate.
- Split renderer UI tests into three Vitest shards for both related PR tests and full coverage runs. Keep renderer logic and main on one runner each, and use unique blob/artifact names so reports cannot overwrite each other.
- Preserve all five protected-branch check names. The coverage checks fail if detection or any shard fails; merged full coverage still enforces the existing global thresholds.
- Use shallow checkout for CI Build's PR path filter, which reads changed files through the GitHub API. Retain full history for push-like events and the separate merge-base test detector.

This trades two additional test runners and one lint runner for shorter developer waits. Hosted timings will depend on runner availability and test distribution; the baseline numbers above are measurements, not a promised speedup.

## Validation

- `pnpm run check:pr`: full lint, typecheck, strict-shared typecheck, and 10,419 tests passed (5 existing skips).
- `pnpm run lint --concurrency 2`: passed.
- `actionlint`, `yamllint -f github -s .`, and `git diff --check`: passed.
- 24 targeted CI tests passed, including shell execution of the required-check gates for success/failure/cancelled/skipped results, invalid shard rejection, unique report paths, and failure propagation.
- Verified Vitest's actual sequencer partitions all 345 renderer UI test files exactly once into three groups of 115.
- Executed three real coverage shards against the targeted suites, including an empty shard, and merged their blob reports: all 24 tests retained. Global thresholds were disabled only for this small local report-format experiment; workflow coverage thresholds are unchanged.

## Hosted results

All GitHub Actions checks passed on `29afdfdd`, including full merged coverage thresholds, Rust sidecar coverage, Buttonmash, and CodeQL.

- [CI Build](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34232065294): **3m41s**, versus **5m45s** in the baseline run (about 36% shorter).
- [Renderer UI test jobs](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34232065152): **2m59s** for the slowest shard, versus **6m38s** for the previous single UI job (about 55% shorter).

These are single-run comparisons on hosted runners, including job setup where applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
  - ESLint now runs as a dedicated quality check and is included in the final build validation.
  - Test execution is distributed across parallel shards to improve CI efficiency.
  - Coverage checks now verify that all required test shards complete successfully.
  - Sharded test reports use unique names to prevent results from being overwritten.

- **Documentation**
  - Updated CI/CD documentation to describe parallel linting, test sharding, and coverage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->