### PR TITLE
fix(nomad): queue in-page /media fetches so multiple images load

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1295,20 +1295,20 @@ In dev, **Start stack** now rebuilds when `reticulum-sidecar/src/**/*.rs` or `Ca
 
 **Humanized error categories** (sidecar code → user message):
 
-| Sidecar code            | Meaning                                                             |
-| ----------------------- | ------------------------------------------------------------------- |
-| `path_timeout`          | No route to the node (path lookup timed out)                        |
-| `pubkey_not_found`      | Destination identity key not cached yet — wait for a Nomad announce |
-| `link_timeout`          | Link could not be established in time (UI may say path OK vs stale) |
-| `response_timeout`      | Link opened but page payload did not arrive in time                 |
-| `missing_identity_hash` | No remembered identity for the node yet                             |
-| `network_not_ready`     | No usable path/interface yet — wait for hub/path or restart stack   |
-| `nomad_not_serving`     | Remote node is not serving Nomad pages                              |
-| `invalid_url`           | Malformed Nomad page/file URL                                       |
-| `transport_unavailable` | Reticulum transport unavailable — restart stack                     |
-| `sidecar_not_running`   | Sidecar not running — start stack from Connection                   |
-| `response_too_large`    | Remote response exceeded the sidecar size cap                       |
-| `nomad_busy`            | Another Nomad page/file query still holds the link lock             |
+| Sidecar code            | Meaning                                                                                                                                                                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path_timeout`          | No route to the node (path lookup timed out)                                                                                                                                                                                                    |
+| `pubkey_not_found`      | Destination identity key not cached yet — wait for a Nomad announce                                                                                                                                                                             |
+| `link_timeout`          | Link could not be established in time (UI may say path OK vs stale)                                                                                                                                                                             |
+| `response_timeout`      | Link opened but page payload did not arrive in time                                                                                                                                                                                             |
+| `missing_identity_hash` | No remembered identity for the node yet                                                                                                                                                                                                         |
+| `network_not_ready`     | No usable path/interface yet — wait for hub/path or restart stack                                                                                                                                                                               |
+| `nomad_not_serving`     | Remote node is not serving Nomad pages                                                                                                                                                                                                          |
+| `invalid_url`           | Malformed Nomad page/file URL                                                                                                                                                                                                                   |
+| `transport_unavailable` | Reticulum transport unavailable — restart stack                                                                                                                                                                                                 |
+| `sidecar_not_running`   | Sidecar not running — start stack from Connection                                                                                                                                                                                               |
+| `response_too_large`    | Remote response exceeded the sidecar size cap                                                                                                                                                                                                   |
+| `nomad_busy`            | Another Nomad page/file query still holds the link lock, or a page navigation preempted an in-flight query. In-page `/media` images queue (do not cancel each other); rebuild sidecar if multiple images fail with this code on an older build. |
 
 Unrecognized codes pass through unchanged.
 

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -53,6 +53,10 @@ use super::lxmf_delivery::{
 };
 use super::nomad_file::{nomad_file_name_from_metadata_or_path, nomad_file_name_from_path};
 use super::nomad_link_errors::map_nomad_link_error;
+use super::nomad_link_schedule::{
+    NomadLinkSchedule, nomad_link_lock_wait, nomad_link_schedule_bumps_generation,
+    nomad_link_schedule_cancels_prior,
+};
 use super::nomad_request_payload::{nomad_media_request_payload, nomad_page_request_payload};
 use super::nomad_server::NomadServerHandle;
 use super::nomad_timeouts;
