### PR TITLE
feat(rrc): ChatComposer hub WELCOME limits and byte counters

### DIFF
--- a/reticulum-sidecar/src/stack/rrc_session.rs
+++ b/reticulum-sidecar/src/stack/rrc_session.rs
@@ -1077,7 +1077,7 @@ async fn establish_session(
                         g.hub_name = hub_name.clone();
                         g.hub_version = hub_version;
                         g.capabilities = capabilities.clone();
-                        g.limits = limits;
+                        g.limits = limits.clone();
                         g.last_error = None;
                     }
                     emit(
@@ -1091,6 +1091,13 @@ async fn establish_session(
                                 "direct_notice": capabilities.direct_notice,
                                 "action": capabilities.action,
                                 "resource_envelope": capabilities.resource_envelope,
+                            },
+                            "limits": {
+                                "max_nick_bytes": limits.max_nick_bytes,
+                                "max_room_name_bytes": limits.max_room_name_bytes,
+                                "max_msg_body_bytes": limits.max_msg_body_bytes,
+                                "max_rooms_per_session": limits.max_rooms_per_session,
+                                "rate_limit_msgs_per_minute": limits.rate_limit_msgs_per_minute,
                             },
                         }),
                     );
@@ -1764,6 +1771,25 @@ mod tests {
         assert!(inner.hub_version.is_none());
         assert!(inner.limits.max_nick_bytes.is_none());
         assert!(inner.pending_resources.is_empty());
+    }
+
+    #[test]
+    fn session_json_includes_welcome_limits() {
+        let mut inner = RrcSessionInner::new([0u8; 16]);
+        inner.limits.max_msg_body_bytes = Some(350);
+        inner.limits.max_nick_bytes = Some(32);
+        inner.limits.max_room_name_bytes = Some(64);
+        let snap = session_json("aabbccddeeff00112233445566778899", &inner);
+        let limits = snap.get("limits").expect("limits");
+        assert_eq!(
+            limits.get("max_msg_body_bytes"),
+            Some(&serde_json::json!(350))
+        );
+        assert_eq!(limits.get("max_nick_bytes"), Some(&serde_json::json!(32)));
+        assert_eq!(
+            limits.get("max_room_name_bytes"),
+            Some(&serde_json::json!(64))
+        );
     }
 
     #[test]

--- a/src/renderer/components/ChatComposer.test.tsx
+++ b/src/renderer/components/ChatComposer.test.tsx
@@ -1188,4 +1188,58 @@ describe('ChatComposer', () => {
       expect(await axe(container)).toHaveNoViolations();
     });
   });
