### PR TITLE
fix(nomad): apply NomadNet 1.4.1 image width and center align

### DIFF
--- a/src/renderer/lib/nomad/micronParser.test.ts
+++ b/src/renderer/lib/nomad/micronParser.test.ts
@@ -342,6 +342,56 @@ describe('NomadNet 1.4.1 micron images and collapsibles', () => {
     expect(img?.alt).toBe('The RNS logo');
     const figure = container.querySelector<HTMLElement>('.nomad-micron-media-figure');
     expect(figure?.style.textAlign).toBe('center');
+    expect(figure?.style.width).toBe('100%');
+    // w=n → no forced ch/% width
+    expect(img?.style.width).toBe('');
+  });
+
+  it('applies NomadNet column width and center align', () => {
+    const html = renderNomadMicronPage('`(x`w=30`a=c`:/media/x.webp)');
+    const container = document.createElement('div');
+    mountNomadMicronHtml(container, html);
+    const img = container.querySelector<HTMLImageElement>('.nomad-micron-media');
+    const figure = container.querySelector<HTMLElement>('.nomad-micron-media-figure');
+    expect(img?.style.width).toBe('30ch');
+    expect(img?.style.height).toBe('auto');
+    expect(figure?.style.textAlign).toBe('center');
+  });
+
+  it('applies percent width specs', () => {
+    const html = renderNomadMicronPage('`(x`w=30%`:/media/x.webp)');
+    const container = document.createElement('div');
+    mountNomadMicronHtml(container, html);
+    const img = container.querySelector<HTMLImageElement>('.nomad-micron-media');
+    expect(img?.style.width).toBe('30%');
+  });
+
+  it('defaults omitted width to full layout width and omitted align to center', () => {
+    const html = renderNomadMicronPage('`(x`:/media/x.webp)');
+    const container = document.createElement('div');
+    mountNomadMicronHtml(container, html);
+    const img = container.querySelector<HTMLImageElement>('.nomad-micron-media');
+    const figure = container.querySelector<HTMLElement>('.nomad-micron-media-figure');
+    expect(img?.style.width).toBe('100%');
+    expect(figure?.style.textAlign).toBe('center');
+  });
+
+  it('does not inherit page left align when image a= is omitted', () => {
+    const html = renderNomadMicronPage('`l\n`(x`w=20`:/media/x.webp)');
+    const container = document.createElement('div');
+    mountNomadMicronHtml(container, html);
+    const figure = container.querySelector<HTMLElement>('.nomad-micron-media-figure');
+    expect(figure?.style.textAlign).toBe('center');
+  });
+
+  it('applies both width and height with object-fit contain', () => {
+    const html = renderNomadMicronPage('`(x`w=40`h=10`:/media/x.webp)');
+    const container = document.createElement('div');
+    mountNomadMicronHtml(container, html);
+    const img = container.querySelector<HTMLImageElement>('.nomad-micron-media');
+    expect(img?.style.width).toBe('40ch');
+    expect(img?.style.height).toBe('10lh');
+    expect(img?.style.objectFit).toBe('contain');
   });
 
   it('renders open and collapsed collapsible headings as details/summary', () => {

--- a/src/renderer/lib/nomad/micronParser.test.ts
+++ b/src/renderer/lib/nomad/micronParser.test.ts
@@ -394,6 +394,19 @@ describe('NomadNet 1.4.1 micron images and collapsibles', () => {
     expect(img?.style.objectFit).toBe('contain');
   });
 
+  it('keeps full-width default for height-only images and centers independently of page align', () => {
+    const html = renderNomadMicronPage('`l\n`(x`h=12`:/media/x.webp)');
+    const container = document.createElement('div');
+    mountNomadMicronHtml(container, html);
+    const img = container.querySelector<HTMLImageElement>('.nomad-micron-media');
+    const figure = container.querySelector<HTMLElement>('.nomad-micron-media-figure');
+    expect(img?.style.width).toBe('100%');
+    expect(img?.style.height).toBe('12lh');
+    expect(img?.style.maxHeight).toBe('12lh');
+    expect(img?.style.objectFit).toBe('contain');
+    expect(figure?.style.textAlign).toBe('center');
+  });
+
   it('renders open and collapsed collapsible headings as details/summary', () => {
     const markup = [
       '`+>Open by default',

--- a/src/renderer/lib/nomad/vendor/micron-parser.js
+++ b/src/renderer/lib/nomad/vendor/micron-parser.js
@@ -1224,6 +1224,8 @@ class MicronParser {
   /**
    * NomadNet 1.4.1 image tag: `(alt`w=`h=`a=`url)
    * Emits an <img> placeholder; the view layer fetches /media bytes.
+   * Size/align match ImageWidget (columns→ch, NN%, n=native, omitted w=100%,
+   * omitted a=center).
    */
   parseImage(line, state) {
     const endpos = line.lastIndexOf(')');
@@ -1249,22 +1251,18 @@ class MicronParser {
       else if (key === 'a') alignProp = value;
     }
 
-    let alignCss = null;
-    if (alignProp === 'c') alignCss = 'center';
-    else if (alignProp === 'l') alignCss = 'left';
-    else if (alignProp === 'r') alignCss = 'right';
-    else if (alignProp === 'center' || alignProp === 'left' || alignProp === 'right') {
-      alignCss = alignProp;
-    } else if (state?.align === 'center' || state?.align === 'left' || state?.align === 'right') {
-      // Inherit page alignment when `a=` is omitted (avoids old NomadNet
-      // interpreting `` `a `` inside the image tag as an align reset).
-      alignCss = state.align;
-    }
+    // NomadNet ImageWidget defaults align to center when `a=` is omitted
+    // (does not inherit page `` `c `` / `` `l ``).
+    let alignCss = 'center';
+    if (alignProp === 'c' || alignProp === 'center') alignCss = 'center';
+    else if (alignProp === 'l' || alignProp === 'left') alignCss = 'left';
+    else if (alignProp === 'r' || alignProp === 'right') alignCss = 'right';
 
     const figure = document.createElement('figure');
     figure.className = 'nomad-micron-media-figure';
     this.applySectionIndent(figure, state);
-    if (alignCss) figure.style.textAlign = alignCss;
+    figure.style.width = '100%';
+    figure.style.textAlign = alignCss;
 
     const img = document.createElement('img');
     img.className = 'nomad-micron-media';
@@ -1275,6 +1273,44 @@ class MicronParser {
     if (height != null) img.setAttribute('data-h', String(height));
     if (alignProp != null) img.setAttribute('data-a', String(alignProp));
 
+    img.style.display = 'inline-block';
+    img.style.maxWidth = '100%';
+    img.style.verticalAlign = 'middle';
+
+    const widthCss = MicronParser._nomadImageSizeToCss(width, 'width');
+    const heightCss = MicronParser._nomadImageSizeToCss(height, 'height');
+    const widthConcrete = widthCss && widthCss !== 'native' && widthCss !== 'full';
+    const heightConcrete = heightCss && heightCss !== 'native' && heightCss !== 'full';
+
+    if (widthCss === 'native') {
+      // Leave width unset (intrinsic), capped by max-width.
+      img.style.height = 'auto';
+    } else if (widthConcrete) {
+      img.style.width = widthCss;
+      img.style.height = 'auto';
+    } else {
+      // Omitted w or invalid → NomadNet full layout width.
+      img.style.width = '100%';
+      img.style.height = 'auto';
+    }
+
+    if (heightConcrete) {
+      img.style.height = heightCss;
+      if (widthConcrete) {
+        img.style.objectFit = 'contain';
+      } else if (widthCss === 'native') {
+        img.style.maxHeight = heightCss;
+        img.style.height = 'auto';
+        img.style.objectFit = 'contain';
+      } else {
+        // Height-only (or full-width + height): constrain height, keep aspect.
+        img.style.width = 'auto';
+        img.style.maxHeight = heightCss;
+        img.style.height = heightCss;
+        img.style.objectFit = 'contain';
+      }
+    }
+
     const notice = document.createElement('figcaption');
     notice.className = 'nomad-micron-media-notice';
     notice.textContent = altText ? `[${altText}]` : '[image]';
@@ -1282,6 +1318,23 @@ class MicronParser {
     figure.appendChild(img);
     figure.appendChild(notice);
     return [figure];
+  }
+
+  /**
+   * Map NomadNet ImageWidget size specs to CSS.
+   * @returns {'full'|'native'|string|null} CSS length, sentinel, or null if omitted
+   */
+  static _nomadImageSizeToCss(value, axis) {
+    if (value == null || value === '') return null;
+    const v = String(value).trim();
+    if (!v) return null;
+    if (v.toLowerCase() === 'n') return 'native';
+    if (/^\d+$/.test(v)) {
+      // Terminal columns / rows → ch / lh.
+      return axis === 'height' ? `${v}lh` : `${v}ch`;
+    }
+    if (/^\d+(\.\d+)?%$/.test(v)) return v;
+    return null;
   }
 
   static upgradeInputToTextarea(input, options = {}) {

--- a/src/renderer/lib/nomad/vendor/micron-parser.js
+++ b/src/renderer/lib/nomad/vendor/micron-parser.js
@@ -1303,10 +1303,8 @@ class MicronParser {
         img.style.height = 'auto';
         img.style.objectFit = 'contain';
       } else {
-        // Height-only (or full-width + height): constrain height, keep aspect.
-        img.style.width = 'auto';
+        // Height-only (omitted w): keep full-width default; constrain height.
         img.style.maxHeight = heightCss;
-        img.style.height = heightCss;
         img.style.objectFit = 'contain';
       }
     }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -372,9 +372,11 @@ html[data-reduce-motion='true'] .cm-watermark-mesh-tube--flicker-off .cm-waterma
 }
 .nomad-micron-page .nomad-micron-media-figure {
   margin: 0.5em 0;
+  width: 100%;
   max-width: 100%;
 }
 .nomad-micron-page .nomad-micron-media {
+  display: inline-block;
   max-width: 100%;
   height: auto;
   vertical-align: middle;


### PR DESCRIPTION
## Summary
- Apply Micron image `w=` / `h=` / `a=` as CSS so pages like Zeva’s about.mu actually shrink and center (NomadNet 1.4.1 ImageWidget parity: columns→`ch`, `NN%`, `n`, omitted `w`→100%, omitted `a`→center).
- Stop inheriting page `` `c ``/`l` for images; figure is full-width with `text-align`, img is `inline-block`.
- Tests cover column/percent/native/full-width defaults, no page-align inheritance, and both `w`+`h` with `object-fit: contain`.

## Test plan
- [ ] `pnpm exec vitest run src/renderer/lib/nomad/micronParser.test.ts src/renderer/components/NomadMicronPageView.test.tsx`
- [ ] Open a Nomad page with `` `(alt`w=30`a=c`:/media/…) `` — image ~30ch wide and centered
- [ ] Omitted `a=` still centers; `` `a=l` `` left-aligns
- [ ] `w=n` stays native (capped by max-width); omitted `w` fills the pane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying image widths and heights using native, column, line-height, and percentage values.
  * Images now default to centered alignment and full available width when no size or alignment is provided.
  * Added support for preserving image proportions with contain-style fitting when both dimensions are specified.

* **Bug Fixes**
  * Image alignment now remains independent of page-level text alignment.
  * Improved consistency for inline image sizing and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->