### PR TITLE
fix(ci): prefer pnpm.exe on Windows after pnpm 12 bootstrap

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yaml
+++ b/.github/actions/setup-node-pnpm/action.yaml
@@ -14,18 +14,18 @@ runs:
       # pnpm/action-setup v6.1.0 (pnpm 12 native bootstrap; older pins break Windows store path)
       uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
+    # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
+    - name: Prefer native pnpm.exe on Windows PATH
+      if: runner.os == 'Windows'
+      shell: bash
+      run: node scripts/ci-prefer-windows-pnpm-exe.mjs
+
     - name: Setup Node
       # actions/setup-node v6.5.0
       uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
-
-    # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
-    - name: Prefer native pnpm.exe on Windows PATH
-      if: runner.os == 'Windows'
-      shell: bash
-      run: node scripts/ci-prefer-windows-pnpm-exe.mjs
 
     - name: Verify pnpm
       shell: bash

--- a/.github/actions/setup-node-pnpm/action.yaml
+++ b/.github/actions/setup-node-pnpm/action.yaml
@@ -21,6 +21,16 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
 
+    # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
+    - name: Prefer native pnpm.exe on Windows PATH
+      if: runner.os == 'Windows'
+      shell: bash
+      run: node scripts/ci-prefer-windows-pnpm-exe.mjs
+
+    - name: Verify pnpm
+      shell: bash
+      run: node scripts/ci-verify-pnpm.mjs
+
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,16 +67,16 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
+      # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
+      - name: Prefer native pnpm.exe on Windows PATH
+        if: runner.os == 'Windows'
+        run: node scripts/ci-prefer-windows-pnpm-exe.mjs
+
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
-
-      # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
-      - name: Prefer native pnpm.exe on Windows PATH
-        if: runner.os == 'Windows'
-        run: node scripts/ci-prefer-windows-pnpm-exe.mjs
 
       - name: Verify pnpm
         run: node scripts/ci-verify-pnpm.mjs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,14 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
+      - name: Prefer native pnpm.exe on Windows PATH
+        if: runner.os == 'Windows'
+        run: node scripts/ci-prefer-windows-pnpm-exe.mjs
+
+      - name: Verify pnpm
+        run: node scripts/ci-verify-pnpm.mjs
+
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -157,6 +165,11 @@ jobs:
       - name: Rename test-build installers with run number
         run: node scripts/rename-test-build-artifacts.mjs --root release
 
+      # Fail closed before upload: README alone must not satisfy a green Windows job.
+      - name: Assert Windows NSIS installers present
+        if: matrix.os == 'windows-latest'
+        run: node scripts/assert-win-setup-installers.mjs --root release
+
       # Stage under release/ so upload-artifact@v7's least-common-ancestor stays
       # release/ (paths outside release/ nest installers as release/release/*.exe and
       # break packaging-smoke, which downloads to path: release).
@@ -209,6 +222,7 @@ jobs:
             # Per-arch NSIS installers (test builds: …-run{N}.exe / …-run{N}-arm64.exe)
             release/*.exe
             release/READ-ME-FIRST-test-build.md
+          if-no-files-found: error
           retention-days: 30
 
   packaging-smoke:

--- a/.github/workflows/buttonmash.yaml
+++ b/.github/workflows/buttonmash.yaml
@@ -37,6 +37,9 @@ jobs:
           node-version: '22.23.2'
           cache: 'pnpm'
 
+      - name: Verify pnpm
+        run: node scripts/ci-verify-pnpm.mjs
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -80,6 +80,9 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - name: Verify pnpm
+        run: node scripts/ci-verify-pnpm.mjs
+
       - name: Install dependencies
         # dry_run only needs the detect script + package.json; still install so
         # node_modules layout matches (detect has no deps beyond node builtins).

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,6 +40,14 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
+      - name: Prefer native pnpm.exe on Windows PATH
+        if: runner.os == 'Windows'
+        run: node scripts/ci-prefer-windows-pnpm-exe.mjs
+
+      - name: Verify pnpm
+        run: node scripts/ci-verify-pnpm.mjs
+
       # After toolchain is on PATH; skip node_modules until install (still fatal on git/node/pnpm).
       - name: Check environment (pre-install)
         run: node scripts/check-environment.mjs --skip-node-modules

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,15 +35,15 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-
       # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
       - name: Prefer native pnpm.exe on Windows PATH
         if: runner.os == 'Windows'
         run: node scripts/ci-prefer-windows-pnpm-exe.mjs
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
 
       - name: Verify pnpm
         run: node scripts/ci-verify-pnpm.mjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,6 +146,14 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
+      - name: Prefer native pnpm.exe on Windows PATH
+        if: runner.os == 'Windows'
+        run: node scripts/ci-prefer-windows-pnpm-exe.mjs
+
+      - name: Verify pnpm
+        run: node scripts/ci-verify-pnpm.mjs
+
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -238,6 +246,10 @@ jobs:
         # dist:* uses --publish never so electron-builder never POSTs a draft release.
         run: ${{ matrix.build_script }}
 
+      - name: Assert Windows NSIS installers present
+        if: matrix.os == 'windows-latest'
+        run: node scripts/assert-win-setup-installers.mjs --root release
+
       - name: Upload assets to draft GitHub release
         if: >-
           ${{ needs.prepare-github-release.result == 'success'
@@ -299,6 +311,7 @@ jobs:
             release/win-unpacked/**/*
             release/win-arm64-unpacked/**/*
             release/win-x64-unpacked/**/*