+
+  describe('RRC hub body limits', () => {
+    it('shows a wire-byte counter and splits sends under a hub payloadLimit', async () => {
+      const onSendChunk = vi.fn().mockResolvedValue(undefined);
+      const onInterceptSend = vi.fn().mockResolvedValue(false);
+      render(
+        <ChatComposer
+          protocol="reticulum"
+          viewKey="rrc:hub:general"
+          isConnected
+          allowOutbox={false}
+          payloadLimit={50}
+          useWireByteCount
+          shouldSuppressLimits={() => false}
+          onInterceptSend={onInterceptSend}
+          onSendChunk={onSendChunk}
+          sendButtonLabel="Send"
+        />,
+      );
+      const body = 'a'.repeat(60);
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: body } });
+      expect(await screen.findByRole('button', { name: 'Send 2 parts' })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Send 2 parts' }));
+      await waitFor(() => {
+        expect(onSendChunk.mock.calls.length).toBeGreaterThan(1);
+      });
+      expect(onInterceptSend).toHaveBeenCalled();
+    });
+
+    it('intercepts slash commands without calling onSendChunk', async () => {
+      const onSendChunk = vi.fn().mockResolvedValue(undefined);
+      const onInterceptSend = vi.fn().mockResolvedValue(true);
+      render(
+        <ChatComposer
+          protocol="reticulum"
+          viewKey="rrc:hub:general"
+          isConnected
+          allowOutbox={false}
+          payloadLimit={350}
+          useWireByteCount
+          shouldSuppressLimits={() => true}
+          onInterceptSend={onInterceptSend}
+          onSendChunk={onSendChunk}
+          sendButtonLabel="Send"
+        />,
+      );
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '/help' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+      await waitFor(() => {
+        expect(onInterceptSend).toHaveBeenCalledWith('/help');
+      });
+      expect(onSendChunk).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/renderer/components/ChatComposer.tsx
+++ b/src/renderer/components/ChatComposer.tsx
@@ -59,7 +59,10 @@ import { withMeshtasticTextSendPacing } from '../lib/meshtasticTextSendPacing';
 import { useRadioProvider } from '../lib/radio/providerFactory';
 import { MESHCORE_FAST_SEND_WARN_INTERVAL_MS } from '../lib/timeConstants';
 import { HelpTooltip } from './HelpTooltip';
-import MentionAutocomplete, { buildMentionCandidates } from './MentionAutocomplete';
+import MentionAutocomplete, {
+  buildMentionCandidates,
+  type MentionCandidate,
+} from './MentionAutocomplete';
 import { useToast } from './Toast';
 
 /**
@@ -196,6 +199,28 @@ export interface ChatComposerProps {
   /** When set, renders a mic button that triggers voice memo recording. */
   onVoiceMemo?: () => void;
   className?: string;
+  /**
+   * When provided and returns true, ChatComposer clears the draft and skips split/send
+   * (RRC slash commands handled by the panel).
+   */
+  onInterceptSend?: (text: string) => Promise<boolean>;
+  /** Count approaching/warn using UTF-8 wire bytes (RRC hub body limits). */
+  useWireByteCount?: boolean;
+  /** Hide split/overMax chrome for this draft (RRC slash bypass). */
+  shouldSuppressLimits?: (text: string) => boolean;
+  /**
+   * Alternate @mention completion (RRC IRC nicks). When set, replaces MeshNode lookup
+   * and default `@[name] ` insert format.
+   */
+  mentionAdapter?: {
+    findAtCaret: (text: string, caret: number) => { start: number; query: string } | null;
+    buildCandidates: (query: string) => MentionCandidate[];
+    formatInsert: (name: string) => string;
+  };
+  /**
+   * When `token` changes, replace the composer input (e.g. RRC nicklist → `/msg nick `).
+   */
+  composeSeed?: { text: string; token: number } | null;
 }
 
 export function ChatComposer({
@@ -230,6 +255,11 @@ export function ChatComposer({
   textareaRef,
   onVoiceMemo,
   className,
+  onInterceptSend,
+  useWireByteCount = false,
+  shouldSuppressLimits,
+  mentionAdapter,
+  composeSeed,
 }: ChatComposerProps) {
   const { t } = useTranslation();
   const { addToast } = useToast();
@@ -381,6 +411,8 @@ export function ChatComposer({
       ? replyTo.reticulum_message_hash
       : undefined;
 
+  const suppressLimits = shouldSuppressLimits?.(input) ?? false;
+
   const limitStatus = useMemo(
     () =>
       computeComposerLimitStatus(input, protocol, {
@@ -390,6 +422,8 @@ export function ChatComposer({
         replyToSenderName,
         replyKey,
         useKeyedReplies: meshcoreOpenWireCompat,
+        useWireByteCount,
+        suppressLimits,
       }),
     [
       input,
@@ -400,6 +434,8 @@ export function ChatComposer({
       replyToSenderName,
       replyKey,
       meshcoreOpenWireCompat,
+      useWireByteCount,
+      suppressLimits,
     ],
   );
 
@@ -476,16 +512,30 @@ export function ChatComposer({
     setMeshcoreFastSendWarn(false);
   }, [viewKey, protocol, showFloodScopeOverride]);
 
+  // Apply nicklist `/msg` seeds without an effect (avoids set-state-in-effect).
+  const [appliedComposeSeedToken, setAppliedComposeSeedToken] = useState<number | null>(null);
+  if (composeSeed && composeSeed.token !== appliedComposeSeedToken) {
+    setAppliedComposeSeedToken(composeSeed.token);
+    setInput(composeSeed.text);
+    setMentionQuery(null);
+    setChatActionError(null);
+  }
+
   const mentionCandidates = useMemo(
-    () => (mentionQuery != null ? buildMentionCandidates(nodes, protocol, mentionQuery) : []),
-    [mentionQuery, nodes, protocol],
+    () =>
+      mentionQuery != null
+        ? mentionAdapter
+          ? mentionAdapter.buildCandidates(mentionQuery)
+          : buildMentionCandidates(nodes, protocol, mentionQuery)
+        : [],
+    [mentionQuery, mentionAdapter, nodes, protocol],
   );
 
   const insertMention = useCallback(
     (name: string) => {
       const textarea = inputRef.current;
       const currentInput = inputValueRef.current;
-      const insert = `@[${name}] `;
+      const insert = mentionAdapter ? mentionAdapter.formatInsert(name) : `@[${name}] `;
       const before = currentInput.slice(0, mentionTriggerPos);
       const after = currentInput.slice(mentionTriggerPos + (mentionQuery?.length ?? 0) + 1);
       const newVal = before + insert + after;
@@ -498,7 +548,7 @@ export function ChatComposer({
         textarea?.setSelectionRange(newCursor, newCursor);
       });
     },
-    [maxInputLength, mentionTriggerPos, mentionQuery],
+    [maxInputLength, mentionAdapter, mentionTriggerPos, mentionQuery],
   );
 
   const clearSentDraft = useCallback(
@@ -568,15 +618,45 @@ export function ChatComposer({
       const gifWire = normalizeMeshcoreGifOutboundWire(trimmedSend);
       if (gifWire != null) trimmedSend = gifWire;
     }
-    const chunks = splitChatMessage(
-      trimmedSend,
-      protocol,
-      limitStatus.singleMessageLimit,
-      wireOverheadFirstChunk,
-    );
-    if (chunks === null) return;
-
-    const textsToSend = chunks.length === 0 ? [trimmedSend] : chunks;
+    if (onInterceptSend) {
+      setSending(true);
+      setChatActionError(null);
+      try {
+        const handled = await onInterceptSend(trimmedSend);
+        if (handled) {
+          clearSentDraft(draftSnapshot);
+          setMentionQuery(null);
+          onReplyClear?.();
+          onSendSuccess?.();
+          return;
+        }
+      } catch (err) {
+        console.error('[ChatComposer] Intercept send failed: ' + errLikeToLogString(err));
+        const fallback =
+          variant === 'room' ? t('roomsPanel.postFailed') : t('chatPanel.sendFailed');
+        setChatActionError({
+          message: err instanceof Error ? err.message : fallback,
+          viewKey,
+        });
+        return;
+      } finally {
+        setSending(false);
+      }
+    }
+    // suppressLimits: slash / no hub cap — never multi-part split this draft.
+    let textsToSend: string[];
+    if (suppressLimits) {
+      textsToSend = [trimmedSend];
+    } else {
+      const chunks = splitChatMessage(
+        trimmedSend,
+        protocol,
+        limitStatus.singleMessageLimit,
+        wireOverheadFirstChunk,
+      );
+      if (chunks === null) return;
+      textsToSend = chunks.length === 0 ? [trimmedSend] : chunks;
+    }
 
     if (replyTo && protocol === 'meshtastic' && (replyKey == null || replyKey === 0)) {
       setChatActionError({
@@ -699,6 +779,7 @@ export function ChatComposer({
     isConnected,
     isMqttOnly,
     limitStatus.singleMessageLimit,
+    onInterceptSend,
     onReplyClear,
     onSendChunk,
     onSendSuccess,
@@ -719,6 +800,7 @@ export function ChatComposer({
     meshcoreOpenWireCompat,
     tracksSendCadence,
     finishSendCadence,
+    suppressLimits,
   ]);
 
   const sendGifWire = useCallback(
@@ -1234,13 +1316,25 @@ export function ChatComposer({
               const val = e.target.value;
               setInput(val);
               setChatActionError(null);
-              const match = /@(\w*)$/.exec(val);
-              if (match) {
-                setMentionQuery(match[1]);
-                setMentionTriggerPos(val.length - match[0].length);
-                setMentionSelectedIdx(0);
+              if (mentionAdapter) {
+                const caret = e.target.selectionStart ?? val.length;
+                const at = mentionAdapter.findAtCaret(val, caret);
+                if (at) {
+                  setMentionQuery(at.query);
+                  setMentionTriggerPos(at.start);
+                  setMentionSelectedIdx(0);
+                } else {
+                  setMentionQuery(null);
+                }
               } else {
-                setMentionQuery(null);
+                const match = /@(\w*)$/.exec(val);
+                if (match) {
+                  setMentionQuery(match[1]);
+                  setMentionTriggerPos(val.length - match[0].length);
+                  setMentionSelectedIdx(0);
+                } else {
+                  setMentionQuery(null);
+                }
               }
             }}
             onKeyDown={handleKeyDown}
@@ -1257,7 +1351,7 @@ export function ChatComposer({
             aria-busy={sending}
             disabled={disabled || (!isConnected && !allowOutbox)}
             className={`${textareaClass} ${!isConnected ? 'opacity-60' : ''} ${disabled ? 'opacity-40' : ''}`}
-            maxLength={maxInputLength}
+            maxLength={suppressLimits ? undefined : maxInputLength}
           />
         </div>
         <HelpTooltip text={t('chatPanel.insertEmoji')}>
@@ -1326,7 +1420,9 @@ export function ChatComposer({
               onClick={() => {
                 void handleSend();
               }}
-              disabled={!input.trim() || sending || inputChunks === null || disabled}
+              disabled={
+                !input.trim() || sending || (!suppressLimits && inputChunks === null) || disabled
+              }
               aria-label={sendLabel}
               className={sendButtonSplitMainClass}
             >
@@ -1546,7 +1642,9 @@ export function ChatComposer({
               onClick={() => {
                 void handleSend();
               }}
-              disabled={!input.trim() || sending || inputChunks === null || disabled}
+              disabled={
+                !input.trim() || sending || (!suppressLimits && inputChunks === null) || disabled
+              }
               aria-label={sendLabel}
               className={sendButtonClass}
             >

--- a/src/renderer/components/ChatComposer.tsx
+++ b/src/renderer/components/ChatComposer.tsx
@@ -57,6 +57,7 @@ import {
 import { isMeshcoreSendTooFast, recordMeshcoreSend } from '../lib/meshcoreSendRateNotice';
 import { withMeshtasticTextSendPacing } from '../lib/meshtasticTextSendPacing';
 import { useRadioProvider } from '../lib/radio/providerFactory';
+import { insertRrcNickMention, nextRrcNickCompleteIndex } from '../lib/rrcNickComplete';
 import { MESHCORE_FAST_SEND_WARN_INTERVAL_MS } from '../lib/timeConstants';
 import { HelpTooltip } from './HelpTooltip';
 import MentionAutocomplete, {
@@ -300,6 +301,10 @@ export function ChatComposer({
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionTriggerPos, setMentionTriggerPos] = useState(0);
   const [mentionSelectedIdx, setMentionSelectedIdx] = useState(0);
+  /** RRC Tab cycle: original `@` query while cycling through matches. */
+  const [mentionCyclePrefix, setMentionCyclePrefix] = useState<string | null>(null);
+  const [mentionInsertedNickLen, setMentionInsertedNickLen] = useState(0);
+  const [mentionTabCycleIndex, setMentionTabCycleIndex] = useState(-1);
   const [meshcoreFastSendWarn, setMeshcoreFastSendWarn] = useState(false);
 
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -321,6 +326,12 @@ export function ChatComposer({
     setFloodScopeCustomEditing(false);
     setFloodScopeCustomDraft('');
     setFloodScopeCustomError(null);
+  }, []);
+
+  const clearMentionCycle = useCallback(() => {
+    setMentionCyclePrefix(null);
+    setMentionInsertedNickLen(0);
+    setMentionTabCycleIndex(-1);
   }, []);
 
   const persistFloodScopeOverride = useCallback(
@@ -504,13 +515,14 @@ export function ChatComposer({
     }
     setMentionQuery(null);
     setChatActionError(null);
+    clearMentionCycle();
     // Clear any lingering fast-send advisory when switching chat views.
     if (meshcoreFastSendWarnTimerRef.current) {
       clearTimeout(meshcoreFastSendWarnTimerRef.current);
       meshcoreFastSendWarnTimerRef.current = null;
     }
     setMeshcoreFastSendWarn(false);
-  }, [viewKey, protocol, showFloodScopeOverride]);
+  }, [viewKey, protocol, showFloodScopeOverride, clearMentionCycle]);
 
   // Apply nicklist `/msg` seeds without an effect (avoids set-state-in-effect).
   const [appliedComposeSeedToken, setAppliedComposeSeedToken] = useState<number | null>(null);
@@ -519,17 +531,19 @@ export function ChatComposer({
     setInput(composeSeed.text);
     setMentionQuery(null);
     setChatActionError(null);
+    setMentionCyclePrefix(null);
+    setMentionInsertedNickLen(0);
+    setMentionTabCycleIndex(-1);
   }
 
-  const mentionCandidates = useMemo(
-    () =>
-      mentionQuery != null
-        ? mentionAdapter
-          ? mentionAdapter.buildCandidates(mentionQuery)
-          : buildMentionCandidates(nodes, protocol, mentionQuery)
-        : [],
-    [mentionQuery, mentionAdapter, nodes, protocol],
-  );
+  const mentionCandidates = useMemo(() => {
+    if (mentionQuery == null) return [];
+    const queryForBuild =
+      mentionAdapter && mentionCyclePrefix != null ? mentionCyclePrefix : mentionQuery;
+    return mentionAdapter
+      ? mentionAdapter.buildCandidates(queryForBuild)
+      : buildMentionCandidates(nodes, protocol, mentionQuery);
+  }, [mentionQuery, mentionCyclePrefix, mentionAdapter, nodes, protocol]);
 
   const insertMention = useCallback(
     (name: string) => {
@@ -542,13 +556,14 @@ export function ChatComposer({
       if (newVal.length > maxInputLength) return;
       setInput(newVal);
       setMentionQuery(null);
+      clearMentionCycle();
       requestAnimationFrame(() => {
         const newCursor = mentionTriggerPos + insert.length;
         textarea?.focus();
         textarea?.setSelectionRange(newCursor, newCursor);
       });
     },
-    [maxInputLength, mentionAdapter, mentionTriggerPos, mentionQuery],
+    [clearMentionCycle, maxInputLength, mentionAdapter, mentionTriggerPos, mentionQuery],
   );
 
   const clearSentDraft = useCallback(
@@ -978,6 +993,42 @@ export function ChatComposer({
           setMentionSelectedIdx((i) => Math.max(0, i - 1));
           return;
         }
+        if (e.key === 'Tab' && mentionAdapter) {
+          e.preventDefault();
+          const cycling = mentionCyclePrefix != null;
+          const prefix = cycling ? mentionCyclePrefix : mentionQuery;
+          const names = mentionAdapter.buildCandidates(prefix).map((c) => c.name);
+          if (names.length === 0) return;
+          const nextIdx = nextRrcNickCompleteIndex(
+            names,
+            cycling ? mentionTabCycleIndex : -1,
+            e.shiftKey,
+          );
+          if (nextIdx < 0) return;
+          const nick = names[nextIdx];
+          if (!nick) return;
+          const replaceLen = cycling ? mentionInsertedNickLen : mentionQuery.length;
+          const { text, caret } = insertRrcNickMention(
+            inputValueRef.current,
+            mentionTriggerPos,
+            replaceLen,
+            nick,
+          );
+          if (text.length > maxInputLength) return;
+          if (!cycling) setMentionCyclePrefix(mentionQuery);
+          setMentionInsertedNickLen(nick.length);
+          setMentionTabCycleIndex(nextIdx);
+          setMentionSelectedIdx(nextIdx);
+          setInput(text);
+          // Keep the list open while Tab/Shift+Tab cycles (do not clear mentionQuery).
+          setMentionQuery(nick);
+          requestAnimationFrame(() => {
+            const textarea = inputRef.current;
+            textarea?.focus();
+            textarea?.setSelectionRange(caret, caret);
+          });
+          return;
+        }
         if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
           e.preventDefault();
           const candidate = mentionCandidates[mentionSelectedIdx];
@@ -990,7 +1041,19 @@ export function ChatComposer({
         void handleSend();
       }
     },
-    [handleSend, insertMention, mentionCandidates, mentionQuery, mentionSelectedIdx],
+    [
+      handleSend,
+      insertMention,
+      maxInputLength,
+      mentionAdapter,
+      mentionCandidates,
+      mentionCyclePrefix,
+      mentionInsertedNickLen,
+      mentionQuery,
+      mentionSelectedIdx,
+      mentionTabCycleIndex,
+      mentionTriggerPos,
+    ],
   );
 
   useEffect(() => {
@@ -1316,6 +1379,7 @@ export function ChatComposer({
               const val = e.target.value;
               setInput(val);
               setChatActionError(null);
+              clearMentionCycle();
               if (mentionAdapter) {
                 const caret = e.target.selectionStart ?? val.length;
                 const at = mentionAdapter.findAtCaret(val, caret);

--- a/src/renderer/components/RrcPanel.test.tsx
+++ b/src/renderer/components/RrcPanel.test.tsx
@@ -1170,16 +1170,18 @@ describe('RrcPanel', () => {
     store.applyStatus('active', hubA, 'Hub A');
     store.setCapabilities({ direct_notice: true });
     store.setActiveRoom('[hub]');
+    store.setError(null);
     vi.mocked(window.electronAPI.reticulum.rrc.send).mockClear();
+    localStorage.clear();
 
     render(<RrcPanel isActive />);
 
-    const composer = screen.getByRole('textbox', { name: /Message or \/command/i });
-    await user.type(composer, 'hello hub');
-    await user.click(screen.getByRole('button', { name: 'Send' }));
+    const composer = await screen.findByRole('textbox', { name: /Message or \/command/i });
+    await user.clear(composer);
+    await user.type(composer, 'hello hub{Enter}');
 
     await waitFor(() => {
-      expect(useRrcSessionStore.getState().lastError).toBe('Join a room to start chatting.');
+      expect(useRrcSessionStore.getState().lastError).toMatch(/join a room/i);
     });
     expect(window.electronAPI.reticulum.rrc.send).not.toHaveBeenCalled();
   });

--- a/src/renderer/components/RrcPanel.tsx
+++ b/src/renderer/components/RrcPanel.tsx
@@ -26,7 +26,9 @@ import {
   computeRrcByteLimitStatus,
   isRrcHubMsgBodyLimitError,
   isRrcHubNickLimitError,
+  resolveRrcMsgBodyLimit,
   rrcComposerBypassesSplit,
+  RrcComposerPreflightError,
 } from '@/renderer/lib/rrcHubLimits';
 import { isRrcHubAutoJoin, toggleRrcHubAutoJoin } from '@/renderer/lib/rrcHubPrefs';
 import { isRrcHubLinked } from '@/renderer/lib/rrcHubSession';
@@ -577,14 +579,15 @@ export default function RrcPanel({
     async (hash: string, opts?: { focus?: boolean }) => {
       const target = hash.trim().toLowerCase();
       if (!target) return;
-      const nickLim = computeRrcByteLimitStatus(nickname, limits.max_nick_bytes);
-      if (nickLim?.phase === 'overMax') {
-        setError(t('rrc.nickLimit.overMax', { limit: nickLim.limit }));
-        return;
-      }
       const wantFocus = opts?.focus !== false;
       const session = useRrcSessionStore.getState();
       const existing = session.sessionsByHub.get(target);
+      const targetNickLimit = existing?.limits.max_nick_bytes;
+      const nickLim = computeRrcByteLimitStatus(nickname, targetNickLimit);
+      if (nickLim?.phase === 'overMax') {
+        setError(t('rrc.nickLimit.overMax', { limit: nickLim.limit }), target);
+        return;
+      }
       // Already tracked and connecting/active — just bring it into focus, never re-connect.
       if (existing && isRrcHubLinked(existing.status)) {
         if (wantFocus) setFocusedHub(target);
@@ -633,7 +636,7 @@ export default function RrcPanel({
         }
       }
     },
-    [limits.max_nick_bytes, nickname, setDisconnectIntent, setError, setFocusedHub, t],
+    [nickname, setDisconnectIntent, setError, setFocusedHub, t],
   );
 
   // Batch-connect hubs marked for auto-join when the Reticulum stack is up.
@@ -811,7 +814,9 @@ export default function RrcPanel({
           if (parsed.command === 'nick') {
             const nickLim = computeRrcByteLimitStatus(parsed.nickname, limits.max_nick_bytes);
             if (nickLim?.phase === 'overMax') {
-              throw new Error(t('rrc.nickLimit.overMax', { limit: nickLim.limit }));
+              throw new RrcComposerPreflightError(
+                t('rrc.nickLimit.overMax', { limit: nickLim.limit }),
+              );
             }
             setNickname(parsed.nickname);
             try {
@@ -853,7 +858,9 @@ export default function RrcPanel({
           if (parsed.command === 'join') {
             const roomLim = computeRrcByteLimitStatus(parsed.room, limits.max_room_name_bytes);
             if (roomLim?.phase === 'overMax') {
-              throw new Error(t('rrc.roomNameLimit.overMax', { limit: roomLim.limit }));
+              throw new RrcComposerPreflightError(
+                t('rrc.roomNameLimit.overMax', { limit: roomLim.limit }),
+              );
             }
             await joinRoom(parsed.room, parsed.key);
             return;
@@ -870,6 +877,15 @@ export default function RrcPanel({
             if (!activeRoom || activeRoom.startsWith('[') || isRrcDmRoom(activeRoom)) {
               useRrcSessionStore.getState().setError(t('rrc.joinRoomPrompt'));
               return;
+            }
+            const bodyLim = computeRrcByteLimitStatus(
+              parsed.action,
+              resolveRrcMsgBodyLimit(limits.max_msg_body_bytes),
+            );
+            if (bodyLim?.phase === 'overMax') {
+              throw new RrcComposerPreflightError(
+                t('rrc.byteLimit.overMax', { limit: bodyLim.limit }),
+              );
             }
             const res = await rrcSendBounded({
               hub_dest_hash: hubDestHash,
@@ -898,6 +914,15 @@ export default function RrcPanel({
             if (resolved?.identity_hash.length !== 32) {
               useRrcSessionStore.getState().setError(t('rrc.slash.msgTargetNotFound'));
               return;
+            }
+            const bodyLim = computeRrcByteLimitStatus(
+              parsed.text,
+              resolveRrcMsgBodyLimit(limits.max_msg_body_bytes),
+            );
+            if (bodyLim?.phase === 'overMax') {
+              throw new RrcComposerPreflightError(
+                t('rrc.byteLimit.overMax', { limit: bodyLim.limit }),
+              );
             }
             const res = await rrcSendBounded({
               hub_dest_hash: hubDestHash,
@@ -1039,6 +1064,8 @@ export default function RrcPanel({
           return;
         }
       } catch (e) {
+        // Keep the draft: ChatComposer only clears after onInterceptSend resolves.
+        if (e instanceof RrcComposerPreflightError) throw e;
         console.warn('[RrcPanel] send ' + errLikeToLogString(e));
         useRrcSessionStore.getState().setError(formatRrcErrorMessage(errLikeToLogString(e), t));
       }
@@ -1054,6 +1081,7 @@ export default function RrcPanel({
       handlePart,
       hubDestHash,
       joinRoom,
+      limits.max_msg_body_bytes,
       limits.max_nick_bytes,
       limits.max_room_name_bytes,
       localIdentityHash,

--- a/src/renderer/components/RrcPanel.tsx
+++ b/src/renderer/components/RrcPanel.tsx
@@ -22,6 +22,12 @@ import {
 import { formatRrcErrorMessage } from '@/renderer/lib/rrcErrorHumanize';
 import { clearRrcHubAutoJoinBackoff } from '@/renderer/lib/rrcHubAutoJoinBackoff';
 import { setRrcHubDisconnectSuppressed } from '@/renderer/lib/rrcHubDisconnectSuppress';
+import {
+  computeRrcByteLimitStatus,
+  isRrcHubMsgBodyLimitError,
+  isRrcHubNickLimitError,
+  rrcComposerBypassesSplit,
+} from '@/renderer/lib/rrcHubLimits';
 import { isRrcHubAutoJoin, toggleRrcHubAutoJoin } from '@/renderer/lib/rrcHubPrefs';
 import { isRrcHubLinked } from '@/renderer/lib/rrcHubSession';
 import { migrateLegacyWhispersForHub } from '@/renderer/lib/rrcLegacyWhispersMigrate';
@@ -138,6 +144,7 @@ export default function RrcPanel({
   const sessionsByHub = useRrcSessionStore((s) => s.sessionsByHub);
   const showTimestamps = useRrcSessionStore((s) => s.showTimestamps);
   const capabilities = useRrcSessionStore((s) => s.capabilities);
+  const limits = useRrcSessionStore((s) => s.limits);
   const setNickname = useRrcSessionStore((s) => s.setNickname);
   const setFocusedHub = useRrcSessionStore((s) => s.setFocusedHub);
   const setRrcPanelFocused = useRrcSessionStore((s) => s.setRrcPanelFocused);
@@ -175,7 +182,7 @@ export default function RrcPanel({
   /** Short-lived join/part only — never block the whole panel on connect. */
   const [actionBusy, setActionBusy] = useState(false);
   const [mutedViews, setMutedViews] = useState(() => loadMutedViews('reticulum'));
-  const [draft, setDraft] = useState('');
+  const [composeSeed, setComposeSeed] = useState<{ text: string; token: number } | null>(null);
   const [confirmClearHistory, setConfirmClearHistory] = useState(false);
 
   useEffect(() => {
@@ -570,6 +577,11 @@ export default function RrcPanel({
     async (hash: string, opts?: { focus?: boolean }) => {
       const target = hash.trim().toLowerCase();
       if (!target) return;
+      const nickLim = computeRrcByteLimitStatus(nickname, limits.max_nick_bytes);
+      if (nickLim?.phase === 'overMax') {
+        setError(t('rrc.nickLimit.overMax', { limit: nickLim.limit }));
+        return;
+      }
       const wantFocus = opts?.focus !== false;
       const session = useRrcSessionStore.getState();
       const existing = session.sessionsByHub.get(target);
@@ -621,7 +633,7 @@ export default function RrcPanel({
         }
       }
     },
-    [nickname, setDisconnectIntent, setError, setFocusedHub, t],
+    [limits.max_nick_bytes, nickname, setDisconnectIntent, setError, setFocusedHub, t],
   );
 
   // Batch-connect hubs marked for auto-join when the Reticulum stack is up.
@@ -666,6 +678,11 @@ export default function RrcPanel({
   const joinRoom = useCallback(
     async (roomRaw: string, key?: string) => {
       if (!hubDestHash) return;
+      const roomLim = computeRrcByteLimitStatus(roomRaw, limits.max_room_name_bytes);
+      if (roomLim?.phase === 'overMax') {
+        setError(t('rrc.roomNameLimit.overMax', { limit: roomLim.limit }));
+        return;
+      }
       const room = resolveRrcJoinRoomName(roomRaw, {
         listed: listedRooms,
         joined: [...rooms.keys()].map((name) => ({ name })),
@@ -703,7 +720,7 @@ export default function RrcPanel({
         setActionBusy(false);
       }
     },
-    [hubDestHash, listedRooms, rooms, setActiveRoom, setError, t],
+    [hubDestHash, limits.max_room_name_bytes, listedRooms, rooms, setActiveRoom, setError, t],
   );
 
   const handlePart = useCallback(
@@ -764,6 +781,18 @@ export default function RrcPanel({
     [activeRoom, addMessage, setActiveRoom],
   );
 
+  const setRrcSendError = useCallback((message: string | null) => {
+    if (!message) {
+      useRrcSessionStore.getState().setError(null);
+      return;
+    }
+    if (isRrcHubMsgBodyLimitError(message) || isRrcHubNickLimitError(message)) {
+      // Composer / field counters already explain hub WELCOME limits.
+      return;
+    }
+    useRrcSessionStore.getState().setError(message);
+  }, []);
+
   const handleSend = useCallback(
     async (text: string) => {
       try {
@@ -773,7 +802,6 @@ export default function RrcPanel({
         if (parsed.kind === 'local') {
           if (parsed.command === 'help') {
             appendSystemLines(RRC_HELP_I18N_KEYS.map((k) => t(k)));
-            setDraft('');
             return;
           }
           if (parsed.command === 'usage') {
@@ -781,6 +809,10 @@ export default function RrcPanel({
             return;
           }
           if (parsed.command === 'nick') {
+            const nickLim = computeRrcByteLimitStatus(parsed.nickname, limits.max_nick_bytes);
+            if (nickLim?.phase === 'overMax') {
+              throw new Error(t('rrc.nickLimit.overMax', { limit: nickLim.limit }));
+            }
             setNickname(parsed.nickname);
             try {
               localStorage.setItem(NICK_KEY, parsed.nickname);
@@ -793,7 +825,7 @@ export default function RrcPanel({
                 hub_dest_hash: hubDestHash,
               });
               if (!nickRes.ok) {
-                useRrcSessionStore.getState().setError(nickRes.error ?? t('rrc.sendFailed'));
+                setRrcSendError(nickRes.error ?? t('rrc.sendFailed'));
                 return;
               }
               // Push K_NICK to the hub so /who and member lists pick up the new nick.
@@ -816,17 +848,18 @@ export default function RrcPanel({
               useRrcSessionStore.getState().mergeRoomMembers(activeRoom, next, 'replace');
             }
             appendSystemLines([t('rrc.slash.nickChanged', { name: parsed.nickname })]);
-            setDraft('');
             return;
           }
           if (parsed.command === 'join') {
+            const roomLim = computeRrcByteLimitStatus(parsed.room, limits.max_room_name_bytes);
+            if (roomLim?.phase === 'overMax') {
+              throw new Error(t('rrc.roomNameLimit.overMax', { limit: roomLim.limit }));
+            }
             await joinRoom(parsed.room, parsed.key);
-            setDraft('');
             return;
           }
           if (parsed.command === 'part') {
             await handlePart(parsed.room);
-            setDraft('');
             return;
           }
           if (parsed.command === 'me') {
@@ -845,10 +878,9 @@ export default function RrcPanel({
               type: 'action',
             });
             if (!res.ok) {
-              useRrcSessionStore.getState().setError(res.error ?? t('rrc.sendFailed'));
+              setRrcSendError(res.error ?? t('rrc.sendFailed'));
               return;
             }
-            setDraft('');
             return;
           }
           if (parsed.command === 'msg') {
@@ -874,7 +906,7 @@ export default function RrcPanel({
               dst_hash: resolved.identity_hash,
             });
             if (!res.ok) {
-              useRrcSessionStore.getState().setError(res.error ?? t('rrc.sendFailed'));
+              setRrcSendError(res.error ?? t('rrc.sendFailed'));
               return;
             }
             const dmRoom = rrcDmRoomKey(resolved.identity_hash);
@@ -896,17 +928,14 @@ export default function RrcPanel({
               timestamp: Date.now(),
               dst_hash: resolved.identity_hash,
             });
-            setDraft('');
             return;
           }
           if (parsed.command === 'clear') {
             clearActiveRoomMessages();
-            setDraft('');
             return;
           }
           if (parsed.command === 'quit') {
             await handleDisconnect();
-            setDraft('');
             return;
           }
         }
@@ -951,12 +980,11 @@ export default function RrcPanel({
             if (whoForceRoom) {
               useRrcSessionStore.getState().releaseWhoTranscriptForce(whoForceRoom, hubDestHash);
             }
-            useRrcSessionStore.getState().setError(res.error ?? t('rrc.sendFailed'));
+            setRrcSendError(res.error ?? t('rrc.sendFailed'));
             return;
           }
           if (whoForceRoom) scheduleWhoReplyWatchdog(whoForceRoom, { forced: true });
           appendSystemLines([t('rrc.slash.commandSent', { cmd: expanded })]);
-          setDraft('');
           return;
         }
 
@@ -977,7 +1005,7 @@ export default function RrcPanel({
             dst_hash: activeDmHash,
           });
           if (!res.ok) {
-            useRrcSessionStore.getState().setError(res.error ?? t('rrc.sendFailed'));
+            setRrcSendError(res.error ?? t('rrc.sendFailed'));
             return;
           }
           addMessage({
@@ -990,7 +1018,6 @@ export default function RrcPanel({
             timestamp: Date.now(),
             dst_hash: activeDmHash,
           });
-          setDraft('');
           return;
         }
         if (!activeRoom || activeRoom.startsWith('[')) {
@@ -1008,10 +1035,9 @@ export default function RrcPanel({
           type: 'msg',
         });
         if (!res.ok) {
-          useRrcSessionStore.getState().setError(res.error ?? t('rrc.sendFailed'));
+          setRrcSendError(res.error ?? t('rrc.sendFailed'));
           return;
         }
-        setDraft('');
       } catch (e) {
         console.warn('[RrcPanel] send ' + errLikeToLogString(e));
         useRrcSessionStore.getState().setError(formatRrcErrorMessage(errLikeToLogString(e), t));
@@ -1028,6 +1054,8 @@ export default function RrcPanel({
       handlePart,
       hubDestHash,
       joinRoom,
+      limits.max_nick_bytes,
+      limits.max_room_name_bytes,
       localIdentityHash,
       nickname,
       openDm,
@@ -1035,6 +1063,7 @@ export default function RrcPanel({
       scheduleWhoReplyWatchdog,
       sendHubCommand,
       setNickname,
+      setRrcSendError,
       status,
       t,
     ],
@@ -1078,6 +1107,7 @@ export default function RrcPanel({
             // catch-no-log-ok
           }
         }}
+        maxNickBytes={limits.max_nick_bytes}
         favourites={hubList.favourites}
         discovered={hubList.discovered}
         hubDestHash={hubDestHash}
@@ -1120,6 +1150,7 @@ export default function RrcPanel({
           onJoinRoomNameChange={setJoinRoomName}
           joinRoomKey={joinRoomKey}
           onJoinRoomKeyChange={setJoinRoomKey}
+          maxRoomNameBytes={limits.max_room_name_bytes}
           busy={actionBusy}
           onJoin={() => void joinRoom(joinRoomName, joinRoomKey)}
           onRefreshList={() => void sendHubCommand('/list')}
@@ -1270,11 +1301,9 @@ export default function RrcPanel({
             activeRoom={activeRoom}
             messages={activeMessages}
             showTimestamps={showTimestamps}
-            draft={draft}
-            onDraftChange={setDraft}
-            onSend={(text) => void handleSend(text)}
             canSend={status === 'active'}
             isMuted={isMuted}
+            maxMsgBodyBytes={limits.max_msg_body_bytes}
             nickname={nickname}
             members={chatCompleteMembers}
             alwaysShowMessageActions={alwaysShowMessageActions}
@@ -1282,6 +1311,15 @@ export default function RrcPanel({
             isActive={isActive}
             onCaughtUp={handleCaughtUp}
             onOpenDm={onOpenDm}
+            composeSeed={composeSeed}
+            onSendChunk={async (chunk) => {
+              await handleSend(chunk);
+            }}
+            onInterceptSend={async (fullText) => {
+              if (!rrcComposerBypassesSplit(fullText)) return false;
+              await handleSend(fullText);
+              return true;
+            }}
           />
           {showNicklist && (
             <RrcNickList
@@ -1302,7 +1340,7 @@ export default function RrcPanel({
               }}
               onNickClick={(member: RrcRoomMember) => {
                 const label = member.nickname || member.identity_hash.slice(0, 8);
-                setDraft(`/msg ${label} `);
+                setComposeSeed({ text: `/msg ${label} `, token: Date.now() });
               }}
             />
           )}

--- a/src/renderer/components/rrc/RrcByteLimitHint.tsx
+++ b/src/renderer/components/rrc/RrcByteLimitHint.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next';
+
+import { computeRrcByteLimitStatus, type RrcByteLimitStatus } from '@/renderer/lib/rrcHubLimits';
+
+/** Right-aligned UTF-8 byte counter for RRC nick / room-name fields. */
+export function RrcByteLimitHint({
+  text,
+  limit,
+  overMaxKey,
+}: {
+  text: string;
+  limit: number | null | undefined;
+  /** i18n key when over max (receives `{ limit }`). */
+  overMaxKey: string;
+}) {
+  const { t } = useTranslation();
+  const status: RrcByteLimitStatus | null = computeRrcByteLimitStatus(text, limit);
+  if (!status || status.phase === 'ok') return null;
+
+  const color =
+    status.phase === 'overMax'
+      ? 'text-red-400'
+      : status.byteCount >= status.limit
+        ? 'text-amber-400'
+        : 'text-muted';
+
+  return (
+    <div className={`mt-0.5 text-right text-[10px] ${color}`} role="status">
+      {status.phase === 'overMax'
+        ? t(overMaxKey, { limit: status.limit })
+        : t('rrc.byteLimit.approaching', { count: status.byteCount, limit: status.limit })}
+    </div>
+  );
+}
+
+export function isRrcByteLimitOverMax(text: string, limit: number | null | undefined): boolean {
+  return computeRrcByteLimitStatus(text, limit)?.phase === 'overMax';
+}

--- a/src/renderer/components/rrc/RrcChatView.test.tsx
+++ b/src/renderer/components/rrc/RrcChatView.test.tsx
@@ -475,7 +475,7 @@ describe('RrcChatView mention completer', () => {
     expect(box).toHaveValue('@Zeva ');
   });
 
-  it('Tab selects the highlighted nick from ChatComposer mention list', async () => {
+  it('Tab cycles nick completion while the mention list stays open', async () => {
     const user = userEvent.setup();
     const members = [
       { identity_hash: 'aa'.repeat(16), nickname: 'Zeva' },
@@ -490,6 +490,13 @@ describe('RrcChatView mention completer', () => {
     });
     await user.keyboard('{Tab}');
     expect(box).toHaveValue('@Zeva ');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await user.keyboard('{Tab}');
+    expect(box).toHaveValue('@Zoe ');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(box).toHaveValue('@Zeva ');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
   });
 });
 

--- a/src/renderer/components/rrc/RrcChatView.test.tsx
+++ b/src/renderer/components/rrc/RrcChatView.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
@@ -68,11 +67,11 @@ const baseProps = {
   connected: true as const,
   activeRoom: '#general',
   showTimestamps: false,
-  draft: '',
-  onDraftChange: vi.fn(),
-  onSend: vi.fn(),
   canSend: true,
   isMuted: false,
+  maxMsgBodyBytes: 350,
+  onSendChunk: vi.fn().mockResolvedValue(undefined),
+  onInterceptSend: vi.fn().mockResolvedValue(false),
 };
 
 describe('estimateRrcRowHeight', () => {
@@ -441,27 +440,15 @@ describe('RrcChatView mention completer', () => {
   beforeEach(() => {
     mockIsAtEnd = true;
     mockScrollToEnd.mockClear();
+    localStorage.clear();
     hydrateAxeThemeColors(document.documentElement);
   });
 
-  it('shows listbox and inserts @Zeva on select', async () => {
+  it('shows listbox and inserts @Zeva on select via ChatComposer', async () => {
     const user = userEvent.setup();
     const members = [{ identity_hash: 'aa'.repeat(16), nickname: 'Zeva' }];
 
-    function Harness() {
-      const [draft, setDraft] = useState('');
-      return (
-        <RrcChatView
-          {...baseProps}
-          draft={draft}
-          onDraftChange={setDraft}
-          members={members}
-          messages={[]}
-        />
-      );
-    }
-
-    const { container } = render(<Harness />);
+    const { container } = render(<RrcChatView {...baseProps} members={members} messages={[]} />);
     const box = screen.getByRole('textbox');
     await user.type(box, '@ze');
     await waitFor(() => {
@@ -469,9 +456,6 @@ describe('RrcChatView mention completer', () => {
     });
     hydrateAxeThemeColors(container);
     expect(await axe(container)).toHaveNoViolations();
-    const combo = screen.getByRole('combobox');
-    expect(combo).toHaveAttribute('aria-expanded', 'true');
-    expect(combo).toHaveAttribute('aria-controls', 'rrc-mention-listbox');
     await user.click(screen.getByRole('option', { name: /Zeva/i }));
     expect(box).toHaveValue('@Zeva ');
     expect((box as HTMLTextAreaElement).value).not.toContain('@[');
@@ -481,21 +465,7 @@ describe('RrcChatView mention completer', () => {
     const user = userEvent.setup();
     const members = [{ identity_hash: 'aa'.repeat(16), nickname: 'Zeva' }];
 
-    function Harness() {
-      const [draft, setDraft] = useState('');
-      return (
-        <RrcChatView
-          {...baseProps}
-          activeRoom="[whispers]"
-          draft={draft}
-          onDraftChange={setDraft}
-          members={members}
-          messages={[]}
-        />
-      );
-    }
-
-    render(<Harness />);
+    render(<RrcChatView {...baseProps} activeRoom="[whispers]" members={members} messages={[]} />);
     const box = screen.getByRole('textbox');
     await user.type(box, '@ze');
     await waitFor(() => {
@@ -505,27 +475,14 @@ describe('RrcChatView mention completer', () => {
     expect(box).toHaveValue('@Zeva ');
   });
 
-  it('Tab cycles nicks without narrowing the original prefix', async () => {
+  it('Tab selects the highlighted nick from ChatComposer mention list', async () => {
     const user = userEvent.setup();
     const members = [
       { identity_hash: 'aa'.repeat(16), nickname: 'Zeva' },
       { identity_hash: 'bb'.repeat(16), nickname: 'Zoe' },
     ];
 
-    function Harness() {
-      const [draft, setDraft] = useState('');
-      return (
-        <RrcChatView
-          {...baseProps}
-          draft={draft}
-          onDraftChange={setDraft}
-          members={members}
-          messages={[]}
-        />
-      );
-    }
-
-    render(<Harness />);
+    render(<RrcChatView {...baseProps} members={members} messages={[]} />);
     const box = screen.getByRole('textbox');
     await user.type(box, '@z');
     await waitFor(() => {
@@ -533,8 +490,6 @@ describe('RrcChatView mention completer', () => {
     });
     await user.keyboard('{Tab}');
     expect(box).toHaveValue('@Zeva ');
-    await user.keyboard('{Tab}');
-    expect(box).toHaveValue('@Zoe ');
   });
 });
 

--- a/src/renderer/components/rrc/RrcChatView.tsx
+++ b/src/renderer/components/rrc/RrcChatView.tsx
@@ -2,7 +2,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ArrowDown, Copy } from 'lucide-react-motion';
 import {
-  type KeyboardEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -13,8 +12,8 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ChatComposer } from '@/renderer/components/ChatComposer';
 import { ConfirmModal } from '@/renderer/components/ConfirmModal';
-import MentionAutocomplete from '@/renderer/components/MentionAutocomplete';
 import { useAppWindowActivity } from '@/renderer/lib/appWindowActivity';
 import { isSafeChatUrl } from '@/renderer/lib/chatMentionSegments';
 import {
@@ -31,6 +30,7 @@ import {
   findReticulumChatLinks,
   type ReticulumChatLink,
 } from '@/renderer/lib/nomad/reticulumLinkText';
+import { normalizeRrcHubByteLimit, rrcComposerBypassesSplit } from '@/renderer/lib/rrcHubLimits';
 import {
   bodyMentionsRrcNick,
   findNextRrcNickMention,
@@ -40,9 +40,7 @@ import { parseRrcWhisperEcho, shouldDisplayRrcChatMessage } from '@/renderer/lib
 import { rrcNickColorClass } from '@/renderer/lib/rrcNickColor';
 import {
   findRrcAtMentionAtCaret,
-  insertRrcNickMention,
   listRrcNickCompleteCandidates,
-  nextRrcNickCompleteIndex,
   rrcMemberNickLabels,
 } from '@/renderer/lib/rrcNickComplete';
 import { useTimeFormatStore } from '@/renderer/stores/timeFormatStore';
@@ -77,7 +75,6 @@ function rrcMessageVirtualizerKey(msg: RrcChatMessage | null | undefined, index:
 }
 
 const EMPTY_RRC_MEMBERS: readonly RrcRoomMember[] = Object.freeze([]);
-const RRC_MENTION_LISTBOX_ID = 'rrc-mention-listbox';
 
 const URL_PATTERN = /https?:\/\/[^\s<>"{}|\\^`[\]]+/gu;
 const TRAILING_PUNCT = /[.,!?;:'"()]+$/;
@@ -251,14 +248,13 @@ export interface RrcChatViewProps {
   activeRoom: string | null;
   messages: RrcChatMessage[];
   showTimestamps: boolean;
-  draft: string;
-  onDraftChange: (v: string) => void;
-  onSend: (text: string) => void;
   canSend: boolean;
   isMuted: boolean;
+  /** Hub WELCOME max_msg_body_bytes (drives ChatComposer payloadLimit). */
+  maxMsgBodyBytes?: number | null;
   /** Local session nick — used to highlight @mentions of self. */
   nickname?: string;
-  /** Active room members for @ / Tab nick completion. */
+  /** Active room members for @ nick completion. */
   members?: readonly RrcRoomMember[];
   /** Keep the per-message copy control visible (same App Appearance setting as Chat). */
   alwaysShowMessageActions?: boolean;
@@ -270,6 +266,14 @@ export interface RrcChatViewProps {
   onCaughtUp?: () => void;
   /** Open a Chat DM for an LXMF destination hash posted in a message. */
   onOpenDm?: (destinationHash: string) => void;
+  /** Plain chat / action chunk send (ChatComposer may call multiple times when splitting). */
+  onSendChunk: (text: string) => Promise<void>;
+  /**
+   * When true, ChatComposer skips split/send (slash commands). Return false for plain chat.
+   */
+  onInterceptSend: (text: string) => Promise<boolean>;
+  /** Seed composer from nicklist `/msg` clicks. */
+  composeSeed?: { text: string; token: number } | null;
 }
 
 export function RrcChatView({
@@ -278,11 +282,9 @@ export function RrcChatView({
   activeRoom,
   messages,
   showTimestamps,
-  draft,
-  onDraftChange,
-  onSend,
   canSend,
   isMuted,
+  maxMsgBodyBytes = null,
   nickname = '',
   members = EMPTY_RRC_MEMBERS,
   alwaysShowMessageActions = false,
@@ -290,6 +292,9 @@ export function RrcChatView({
   isActive = true,
   onCaughtUp,
   onOpenDm,
+  onSendChunk,
+  onInterceptSend,
+  composeSeed = null,
 }: RrcChatViewProps) {
   const { t } = useTranslation();
   const { inactive: appWindowInactive } = useAppWindowActivity();
@@ -323,9 +328,6 @@ export function RrcChatView({
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  /** Skip one caret sync after programmatic Tab/insert selection updates. */
-  const skipMentionSyncRef = useRef(false);
   /** Sticky intent: user is reading latest messages and wants auto-follow on new traffic. */
   const isPinnedToBottomRef = useRef(true);
   /** Hub/room stream switch — trust pin until the user scrolls (virtualizer can lag). */
@@ -337,76 +339,30 @@ export function RrcChatView({
   const prevStreamKeyRef = useRef<string | null>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
 
-  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
-  const [mentionTriggerPos, setMentionTriggerPos] = useState(0);
-  const [mentionSelectedIdx, setMentionSelectedIdx] = useState(0);
-  const [tabCycleIndex, setTabCycleIndex] = useState(-1);
-  /** Original `@` prefix while Tab-cycling so candidates do not narrow to the inserted nick. */
-  const [mentionCyclePrefix, setMentionCyclePrefix] = useState<string | null>(null);
-  /** Length of the nick currently inserted during an active Tab cycle. */
-  const [mentionInsertedNickLen, setMentionInsertedNickLen] = useState(0);
-
   const visibleMessages = useMemo(() => messages.filter(shouldDisplayRrcChatMessage), [messages]);
 
   const nickLabels = useMemo(() => rrcMemberNickLabels(members), [members]);
 
-  const mentionCandidates = useMemo(() => {
-    if (mentionQuery == null) return [];
-    const filterQuery = mentionCyclePrefix ?? mentionQuery;
-    return listRrcNickCompleteCandidates(nickLabels, filterQuery).map((name, i) => ({
-      nodeId: i,
-      name,
-    }));
-  }, [mentionQuery, mentionCyclePrefix, nickLabels]);
-
-  const clearMentionCycle = useCallback(() => {
-    setMentionCyclePrefix(null);
-    setMentionInsertedNickLen(0);
-    setTabCycleIndex(-1);
-  }, []);
-
-  const syncMentionFromCaret = useCallback(
-    (value: string, caret: number) => {
-      const at = findRrcAtMentionAtCaret(value, caret);
-      if (!at) {
-        setMentionQuery(null);
-        clearMentionCycle();
-        return;
-      }
-      setMentionTriggerPos(at.start);
-      setMentionQuery(at.query);
-      setMentionSelectedIdx(0);
-      clearMentionCycle();
-    },
-    [clearMentionCycle],
+  const mentionAdapter = useMemo(
+    () => ({
+      findAtCaret: findRrcAtMentionAtCaret,
+      buildCandidates: (query: string) =>
+        listRrcNickCompleteCandidates(nickLabels, query).map((name, i) => ({
+          nodeId: i,
+          name,
+        })),
+      formatInsert: (name: string) => `@${name} `,
+    }),
+    [nickLabels],
   );
 
-  const insertMention = useCallback(
-    (name: string) => {
-      const queryLen =
-        mentionCyclePrefix != null ? mentionInsertedNickLen : (mentionQuery?.length ?? 0);
-      const { text, caret } = insertRrcNickMention(draft, mentionTriggerPos, queryLen, name);
-      onDraftChange(text);
-      setMentionQuery(null);
-      clearMentionCycle();
-      skipMentionSyncRef.current = true;
-      requestAnimationFrame(() => {
-        const el = textareaRef.current;
-        if (!el) return;
-        el.focus();
-        el.setSelectionRange(caret, caret);
-      });
-    },
-    [
-      clearMentionCycle,
-      draft,
-      mentionCyclePrefix,
-      mentionInsertedNickLen,
-      mentionQuery,
-      mentionTriggerPos,
-      onDraftChange,
-    ],
-  );
+  const composerViewKey = useMemo(() => {
+    const hub = (hubDestHash ?? 'none').toLowerCase();
+    const room = activeRoom ?? '_none';
+    return `rrc:${hub}:${room}`;
+  }, [hubDestHash, activeRoom]);
+
+  const payloadLimit = normalizeRrcHubByteLimit(maxMsgBodyBytes ?? null) ?? undefined;
 
   const estimateSize = useCallback(
     (index: number) => estimateRrcRowHeight(visibleMessages[index]),
@@ -600,97 +556,6 @@ export function RrcChatView({
     });
   }, [updateScrollButtonVisibility]);
 
-  const handleComposerKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (mentionQuery != null && mentionCandidates.length > 0) {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setMentionSelectedIdx((i) => Math.min(i + 1, mentionCandidates.length - 1));
-        return;
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setMentionSelectedIdx((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        setMentionQuery(null);
-        clearMentionCycle();
-        return;
-      }
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        const candidate = mentionCandidates[mentionSelectedIdx];
-        if (candidate) insertMention(candidate.name);
-        return;
-      }
-      if (e.key === 'Tab') {
-        e.preventDefault();
-        const cycling = mentionCyclePrefix != null;
-        const prefix = cycling ? mentionCyclePrefix : mentionQuery;
-        const names = listRrcNickCompleteCandidates(nickLabels, prefix);
-        const nextIdx = nextRrcNickCompleteIndex(names, tabCycleIndex, e.shiftKey);
-        if (nextIdx < 0) return;
-        const nick = names[nextIdx];
-        if (!nick) return;
-        const replaceLen = cycling ? mentionInsertedNickLen : mentionQuery.length;
-        if (!cycling) setMentionCyclePrefix(mentionQuery);
-        setMentionInsertedNickLen(nick.length);
-        setTabCycleIndex(nextIdx);
-        setMentionSelectedIdx(nextIdx);
-        const { text, caret } = insertRrcNickMention(draft, mentionTriggerPos, replaceLen, nick);
-        onDraftChange(text);
-        // Keep dropdown open for further Tab cycles (query = completed nick).
-        setMentionQuery(nick);
-        skipMentionSyncRef.current = true;
-        requestAnimationFrame(() => {
-          const el = textareaRef.current;
-          if (!el) return;
-          el.focus();
-          el.setSelectionRange(caret, caret);
-        });
-        return;
-      }
-    } else if (e.key === 'Tab') {
-      const el = e.currentTarget;
-      const caret = el.selectionStart ?? draft.length;
-      const at = findRrcAtMentionAtCaret(draft, caret);
-      if (at) {
-        e.preventDefault();
-        const candidates = listRrcNickCompleteCandidates(nickLabels, at.query);
-        if (candidates.length === 0) return;
-        const nextIdx = nextRrcNickCompleteIndex(candidates, -1, e.shiftKey);
-        const nick = candidates[nextIdx];
-        if (!nick) return;
-        setMentionTriggerPos(at.start);
-        setMentionCyclePrefix(at.query);
-        setMentionInsertedNickLen(nick.length);
-        setTabCycleIndex(nextIdx);
-        setMentionSelectedIdx(nextIdx);
-        const { text, caret: newCaret } = insertRrcNickMention(
-          draft,
-          at.start,
-          at.query.length,
-          nick,
-        );
-        onDraftChange(text);
-        setMentionQuery(nick);
-        skipMentionSyncRef.current = true;
-        requestAnimationFrame(() => {
-          textareaRef.current?.setSelectionRange(newCaret, newCaret);
-        });
-        return;
-      }
-    }
-
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      setMentionQuery(null);
-      clearMentionCycle();
-      onSend(draft);
-    }
-  };
-
   if (!connected) {
     return (
       <div className="flex flex-1 items-center justify-center p-6 text-sm text-gray-400">
@@ -833,66 +698,24 @@ export function RrcChatView({
           </button>
         )}
       </div>
-      <div className="relative flex gap-2 border-t border-gray-700 p-2">
-        {mentionQuery != null && mentionCandidates.length > 0 && (
-          <MentionAutocomplete
-            listboxId={RRC_MENTION_LISTBOX_ID}
-            candidates={mentionCandidates}
-            selectedIdx={mentionSelectedIdx}
-            onSelect={insertMention}
-            onSetSelectedIdx={setMentionSelectedIdx}
-          />
-        )}
-        <div
-          role="combobox"
-          tabIndex={-1}
-          aria-label={composerPlaceholder}
-          aria-haspopup="listbox"
-          aria-expanded={mentionQuery != null && mentionCandidates.length > 0}
-          aria-controls={RRC_MENTION_LISTBOX_ID}
-          aria-activedescendant={
-            mentionQuery != null && mentionCandidates.length > 0
-              ? `${RRC_MENTION_LISTBOX_ID}-option-${mentionSelectedIdx}`
-              : undefined
-          }
-          className="min-w-0 flex-1"
-        >
-          <textarea
-            ref={textareaRef}
-            value={draft}
-            onChange={(e) => {
-              const value = e.target.value;
-              onDraftChange(value);
-              syncMentionFromCaret(value, e.target.selectionStart ?? value.length);
-            }}
-            onSelect={(e) => {
-              if (skipMentionSyncRef.current) {
-                skipMentionSyncRef.current = false;
-                return;
-              }
-              const el = e.currentTarget;
-              syncMentionFromCaret(el.value, el.selectionStart ?? el.value.length);
-            }}
-            onKeyDown={handleComposerKeyDown}
-            disabled={!canSend || isMuted}
-            placeholder={composerPlaceholder}
-            aria-label={composerPlaceholder}
-            aria-autocomplete="list"
-            rows={2}
-            className="bg-deep-black w-full resize-none rounded border border-gray-600 px-2 py-1.5 font-sans text-sm text-gray-100 disabled:opacity-50"
-          />
-        </div>
-        <button
-          type="button"
-          className="bg-readable-green self-end rounded px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
-          aria-label={t('rrc.send')}
-          disabled={!canSend || isMuted || !draft.trim()}
-          onClick={() => {
-            onSend(draft);
-          }}
-        >
-          {t('rrc.send')}
-        </button>
+      <div className="border-t border-gray-700 p-2 font-sans">
+        <ChatComposer
+          protocol="reticulum"
+          viewKey={composerViewKey}
+          isConnected={canSend}
+          allowOutbox={false}
+          disabled={isMuted || !activeRoom}
+          placeholder={composerPlaceholder}
+          sendButtonLabel={t('rrc.send')}
+          payloadLimit={payloadLimit}
+          useWireByteCount
+          shouldSuppressLimits={(text) => rrcComposerBypassesSplit(text) || payloadLimit == null}
+          onInterceptSend={onInterceptSend}
+          onSendChunk={onSendChunk}
+          mentionAdapter={mentionAdapter}
+          composeSeed={composeSeed}
+          className="w-full"
+        />
       </div>
       {pendingAddress && (
         <ConfirmModal

--- a/src/renderer/components/rrc/RrcChatView.tsx
+++ b/src/renderer/components/rrc/RrcChatView.tsx
@@ -30,7 +30,7 @@ import {
   findReticulumChatLinks,
   type ReticulumChatLink,
 } from '@/renderer/lib/nomad/reticulumLinkText';
-import { normalizeRrcHubByteLimit, rrcComposerBypassesSplit } from '@/renderer/lib/rrcHubLimits';
+import { resolveRrcMsgBodyLimit, rrcComposerBypassesSplit } from '@/renderer/lib/rrcHubLimits';
 import {
   bodyMentionsRrcNick,
   findNextRrcNickMention,
@@ -362,7 +362,7 @@ export function RrcChatView({
     return `rrc:${hub}:${room}`;
   }, [hubDestHash, activeRoom]);
 
-  const payloadLimit = normalizeRrcHubByteLimit(maxMsgBodyBytes ?? null) ?? undefined;
+  const payloadLimit = resolveRrcMsgBodyLimit(maxMsgBodyBytes);
 
   const estimateSize = useCallback(
     (index: number) => estimateRrcRowHeight(visibleMessages[index]),
@@ -709,7 +709,7 @@ export function RrcChatView({
           sendButtonLabel={t('rrc.send')}
           payloadLimit={payloadLimit}
           useWireByteCount
-          shouldSuppressLimits={(text) => rrcComposerBypassesSplit(text) || payloadLimit == null}
+          shouldSuppressLimits={rrcComposerBypassesSplit}
           onInterceptSend={onInterceptSend}
           onSendChunk={onSendChunk}
           mentionAdapter={mentionAdapter}

--- a/src/renderer/components/rrc/RrcHubBrowser.tsx
+++ b/src/renderer/components/rrc/RrcHubBrowser.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeft, ChevronRight, RefreshCw, Star } from 'lucide-react-motion';
 import { useTranslation } from 'react-i18next';
 
+import { RrcByteLimitHint } from '@/renderer/components/rrc/RrcByteLimitHint';
 import { resolveRrcHubSidebarMarker, type RrcHubSidebarMarker } from '@/renderer/lib/rrcHubPrefs';
 import type { RrcHubInfo } from '@/shared/rrc-types';
 
@@ -16,6 +17,8 @@ export interface RrcHubBrowserProps {
   onHubSearchChange: (v: string) => void;
   nickname: string;
   onNicknameChange: (v: string) => void;
+  /** Hub WELCOME max_nick_bytes when known. */
+  maxNickBytes?: number | null;
   favourites: RrcHubInfo[];
   discovered: RrcHubInfo[];
   hubDestHash: string | null;
@@ -202,6 +205,7 @@ export function RrcHubBrowser({
   onHubSearchChange,
   nickname,
   onNicknameChange,
+  maxNickBytes = null,
   favourites,
   discovered,
   hubDestHash,
@@ -313,6 +317,11 @@ export function RrcHubBrowser({
               }}
               aria-label={t('rrc.nickname')}
               className="bg-deep-black mt-0.5 w-full rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
+            />
+            <RrcByteLimitHint
+              text={nickname}
+              limit={maxNickBytes}
+              overMaxKey="rrc.nickLimit.overMax"
             />
           </label>
           {rows.length > 0 ? (

--- a/src/renderer/components/rrc/RrcRoomSidebar.tsx
+++ b/src/renderer/components/rrc/RrcRoomSidebar.tsx
@@ -1,6 +1,10 @@
 import { ChevronLeft, ChevronRight, LogIn, Star } from 'lucide-react-motion';
 import { useTranslation } from 'react-i18next';
 
+import {
+  isRrcByteLimitOverMax,
+  RrcByteLimitHint,
+} from '@/renderer/components/rrc/RrcByteLimitHint';
 import { isRrcWhisperRoom } from '@/renderer/lib/rrcMention';
 import { rrcRoomMatchKey, rrcRoomsMatch } from '@/renderer/lib/rrcRoomName';
 import type { RrcListedRoom, RrcRoomInfo } from '@/shared/rrc-types';
@@ -50,6 +54,8 @@ export interface RrcRoomSidebarProps {
   onJoinRoomNameChange: (v: string) => void;
   joinRoomKey: string;
   onJoinRoomKeyChange: (v: string) => void;
+  /** Hub WELCOME max_room_name_bytes when known. */
+  maxRoomNameBytes?: number | null;
   busy: boolean;
   onJoin: () => void;
   onRefreshList: () => void;
@@ -76,6 +82,7 @@ export function RrcRoomSidebar({
   onJoinRoomNameChange,
   joinRoomKey,
   onJoinRoomKeyChange,
+  maxRoomNameBytes = null,
   busy,
   onJoin,
   onRefreshList,
@@ -283,25 +290,32 @@ export function RrcRoomSidebar({
             className="bg-deep-black w-full rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
           />
           <p className="text-muted px-1 text-[10px] leading-snug">{t('rrc.roomLegend')}</p>
-          <div className="flex gap-1">
-            <input
-              type="text"
-              value={joinRoomName}
-              onChange={(e) => {
-                onJoinRoomNameChange(e.target.value);
-              }}
-              aria-label={t('rrc.joinRoom')}
-              className="bg-deep-black min-w-0 flex-1 rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
+          <div className="flex flex-col gap-0.5">
+            <div className="flex gap-1">
+              <input
+                type="text"
+                value={joinRoomName}
+                onChange={(e) => {
+                  onJoinRoomNameChange(e.target.value);
+                }}
+                aria-label={t('rrc.joinRoom')}
+                className="bg-deep-black min-w-0 flex-1 rounded border border-gray-600 px-2 py-1 text-xs text-gray-100"
+              />
+              <button
+                type="button"
+                className="bg-readable-green rounded px-2 py-1 text-xs text-white hover:opacity-90 disabled:opacity-50"
+                aria-label={t('rrc.join')}
+                disabled={busy || isRrcByteLimitOverMax(joinRoomName, maxRoomNameBytes)}
+                onClick={onJoin}
+              >
+                <LogIn size={14} />
+              </button>
+            </div>
+            <RrcByteLimitHint
+              text={joinRoomName}
+              limit={maxRoomNameBytes}
+              overMaxKey="rrc.roomNameLimit.overMax"
             />
-            <button
-              type="button"
-              className="bg-readable-green rounded px-2 py-1 text-xs text-white hover:opacity-90"
-              aria-label={t('rrc.join')}
-              disabled={busy}
-              onClick={onJoin}
-            >
-              <LogIn size={14} />
-            </button>
           </div>
           <input
             type="password"

--- a/src/renderer/lib/chatComposerLimits.ts
+++ b/src/renderer/lib/chatComposerLimits.ts
@@ -171,6 +171,13 @@ export function computeComposerLimitStatus(
     replyToSenderName?: string;
     replyKey?: number;
     useKeyedReplies?: boolean;
+    /**
+     * When true, UI count / warn threshold use UTF-8 wire bytes (RRC hub body limits).
+     * Split/overMax already use wire bytes via `splitChatMessage`.
+     */
+    useWireByteCount?: boolean;
+    /** When true, skip limit chrome (RRC slash commands that bypass multi-part send). */
+    suppressLimits?: boolean;
   },
 ): ComposerLimitStatus {
   const singleMessageLimit = getComposerPayloadLimit({
@@ -186,13 +193,26 @@ export function computeComposerLimitStatus(
     useKeyedReplies: opts?.useKeyedReplies,
   });
   const trimmed = text.trim();
-  const charCount = countMessageChars(trimmed);
+  const charCount = opts?.useWireByteCount
+    ? countMessageWireBytes(trimmed)
+    : countMessageChars(trimmed);
   const showThreshold = Math.floor(singleMessageLimit * 0.8);
   const totalMaxChars = computeComposerTotalMaxChars(
     singleMessageLimit,
     wireOverheadFirstChunk,
     getMaxChunks(protocol),
   );
+
+  if (opts?.suppressLimits) {
+    return {
+      charCount,
+      singleMessageLimit,
+      chunkCount: 1,
+      totalMaxChars: Number.MAX_SAFE_INTEGER,
+      phase: 'ok',
+      showThreshold,
+    };
+  }
 
   const chunks = splitChatMessage(trimmed, protocol, singleMessageLimit, wireOverheadFirstChunk);
 

--- a/src/renderer/lib/rrcHubLimits.test.ts
+++ b/src/renderer/lib/rrcHubLimits.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeRrcByteLimitStatus,
+  isRrcHubMsgBodyLimitError,
+  isRrcHubNickLimitError,
+  parseRrcHubLimits,
+  rrcComposerBypassesSplit,
+} from './rrcHubLimits';
+
+describe('parseRrcHubLimits', () => {
+  it('normalizes positive integers and drops invalid values', () => {
+    expect(
+      parseRrcHubLimits({
+        max_msg_body_bytes: 350,
+        max_nick_bytes: 32.9,
+        max_room_name_bytes: 0,
+        max_rooms_per_session: -1,
+        rate_limit_msgs_per_minute: 'nope',
+      }),
+    ).toEqual({
+      max_msg_body_bytes: 350,
+      max_nick_bytes: 32,
+      max_room_name_bytes: null,
+      max_rooms_per_session: null,
+      rate_limit_msgs_per_minute: null,
+    });
+  });
+});
+
+describe('computeRrcByteLimitStatus', () => {
+  it('returns null when the hub did not advertise a limit', () => {
+    expect(computeRrcByteLimitStatus('hello', null)).toBeNull();
+  });
+
+  it('stays ok below 80% and warns at the threshold', () => {
+    expect(computeRrcByteLimitStatus('a'.repeat(279), 350)?.phase).toBe('ok');
+    expect(computeRrcByteLimitStatus('a'.repeat(280), 350)?.phase).toBe('warn');
+  });
+
+  it('counts UTF-8 wire bytes for emoji', () => {
+    // 🦊 is 4 UTF-8 bytes
+    const status = computeRrcByteLimitStatus('🦊'.repeat(88), 350);
+    expect(status?.byteCount).toBe(352);
+    expect(status?.phase).toBe('overMax');
+  });
+});
+
+describe('rrcComposerBypassesSplit', () => {
+  it('bypasses slash commands but not plain chat', () => {
+    expect(rrcComposerBypassesSplit('hello')).toBe(false);
+    expect(rrcComposerBypassesSplit('/help')).toBe(true);
+    expect(rrcComposerBypassesSplit('/me waves')).toBe(true);
+    expect(rrcComposerBypassesSplit('/join lobby')).toBe(true);
+  });
+});
+
+describe('hub limit error detectors', () => {
+  it('matches sidecar hub limit error strings', () => {
+    expect(isRrcHubMsgBodyLimitError('message exceeds hub limit (350 bytes)')).toBe(true);
+    expect(isRrcHubNickLimitError('nickname exceeds hub limit (32 bytes)')).toBe(true);
+    expect(isRrcHubMsgBodyLimitError('send failed')).toBe(false);
+  });
+});

--- a/src/renderer/lib/rrcHubLimits.test.ts
+++ b/src/renderer/lib/rrcHubLimits.test.ts
@@ -5,6 +5,8 @@ import {
   isRrcHubMsgBodyLimitError,
   isRrcHubNickLimitError,
   parseRrcHubLimits,
+  resolveRrcMsgBodyLimit,
+  RRC_FALLBACK_MAX_MSG_BODY_BYTES,
   rrcComposerBypassesSplit,
 } from './rrcHubLimits';
 
@@ -25,6 +27,19 @@ describe('parseRrcHubLimits', () => {
       max_rooms_per_session: null,
       rate_limit_msgs_per_minute: null,
     });
+  });
+});
+
+describe('resolveRrcMsgBodyLimit', () => {
+  it('uses the hub WELCOME limit when present', () => {
+    expect(resolveRrcMsgBodyLimit(350)).toBe(350);
+  });
+
+  it('falls back below typical Link MDU when the hub omits a body limit', () => {
+    expect(resolveRrcMsgBodyLimit(null)).toBe(RRC_FALLBACK_MAX_MSG_BODY_BYTES);
+    expect(resolveRrcMsgBodyLimit(undefined)).toBe(RRC_FALLBACK_MAX_MSG_BODY_BYTES);
+    expect(RRC_FALLBACK_MAX_MSG_BODY_BYTES).toBeLessThan(431);
+    expect(RRC_FALLBACK_MAX_MSG_BODY_BYTES).toBeGreaterThan(0);
   });
 });
 

--- a/src/renderer/lib/rrcHubLimits.ts
+++ b/src/renderer/lib/rrcHubLimits.ts
@@ -13,11 +13,33 @@ export interface RrcByteLimitStatus {
   showThreshold: number;
 }
 
+/**
+ * Typical RNS Link MDU for RRC traffic (rrcd `/who` / MSG frames).
+ * When a hub omits WELCOME `max_msg_body_bytes`, plain chat uses a body budget
+ * below this so the full envelope still fits a single link frame.
+ */
+export const RRC_TYPICAL_LINK_MDU_BYTES = 431;
+
+/**
+ * Conservative msgpack framing budget (msg type, identity hash, room, nick, map keys)
+ * for a typical RRC MSG/ACTION/NOTICE body on a Link.
+ */
+export const RRC_MSG_ENVELOPE_OVERHEAD_BUDGET_BYTES = 96;
+
+/** Plain-chat body cap when the hub did not advertise `max_msg_body_bytes`. */
+export const RRC_FALLBACK_MAX_MSG_BODY_BYTES =
+  RRC_TYPICAL_LINK_MDU_BYTES - RRC_MSG_ENVELOPE_OVERHEAD_BUDGET_BYTES;
+
 /** Normalize optional hub limit integers (reject non-positive). */
 export function normalizeRrcHubByteLimit(value: unknown): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value)) return null;
   const n = Math.floor(value);
   return n > 0 ? n : null;
+}
+
+/** Hub WELCOME body limit, or Link-MDU-safe fallback when the hub omits one. */
+export function resolveRrcMsgBodyLimit(hubLimit: number | null | undefined): number {
+  return normalizeRrcHubByteLimit(hubLimit ?? null) ?? RRC_FALLBACK_MAX_MSG_BODY_BYTES;
 }
 
 export function parseRrcHubLimits(raw: unknown): RrcHubLimits {
@@ -53,12 +75,22 @@ export function computeRrcByteLimitStatus(
 /**
  * Slash drafts (local/hub commands) bypass ChatComposer multi-part split so
  * `/join` / `/help` / `/nick` are never turned into `[1/N]` room spam.
+ * Body-bearing slash commands (`/me`, `/msg`) are still validated against the
+ * message body limit before send.
  */
 export function rrcComposerBypassesSplit(raw: string): boolean {
   const text = raw.trim();
   if (!text.startsWith('/')) return false;
   const parsed = parseRrcSlashInput(text);
   return parsed != null && parsed.kind !== 'chat';
+}
+
+/**
+ * Composer / field preflight rejection. RrcPanel rethrows these from handleSend
+ * so ChatComposer’s onInterceptSend path keeps the draft and shows the message.
+ */
+export class RrcComposerPreflightError extends Error {
+  override readonly name = 'RrcComposerPreflightError';
 }
 
 /** True when sidecar/hub rejected a body for exceeding WELCOME max_msg_body_bytes. */

--- a/src/renderer/lib/rrcHubLimits.ts
+++ b/src/renderer/lib/rrcHubLimits.ts
@@ -1,0 +1,72 @@
+/** Helpers for RRC WELCOME hub byte limits (nick / room name / message body). */
+
+import { countMessageWireBytes } from '@/renderer/lib/chatComposerLimits';
+import { parseRrcSlashInput } from '@/renderer/lib/rrcSlashCommands';
+import type { RrcHubLimits } from '@/shared/rrc-types';
+
+export type RrcByteLimitPhase = 'ok' | 'warn' | 'overMax';
+
+export interface RrcByteLimitStatus {
+  byteCount: number;
+  limit: number;
+  phase: RrcByteLimitPhase;
+  showThreshold: number;
+}
+
+/** Normalize optional hub limit integers (reject non-positive). */
+export function normalizeRrcHubByteLimit(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  const n = Math.floor(value);
+  return n > 0 ? n : null;
+}
+
+export function parseRrcHubLimits(raw: unknown): RrcHubLimits {
+  if (!raw || typeof raw !== 'object') return {};
+  const o = raw as Record<string, unknown>;
+  return {
+    max_nick_bytes: normalizeRrcHubByteLimit(o.max_nick_bytes),
+    max_room_name_bytes: normalizeRrcHubByteLimit(o.max_room_name_bytes),
+    max_msg_body_bytes: normalizeRrcHubByteLimit(o.max_msg_body_bytes),
+    max_rooms_per_session: normalizeRrcHubByteLimit(o.max_rooms_per_session),
+    rate_limit_msgs_per_minute: normalizeRrcHubByteLimit(o.rate_limit_msgs_per_minute),
+  };
+}
+
+/**
+ * UTF-8 byte counter status for nick / room-name / body fields.
+ * Counter hidden until ≥80% of the hub limit (same pattern as ChatComposer).
+ */
+export function computeRrcByteLimitStatus(
+  text: string,
+  limit: number | null | undefined,
+): RrcByteLimitStatus | null {
+  const max = normalizeRrcHubByteLimit(limit ?? null);
+  if (max == null) return null;
+  const byteCount = countMessageWireBytes(text);
+  const showThreshold = Math.floor(max * 0.8);
+  let phase: RrcByteLimitPhase = 'ok';
+  if (byteCount > max) phase = 'overMax';
+  else if (byteCount >= showThreshold) phase = 'warn';
+  return { byteCount, limit: max, phase, showThreshold };
+}
+
+/**
+ * Slash drafts (local/hub commands) bypass ChatComposer multi-part split so
+ * `/join` / `/help` / `/nick` are never turned into `[1/N]` room spam.
+ */
+export function rrcComposerBypassesSplit(raw: string): boolean {
+  const text = raw.trim();
+  if (!text.startsWith('/')) return false;
+  const parsed = parseRrcSlashInput(text);
+  return parsed != null && parsed.kind !== 'chat';
+}
+
+/** True when sidecar/hub rejected a body for exceeding WELCOME max_msg_body_bytes. */
+export function isRrcHubMsgBodyLimitError(message: string): boolean {
+  return /message exceeds hub limit/i.test(message);
+}
+
+/** True when sidecar/hub rejected a nickname for exceeding WELCOME max_nick_bytes. */
+export function isRrcHubNickLimitError(message: string): boolean {
+  return /nickname exceeds hub limit/i.test(message);
+}

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -5412,7 +5412,8 @@
     "memberCount_few": "{{count}} členové",
     "userCount_few": "{{count}} uživatelé",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Zpráva je příliš dlouhá — limit rozbočovače je {{limit}} bajtů"
     },
     "nickLimit": {
       "overMax": "Přezdívka je příliš dlouhá — limit rozbočovače je {{limit}} bajtů"

--- a/src/renderer/locales/cs/translation.json
+++ b/src/renderer/locales/cs/translation.json
@@ -5410,7 +5410,16 @@
     "addressChoiceDm": "Přímá zpráva",
     "hopsAway_few": "{{count}} skoky daleko",
     "memberCount_few": "{{count}} členové",
-    "userCount_few": "{{count}} uživatelé"
+    "userCount_few": "{{count}} uživatelé",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Přezdívka je příliš dlouhá — limit rozbočovače je {{limit}} bajtů"
+    },
+    "roomNameLimit": {
+      "overMax": "Název místnosti je příliš dlouhý — limit rozbočovače je {{limit}} bajtů"
+    }
   },
   "signalMeter": {
     "rssi": "\"RSSI\"",

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Nomad-Seite",
     "addressChoiceDm": "Direktnachricht",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Nachricht zu lang — Hub-Limit ist {{limit}} Bytes"
     },
     "nickLimit": {
       "overMax": "Spitzname zu lang — Hub-Limit ist {{limit}} Bytes"

--- a/src/renderer/locales/de/translation.json
+++ b/src/renderer/locales/de/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Reticulum-Adresse öffnen",
     "addressChoiceMessage": "{{address}} könnte eine Nomad-Seite oder ein Peer sein. Was möchten Sie öffnen?",
     "addressChoiceNomad": "Nomad-Seite",
-    "addressChoiceDm": "Direktnachricht"
+    "addressChoiceDm": "Direktnachricht",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Spitzname zu lang — Hub-Limit ist {{limit}} Bytes"
+    },
+    "roomNameLimit": {
+      "overMax": "Raumname zu lang — Hub-Limit ist {{limit}} Bytes"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -5538,6 +5538,15 @@
     "dismissBanner": "Dismiss notice",
     "directNoticeUnsupported": "This hub does not support direct NOTICE (/msg).",
     "capDirectNotice": "direct msg",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Nickname too long — hub limit is {{limit}} bytes"
+    },
+    "roomNameLimit": {
+      "overMax": "Room name too long — hub limit is {{limit}} bytes"
+    },
     "errors": {
       "linkProofTimeout": "Timed out waiting for the hub link (link proof). Try again, or check path/hops to the hub.",
       "pathTimeout": "Could not find a path to the hub. Wait for a fresher announce, then reconnect.",

--- a/src/renderer/locales/en/translation.json
+++ b/src/renderer/locales/en/translation.json
@@ -5539,7 +5539,8 @@
     "directNoticeUnsupported": "This hub does not support direct NOTICE (/msg).",
     "capDirectNotice": "direct msg",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Message too long — hub limit is {{limit}} bytes"
     },
     "nickLimit": {
       "overMax": "Nickname too long — hub limit is {{limit}} bytes"

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Abrir dirección Reticulum",
     "addressChoiceMessage": "{{address}} podría ser una página Nomad o un par. ¿Cuál quieres abrir?",
     "addressChoiceNomad": "Página Nomad",
-    "addressChoiceDm": "Mensaje directo"
+    "addressChoiceDm": "Mensaje directo",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Apodo demasiado largo: el límite del concentrador es {{limit}} bytes"
+    },
+    "roomNameLimit": {
+      "overMax": "El nombre de la sala es demasiado largo: el límite del hub es de {{limit}} bytes"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/es/translation.json
+++ b/src/renderer/locales/es/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Página Nomad",
     "addressChoiceDm": "Mensaje directo",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "El mensaje es demasiado largo: el límite del concentrador es de {{limit}} bytes"
     },
     "nickLimit": {
       "overMax": "Apodo demasiado largo: el límite del concentrador es {{limit}} bytes"

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Ouvrir l'adresse Reticulum",
     "addressChoiceMessage": "{{address}} peut être une page Nomad ou un pair. Que voulez-vous ouvrir ?",
     "addressChoiceNomad": "Page Nomad",
-    "addressChoiceDm": "Message direct"
+    "addressChoiceDm": "Message direct",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Pseudonyme trop long — la limite du hub est de {{limit}} octets"
+    },
+    "roomNameLimit": {
+      "overMax": "Nom de salle trop long — la limite du hub est de {{limit}} octets"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/fr/translation.json
+++ b/src/renderer/locales/fr/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Page Nomad",
     "addressChoiceDm": "Message direct",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Message trop long — la limite du hub est de {{limit}} octets"
     },
     "nickLimit": {
       "overMax": "Pseudonyme trop long — la limite du hub est de {{limit}} octets"

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Halaman Nomad",
     "addressChoiceDm": "Pesan langsung",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Pesan terlalu panjang — batas hub {{limit}} byte"
     },
     "nickLimit": {
       "overMax": "Nama panggilan terlalu panjang — batas hub adalah {{limit}} byte"

--- a/src/renderer/locales/id/translation.json
+++ b/src/renderer/locales/id/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Buka alamat Reticulum",
     "addressChoiceMessage": "{{address}} bisa berupa halaman Nomad atau sebuah peer. Mana yang ingin dibuka?",
     "addressChoiceNomad": "Halaman Nomad",
-    "addressChoiceDm": "Pesan langsung"
+    "addressChoiceDm": "Pesan langsung",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Nama panggilan terlalu panjang — batas hub adalah {{limit}} byte"
+    },
+    "roomNameLimit": {
+      "overMax": "Nama ruangan terlalu panjang — batas hub {{limit}} byte"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Apri indirizzo Reticulum",
     "addressChoiceMessage": "{{address}} potrebbe essere una pagina Nomad o un peer. Quale vuoi aprire?",
     "addressChoiceNomad": "Pagina Nomad",
-    "addressChoiceDm": "Messaggio diretto"
+    "addressChoiceDm": "Messaggio diretto",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Soprannome troppo lungo — il limite dell'hub è {{limit}} byte"
+    },
+    "roomNameLimit": {
+      "overMax": "Nome della stanza troppo lungo — il limite dell'hub è di {{limit}} byte"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/it/translation.json
+++ b/src/renderer/locales/it/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Pagina Nomad",
     "addressChoiceDm": "Messaggio diretto",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Messaggio troppo lungo — il limite dell'hub è di {{limit}} byte"
     },
     "nickLimit": {
       "overMax": "Soprannome troppo lungo — il limite dell'hub è {{limit}} byte"

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Reticulum アドレスを開く",
     "addressChoiceMessage": "{{address}} は Nomad ページかピアの可能性があります。どちらを開きますか？",
     "addressChoiceNomad": "Nomad ページ",
-    "addressChoiceDm": "ダイレクトメッセージ"
+    "addressChoiceDm": "ダイレクトメッセージ",
+    "byteLimit": {
+      "approaching": "{{count}}/{{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "ニックネームが長すぎます—ハブの制限は{{limit}}バイトです"
+    },
+    "roomNameLimit": {
+      "overMax": "ルーム名が長すぎます—ハブの制限は{{limit}}バイトです"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/ja/translation.json
+++ b/src/renderer/locales/ja/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Nomad ページ",
     "addressChoiceDm": "ダイレクトメッセージ",
     "byteLimit": {
-      "approaching": "{{count}}/{{limit}}"
+      "approaching": "{{count}}/{{limit}}",
+      "overMax": "メッセージが長すぎます—ハブの制限は{{limit}}バイトです"
     },
     "nickLimit": {
       "overMax": "ニックネームが長すぎます—ハブの制限は{{limit}}バイトです"

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Reticulum 주소 열기",
     "addressChoiceMessage": "{{address}}는 Nomad 페이지이거나 피어일 수 있습니다. 무엇을 열까요?",
     "addressChoiceNomad": "Nomad 페이지",
-    "addressChoiceDm": "다이렉트 메시지"
+    "addressChoiceDm": "다이렉트 메시지",
+    "byteLimit": {
+      "approaching": "{{count}}/{{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "별명이 너무 깁니다 — 허브 한도는 {{limit}} 바이트입니다"
+    },
+    "roomNameLimit": {
+      "overMax": "방 이름이 너무 깁니다 — 허브 한도는 {{limit}} 바이트입니다"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/ko/translation.json
+++ b/src/renderer/locales/ko/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Nomad 페이지",
     "addressChoiceDm": "다이렉트 메시지",
     "byteLimit": {
-      "approaching": "{{count}}/{{limit}}"
+      "approaching": "{{count}}/{{limit}}",
+      "overMax": "메시지가 너무 깁니다 — 허브 한도는 {{limit}} 바이트입니다"
     },
     "nickLimit": {
       "overMax": "별명이 너무 깁니다 — 허브 한도는 {{limit}} 바이트입니다"

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Nomad-pagina",
     "addressChoiceDm": "Direct bericht",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Bericht te lang — hublimiet is {{limit}} bytes"
     },
     "nickLimit": {
       "overMax": "Bijnaam te lang — hublimiet is {{limit}} bytes"

--- a/src/renderer/locales/nl/translation.json
+++ b/src/renderer/locales/nl/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Reticulum-adres openen",
     "addressChoiceMessage": "{{address}} kan een Nomad-pagina of een peer zijn. Wat wil je openen?",
     "addressChoiceNomad": "Nomad-pagina",
-    "addressChoiceDm": "Direct bericht"
+    "addressChoiceDm": "Direct bericht",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Bijnaam te lang — hublimiet is {{limit}} bytes"
+    },
+    "roomNameLimit": {
+      "overMax": "Kamernaam te lang — hublimiet is {{limit}} bytes"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -5454,7 +5454,16 @@
     "memberCount_few": "{{count}} członkowie",
     "memberCount_many": "{{count}} członków",
     "userCount_few": "{{count}} użytkownicy",
-    "userCount_many": "{{count}} użytkowników"
+    "userCount_many": "{{count}} użytkowników",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Pseudonim zbyt długi — limit koncentratora to {{limit}} bajtów"
+    },
+    "roomNameLimit": {
+      "overMax": "Nazwa pokoju jest zbyt długa — limit koncentratora wynosi {{limit}} bajtów"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/pl/translation.json
+++ b/src/renderer/locales/pl/translation.json
@@ -5456,7 +5456,8 @@
     "userCount_few": "{{count}} użytkownicy",
     "userCount_many": "{{count}} użytkowników",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Wiadomość zbyt długa — limit koncentratora wynosi {{limit}} bajtów"
     },
     "nickLimit": {
       "overMax": "Pseudonim zbyt długi — limit koncentratora to {{limit}} bajtów"

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Abrir endereço Reticulum",
     "addressChoiceMessage": "{{address}} pode ser uma página Nomad ou um par. Qual você quer abrir?",
     "addressChoiceNomad": "Página Nomad",
-    "addressChoiceDm": "Mensagem direta"
+    "addressChoiceDm": "Mensagem direta",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Apelido muito longo — o limite do hub é {{limit}} bytes"
+    },
+    "roomNameLimit": {
+      "overMax": "Nome da sala muito longo — o limite do hub é de {{limit}} bytes"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/pt-BR/translation.json
+++ b/src/renderer/locales/pt-BR/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Página Nomad",
     "addressChoiceDm": "Mensagem direta",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Mensagem muito longa — o limite do hub é de {{limit}} bytes"
     },
     "nickLimit": {
       "overMax": "Apelido muito longo — o limite do hub é {{limit}} bytes"

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -5454,7 +5454,16 @@
     "memberCount_few": "{{count}} участника",
     "memberCount_many": "{{count}} участников",
     "userCount_few": "{{count}} пользователя",
-    "userCount_many": "{{count}} пользователей"
+    "userCount_many": "{{count}} пользователей",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Слишком длинное имя псевдонима — ограничение концентратора составляет {{limit}} байт"
+    },
+    "roomNameLimit": {
+      "overMax": "Слишком длинное название комнаты — ограничение концентратора составляет {{limit}} байт"
+    }
   },
   "signalMeter": {
     "rssi": "РССИ",

--- a/src/renderer/locales/ru/translation.json
+++ b/src/renderer/locales/ru/translation.json
@@ -5456,7 +5456,8 @@
     "userCount_few": "{{count}} пользователя",
     "userCount_many": "{{count}} пользователей",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Слишком длинное сообщение — ограничение концентратора составляет {{limit}} байт"
     },
     "nickLimit": {
       "overMax": "Слишком длинное имя псевдонима — ограничение концентратора составляет {{limit}} байт"

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Nomad sayfası",
     "addressChoiceDm": "Doğrudan mesaj",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Mesaj çok uzun — hub sınırı {{limit}} bayt"
     },
     "nickLimit": {
       "overMax": "Takma ad çok uzun — hub sınırı {{limit}} bayt"

--- a/src/renderer/locales/tr/translation.json
+++ b/src/renderer/locales/tr/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "Reticulum adresini aç",
     "addressChoiceMessage": "{{address}} bir Nomad sayfası veya eş olabilir. Hangisini açmak istersiniz?",
     "addressChoiceNomad": "Nomad sayfası",
-    "addressChoiceDm": "Doğrudan mesaj"
+    "addressChoiceDm": "Doğrudan mesaj",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Takma ad çok uzun — hub sınırı {{limit}} bayt"
+    },
+    "roomNameLimit": {
+      "overMax": "Oda adı çok uzun — merkez sınırı {{limit}} bayt"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -5456,7 +5456,8 @@
     "userCount_few": "{{count}} користувачі",
     "userCount_many": "{{count}} користувачів",
     "byteLimit": {
-      "approaching": "{{count}} / {{limit}}"
+      "approaching": "{{count}} / {{limit}}",
+      "overMax": "Задовге повідомлення — ліміт концентратора становить {{limit}} байт"
     },
     "nickLimit": {
       "overMax": "Задовгий псевдонім — ліміт концентратора становить {{limit}} байт"

--- a/src/renderer/locales/uk/translation.json
+++ b/src/renderer/locales/uk/translation.json
@@ -5454,7 +5454,16 @@
     "memberCount_few": "{{count}} учасники",
     "memberCount_many": "{{count}} учасників",
     "userCount_few": "{{count}} користувачі",
-    "userCount_many": "{{count}} користувачів"
+    "userCount_many": "{{count}} користувачів",
+    "byteLimit": {
+      "approaching": "{{count}} / {{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "Задовгий псевдонім — ліміт концентратора становить {{limit}} байт"
+    },
+    "roomNameLimit": {
+      "overMax": "Назва кімнати задовга — ліміт концентратора становить {{limit}} байт"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI (індикатор потужності прийнятого сигналу)",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -5364,7 +5364,16 @@
     "addressChoiceTitle": "打开 Reticulum 地址",
     "addressChoiceMessage": "{{address}} 可能是 Nomad 页面，也可能是一个节点。要打开哪一个？",
     "addressChoiceNomad": "Nomad 页面",
-    "addressChoiceDm": "私信"
+    "addressChoiceDm": "私信",
+    "byteLimit": {
+      "approaching": "{{count}}/{{limit}}"
+    },
+    "nickLimit": {
+      "overMax": "昵称太长—集线器限制为{{limit}}字节"
+    },
+    "roomNameLimit": {
+      "overMax": "房间名称太长—集线器限制为{{limit}}字节"
+    }
   },
   "signalMeter": {
     "rssi": "RSSI",

--- a/src/renderer/locales/zh/translation.json
+++ b/src/renderer/locales/zh/translation.json
@@ -5366,7 +5366,8 @@
     "addressChoiceNomad": "Nomad 页面",
     "addressChoiceDm": "私信",
     "byteLimit": {
-      "approaching": "{{count}}/{{limit}}"
+      "approaching": "{{count}}/{{limit}}",
+      "overMax": "消息太长—集线器限制为{{limit}}字节"
     },
     "nickLimit": {
       "overMax": "昵称太长—集线器限制为{{limit}}字节"

--- a/src/renderer/runtime/useReticulumRuntime.ts
+++ b/src/renderer/runtime/useReticulumRuntime.ts
@@ -1069,9 +1069,8 @@ export function useReticulumRuntime(): ProtocolRuntime {
             hubDestHash,
           );
         }
-        if (p.limits) {
-          useRrcSessionStore.getState().setLimits(parseRrcHubLimits(p.limits), hubDestHash);
-        }
+        // Always apply: absent WELCOME limits normalize to {} and clear stale caps.
+        useRrcSessionStore.getState().setLimits(parseRrcHubLimits(p.limits), hubDestHash);
         if (st === 'active' && hubDestHash && p.hub_name) {
           useRrcHubStore.getState().applyWelcomeName(hubDestHash, p.hub_name);
         }
@@ -1096,7 +1095,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
                 hubDestHash,
               );
             }
-            if (sessionSnap?.limits) {
+            if (sessionSnap) {
               useRrcSessionStore
                 .getState()
                 .setLimits(parseRrcHubLimits(sessionSnap.limits), hubDestHash);

--- a/src/renderer/runtime/useReticulumRuntime.ts
+++ b/src/renderer/runtime/useReticulumRuntime.ts
@@ -146,6 +146,7 @@ import {
   isRrcAutoJoinBackoffWorthyReason,
   recordRrcHubAutoJoinFailure,
 } from '@/renderer/lib/rrcHubAutoJoinBackoff';
+import { parseRrcHubLimits } from '@/renderer/lib/rrcHubLimits';
 import { isRrcRoomMuted, resolveRrcAlertType } from '@/renderer/lib/rrcMention';
 import {
   resolveRrcHubScopedNoticeRoom,
@@ -1038,6 +1039,13 @@ export function useReticulumRuntime(): ProtocolRuntime {
             action?: boolean;
             resource_envelope?: boolean;
           };
+          limits?: {
+            max_nick_bytes?: number | null;
+            max_room_name_bytes?: number | null;
+            max_msg_body_bytes?: number | null;
+            max_rooms_per_session?: number | null;
+            rate_limit_msgs_per_minute?: number | null;
+          };
         };
         const hubDestHash = p.hub_dest_hash ?? undefined;
         const st =
@@ -1060,6 +1068,9 @@ export function useReticulumRuntime(): ProtocolRuntime {
             },
             hubDestHash,
           );
+        }
+        if (p.limits) {
+          useRrcSessionStore.getState().setLimits(parseRrcHubLimits(p.limits), hubDestHash);
         }
         if (st === 'active' && hubDestHash && p.hub_name) {
           useRrcHubStore.getState().applyWelcomeName(hubDestHash, p.hub_name);
@@ -1084,6 +1095,11 @@ export function useReticulumRuntime(): ProtocolRuntime {
                 },
                 hubDestHash,
               );
+            }
+            if (sessionSnap?.limits) {
+              useRrcSessionStore
+                .getState()
+                .setLimits(parseRrcHubLimits(sessionSnap.limits), hubDestHash);
             }
           })
           .catch((e: unknown) => {

--- a/src/renderer/stores/rrcSessionStore.limits.test.ts
+++ b/src/renderer/stores/rrcSessionStore.limits.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { useRrcSessionStore } from '@/renderer/stores/rrcSessionStore';
+
+describe('rrcSessionStore limits', () => {
+  it('stores and mirrors WELCOME hub limits on the focused hub', () => {
+    const hub = 'aa'.repeat(16);
+    useRrcSessionStore.getState().clearSession();
+    useRrcSessionStore.getState().applyStatus('active', hub, 'Test Hub');
+    useRrcSessionStore.getState().setLimits(
+      {
+        max_msg_body_bytes: 350,
+        max_nick_bytes: 32,
+        max_room_name_bytes: 64,
+      },
+      hub,
+    );
+    expect(useRrcSessionStore.getState().limits).toEqual({
+      max_msg_body_bytes: 350,
+      max_nick_bytes: 32,
+      max_room_name_bytes: 64,
+    });
+    expect(useRrcSessionStore.getState().sessionsByHub.get(hub)?.limits.max_msg_body_bytes).toBe(
+      350,
+    );
+  });
+});

--- a/src/renderer/stores/rrcSessionStore.ts
+++ b/src/renderer/stores/rrcSessionStore.ts
@@ -25,6 +25,7 @@ import {
 import type {
   RrcChatMessage,
   RrcHubCapabilities,
+  RrcHubLimits,
   RrcListedRoom,
   RrcRoomInfo,
   RrcRoomMember,
@@ -127,6 +128,8 @@ export interface RrcHubSessionState {
   status: RrcSessionStatus;
   hubName: string | null;
   capabilities: RrcHubCapabilities;
+  /** WELCOME hub operational limits (bytes / rates). */
+  limits: RrcHubLimits;
   rooms: Map<string, RrcRoomInfo>;
   listedRooms: RrcListedRoom[];
   activeRoom: string | null;
@@ -151,6 +154,7 @@ export function emptyHubSession(): RrcHubSessionState {
     status: 'disconnected',
     hubName: null,
     capabilities: {},
+    limits: {},
     rooms: new Map(),
     listedRooms: [],
     activeRoom: null,
@@ -183,6 +187,7 @@ function mirrorFromSession(
   | 'status'
   | 'hubName'
   | 'capabilities'
+  | 'limits'
   | 'rooms'
   | 'listedRooms'
   | 'activeRoom'
@@ -197,6 +202,7 @@ function mirrorFromSession(
     status: session.status,
     hubName: session.hubName,
     capabilities: session.capabilities,
+    limits: session.limits,
     rooms: session.rooms,
     listedRooms: session.listedRooms,
     activeRoom: session.activeRoom,
@@ -328,6 +334,7 @@ interface RrcSessionStoreState {
   hubDestHash: string | null;
   hubName: string | null;
   capabilities: RrcHubCapabilities;
+  limits: RrcHubLimits;
   rooms: Map<string, RrcRoomInfo>;
   listedRooms: RrcListedRoom[];
   activeRoom: string | null;
@@ -346,6 +353,7 @@ interface RrcSessionStoreState {
   setActiveRoom: (room: string | null, hubHash?: string) => void;
   setShowTimestamps: (show: boolean) => void;
   setCapabilities: (caps: RrcHubCapabilities, hubHash?: string) => void;
+  setLimits: (limits: RrcHubLimits, hubHash?: string) => void;
   setListedRooms: (rooms: RrcListedRoom[], hubHash?: string) => void;
   setRoomTopic: (room: string, topic: string | null, hubHash?: string) => void;
   mergeRoomMembers: (
@@ -474,6 +482,7 @@ export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
   hubDestHash: null,
   hubName: null,
   capabilities: {},
+  limits: {},
   rooms: new Map(),
   listedRooms: [],
   activeRoom: null,
@@ -524,6 +533,10 @@ export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
 
   setCapabilities: (caps, hubHash) => {
     set((s) => mutateHubSession(s, hubHash, (session) => ({ ...session, capabilities: caps })));
+  },
+
+  setLimits: (limits, hubHash) => {
+    set((s) => mutateHubSession(s, hubHash, (session) => ({ ...session, limits })));
   },
 
   setListedRooms: (rooms, hubHash) => {

--- a/src/shared/rrc-types.ts
+++ b/src/shared/rrc-types.ts
@@ -64,6 +64,15 @@ export interface RrcHubCapabilities {
   resource_envelope?: boolean;
 }
 
+/** WELCOME `B_WELCOME_LIMITS` — hub-advertised operational caps (bytes / counts). */
+export interface RrcHubLimits {
+  max_nick_bytes?: number | null;
+  max_room_name_bytes?: number | null;
+  max_msg_body_bytes?: number | null;
+  max_rooms_per_session?: number | null;
+  rate_limit_msgs_per_minute?: number | null;
+}
+
 export interface RrcSessionSnapshot {
   status: RrcSessionStatus;
   hub_dest_hash?: string | null;
@@ -73,6 +82,7 @@ export interface RrcSessionSnapshot {
   rooms: RrcRoomInfo[];
   error?: string | null;
   capabilities?: RrcHubCapabilities | null;
+  limits?: RrcHubLimits | null;
 }
 
 /** Multi-hub status from sidecar `GET /rrc/status`. */


### PR DESCRIPTION
## Summary
- Plumb hub WELCOME limits (`max_msg_body_bytes`, `max_nick_bytes`, `max_room_name_bytes`) from the sidecar into `rrcSessionStore` (including `rrc.connected` emit).
- Replace the RRC room textarea with shared `ChatComposer` so oversize drafts get an input-line byte counter, emoji picker, and multi-part send under the hub body limit — slash commands still bypass split.
- Add nick/join field counters and block connect/join/`/nick`/`/join` when over hub caps; suppress the top red banner for residual hub body/nick limit errors.

## Test plan
- [ ] Connect to an RRC hub that advertises a body limit (e.g. 350) and confirm the composer counter appears near the limit and Send is disabled when over max
- [ ] Confirm a mid-length draft offers “Send N parts” and posts multiple room messages
- [ ] Confirm `/help`, `/join`, `/nick`, `/me` still work without `[1/N]` splitting
- [ ] Confirm emoji picker inserts into the RRC composer
- [ ] Confirm `@nick` autocomplete still inserts IRC-style `@Nick `
- [ ] Confirm nick and join-room fields show counters and block when over hub nick/room-name limits
- [ ] Confirm oversize send no longer leaves `message exceeds hub limit` in the top RRC error banner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hub-advertised limits for nicknames, room names, message sizes, rooms, and message rates.
  * Added UTF-8 byte counters and warnings for oversized nicknames and room names.
  * Prevented joining or connecting with inputs that exceed hub limits.
  * Large messages are automatically split when supported; slash commands bypass splitting.
  * Added slash-command interception and improved mention completion in chat.
* **Bug Fixes**
  * Improved validation and error handling for over-limit messages and names.
* **Tests**
  * Expanded coverage for limit handling, message splitting, and command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->