### PR TITLE
fix: hide Reticulum setup guide and reopen from Network

### DIFF
--- a/docs/reticulum-setup-guide.md
+++ b/docs/reticulum-setup-guide.md
@@ -2,6 +2,8 @@
 
 Open **Reticulum → Connection → Open setup guide**. You can get started with your computer and an internet connection; a radio is optional.
 
+**Hide guide** removes the whole guide and its banner from Connection, including after restarting the app. To use it again, select **Network → Open setup guide**. This opens the guide on Connection without resetting your dismissal preference.
+
 1. **Start here:** start Reticulum inside mesh-client. Opening the guide itself does not change your settings.
 2. **Your identity:** choose a name or callsign. The guide keeps an existing identity. For a new identity, save the recovery words before continuing. These words are private; your messaging address is what you share with friends. Already have an identity? Open the restore controls in Network instead of generating a replacement.
 3. **Get connected:** select one public internet hub, configure your RNode through the existing connection controls, or check your existing setup. Internet setup adds or enables only the selected hub and restarts Reticulum. It leaves your other connections intact. A failed restart does not remove the saved connection; retrying reuses it.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -304,6 +304,7 @@ import { usePositionHistoryStore } from './stores/positionHistoryStore';
 import { useReticulumGamesStore } from './stores/reticulumGamesStore';
 import { useReticulumIdentityStore } from './stores/reticulumIdentityStore';
 import { useReticulumPeerStore } from './stores/reticulumPeerStore';
+import { useReticulumSetupGuideStore } from './stores/reticulumSetupGuideStore';
 import { useReticulumVoiceMemoStore } from './stores/reticulumVoiceMemoStore';
 import { useRncpTransferStore } from './stores/rncpTransferStore';
 import { useRrcSessionStore } from './stores/rrcSessionStore';