+          if-no-files-found: error
           retention-days: 30
 
   finalize-github-release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,16 +140,16 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
 
+      # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
+      - name: Prefer native pnpm.exe on Windows PATH
+        if: runner.os == 'Windows'
+        run: node scripts/ci-prefer-windows-pnpm-exe.mjs
+
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
-
-      # pnpm 12 native bootstrap: PowerShell prefers broken .bin/pnpm.ps1 (silent exit 0).
-      - name: Prefer native pnpm.exe on Windows PATH
-        if: runner.os == 'Windows'
-        run: node scripts/ci-prefer-windows-pnpm-exe.mjs
 
       - name: Verify pnpm
         run: node scripts/ci-verify-pnpm.mjs

--- a/.github/workflows/third-party-licenses.yaml
+++ b/.github/workflows/third-party-licenses.yaml
@@ -44,6 +44,9 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - name: Verify pnpm
+        run: node scripts/ci-verify-pnpm.mjs
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/scripts/assert-win-setup-installers.mjs
+++ b/scripts/assert-win-setup-installers.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Fail closed if release/ is missing the split x64 + arm64 NSIS Setup installers.
+ * Accepts default and test-build `-run{N}` stamped basenames.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { collectWinSetupInstallers } from './win-setup-installer-names.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * @param {string[]} argv
+ * @returns {{ rootDir: string }}
+ */
+export function parseAssertWinSetupArgs(argv) {
+  let rootDir = path.join(ROOT, 'release');
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--root') {
+      const next = argv[++i];
+      if (!next) throw new Error('--root requires a directory');
+      rootDir = path.resolve(next);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return { rootDir };
+}
+
+/**
+ * @param {{ rootDir: string, version?: string, packageJsonPath?: string }} opts
+ * @returns {{ x64: string, arm64: string }}
+ */
+export function assertWinSetupInstallers(opts) {
+  const packageJsonPath = opts.packageJsonPath ?? path.join(ROOT, 'package.json');
+  const version = opts.version ?? JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version;
+  if (typeof version !== 'string' || !version) {
+    throw new Error('[assert-win-setup-installers] package.json version is missing');
+  }
+  if (!fs.existsSync(opts.rootDir)) {
+    throw new Error(`[assert-win-setup-installers] missing directory: ${opts.rootDir}`);
+  }
+  const names = fs.readdirSync(opts.rootDir);
+  const found = collectWinSetupInstallers(version, names);
+  console.debug(`[assert-win-setup-installers] OK — x64=${found.x64} arm64=${found.arm64}`);
+  return found;
+}
+
+function main() {
+  const { rootDir } = parseAssertWinSetupArgs(process.argv.slice(2));
+  assertWinSetupInstallers({ rootDir });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/scripts/ci-prefer-windows-pnpm-exe.mjs
+++ b/scripts/ci-prefer-windows-pnpm-exe.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Prefer the real pnpm.exe on Windows PATH after pnpm/action-setup.
+ *
+ * Failure point: action-setup v6.1.0 native bootstrap (pnpm 12) sets PNPM_HOME to
+ * `node_modules/.bin`. PowerShell resolves `pnpm` to npm's `pnpm.ps1` shim there,
+ * which exits 0 with no stdout — so `pnpm install` / `pnpm run dist:win` become
+ * silent no-ops and Windows packaging uploads only READ-ME-FIRST.
+ *
+ * Fallback: the native package binary lives at `node_modules/pnpm/pnpm.exe`.
+ * Prepend that directory to GITHUB_PATH so subsequent steps find pnpm.exe before
+ * the broken .ps1. Self-update layouts may place pnpm.exe under PNPM_HOME or
+ * PNPM_HOME/bin instead.
+ *
+ * No-op on non-Windows. Requires PNPM_HOME + GITHUB_PATH (GitHub Actions).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * @param {string} pnpmHome
+ * @returns {string[]}
+ */
+export function windowsPnpmExeCandidates(pnpmHome) {
+  return [
+    path.resolve(pnpmHome, '..', 'pnpm', 'pnpm.exe'),
+    path.join(pnpmHome, 'pnpm.exe'),
+    path.join(pnpmHome, 'bin', 'pnpm.exe'),
+  ];
+}
+
+/**
+ * @param {{
+ *   platform?: NodeJS.Platform
+ *   pnpmHome?: string
+ *   githubPath?: string
+ *   existsSync?: (p: string) => boolean
+ *   appendFileSync?: (p: string, data: string) => void
+ *   log?: (msg: string) => void
+ * }} [opts]
+ * @returns {{ skipped: boolean, exeDir?: string, exe?: string, reason?: string }}
+ */
+export function preferWindowsPnpmExe(opts = {}) {
+  const platform = opts.platform ?? process.platform;
+  const log = opts.log ?? ((msg) => console.debug(msg));
+  if (platform !== 'win32') {
+    return { skipped: true, reason: 'not-win32' };
+  }
+
+  const pnpmHome = opts.pnpmHome ?? process.env.PNPM_HOME;
+  if (!pnpmHome || !String(pnpmHome).trim()) {
+    throw new Error('[ci-prefer-windows-pnpm-exe] PNPM_HOME is unset');
+  }
+
+  const githubPath = opts.githubPath ?? process.env.GITHUB_PATH;
+  if (!githubPath || !String(githubPath).trim()) {
+    throw new Error(
+      '[ci-prefer-windows-pnpm-exe] GITHUB_PATH is unset (expected on GitHub Actions runners)',
+    );
+  }
+
+  const existsSync = opts.existsSync ?? fs.existsSync;
+  const appendFileSync = opts.appendFileSync ?? fs.appendFileSync;
+  const candidates = windowsPnpmExeCandidates(pnpmHome);
+  const exe = candidates.find((p) => existsSync(p));
+  if (!exe) {
+    throw new Error(
+      `[ci-prefer-windows-pnpm-exe] pnpm.exe not found. Tried:\n${candidates
+        .map((c) => `  ${c}`)
+        .join('\n')}`,
+    );
+  }
+
+  const exeDir = path.dirname(exe);
+  appendFileSync(githubPath, `${exeDir}\n`);
+  log(`[ci-prefer-windows-pnpm-exe] prepended ${exeDir} (${exe})`);
+  return { skipped: false, exeDir, exe };
+}
+
+function main() {
+  const result = preferWindowsPnpmExe();
+  if (result.skipped) {
+    console.debug(`[ci-prefer-windows-pnpm-exe] skip (${result.reason ?? 'unknown'})`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/scripts/ci-prefer-windows-pnpm-exe.test.mjs
+++ b/scripts/ci-prefer-windows-pnpm-exe.test.mjs
@@ -1,0 +1,143 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { preferWindowsPnpmExe, windowsPnpmExeCandidates } from './ci-prefer-windows-pnpm-exe.mjs';
+import { parsePnpmVersionOutput, verifyPnpmVersion } from './ci-verify-pnpm.mjs';
+import { assertWinSetupInstallers } from './assert-win-setup-installers.mjs';
+
+/** @type {string[]} */
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('ci-prefer-windows-pnpm-exe', () => {
+  it('lists native bootstrap, PNPM_HOME, and self-update candidates', () => {
+    const home = path.join('C:', 'setup-pnpm', 'node_modules', '.bin');
+    expect(windowsPnpmExeCandidates(home)).toEqual([
+      path.resolve(home, '..', 'pnpm', 'pnpm.exe'),
+      path.join(home, 'pnpm.exe'),
+      path.join(home, 'bin', 'pnpm.exe'),
+    ]);
+  });
+
+  it('skips on non-Windows', () => {
+    const result = preferWindowsPnpmExe({
+      platform: 'darwin',
+      pnpmHome: '/tmp/pnpm',
+      githubPath: '/tmp/github_path',
+    });
+    expect(result).toEqual({ skipped: true, reason: 'not-win32' });
+  });
+
+  it('prepends the native package directory when pnpm.exe is beside .bin', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-pnpm-path-'));
+    tempDirs.push(root);
+    const bin = path.join(root, 'node_modules', '.bin');
+    const pkg = path.join(root, 'node_modules', 'pnpm');
+    fs.mkdirSync(bin, { recursive: true });
+    fs.mkdirSync(pkg, { recursive: true });
+    const exe = path.join(pkg, 'pnpm.exe');
+    fs.writeFileSync(exe, '');
+    const githubPath = path.join(root, 'github_path');
+    fs.writeFileSync(githubPath, '');
+
+    /** @type {string[]} */
+    const logs = [];
+    const result = preferWindowsPnpmExe({
+      platform: 'win32',
+      pnpmHome: bin,
+      githubPath,
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.exeDir).toBe(pkg);
+    expect(fs.readFileSync(githubPath, 'utf8')).toBe(`${pkg}\n`);
+    expect(logs[0]).toContain(pkg);
+  });
+
+  it('fails when pnpm.exe is missing', () => {
+    expect(() =>
+      preferWindowsPnpmExe({
+        platform: 'win32',
+        pnpmHome: path.join('C:', 'missing', '.bin'),
+        githubPath: path.join('C:', 'github_path'),
+        existsSync: () => false,
+        appendFileSync: () => {},
+      }),
+    ).toThrow(/pnpm\.exe not found/);
+  });
+});
+
+describe('ci-verify-pnpm', () => {
+  it('parses plain semver stdout', () => {
+    expect(parsePnpmVersionOutput('12.3.4\n')).toBe('12.3.4');
+    expect(parsePnpmVersionOutput('')).toBeNull();
+    expect(parsePnpmVersionOutput('not-a-version')).toBeNull();
+  });
+
+  it('accepts matching major and rejects empty or wrong-major output', () => {
+    const packageJsonPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-verify-pnpm-')),
+      'package.json',
+    );
+    tempDirs.push(path.dirname(packageJsonPath));
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({ packageManager: 'pnpm@12.3.4+sha512.deadbeef' }),
+    );
+
+    expect(
+      verifyPnpmVersion({
+        packageJsonPath,
+        spawnSyncFn: () => ({ status: 0, stdout: '12.9.0\n', stderr: '', error: undefined }),
+        log: () => {},
+      }),
+    ).toBe('12.9.0');
+
+    expect(() =>
+      verifyPnpmVersion({
+        packageJsonPath,
+        spawnSyncFn: () => ({ status: 0, stdout: '', stderr: '', error: undefined }),
+        log: () => {},
+      }),
+    ).toThrow(/did not return semver/);
+
+    expect(() =>
+      verifyPnpmVersion({
+        packageJsonPath,
+        spawnSyncFn: () => ({ status: 0, stdout: '11.25.0\n', stderr: '', error: undefined }),
+        log: () => {},
+      }),
+    ).toThrow(/major mismatch/);
+  });
+});
+
+describe('assert-win-setup-installers', () => {
+  it('accepts stamped split installers and rejects README-only release dirs', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-assert-win-'));
+    tempDirs.push(root);
+    const packageJsonPath = path.join(root, 'package.json');
+    fs.writeFileSync(packageJsonPath, JSON.stringify({ version: '5.35.0' }));
+    const releaseDir = path.join(root, 'release');
+    fs.mkdirSync(releaseDir);
+    fs.writeFileSync(path.join(releaseDir, 'READ-ME-FIRST-test-build.md'), 'x');
+
+    expect(() => assertWinSetupInstallers({ rootDir: releaseDir, packageJsonPath })).toThrow(
+      /Expected exactly one x64 NSIS installer/,
+    );
+
+    fs.writeFileSync(path.join(releaseDir, 'Mesh-client Setup 5.35.0-run281.exe'), '');
+    fs.writeFileSync(path.join(releaseDir, 'Mesh-client Setup 5.35.0-run281-arm64.exe'), '');
+    expect(assertWinSetupInstallers({ rootDir: releaseDir, packageJsonPath })).toEqual({
+      x64: 'Mesh-client Setup 5.35.0-run281.exe',
+      arm64: 'Mesh-client Setup 5.35.0-run281-arm64.exe',
+    });
+  });
+});

--- a/scripts/ci-verify-pnpm.mjs
+++ b/scripts/ci-verify-pnpm.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Fail closed if `pnpm --version` does not print a semver string.
+ *
+ * Failure point: broken Windows PowerShell shims can exit 0 with empty stdout,
+ * so packaging jobs appear green while never installing or building.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * @param {string} text
+ * @returns {string | null}
+ */
+export function parsePnpmVersionOutput(text) {
+  const line = String(text ?? '')
+    .trim()
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!line) return null;
+  // Keep the pattern linear — eslint security/detect-unsafe-regex rejects nested quantifiers.
+  const m = line.match(/^(\d+\.\d+\.\d+)\s*$/);
+  return m ? m[1] : null;
+}
+
+/**
+ * @param {string} [packageJsonPath]
+ * @returns {string | null} major.minor.patch (no integrity)
+ */
+export function readPinnedPnpmVersion(packageJsonPath = path.join(ROOT, 'package.json')) {
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const raw = pkg.packageManager;
+  if (typeof raw !== 'string' || !raw.startsWith('pnpm@')) return null;
+  return raw.slice('pnpm@'.length).split('+', 1)[0] ?? null;
+}
+
+/**
+ * @param {{
+ *   spawnSyncFn?: typeof spawnSync
+ *   packageJsonPath?: string
+ *   log?: (msg: string) => void
+ * }} [opts]
+ * @returns {string} resolved pnpm version
+ */
+export function verifyPnpmVersion(opts = {}) {
+  const spawnSyncFn = opts.spawnSyncFn ?? spawnSync;
+  const log = opts.log ?? ((msg) => console.debug(msg));
+  const pinned = readPinnedPnpmVersion(opts.packageJsonPath);
+  const result = spawnSyncFn('pnpm', ['--version'], {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+  if (result.error) {
+    throw new Error(`[ci-verify-pnpm] failed to spawn pnpm: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+  if (result.status !== 0) {
+    const errText = String(result.stderr ?? result.stdout ?? '').trim();
+    throw new Error(
+      `[ci-verify-pnpm] pnpm --version exited ${String(result.status)}${
+        errText ? `: ${errText}` : ''
+      }`,
+    );
+  }
+  const version = parsePnpmVersionOutput(String(result.stdout ?? ''));
+  if (!version) {
+    throw new Error(
+      `[ci-verify-pnpm] pnpm --version did not return semver (got ${JSON.stringify(
+        String(result.stdout ?? ''),
+      )})`,
+    );
+  }
+  if (pinned) {
+    const pinnedMajor = pinned.split('.', 1)[0];
+    const actualMajor = version.split('.', 1)[0];
+    if (pinnedMajor !== actualMajor) {
+      throw new Error(
+        `[ci-verify-pnpm] pnpm major mismatch: PATH has ${version}, package.json pins ${pinned}`,
+      );
+    }
+  }
+  log(`[ci-verify-pnpm] pnpm ${version}${pinned ? ` (packageManager ${pinned})` : ''}`);
+  return version;
+}
+
+function main() {
+  verifyPnpmVersion();
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -57,6 +57,23 @@ describe('CI workflow contracts', () => {
     expect(setupAction).toContain(`actions/setup-node@${SETUP_NODE_SHA}`);
     expect(setupAction).toContain("default: '22.23.2'");
     expect(setupAction).toContain('pnpm install --frozen-lockfile');
+    // pnpm 12 native bootstrap: Windows PowerShell hits silent .ps1 shims without this.
+    expect(setupAction).toContain('ci-prefer-windows-pnpm-exe.mjs');
+    expect(setupAction).toContain('ci-verify-pnpm.mjs');
+  });
+
+  it('fixes Windows pnpm PATH and verifies pnpm before packaging installs', () => {
+    for (const relativePath of [
+      '.github/workflows/build.yaml',
+      '.github/workflows/release.yaml',
+      '.github/workflows/e2e.yaml',
+    ]) {
+      const yaml = read(relativePath);
+      expect(yaml, relativePath).toContain('ci-prefer-windows-pnpm-exe.mjs');
+      expect(yaml, relativePath).toContain('ci-verify-pnpm.mjs');
+    }
+    expect(read('.github/workflows/build.yaml')).toContain('assert-win-setup-installers.mjs');
+    expect(read('.github/workflows/release.yaml')).toContain('assert-win-setup-installers.mjs');
   });
 
   it('pins checkout and removes persisted credentials before running repository code', () => {

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -15,6 +15,18 @@ function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
 }
 
+/**
+ * @param {string} haystack
+ * @param {string} needle
+ * @param {string} label
+ * @returns {number}
+ */
+function requireIndex(haystack, needle, label) {
+  const idx = haystack.indexOf(needle);
+  expect(idx, label).toBeGreaterThan(-1);
+  return idx;
+}
+
 describe('CI workflow contracts', () => {
   const ciWorkflow = read('.github/workflows/ci.yaml');
   const testsWorkflow = read('.github/workflows/tests.yaml');
@@ -111,8 +123,32 @@ describe('CI workflow contracts', () => {
     expect(setupAction).toContain("default: '22.23.2'");
     expect(setupAction).toContain('pnpm install --frozen-lockfile');
     // pnpm 12 native bootstrap: Windows PowerShell hits silent .ps1 shims without this.
-    expect(setupAction).toContain('ci-prefer-windows-pnpm-exe.mjs');
-    expect(setupAction).toContain('ci-verify-pnpm.mjs');
+    const preferIdx = requireIndex(
+      setupAction,
+      'ci-prefer-windows-pnpm-exe.mjs',
+      'setup-node-pnpm prefer helper',
+    );
+    const verifyIdx = requireIndex(
+      setupAction,
+      'ci-verify-pnpm.mjs',
+      'setup-node-pnpm verify helper',
+    );
+    const installIdx = requireIndex(
+      setupAction,
+      'pnpm install --frozen-lockfile',
+      'setup-node-pnpm install',
+    );
+    const setupNodeIdx = requireIndex(
+      setupAction,
+      `actions/setup-node@${SETUP_NODE_SHA}`,
+      'setup-node-pnpm setup-node',
+    );
+    expect(preferIdx).toBeLessThan(setupNodeIdx);
+    expect(preferIdx).toBeLessThan(installIdx);
+    expect(verifyIdx).toBeLessThan(installIdx);
+    expect(setupAction).toMatch(
+      /Prefer native pnpm\.exe on Windows PATH[\s\S]*?if: runner\.os == 'Windows'/,
+    );
   });
 
   it('fixes Windows pnpm PATH and verifies pnpm before packaging installs', () => {
@@ -122,8 +158,23 @@ describe('CI workflow contracts', () => {
       '.github/workflows/e2e.yaml',
     ]) {
       const yaml = read(relativePath);
-      expect(yaml, relativePath).toContain('ci-prefer-windows-pnpm-exe.mjs');
-      expect(yaml, relativePath).toContain('ci-verify-pnpm.mjs');
+      const preferIdx = requireIndex(
+        yaml,
+        'ci-prefer-windows-pnpm-exe.mjs',
+        `${relativePath} prefer`,
+      );
+      const setupNodeIdx = requireIndex(yaml, 'actions/setup-node@', `${relativePath} setup-node`);
+      const verifyIdx = requireIndex(yaml, 'ci-verify-pnpm.mjs', `${relativePath} verify`);
+      const installIdx = requireIndex(
+        yaml,
+        'pnpm install --frozen-lockfile',
+        `${relativePath} install`,
+      );
+      expect(preferIdx, relativePath).toBeLessThan(setupNodeIdx);
+      expect(verifyIdx, relativePath).toBeLessThan(installIdx);
+      expect(yaml, relativePath).toMatch(
+        /Prefer native pnpm\.exe on Windows PATH[\s\S]*?if: runner\.os == 'Windows'[\s\S]*?ci-prefer-windows-pnpm-exe\.mjs/,
+      );
     }
     expect(read('.github/workflows/build.yaml')).toContain('assert-win-setup-installers.mjs');
     expect(read('.github/workflows/release.yaml')).toContain('assert-win-setup-installers.mjs');

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -145,6 +145,7 @@ describe('CI workflow contracts', () => {
     );
     expect(preferIdx).toBeLessThan(setupNodeIdx);
     expect(preferIdx).toBeLessThan(installIdx);
+    expect(setupNodeIdx).toBeLessThan(installIdx);
     expect(verifyIdx).toBeLessThan(installIdx);
     expect(setupAction).toMatch(
       /Prefer native pnpm\.exe on Windows PATH[\s\S]*?if: runner\.os == 'Windows'/,
@@ -171,6 +172,7 @@ describe('CI workflow contracts', () => {
         `${relativePath} install`,
       );
       expect(preferIdx, relativePath).toBeLessThan(setupNodeIdx);
+      expect(setupNodeIdx, relativePath).toBeLessThan(installIdx);
       expect(verifyIdx, relativePath).toBeLessThan(installIdx);
       expect(yaml, relativePath).toMatch(
         /Prefer native pnpm\.exe on Windows PATH[\s\S]*?if: runner\.os == 'Windows'[\s\S]*?ci-prefer-windows-pnpm-exe\.mjs/,

--- a/src/main/windows-packaging.contract.test.ts
+++ b/src/main/windows-packaging.contract.test.ts
@@ -163,6 +163,9 @@ describe('Windows packaging (contract)', () => {
     expect(buildWorkflow).toContain(
       'node scripts/test-win-nsis-install.mjs --arch arm64 --probe-7z',
     );
+    expect(buildWorkflow).toContain('ci-prefer-windows-pnpm-exe.mjs');
+    expect(buildWorkflow).toContain('ci-verify-pnpm.mjs');
+    expect(buildWorkflow).toContain('assert-win-setup-installers.mjs');
     expect(buildWorkflow).toContain('needs: build');
     expect(buildWorkflow).not.toContain('win-arm64-install:');
     // READ-ME-FIRST must live under release/ in uploads so artifact LCA stays release/
@@ -214,6 +217,9 @@ describe('Windows packaging (contract)', () => {
     expect(releaseWorkflow).toContain(
       "contains(matrix.build_script, 'dist:win') && matrix.os != 'windows-latest'",
     );
+    expect(releaseWorkflow).toContain('ci-prefer-windows-pnpm-exe.mjs');
+    expect(releaseWorkflow).toContain('ci-verify-pnpm.mjs');
+    expect(releaseWorkflow).toContain('assert-win-setup-installers.mjs');
     expect(releaseWorkflow).toContain('packaging-smoke:');
     expect(releaseWorkflow).toContain('label: x64 NSIS install');
     expect(releaseWorkflow).toContain('node scripts/test-win-nsis-install.mjs --arch x64');

--- a/src/main/windows-packaging.contract.test.ts
+++ b/src/main/windows-packaging.contract.test.ts
@@ -163,9 +163,24 @@ describe('Windows packaging (contract)', () => {
     expect(buildWorkflow).toContain(
       'node scripts/test-win-nsis-install.mjs --arch arm64 --probe-7z',
     );
-    expect(buildWorkflow).toContain('ci-prefer-windows-pnpm-exe.mjs');
-    expect(buildWorkflow).toContain('ci-verify-pnpm.mjs');
-    expect(buildWorkflow).toContain('assert-win-setup-installers.mjs');
+    const buildPreferIdx = buildWorkflow.indexOf('ci-prefer-windows-pnpm-exe.mjs');
+    const buildSetupNodeIdx = buildWorkflow.indexOf('actions/setup-node@');
+    const buildVerifyIdx = buildWorkflow.indexOf('ci-verify-pnpm.mjs');
+    const buildInstallIdx = buildWorkflow.indexOf('pnpm install --frozen-lockfile');
+    const buildAssertIdx = buildWorkflow.indexOf('assert-win-setup-installers.mjs');
+    const buildUploadWinIdx = buildWorkflow.indexOf('Upload Windows Artifact');
+    expect(buildPreferIdx).toBeGreaterThan(-1);
+    expect(buildSetupNodeIdx).toBeGreaterThan(-1);
+    expect(buildVerifyIdx).toBeGreaterThan(-1);
+    expect(buildInstallIdx).toBeGreaterThan(-1);
+    expect(buildAssertIdx).toBeGreaterThan(-1);
+    expect(buildUploadWinIdx).toBeGreaterThan(-1);
+    expect(buildPreferIdx).toBeLessThan(buildSetupNodeIdx);
+    expect(buildVerifyIdx).toBeLessThan(buildInstallIdx);
+    expect(buildAssertIdx).toBeLessThan(buildUploadWinIdx);
+    expect(buildWorkflow).toMatch(
+      /Prefer native pnpm\.exe on Windows PATH[\s\S]*?if: runner\.os == 'Windows'[\s\S]*?ci-prefer-windows-pnpm-exe\.mjs/,
+    );
     expect(buildWorkflow).toContain('needs: build');
     expect(buildWorkflow).not.toContain('win-arm64-install:');
     // READ-ME-FIRST must live under release/ in uploads so artifact LCA stays release/
@@ -217,9 +232,24 @@ describe('Windows packaging (contract)', () => {
     expect(releaseWorkflow).toContain(
       "contains(matrix.build_script, 'dist:win') && matrix.os != 'windows-latest'",
     );
-    expect(releaseWorkflow).toContain('ci-prefer-windows-pnpm-exe.mjs');
-    expect(releaseWorkflow).toContain('ci-verify-pnpm.mjs');
-    expect(releaseWorkflow).toContain('assert-win-setup-installers.mjs');
+    const releasePreferIdx = releaseWorkflow.indexOf('ci-prefer-windows-pnpm-exe.mjs');
+    const releaseSetupNodeIdx = releaseWorkflow.indexOf('actions/setup-node@');
+    const releaseVerifyIdx = releaseWorkflow.indexOf('ci-verify-pnpm.mjs');
+    const releaseInstallIdx = releaseWorkflow.indexOf('pnpm install --frozen-lockfile');
+    const releaseAssertIdx = releaseWorkflow.indexOf('assert-win-setup-installers.mjs');
+    const releaseUploadWinIdx = releaseWorkflow.indexOf('Upload Windows Artifact');
+    expect(releasePreferIdx).toBeGreaterThan(-1);
+    expect(releaseSetupNodeIdx).toBeGreaterThan(-1);
+    expect(releaseVerifyIdx).toBeGreaterThan(-1);
+    expect(releaseInstallIdx).toBeGreaterThan(-1);
+    expect(releaseAssertIdx).toBeGreaterThan(-1);
+    expect(releaseUploadWinIdx).toBeGreaterThan(-1);
+    expect(releasePreferIdx).toBeLessThan(releaseSetupNodeIdx);
+    expect(releaseVerifyIdx).toBeLessThan(releaseInstallIdx);
+    expect(releaseAssertIdx).toBeLessThan(releaseUploadWinIdx);
+    expect(releaseWorkflow).toMatch(
+      /Prefer native pnpm\.exe on Windows PATH[\s\S]*?if: runner\.os == 'Windows'[\s\S]*?ci-prefer-windows-pnpm-exe\.mjs/,
+    );
     expect(releaseWorkflow).toContain('packaging-smoke:');
     expect(releaseWorkflow).toContain('label: x64 NSIS install');
     expect(releaseWorkflow).toContain('node scripts/test-win-nsis-install.mjs --arch x64');

--- a/src/main/windows-packaging.contract.test.ts
+++ b/src/main/windows-packaging.contract.test.ts
@@ -176,6 +176,7 @@ describe('Windows packaging (contract)', () => {
     expect(buildAssertIdx).toBeGreaterThan(-1);
     expect(buildUploadWinIdx).toBeGreaterThan(-1);
     expect(buildPreferIdx).toBeLessThan(buildSetupNodeIdx);
+    expect(buildSetupNodeIdx).toBeLessThan(buildInstallIdx);
     expect(buildVerifyIdx).toBeLessThan(buildInstallIdx);
     expect(buildAssertIdx).toBeLessThan(buildUploadWinIdx);
     expect(buildWorkflow).toMatch(
@@ -245,6 +246,7 @@ describe('Windows packaging (contract)', () => {
     expect(releaseAssertIdx).toBeGreaterThan(-1);
     expect(releaseUploadWinIdx).toBeGreaterThan(-1);
     expect(releasePreferIdx).toBeLessThan(releaseSetupNodeIdx);
+    expect(releaseSetupNodeIdx).toBeLessThan(releaseInstallIdx);
     expect(releaseVerifyIdx).toBeLessThan(releaseInstallIdx);
     expect(releaseAssertIdx).toBeLessThan(releaseUploadWinIdx);
     expect(releaseWorkflow).toMatch(


### PR DESCRIPTION
## Summary
- Windows packaging smoke failed because PowerShell resolved broken `.bin/pnpm.ps1` shims from pnpm 12’s action-setup native bootstrap (exit 0, empty stdout), so `dist:win` never ran and the artifact was only `READ-ME-FIRST`.
- Prepend the real `node_modules/pnpm/pnpm.exe` directory to `GITHUB_PATH`, verify `pnpm --version` returns semver, and assert both NSIS Setup installers exist before upload.
- Wire the helpers into packaging/e2e workflows and the shared `setup-node-pnpm` composite action.

## Test plan
- [ ] CI unit/contract tests for the new scripts and workflow contracts pass
- [ ] Re-run **Build Binaries (no release)** and confirm Windows `pnpm install` / `dist:win` produce real logs and NSIS `.exe` artifacts
- [ ] Confirm x64 (and arm64) NSIS packaging smoke jobs download installers and pass
- [ ] Confirm a missing-installer Windows build fails at `assert-win-setup-installers` rather than uploading README-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows build and release reliability by ensuring the correct pnpm executable is used and verified before dependencies are installed.
  - Added validation to detect missing Windows x64 and ARM64 installers, preventing incomplete artifacts from being uploaded.
  - Windows artifact uploads now fail when expected installer files are missing.

- **Tests**
  - Expanded automated coverage for pnpm setup, Windows packaging, installer validation, and CI workflow requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->