@@ -160,10 +164,12 @@ pub struct LiveBridge {
     #[allow(dead_code)]
     inbound_lxmf: Arc<super::lxmf_inbound_log::LxmfInboundBuffer>,
     /// Serialize Nomad Link queries — transport actor is single-threaded and
-    /// overlapping page/file fetches contend with path/pubkey discovery.
+    /// overlapping page/file/media fetches contend with path/pubkey discovery.
+    /// Page/file use last-wins cancel; `/media` queues under this lock.
     nomad_link_lock: Arc<tokio::sync::Mutex<()>>,
-    /// Cancel in-flight Nomad Link when a newer page selection arrives (renderer
-    /// debounce coalesces clicks; leaving the Nomad tab does not cancel).
+    /// Cancel in-flight Nomad Link when a newer page/file selection arrives
+    /// (renderer debounce coalesces clicks; leaving the Nomad tab does not cancel).
+    /// `/media` queues without claiming this slot until it holds the link lock.
     nomad_link_cancel: Arc<tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
     nomad_link_generation: Arc<AtomicU64>,
     rrc_session: Arc<RrcSessionManager>,
@@ -934,6 +940,7 @@ impl LiveBridge {
         interfaces: &[InterfaceRow],
         force_path_refresh: bool,
         progress_request_id: Option<&str>,
+        schedule: NomadLinkSchedule,
     ) -> Result<(Vec<u8>, NomadRemoteQueryOk), NomadRemoteQueryError> {
         let query_started = tokio::time::Instant::now();
         let remote_hash = parse_hash16(identity_hash_hex).map_err(|e| NomadRemoteQueryError {
@@ -1122,12 +1129,16 @@ impl LiveBridge {
             &live_interface_names(interfaces),
             interfaces,
         );
-        // One generation for this page request + all via failovers. Bumping per
-        // Link attempt would cancel a newer request when the older one retries.
-        let link_gen = self
-            .nomad_link_generation
-            .fetch_add(1, Ordering::SeqCst)
-            .wrapping_add(1);
+        // Preempt (page/file): one generation for this request + all via failovers.
+        // Queue (media): snapshot only — do not bump or cancel sibling image fetches.
+        // Bumping per Link attempt would cancel a newer request when the older one retries.
+        let link_gen = if nomad_link_schedule_bumps_generation(schedule) {
+            self.nomad_link_generation
+                .fetch_add(1, Ordering::SeqCst)
+                .wrapping_add(1)
+        } else {
+            self.nomad_link_generation.load(Ordering::SeqCst)
+        };
         self.emit_nomad_page_progress(
             hash_hex,
             path,
@@ -1154,6 +1165,7 @@ impl LiveBridge {
                 force_path_ok,
                 path_ensure_kind,
                 link_gen,
+                schedule,
             )
             .await;
 
@@ -1272,6 +1284,7 @@ impl LiveBridge {
                     Some(true),
                     Some(rediscovered),
                     link_gen,
+                    schedule,
                 )
                 .await;
             hops = failover_hops;
@@ -1311,8 +1324,10 @@ impl LiveBridge {
 
     /// One LinkClient Nomad query under the shared Nomad link lock / cancel slot.
     ///
-    /// `my_gen` is owned by the outer page request (see [`Self::query_nomad_node`]) so
+    /// `my_gen` is owned by the outer request (see [`Self::query_nomad_node`]) so
     /// via-failover retries do not bump generation or cancel a newer page load.
+    /// [`NomadLinkSchedule::Queue`] snapshots generation without bumping so sibling
+    /// `/media` fetches serialize on the lock instead of preempting each other.
     #[allow(clippy::too_many_arguments, clippy::result_large_err)] // hops / budgets / Nomad Link Err diagnostics
     async fn nomad_link_client_query(
         &self,
@@ -1326,85 +1341,73 @@ impl LiveBridge {
         force_path_ok: Option<bool>,
         path_ensure_kind: Option<&'static str>,
         my_gen: u64,
+        schedule: NomadLinkSchedule,
     ) -> Result<(Vec<u8>, Option<Vec<u8>>), NomadRemoteQueryError> {
+        let busy = || NomadRemoteQueryError {
+            code: "nomad_busy".into(),
+            egress: Some(egress),
+            path_hops: Some(hops),
+            link_hops: Some(link_hops),
+            timeout_secs: Some(timeout_secs),
+            force_path_ok,
+            path_ensure_kind,
+            raw_error: None,
+            elapsed_ms: None,
+            tried_interfaces: None,
+            failover_rounds: None,
+            last_iface: None,
+        };
         // Abort before touching the cancel slot so a superseded failover cannot
         // cancel the newer request that already owns last-request-wins.
         if self.nomad_link_generation.load(Ordering::SeqCst) != my_gen {
-            return Err(NomadRemoteQueryError {
-                code: "nomad_busy".into(),
-                egress: Some(egress),
-                path_hops: Some(hops),
-                link_hops: Some(link_hops),
-                timeout_secs: Some(timeout_secs),
-                force_path_ok,
-                path_ensure_kind,
-                raw_error: None,
-                elapsed_ms: None,
-                tried_interfaces: None,
-                failover_rounds: None,
-                last_iface: None,
-            });
+            return Err(busy());
         }
+        let lock_wait = nomad_link_lock_wait(schedule, NOMAD_LINK_LOCK_WAIT, timeout_secs);
         let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
-        {
-            let mut slot = self.nomad_link_cancel.lock().await;
+        let guard = if nomad_link_schedule_cancels_prior(schedule) {
+            // Preempt: claim cancel (abort prior Link) then wait for the lock.
+            {
+                let mut slot = self.nomad_link_cancel.lock().await;
+                if self.nomad_link_generation.load(Ordering::SeqCst) != my_gen {
+                    return Err(busy());
+                }
+                if let Some(prev) = slot.take() {
+                    let _ = prev.send(());
+                }
+                *slot = Some(cancel_tx);
+            }
+            let Ok(guard) = tokio::time::timeout(lock_wait, self.nomad_link_lock.lock()).await
+            else {
+                if self.nomad_link_generation.load(Ordering::SeqCst) == my_gen {
+                    *self.nomad_link_cancel.lock().await = None;
+                }
+                return Err(busy());
+            };
+            guard
+        } else {
+            // Queue: wait for the lock without canceling siblings; install cancel
+            // only while holding the lock so a later Preempt can still abort us.
+            let Ok(guard) = tokio::time::timeout(lock_wait, self.nomad_link_lock.lock()).await
+            else {
+                return Err(busy());
+            };
             if self.nomad_link_generation.load(Ordering::SeqCst) != my_gen {
-                return Err(NomadRemoteQueryError {
-                    code: "nomad_busy".into(),
-                    egress: Some(egress),
-                    path_hops: Some(hops),
-                    link_hops: Some(link_hops),
-                    timeout_secs: Some(timeout_secs),
-                    force_path_ok,
-                    path_ensure_kind,
-                    raw_error: None,
-                    elapsed_ms: None,
-                    tried_interfaces: None,
-                    failover_rounds: None,
-                    last_iface: None,
-                });
+                return Err(busy());
             }
-            if let Some(prev) = slot.take() {
-                let _ = prev.send(());
+            {
+                let mut slot = self.nomad_link_cancel.lock().await;
+                if self.nomad_link_generation.load(Ordering::SeqCst) != my_gen {
+                    return Err(busy());
+                }
+                if let Some(prev) = slot.take() {
+                    let _ = prev.send(());
+                }
+                *slot = Some(cancel_tx);
             }
-            *slot = Some(cancel_tx);
-        }
-        let Ok(guard) =
-            tokio::time::timeout(NOMAD_LINK_LOCK_WAIT, self.nomad_link_lock.lock()).await
-        else {
-            if self.nomad_link_generation.load(Ordering::SeqCst) == my_gen {
-                *self.nomad_link_cancel.lock().await = None;
-            }
-            return Err(NomadRemoteQueryError {
-                code: "nomad_busy".into(),
-                egress: Some(egress),
-                path_hops: Some(hops),
-                link_hops: Some(link_hops),
-                timeout_secs: Some(timeout_secs),
-                force_path_ok,
-                path_ensure_kind,
-                raw_error: None,
-                elapsed_ms: None,
-                tried_interfaces: None,
-                failover_rounds: None,
-                last_iface: None,
-            });
+            guard
         };
         if self.nomad_link_generation.load(Ordering::SeqCst) != my_gen {
-            return Err(NomadRemoteQueryError {
-                code: "nomad_busy".into(),
-                egress: Some(egress),
-                path_hops: Some(hops),
-                link_hops: Some(link_hops),
-                timeout_secs: Some(timeout_secs),
-                force_path_ok,
-                path_ensure_kind,
-                raw_error: None,
-                elapsed_ms: None,
-                tried_interfaces: None,
-                failover_rounds: None,
-                last_iface: None,
-            });
+            return Err(busy());
         }
         let client = LinkClient::new(self.handle.transport_tx.clone(), self.identity.clone());
         let query_fut = client.query(
@@ -1417,20 +1420,7 @@ impl LiveBridge {
         );
         let result = tokio::select! {
             biased;
-            _ = cancel_rx => Err(NomadRemoteQueryError {
-                code: "nomad_busy".into(),
-                egress: Some(egress),
-                path_hops: Some(hops),
-                link_hops: Some(link_hops),
-                timeout_secs: Some(timeout_secs),
-                force_path_ok,
-                path_ensure_kind,
-                raw_error: None,
-                elapsed_ms: None,
-                tried_interfaces: None,
-                failover_rounds: None,
-                last_iface: None,
-            }),
+            _ = cancel_rx => Err(busy()),
             query_result = query_fut => {
                 query_result
                     .map(|resp| (resp.data, resp.metadata))
@@ -1690,6 +1680,7 @@ impl LiveBridge {
                 interfaces,
                 force_path_refresh,
                 None,
+                NomadLinkSchedule::Preempt,
             )
             .await
         {
@@ -1715,6 +1706,8 @@ impl LiveBridge {
 
     /// Fetch NomadNet 1.4.1 in-page WebP via Link query path `/media` with
     /// `{path, key: nil}` payload (not the `/file/...` route).
+    /// Uses [`NomadLinkSchedule::Queue`] so multiple images on one page serialize
+    /// under the Link lock instead of last-wins cancel (`nomad_busy`).
     /// See `fetch_nomad_file` for `hash_hex` / `identity_hash_hex` semantics.
     pub async fn fetch_nomad_media(
         &self,
@@ -1762,6 +1755,7 @@ impl LiveBridge {
                 interfaces,
                 force_path_refresh,
                 None,
+                NomadLinkSchedule::Queue,
             )
             .await
         {
@@ -1842,6 +1836,7 @@ impl LiveBridge {
                 interfaces,
                 force_path_refresh,
                 progress_request_id,
+                NomadLinkSchedule::Preempt,
             )
             .await
         {

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -56,6 +56,7 @@ use super::nomad_link_errors::map_nomad_link_error;
 use super::nomad_link_schedule::{
     NomadLinkSchedule, nomad_link_lock_wait, nomad_link_schedule_bumps_generation,
     nomad_link_schedule_cancels_prior, nomad_link_schedule_holds_request_queue,
+    nomad_media_queue_lock_wait,
 };
 use super::nomad_request_payload::{nomad_media_request_payload, nomad_page_request_payload};
 use super::nomad_server::NomadServerHandle;
@@ -1147,8 +1148,17 @@ impl LiveBridge {
         // Queue: hold request mutex across Link attempts + suppress_via_and_rediscover
         // so a sibling /media fetch cannot start in the failover gap. Preempt skips
         // this lock (last-wins via generation/cancel). Attempt lock stays separate.
+        // Wait budget covers full lifecycle (attempts + rediscovery), not one Link.
         let _media_queue_guard = if nomad_link_schedule_holds_request_queue(schedule) {
-            let wait = nomad_link_lock_wait(schedule, NOMAD_LINK_LOCK_WAIT, timeout_secs);
+            let rediscover_secs = path_failover::VIA_FAILOVER_PROBE_WAIT
+                .saturating_add(path_failover::VIA_FAILOVER_EXTRA_PROBE_WAIT)
+                .as_secs();
+            let wait = nomad_media_queue_lock_wait(
+                timeout_secs,
+                NOMAD_LINK_LOCK_WAIT,
+                path_failover::MAX_VIA_FAILOVERS,
+                rediscover_secs,
+            );
             match tokio::time::timeout(wait, self.nomad_media_queue_lock.lock()).await {
                 Ok(g) => Some(g),
                 Err(_) => {

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -55,7 +55,7 @@ use super::nomad_file::{nomad_file_name_from_metadata_or_path, nomad_file_name_f
 use super::nomad_link_errors::map_nomad_link_error;
 use super::nomad_link_schedule::{
     NomadLinkSchedule, nomad_link_lock_wait, nomad_link_schedule_bumps_generation,
-    nomad_link_schedule_cancels_prior,
+    nomad_link_schedule_cancels_prior, nomad_link_schedule_holds_request_queue,
 };
 use super::nomad_request_payload::{nomad_media_request_payload, nomad_page_request_payload};
 use super::nomad_server::NomadServerHandle;
@@ -163,13 +163,17 @@ pub struct LiveBridge {
     /// delivery callback Arc stays alive for the lifetime of the bridge.
     #[allow(dead_code)]
     inbound_lxmf: Arc<super::lxmf_inbound_log::LxmfInboundBuffer>,
-    /// Serialize Nomad Link queries — transport actor is single-threaded and
-    /// overlapping page/file/media fetches contend with path/pubkey discovery.
-    /// Page/file use last-wins cancel; `/media` queues under this lock.
+    /// Serialize Nomad Link *attempts* — transport actor is single-threaded and
+    /// overlapping page/file/media Link queries contend with path/pubkey discovery.
+    /// Held only for one LinkClient query (released between via-failover rounds).
     nomad_link_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Request-scoped serialization for [`NomadLinkSchedule::Queue`] (`/media`):
+    /// held across the initial Link attempt and all via-failover work so a sibling
+    /// image cannot start while the first is in `suppress_via_and_rediscover`.
+    nomad_media_queue_lock: Arc<tokio::sync::Mutex<()>>,
     /// Cancel in-flight Nomad Link when a newer page/file selection arrives
     /// (renderer debounce coalesces clicks; leaving the Nomad tab does not cancel).
-    /// `/media` queues without claiming this slot until it holds the link lock.
+    /// `/media` installs this slot only while holding `nomad_link_lock`.
     nomad_link_cancel: Arc<tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
     nomad_link_generation: Arc<AtomicU64>,
     rrc_session: Arc<RrcSessionManager>,
@@ -525,6 +529,7 @@ impl LiveBridge {
             packet_log,
             inbound_lxmf,
             nomad_link_lock: Arc::new(tokio::sync::Mutex::new(())),
+            nomad_media_queue_lock: Arc::new(tokio::sync::Mutex::new(())),
             nomad_link_cancel: Arc::new(tokio::sync::Mutex::new(None)),
             nomad_link_generation: Arc::new(AtomicU64::new(0)),
             rrc_session: Arc::new(RrcSessionManager::spawn(
@@ -1139,6 +1144,33 @@ impl LiveBridge {
         } else {
             self.nomad_link_generation.load(Ordering::SeqCst)
         };
+        // Queue: hold request mutex across Link attempts + suppress_via_and_rediscover
+        // so a sibling /media fetch cannot start in the failover gap. Preempt skips
+        // this lock (last-wins via generation/cancel). Attempt lock stays separate.
+        let _media_queue_guard = if nomad_link_schedule_holds_request_queue(schedule) {
+            let wait = nomad_link_lock_wait(schedule, NOMAD_LINK_LOCK_WAIT, timeout_secs);
+            match tokio::time::timeout(wait, self.nomad_media_queue_lock.lock()).await {
+                Ok(g) => Some(g),
+                Err(_) => {
+                    return Err(NomadRemoteQueryError {
+                        code: "nomad_busy".into(),
+                        egress: Some(egress),
+                        path_hops: Some(hops),
+                        link_hops: Some(link_hops),
+                        timeout_secs: Some(timeout_secs),
+                        force_path_ok,
+                        path_ensure_kind,
+                        raw_error: None,
+                        elapsed_ms: Some(elapsed_ms_since(query_started)),
+                        tried_interfaces: None,
+                        failover_rounds: None,
+                        last_iface: current_iface.clone(),
+                    });
+                }
+            }
+        } else {
+            None
+        };
         self.emit_nomad_page_progress(
             hash_hex,
             path,
@@ -1327,7 +1359,9 @@ impl LiveBridge {
     /// `my_gen` is owned by the outer request (see [`Self::query_nomad_node`]) so
     /// via-failover retries do not bump generation or cancel a newer page load.
     /// [`NomadLinkSchedule::Queue`] snapshots generation without bumping so sibling
-    /// `/media` fetches serialize on the lock instead of preempting each other.
+    /// `/media` fetches do not preempt each other. Request-level serialization is
+    /// `nomad_media_queue_lock` in [`Self::query_nomad_node`]; this method only holds
+    /// `nomad_link_lock` for one Link attempt.
     #[allow(clippy::too_many_arguments, clippy::result_large_err)] // hops / budgets / Nomad Link Err diagnostics
     async fn nomad_link_client_query(
         &self,
@@ -1707,7 +1741,8 @@ impl LiveBridge {
     /// Fetch NomadNet 1.4.1 in-page WebP via Link query path `/media` with
     /// `{path, key: nil}` payload (not the `/file/...` route).
     /// Uses [`NomadLinkSchedule::Queue`] so multiple images on one page serialize
-    /// under the Link lock instead of last-wins cancel (`nomad_busy`).
+    /// under `nomad_media_queue_lock` across Link + via-failover (not last-wins
+    /// cancel / `nomad_busy` between siblings).
     /// See `fetch_nomad_file` for `hash_hex` / `identity_hash_hex` semantics.
     pub async fn fetch_nomad_media(
         &self,

--- a/reticulum-sidecar/src/stack/mod.rs
+++ b/reticulum-sidecar/src/stack/mod.rs
@@ -16,6 +16,7 @@ mod lxmf_inbound_log;
 mod nomad_content_source;
 mod nomad_file;
 mod nomad_link_errors;
+mod nomad_link_schedule;
 #[cfg(feature = "rns-stack")]
 mod nomad_request_payload;
 mod nomad_timeouts;

--- a/reticulum-sidecar/src/stack/nomad_link_schedule.rs
+++ b/reticulum-sidecar/src/stack/nomad_link_schedule.rs
@@ -1,0 +1,82 @@
+//! Nomad Link scheduling: page/file preempt vs in-page media queue.
+//!
+//! Page and file fetches use last-wins cancel so a newer navigation aborts an
+//! older Link. In-page `/media` images must queue under the shared lock without
+//! canceling siblings — otherwise concurrent media fetches race to `nomad_busy`.
+
+use std::time::Duration;
+
+/// How a Nomad Link query interacts with the shared lock / cancel slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NomadLinkSchedule {
+    /// Page/file: bump generation and cancel any in-flight prior Link.
+    Preempt,
+    /// Media: wait for the lock without canceling siblings; still abort if a
+    /// later [`Preempt`] bumps generation (navigation away).
+    Queue,
+}
+
+/// Whether starting this schedule cancels an in-flight prior Link.
+pub fn nomad_link_schedule_cancels_prior(schedule: NomadLinkSchedule) -> bool {
+    matches!(schedule, NomadLinkSchedule::Preempt)
+}
+
+/// Whether this schedule bumps the shared generation counter (last-wins).
+pub fn nomad_link_schedule_bumps_generation(schedule: NomadLinkSchedule) -> bool {
+    matches!(schedule, NomadLinkSchedule::Preempt)
+}
+
+/// Lock-acquire budget for the given schedule.
+///
+/// Preempt uses a short unwind window after canceling the prior query.
+/// Queue waits up to the Link query timeout so a slow sibling image does not
+/// fail later images with `nomad_busy`.
+pub fn nomad_link_lock_wait(
+    schedule: NomadLinkSchedule,
+    preempt_wait: Duration,
+    query_timeout_secs: u64,
+) -> Duration {
+    match schedule {
+        NomadLinkSchedule::Preempt => preempt_wait,
+        NomadLinkSchedule::Queue => {
+            let secs = query_timeout_secs.max(preempt_wait.as_secs());
+            Duration::from_secs(secs)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preempt_cancels_and_bumps_generation() {
+        assert!(nomad_link_schedule_cancels_prior(
+            NomadLinkSchedule::Preempt
+        ));
+        assert!(nomad_link_schedule_bumps_generation(
+            NomadLinkSchedule::Preempt
+        ));
+        assert!(!nomad_link_schedule_cancels_prior(NomadLinkSchedule::Queue));
+        assert!(!nomad_link_schedule_bumps_generation(
+            NomadLinkSchedule::Queue
+        ));
+    }
+
+    #[test]
+    fn queue_lock_wait_uses_query_timeout_floor_preempt() {
+        let preempt = Duration::from_secs(8);
+        assert_eq!(
+            nomad_link_lock_wait(NomadLinkSchedule::Preempt, preempt, 120),
+            preempt
+        );
+        assert_eq!(
+            nomad_link_lock_wait(NomadLinkSchedule::Queue, preempt, 120),
+            Duration::from_secs(120)
+        );
+        assert_eq!(
+            nomad_link_lock_wait(NomadLinkSchedule::Queue, preempt, 3),
+            Duration::from_secs(8)
+        );
+    }
+}

--- a/reticulum-sidecar/src/stack/nomad_link_schedule.rs
+++ b/reticulum-sidecar/src/stack/nomad_link_schedule.rs
@@ -37,11 +37,10 @@ pub fn nomad_link_schedule_holds_request_queue(schedule: NomadLinkSchedule) -> b
     matches!(schedule, NomadLinkSchedule::Queue)
 }
 
-/// Lock-acquire budget for the given schedule.
+/// Lock-acquire budget for a single Link attempt / Preempt unwind.
 ///
 /// Preempt uses a short unwind window after canceling the prior query.
-/// Queue waits up to the Link query timeout so a slow sibling image does not
-/// fail later images with `nomad_busy`.
+/// Queue attempt waits floor at the Link query timeout (per attempt only).
 pub fn nomad_link_lock_wait(
     schedule: NomadLinkSchedule,
     preempt_wait: Duration,
@@ -54,6 +53,27 @@ pub fn nomad_link_lock_wait(
             Duration::from_secs(secs)
         }
     }
+}
+
+/// Wait budget for the request-scoped `/media` queue mutex.
+///
+/// Covers the full protected lifecycle held under `nomad_media_queue_lock`:
+/// initial Link + up to `max_via_failovers` retries, each with a rediscovery
+/// window (`rediscover_secs_per_failover`), not a single `timeout_secs` attempt.
+pub fn nomad_media_queue_lock_wait(
+    query_timeout_secs: u64,
+    preempt_wait: Duration,
+    max_via_failovers: u8,
+    rediscover_secs_per_failover: u64,
+) -> Duration {
+    let attempts = u64::from(max_via_failovers).saturating_add(1);
+    let link_budget = query_timeout_secs.saturating_mul(attempts);
+    let rediscover_budget =
+        u64::from(max_via_failovers).saturating_mul(rediscover_secs_per_failover);
+    let secs = link_budget
+        .saturating_add(rediscover_budget)
+        .max(preempt_wait.as_secs());
+    Duration::from_secs(secs)
 }
 
 #[cfg(test)]
@@ -100,12 +120,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn media_queue_lock_wait_covers_attempts_plus_rediscovery() {
+        let preempt = Duration::from_secs(8);
+        // 3 attempts × 45s + 2 × 16s rediscover = 167s
+        assert_eq!(
+            nomad_media_queue_lock_wait(45, preempt, 2, 16),
+            Duration::from_secs(167)
+        );
+        // Tiny query timeout still floors at preempt unwind.
+        assert_eq!(
+            nomad_media_queue_lock_wait(1, preempt, 0, 0),
+            Duration::from_secs(8)
+        );
+    }
+
     /// Queue B must stay blocked while Queue A holds the request mutex through
     /// a failover gap (link attempt lock released, rediscover in progress).
     #[tokio::test]
     async fn queue_request_mutex_blocks_sibling_through_failover_gap() {
         let request_queue = Arc::new(Mutex::new(()));
         let link_attempt = Arc::new(Mutex::new(()));
+        let (a_holding_tx, a_holding_rx) = tokio::sync::oneshot::channel::<()>();
         let (a_in_failover_tx, a_in_failover_rx) = tokio::sync::oneshot::channel::<()>();
         let (release_failover_tx, release_failover_rx) = tokio::sync::oneshot::channel::<()>();
         let b_entered_request = Arc::new(AtomicBool::new(false));
@@ -114,6 +150,7 @@ mod tests {
         let link_a = Arc::clone(&link_attempt);
         let task_a = tokio::spawn(async move {
             let _request = queue_a.lock().await;
+            let _ = a_holding_tx.send(());
             {
                 let _link = link_a.lock().await;
                 // initial Link attempt
@@ -126,6 +163,11 @@ mod tests {
                 // failover Link attempt
             }
         });
+
+        // Spawn B only after A holds the request mutex (deterministic ordering).
+        a_holding_rx
+            .await
+            .expect("A acquired request mutex before spawning B");
 
         let queue_b = Arc::clone(&request_queue);
         let link_b = Arc::clone(&link_attempt);

--- a/reticulum-sidecar/src/stack/nomad_link_schedule.rs
+++ b/reticulum-sidecar/src/stack/nomad_link_schedule.rs
@@ -1,8 +1,10 @@
 //! Nomad Link scheduling: page/file preempt vs in-page media queue.
 //!
 //! Page and file fetches use last-wins cancel so a newer navigation aborts an
-//! older Link. In-page `/media` images must queue under the shared lock without
-//! canceling siblings — otherwise concurrent media fetches race to `nomad_busy`.
+//! older Link. In-page `/media` images must queue under a request-scoped mutex
+//! across the full Link + via-failover lifecycle without canceling siblings —
+//! otherwise concurrent media fetches race to `nomad_busy`, including during
+//! the gap when `nomad_link_lock` is released between Link attempts.
 
 use std::time::Duration;
 
@@ -11,8 +13,8 @@ use std::time::Duration;
 pub enum NomadLinkSchedule {
     /// Page/file: bump generation and cancel any in-flight prior Link.
     Preempt,
-    /// Media: wait for the lock without canceling siblings; still abort if a
-    /// later [`Preempt`] bumps generation (navigation away).
+    /// Media: wait for the request queue without canceling siblings; still abort
+    /// if a later [`Preempt`] bumps generation (navigation away).
     Queue,
 }
 
@@ -24,6 +26,15 @@ pub fn nomad_link_schedule_cancels_prior(schedule: NomadLinkSchedule) -> bool {
 /// Whether this schedule bumps the shared generation counter (last-wins).
 pub fn nomad_link_schedule_bumps_generation(schedule: NomadLinkSchedule) -> bool {
     matches!(schedule, NomadLinkSchedule::Preempt)
+}
+
+/// Whether this schedule holds a request-scoped mutex across Link + failover.
+///
+/// Distinct from `nomad_link_lock` (per Link attempt) so Queue can release the
+/// attempt lock during `suppress_via_and_rediscover` without letting another
+/// media fetch start.
+pub fn nomad_link_schedule_holds_request_queue(schedule: NomadLinkSchedule) -> bool {
+    matches!(schedule, NomadLinkSchedule::Queue)
 }
 
 /// Lock-acquire budget for the given schedule.
@@ -48,6 +59,9 @@ pub fn nomad_link_lock_wait(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::Mutex;
 
     #[test]
     fn preempt_cancels_and_bumps_generation() {
@@ -57,8 +71,14 @@ mod tests {
         assert!(nomad_link_schedule_bumps_generation(
             NomadLinkSchedule::Preempt
         ));
+        assert!(!nomad_link_schedule_holds_request_queue(
+            NomadLinkSchedule::Preempt
+        ));
         assert!(!nomad_link_schedule_cancels_prior(NomadLinkSchedule::Queue));
         assert!(!nomad_link_schedule_bumps_generation(
+            NomadLinkSchedule::Queue
+        ));
+        assert!(nomad_link_schedule_holds_request_queue(
             NomadLinkSchedule::Queue
         ));
     }
@@ -78,5 +98,53 @@ mod tests {
             nomad_link_lock_wait(NomadLinkSchedule::Queue, preempt, 3),
             Duration::from_secs(8)
         );
+    }
+
+    /// Queue B must stay blocked while Queue A holds the request mutex through
+    /// a failover gap (link attempt lock released, rediscover in progress).
+    #[tokio::test]
+    async fn queue_request_mutex_blocks_sibling_through_failover_gap() {
+        let request_queue = Arc::new(Mutex::new(()));
+        let link_attempt = Arc::new(Mutex::new(()));
+        let (a_in_failover_tx, a_in_failover_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_failover_tx, release_failover_rx) = tokio::sync::oneshot::channel::<()>();
+        let b_entered_request = Arc::new(AtomicBool::new(false));
+
+        let queue_a = Arc::clone(&request_queue);
+        let link_a = Arc::clone(&link_attempt);
+        let task_a = tokio::spawn(async move {
+            let _request = queue_a.lock().await;
+            {
+                let _link = link_a.lock().await;
+                // initial Link attempt
+            }
+            // Failover gap: attempt lock released; request mutex still held.
+            let _ = a_in_failover_tx.send(());
+            let _ = release_failover_rx.await;
+            {
+                let _link = link_a.lock().await;
+                // failover Link attempt
+            }
+        });
+
+        let queue_b = Arc::clone(&request_queue);
+        let link_b = Arc::clone(&link_attempt);
+        let b_flag = Arc::clone(&b_entered_request);
+        let task_b = tokio::spawn(async move {
+            let _request = queue_b.lock().await;
+            b_flag.store(true, Ordering::SeqCst);
+            let _link = link_b.lock().await;
+        });
+
+        a_in_failover_rx.await.expect("A reached failover gap");
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(
+            !b_entered_request.load(Ordering::SeqCst),
+            "Queue B must not enter the request mutex while A is in failover"
+        );
+        release_failover_tx.send(()).expect("release A failover");
+        task_a.await.expect("A");
+        task_b.await.expect("B");
+        assert!(b_entered_request.load(Ordering::SeqCst));
     }
 }

--- a/src/renderer/lib/nomad/micronParser.test.ts
+++ b/src/renderer/lib/nomad/micronParser.test.ts
@@ -455,11 +455,8 @@ describe('NomadNet 1.4.1 micron images and collapsibles', () => {
     expect(isNomadMediaPath('/file/demo.webp')).toBe(false);
   });
 
-  it('limits concurrent /media fetches to the configured pool size', async () => {
-    const lines = Array.from(
-      { length: NOMAD_MICRON_MEDIA_FETCH_CONCURRENCY + 3 },
-      (_, i) => `\`(Img ${i}\`:/media/i${i}.webp)`,
-    );
+  it('serializes /media fetches (concurrency 1, NomadNet Link parity)', async () => {
+    const lines = Array.from({ length: 4 }, (_, i) => `\`(Img ${i}\`:/media/i${i}.webp)`);
     const container = document.createElement('div');
     mountNomadMicronHtml(container, renderNomadMicronPage(lines.join('\n')));
 
@@ -483,9 +480,9 @@ describe('NomadNet 1.4.1 micron images and collapsibles', () => {
       concurrency: NOMAD_MICRON_MEDIA_FETCH_CONCURRENCY,
     });
 
-    expect(fetchMedia).toHaveBeenCalledTimes(NOMAD_MICRON_MEDIA_FETCH_CONCURRENCY + 3);
-    expect(maxInFlight).toBeLessThanOrEqual(NOMAD_MICRON_MEDIA_FETCH_CONCURRENCY);
-    expect(maxInFlight).toBeGreaterThan(1);
+    expect(fetchMedia).toHaveBeenCalledTimes(4);
+    expect(maxInFlight).toBe(1);
+    expect(NOMAD_MICRON_MEDIA_FETCH_CONCURRENCY).toBe(1);
   });
 
   it('skips DOM updates after AbortSignal aborts', async () => {

--- a/src/renderer/lib/nomad/micronParser.ts
+++ b/src/renderer/lib/nomad/micronParser.ts
@@ -187,8 +187,8 @@ export interface NomadMicronMediaFetchResult {
   error?: string;
 }
 
-/** Max in-flight Nomad `/media` fetches per bind (avoids stampeding a node). */
-export const NOMAD_MICRON_MEDIA_FETCH_CONCURRENCY = 4;
+/** Max in-flight Nomad `/media` fetches per bind (serialize like NomadNet Link use). */
+export const NOMAD_MICRON_MEDIA_FETCH_CONCURRENCY = 1;
 
 async function runPool<T>(
   items: readonly T[],


### PR DESCRIPTION
## Problem

NomadNet 1.4.1 micron pages can embed multiple `/media` images. In mesh-client, opening a page with two images often failed the first (`Could not load Colorado Mesh Banner`) while the second succeeded. The same page loaded both images in NomadNet.

**Root cause:** peer `/media` fetches shared the sidecar’s last-wins Nomad Link cancel path used for page/file navigation.

1. The renderer started up to **4** parallel `/media` fetches.
2. Each call bumped `nomad_link_generation` and canceled the prior in-flight Link.
3. Older images returned `nomad_busy`; with alt text the UI showed only `Could not load ${alt}` (error code hidden).

A follow-up gap remained after the first fix: Queue mode no longer canceled siblings, but `nomad_link_lock` is released between Link attempts. During `suppress_via_and_rediscover` (via failover), a second `/media` request could start while the first was still mid-request.

## Solution

### Link schedule (`NomadLinkSchedule`)

| Mode | Used by | Behavior |
| --- | --- | --- |
| **Preempt** | page / file | Bump generation, cancel prior Link (unchanged last-wins navigation). |
| **Queue** | `/media` | Snapshot generation (no bump), do not cancel siblings. |

### Request-scoped media queue lock

- Added `nomad_media_queue_lock`, held for the **entire** Queue lifecycle: initial Link attempt **and** all via-failover work (including `suppress_via_and_rediscover`).
- `nomad_link_lock` remains **per Link attempt only** (avoids recursive acquisition; Preempt can still cancel an in-flight attempt).
- Queue lock wait uses the Link query timeout floor so a slow first image does not fail later siblings with an 8s preempt-unwind budget.

### Renderer

- `NOMAD_MICRON_MEDIA_FETCH_CONCURRENCY` set to **1** (NomadNet-like serialization; defense in depth).

### Tests / docs

- Unit coverage for schedule helpers + regression test that Queue B stays blocked while Queue A holds the request mutex through a failover gap.
- Troubleshooting note for `nomad_busy` updated for multi-image / older sidecar builds.

## Commits

- `fix(nomad): queue in-page /media fetches so multiple images load`
- `fix(nomad): hold media queue lock across via-failover gaps`

## Test plan

- [ ] Rebuild/restart Reticulum sidecar
- [ ] Open a Nomad page with 2+ `/media` images (e.g. Colorado Mesh banner + Image Test)
- [ ] Confirm both images load (no `Could not load …` on the first)
- [ ] Navigate to another page mid-image-load and confirm the new page still preempts cleanly
- [ ] `pnpm exec vitest run src/renderer/lib/nomad/micronParser.test.ts`
- [ ] `cargo test nomad_link_schedule` in `reticulum-sidecar`