### PR TITLE
fix: stabilize production Electron E2E launches

### DIFF
--- a/e2e/startup.spec.ts
+++ b/e2e/startup.spec.ts
@@ -11,7 +11,13 @@ test.describe('startup', () => {
 
   test('launches main window with protocol switcher', async () => {
     launched = await launchApp();
-    const { page } = launched;
+    const { app, page } = launched;
+
+    expect(
+      await app.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().some((win) => win.webContents.isDevToolsOpened()),
+      ),
+    ).toBe(false);
 
     await expect(page).toHaveTitle('Mesh Client');
     await expect(page.locator('#root')).toBeVisible();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,8 @@ export default tseslint.config(
       '*.config.{ts,js,mjs,cjs}',
       'dist-electron/**',
       'coverage/**',
+      'playwright-report/**',
+      'test-results/**',
     ],
   },
   js.configs.recommended,

--- a/src/main/resolveRendererLoadUrl.test.ts
+++ b/src/main/resolveRendererLoadUrl.test.ts
@@ -23,6 +23,22 @@ describe('resolveRendererLoadUrl', () => {
     });
   });
 
+  it.each([
+    ['linux', 'file:///home/runner/mesh-client/dist/renderer/index.html'],
+    ['darwin', 'file:///Users/runner/mesh-client/dist/renderer/index.html'],
+    ['win32', 'file:///D:/a/mesh-client/dist/renderer/index.html'],
+  ])('loads an explicit production file without DevTools on %s', async (_platform, url) => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const resolved = await resolveRendererLoadUrl({
+      packaged: false,
+      devServerUrl: url,
+      distIndexPath: '/unused/index.html',
+      isDevServerReachable: probe,
+    });
+    expect(resolved).toEqual({ url, openDevTools: false, source: 'env' });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
   it('probes local Vite when unpackaged and env is unset', async () => {
     const probe = vi.fn().mockResolvedValue(true);
     const resolved = await resolveRendererLoadUrl({

--- a/src/main/resolveRendererLoadUrl.test.ts
+++ b/src/main/resolveRendererLoadUrl.test.ts
@@ -27,6 +27,10 @@ describe('resolveRendererLoadUrl', () => {
     ['linux', 'file:///home/runner/mesh-client/dist/renderer/index.html'],
     ['darwin', 'file:///Users/runner/mesh-client/dist/renderer/index.html'],
     ['win32', 'file:///D:/a/mesh-client/dist/renderer/index.html'],
+    ['linux', 'FILE:///home/runner/mesh-client/dist/renderer/index.html'],
+    ['darwin', 'FILE:///Users/runner/mesh-client/dist/renderer/index.html'],
+    ['win32', 'FILE:///D:/a/mesh-client/dist/renderer/index.html'],
+    ['linux', 'FiLe:///home/runner/mesh-client/dist/renderer/index.html'],
   ])('loads an explicit production file without DevTools on %s', async (_platform, url) => {
     const probe = vi.fn().mockResolvedValue(true);
     const resolved = await resolveRendererLoadUrl({

--- a/src/main/resolveRendererLoadUrl.ts
+++ b/src/main/resolveRendererLoadUrl.ts
@@ -92,7 +92,8 @@ export async function resolveRendererLoadUrl(
   if (options.devServerUrl) {
     return {
       url: options.devServerUrl,
-      openDevTools: true,
+      // E2E uses an explicit file URL to bypass the Vite probe and load the production build.
+      openDevTools: !options.devServerUrl.startsWith('file:'),
       source: 'env',
     };
   }

--- a/src/main/resolveRendererLoadUrl.ts
+++ b/src/main/resolveRendererLoadUrl.ts
@@ -93,7 +93,7 @@ export async function resolveRendererLoadUrl(
     return {
       url: options.devServerUrl,
       // E2E uses an explicit file URL to bypass the Vite probe and load the production build.
-      openDevTools: !options.devServerUrl.startsWith('file:'),
+      openDevTools: !/^file:/i.test(options.devServerUrl),
       source: 'env',
     };
   }


### PR DESCRIPTION
The scheduled Electron E2E run failed on Linux, macOS, and Windows before #973 merged. The E2E harness pins `VITE_DEV_SERVER_URL` to the built renderer's `file:` URL, but the renderer resolver treated every explicit URL as a development server and opened DevTools. That adds a second page during `firstWindow()` selection and changes the renderer viewport when docked.

Keep DevTools closed for explicit file URLs, including uppercase and mixed-case schemes, while preserving automatic DevTools for live development servers. Regression tests cover production-file URL forms for all three platforms, and the Electron startup spec now asserts that DevTools stays closed. The harness still bypasses any unrelated Vite server running locally.

Also exclude generated `playwright-report/` and `test-results/` artifacts from ESLint. After an E2E failure, `pnpm run check:pr` otherwise crashes trying to apply typed TypeScript rules to Playwright's bundled report JavaScript.

Validation: reproduced two startup failures locally and three failing resolver regressions before the fix; all 12 Electron E2E specs passed locally on macOS without retries after the fix; `pnpm run check:pr` passed with 10,728 tests; normal commit hooks passed. The [existing E2E workflow passed on Linux, macOS, and Windows](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34613793254). Original failure: [scheduled E2E run](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34603934784).