@@ -3830,6 +3831,16 @@ function AppContent() {
                                 onStartStack={startReticulumStackManual}
                                 propagationSectionOpenKey={reticulumPropagationNavKey}
                                 onOpenInterfaces={handleNavigateToReticulumConnection}
+                                onOpenSetupGuide={() => {
+                                  const target = findFilteredTabIndexForPanel(
+                                    selectByProtocol(tabsByProtocol, 'reticulum'),
+                                    0,
+                                  );
+                                  if (target < 0) return false;
+                                  useReticulumSetupGuideStore.getState().setOpen(true);
+                                  setActiveTab(target);
+                                  return true;
+                                }}
                                 onOpenAppGpsSettings={() => {
                                   const appTabIdx = tabSlotIds.indexOf('App');
                                   if (appTabIdx >= 0) {

--- a/src/renderer/components/ReticulumNetworkPanel.test.tsx
+++ b/src/renderer/components/ReticulumNetworkPanel.test.tsx
@@ -53,6 +53,19 @@ import { buildLxmaContactUri } from '@/shared/meshClientDeepLink';
 import { ReticulumNetworkPanel } from './ReticulumNetworkPanel';
 
 describe('ReticulumNetworkPanel', () => {
+  it('offers the setup guide through the Connection navigation callback', async () => {
+    const onOpenSetupGuide = vi.fn().mockReturnValue(true);
+    render(
+      <ReticulumNetworkPanel
+        connecting={false}
+        onStartStack={vi.fn()}
+        onOpenSetupGuide={onOpenSetupGuide}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'reticulumSetup.open' }));
+    expect(onOpenSetupGuide).toHaveBeenCalledOnce();
+  });
+
   beforeEach(() => {
     refreshIdentity.mockReset();
     identityState.public_key = null;

--- a/src/renderer/components/ReticulumNetworkPanel.test.tsx
+++ b/src/renderer/components/ReticulumNetworkPanel.test.tsx
@@ -51,8 +51,26 @@ import { useBlockStore } from '@/renderer/stores/blockStore';
 import { buildLxmaContactUri } from '@/shared/meshClientDeepLink';
 
 import { ReticulumNetworkPanel } from './ReticulumNetworkPanel';
+import { ToastProvider } from './Toast';
 
 describe('ReticulumNetworkPanel', () => {
+  it('shows an error toast when the setup guide destination is unavailable', async () => {
+    const onOpenSetupGuide = vi.fn().mockReturnValue(false);
+    render(
+      <ToastProvider>
+        <ReticulumNetworkPanel
+          connecting={false}
+          onStartStack={vi.fn()}
+          onOpenSetupGuide={onOpenSetupGuide}
+        />
+      </ToastProvider>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'reticulumSetup.open' }));
+    expect(onOpenSetupGuide).toHaveBeenCalledOnce();
+    expect(await screen.findByText('reticulumSetup.tabUnavailable')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'common.dismiss' })).toBeInTheDocument();
+  });
+
   it('offers the setup guide through the Connection navigation callback', async () => {
     const onOpenSetupGuide = vi.fn().mockReturnValue(true);
     render(

--- a/src/renderer/components/ReticulumNetworkPanel.tsx
+++ b/src/renderer/components/ReticulumNetworkPanel.tsx
@@ -112,6 +112,7 @@ export interface ReticulumNetworkPanelProps {
   propagationSectionOpenKey?: number;
   /** Open Connection → Interfaces (PN establish dual-TCP recovery). */
   onOpenInterfaces?: () => void;
+  onOpenSetupGuide?: () => boolean;
 }
 
 function reticulumExportPinError(
@@ -137,6 +138,7 @@ export function ReticulumNetworkPanel({
   onOpenAppGpsSettings,
   propagationSectionOpenKey = 0,
   onOpenInterfaces,
+  onOpenSetupGuide,
 }: ReticulumNetworkPanelProps) {
   const { t } = useTranslation();
   const { addToast } = useToast();
@@ -656,6 +658,18 @@ export function ReticulumNetworkPanel({
 
   return (
     <div className="space-y-4">
+      {onOpenSetupGuide && (
+        <button
+          type="button"
+          className="text-sm text-amber-300 underline underline-offset-4 hover:text-amber-200"
+          aria-label={t('reticulumSetup.open')}
+          onClick={() => {
+            if (!onOpenSetupGuide()) addToast(t('reticulumSetup.tabUnavailable'), 'error');
+          }}
+        >
+          {t('reticulumSetup.open')}
+        </button>
+      )}
       {!sidecarUiRunning && !connecting ? (
         <p className="rounded-lg border border-amber-600/40 bg-amber-950/20 p-3 text-sm text-amber-200">
           {t('connectionPanel.reticulumIdentity.startStackFirst')}

--- a/src/renderer/components/reticulum/ReticulumSetupGuide.test.tsx
+++ b/src/renderer/components/reticulum/ReticulumSetupGuide.test.tsx
@@ -6,6 +6,7 @@ import { axe } from 'vitest-axe';
 import { hydrateAxeThemeColors } from '@/renderer/lib/a11yTestHelpers';
 import { RETICULUM_DEFAULT_HUB_PRESETS } from '@/renderer/lib/reticulum/reticulumDefaultHubPresets';
 import { withMockedConsoleWarn } from '@/renderer/lib/vitestConsoleMock';
+import { useReticulumSetupGuideStore } from '@/renderer/stores/reticulumSetupGuideStore';
 
 import { ReticulumSetupGuide } from './ReticulumSetupGuide';
 
@@ -45,6 +46,7 @@ function props() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  useReticulumSetupGuideStore.setState({ dismissed: false, open: false });
   interfaces = [onlineHub];
   live = true;
   vi.mocked(window.electronAPI.reticulum.proxyGet).mockImplementation((path) => {
@@ -68,6 +70,23 @@ async function openConnectionStep() {
 }
 
 describe('Reticulum first connection guide', () => {
+  it('removes the entire banner when dismissed and stays hidden after remounting', async () => {
+    const view = render(<ReticulumSetupGuide {...props()} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Hide guide' }));
+    expect(
+      screen.queryByRole('heading', { name: 'Your first connection' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Open setup guide' })).not.toBeInTheDocument();
+    view.unmount();
+    render(<ReticulumSetupGuide {...props()} />);
+    expect(screen.queryByRole('button', { name: 'Open setup guide' })).not.toBeInTheDocument();
+    act(() => {
+      useReticulumSetupGuideStore.getState().setOpen(true);
+    });
+    expect(screen.getByRole('heading', { name: 'Start here' })).toBeInTheDocument();
+    expect(window.electronAPI.reticulum.proxyPost).not.toHaveBeenCalled();
+  });
+
   it('does not start services or change configuration just by displaying the guide', async () => {
     const actions = props();
     render(<ReticulumSetupGuide {...actions} />);
@@ -279,7 +298,9 @@ describe('Reticulum first connection guide', () => {
       await Promise.resolve();
     });
     expect(screen.queryByText('Your connection is available')).not.toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Open setup guide' }));
+    act(() => {
+      useReticulumSetupGuideStore.getState().setOpen(true);
+    });
     expect(screen.queryByText('Your connection is available')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
     await act(async () => {

--- a/src/renderer/components/reticulum/ReticulumSetupGuide.tsx
+++ b/src/renderer/components/reticulum/ReticulumSetupGuide.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/renderer/lib/reticulum/reticulumSetup';
 import { writeClipboardText } from '@/renderer/lib/writeClipboardText';
 import type { ReticulumIdentityStatus } from '@/renderer/stores/reticulumIdentityStore';
+import { useReticulumSetupGuideStore } from '@/renderer/stores/reticulumSetupGuideStore';
 import { MS_PER_SECOND } from '@/shared/timeConstants';
 
 export type ReticulumSetupDestination = 'Nodes' | 'RRC' | 'Radio';
@@ -86,13 +87,16 @@ export function ReticulumSetupGuide({
   const { t } = useTranslation();
   const id = useId();
   const headingRef = useRef<HTMLHeadingElement>(null);
-  const [open, setOpen] = useState(false);
+  const open = useReticulumSetupGuideStore((s) => s.open);
+  const setOpen = useReticulumSetupGuideStore((s) => s.setOpen);
+  const dismissed = useReticulumSetupGuideStore((s) => s.dismissed);
+  const dismiss = useReticulumSetupGuideStore((s) => s.dismiss);
   const [step, setStep] = useState(0);
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-  const [name, setName] = useState('');
+  const [name, setName] = useState(identity?.display_name ?? '');
   const [mnemonic, setMnemonic] = useState<string | null>(null);
   const [savedWords, setSavedWords] = useState(false);
   const [route, setRoute] = useState<'internet' | 'radio' | 'existing'>('internet');
@@ -106,6 +110,13 @@ export function ReticulumSetupGuide({
   useEffect(() => {
     if (open) headingRef.current?.focus();
   }, [open, step]);
+
+  useEffect(() => {
+    if (open && identity?.display_name) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Prefill identities loaded after the Network link opens the guide.
+      setName((current) => current || identity.display_name || '');
+    }
+  }, [open, identity?.display_name]);
 
   // Poll only while the guide is checking a connection. Cleanup prevents stale successes after close.
   useEffect(() => {
@@ -191,6 +202,8 @@ export function ReticulumSetupGuide({
     else setError(t('reticulumSetup.tabUnavailable'));
   };
 
+  if (dismissed && !open) return null;
+
   return (
     <section
       aria-labelledby={`${id}-title`}
@@ -208,20 +221,33 @@ export function ReticulumSetupGuide({
             <p className="mt-1 max-w-lg text-sm text-gray-300">{t('reticulumSetup.intro')}</p>
           )}
         </div>
-        <button
-          type="button"
-          className={SECONDARY}
-          disabled={busy}
-          aria-expanded={open}
-          aria-controls={`${id}-body`}
-          aria-label={t(open ? 'reticulumSetup.hide' : 'reticulumSetup.open')}
-          onClick={() => {
-            if (!open) setName(identity?.display_name ?? name);
-            setOpen(!open);
-          }}
-        >
-          {t(open ? 'reticulumSetup.hide' : 'reticulumSetup.open')}
-        </button>
+        <div className="flex flex-wrap gap-2">
+          {!open && (
+            <button
+              type="button"
+              className={SECONDARY}
+              disabled={busy}
+              aria-expanded={open}
+              aria-controls={`${id}-body`}
+              aria-label={t('reticulumSetup.open')}
+              onClick={() => {
+                if (!open) setName(identity?.display_name ?? name);
+                setOpen(true);
+              }}
+            >
+              {t('reticulumSetup.open')}
+            </button>
+          )}
+          <button
+            type="button"
+            className={SECONDARY}
+            disabled={busy}
+            aria-label={t('reticulumSetup.hide')}
+            onClick={dismiss}
+          >
+            {t('reticulumSetup.hide')}
+          </button>
+        </div>
       </div>
       {open && (
         <div id={`${id}-body`} className="space-y-5 p-5">

--- a/src/renderer/stores/reticulumSetupGuideStore.test.ts
+++ b/src/renderer/stores/reticulumSetupGuideStore.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useReticulumSetupGuideStore } from './reticulumSetupGuideStore';
+
+describe('Reticulum setup guide preference', () => {
+  beforeEach(() => {
+    useReticulumSetupGuideStore.setState({ dismissed: false, open: false });
+  });
+
+  it('restores dismissal after restart without restoring an open guide', async () => {
+    const store = useReticulumSetupGuideStore;
+    store.getState().dismiss();
+    store.getState().setOpen(true);
+    const saved = localStorage.getItem('mesh-client:reticulumSetupGuide')!;
+    expect(JSON.parse(saved).state).toEqual({ dismissed: true });
+    store.setState({ dismissed: false, open: false });
+    localStorage.setItem('mesh-client:reticulumSetupGuide', saved);
+    await store.persist.rehydrate();
+    expect(store.getState().dismissed).toBe(true);
+    expect(store.getState().open).toBe(false);
+  });
+
+  it('keeps dismissal when a user temporarily reopens and leaves the guide', () => {
+    const store = useReticulumSetupGuideStore;
+    store.getState().dismiss();
+    store.getState().setOpen(true);
+    expect(store.getState().open).toBe(true);
+    store.getState().setOpen(false);
+    expect(store.getState().dismissed).toBe(true);
+  });
+});

--- a/src/renderer/stores/reticulumSetupGuideStore.ts
+++ b/src/renderer/stores/reticulumSetupGuideStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface ReticulumSetupGuideState {
+  dismissed: boolean;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  dismiss: () => void;
+}
+
+export const useReticulumSetupGuideStore = create<ReticulumSetupGuideState>()(
+  persist(
+    (set) => ({
+      dismissed: false,
+      open: false,
+      setOpen: (open) => set({ open }),
+      dismiss: () => set({ dismissed: true, open: false }),
+    }),
+    {
+      name: 'mesh-client:reticulumSetupGuide',
+      partialize: (state) => ({ dismissed: state.dismissed }),
+    },
+  ),
+);


### PR DESCRIPTION
Clicking **Hide guide** previously collapsed the Reticulum wizard but left its banner on Connection. It now removes the entire guide and remembers that choice across app restarts.

Add a permanent **Open setup guide** link to Network. It opens the wizard on Connection without clearing the dismissal preference. If Connection is hidden, the link explains how to enable the tab. Users can also dismiss the initial banner without opening the wizard first.

Only the dismissal preference is persisted; open state and setup contents remain temporary. Includes regression tests for dismissal, remounting, persistence, reopening, and stale responses, plus updated user documentation.

Validation: `pnpm run check:pr` and normal pre-commit hooks. Chrome walkthrough verified hide → reload → Network reopening using the real guide with a simulated navigation shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reticulum setup guide dismissal now persists across app restarts.
  * Added separate **Open** and **Hide** controls for the setup guide.
  * Reopen the guide through **Network → Open setup guide** without resetting its dismissal preference.
  * Added a setup-guide button to the Reticulum connection panel, with an error notification when unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->