### PR TITLE
fix(reticulum): stop interface profile apply restart loop

### DIFF
--- a/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
+++ b/src/renderer/components/reticulum/ReticulumInterfacesPanel.tsx
@@ -649,6 +649,7 @@ export function ReticulumInterfacesPanel({
     id: string,
     enabled: boolean,
     ifaceTypeName?: string,
+    opts?: { deferStackRestart?: boolean },
   ): Promise<boolean> => {
     setInterfaceError(null);
     const row = interfaces.find((iface) => iface.id === id);
@@ -678,7 +679,12 @@ export function ReticulumInterfacesPanel({
       if (enabled) {
         await syncRmapAfterInterfaceChange(id);
       }
-      if (enabled && ifaceTypeName && reticulumInterfaceChangeRequiresStackRestart(ifaceTypeName)) {
+      const willRestart =
+        !opts?.deferStackRestart &&
+        enabled &&
+        Boolean(ifaceTypeName) &&
+        reticulumInterfaceChangeRequiresStackRestart(ifaceTypeName);
+      if (willRestart) {
         await restartStackForInterfaceChange();
       }
       return true;
@@ -985,7 +991,9 @@ export function ReticulumInterfacesPanel({
       <ReticulumInterfaceProfilesSection
         interfaces={interfaces}
         actionsDisabled={actionsDisabled}
-        onToggle={(id, enabled, typeName) => toggleInterface(id, enabled, typeName)}
+        onToggle={(id, enabled, typeName) =>
+          toggleInterface(id, enabled, typeName, { deferStackRestart: true })
+        }
         onApplied={(needsRestartHint) => {
           if (needsRestartHint) setRestartStackHint(true);
         }}

--- a/src/renderer/lib/reticulum/interfaceProfiles.test.ts
+++ b/src/renderer/lib/reticulum/interfaceProfiles.test.ts
@@ -61,6 +61,7 @@ describe('interfaceProfiles', () => {
     });
     expect(res.changed).toBe(true);
     expect(res.ok).toBe(true);
+    expect(res.needsRestartHint).toBe(true);
     expect(calls).toEqual([
       { id: 'a', enabled: false },
       { id: 'b', enabled: true },
@@ -75,46 +76,80 @@ describe('interfaceProfiles', () => {
       return id !== 'a';
     });
     expect(res.ok).toBe(false);
+    expect(res.needsRestartHint).toBe(false);
     expect(calls).toEqual([{ id: 'a', enabled: false }]);
   });
 
-  it('skips SharedInstanceServer when applying empty profile', async () => {
-    const withShared = [
-      ...ifaces,
-      {
-        id: 'rns-0',
-        name: 'SharedInstanceServer',
-        enabled: true,
-        type: 'Full',
-      },
+  it('hints restart once for multiple restart-requiring enables', async () => {
+    const rows = [
+      { id: 'tcp-1', name: 'Hub A', enabled: false, type: 'tcp' },
+      { id: 'tcp-2', name: 'Hub B', enabled: false, type: 'tcp' },
+      { id: 'auto-1', name: 'LAN', enabled: true, type: 'auto' },
     ];
-    const calls: { id: string; enabled: boolean }[] = [];
-    const res = await applyInterfaceEnableSet(withShared, new Set(), (id, enabled) => {
-      calls.push({ id, enabled });
-    });
+    const calls: { id: string; enabled: boolean; type?: string }[] = [];
+    const res = await applyInterfaceEnableSet(
+      rows,
+      new Set(['Hub A', 'Hub B']),
+      (id, enabled, type) => {
+        calls.push({ id, enabled, type });
+      },
+    );
     expect(res.ok).toBe(true);
-    expect(res.changed).toBe(true);
-    expect(calls.some((c) => c.id === 'rns-0')).toBe(false);
+    expect(res.needsRestartHint).toBe(true);
     expect(calls).toEqual([
-      { id: 'a', enabled: false },
-      { id: 'c', enabled: false },
+      { id: 'tcp-1', enabled: true, type: 'tcp' },
+      { id: 'tcp-2', enabled: true, type: 'tcp' },
+      { id: 'auto-1', enabled: false, type: 'auto' },
     ]);
   });
 
-  it('omits SharedInstanceServer from saved profile members and active match', () => {
-    expect(isSystemManagedInterfaceProfileName('SharedInstanceServer')).toBe(true);
-    const withShared = [
-      ...ifaces,
-      {
-        id: 'rns-0',
-        name: 'SharedInstanceServer',
-        enabled: true,
-        type: 'Full',
-      },
+  it('does not hint restart for hot-applied enable-only changes', async () => {
+    const rows = [
+      { id: 'hot-1', name: 'Hot', enabled: false, type: 'custom_hot' },
+      { id: 'tcp-1', name: 'Hub', enabled: true, type: 'tcp' },
     ];
-    const state = saveCurrentAsInterfaceProfile(emptyInterfaceProfilesState(), 'Home', withShared);
-    expect(state.profiles[0]?.members).toEqual(['Alpha', 'Gamma']);
-    expect(activeInterfaceProfileId(state, withShared)).toBe(state.profiles[0]?.id);
-    expect(activeInterfaceProfileId(state, ifaces)).toBe(state.profiles[0]?.id);
+    const res = await applyInterfaceEnableSet(rows, new Set(['Hot']), () => true);
+    expect(res.ok).toBe(true);
+    expect(res.changed).toBe(true);
+    expect(res.needsRestartHint).toBe(false);
   });
+
+  it.each([
+    { name: 'SharedInstanceServer', id: 'rns-0' },
+    { name: 'SharedInstanceClient', id: 'rns-client' },
+  ] as const)(
+    'skips $name when applying empty profile and omits it from saved members',
+    async ({ name, id }) => {
+      expect(isSystemManagedInterfaceProfileName(name)).toBe(true);
+      const withShared = [
+        ...ifaces,
+        {
+          id,
+          name,
+          enabled: true,
+          type: 'Full',
+        },
+      ];
+      const calls: { id: string; enabled: boolean }[] = [];
+      const res = await applyInterfaceEnableSet(withShared, new Set(), (ifaceId, enabled) => {
+        calls.push({ id: ifaceId, enabled });
+      });
+      expect(res.ok).toBe(true);
+      expect(res.changed).toBe(true);
+      expect(calls.some((c) => c.id === id)).toBe(false);
+      expect(calls).toEqual([
+        { id: 'a', enabled: false },
+        { id: 'c', enabled: false },
+      ]);
+
+      const state = saveCurrentAsInterfaceProfile(
+        emptyInterfaceProfilesState(),
+        'Home',
+        withShared,
+      );
+      expect(state.profiles[0]?.members).toEqual(['Alpha', 'Gamma']);
+      expect(activeInterfaceProfileId(state, withShared)).toBe(state.profiles[0]?.id);
+      expect(activeInterfaceProfileId(state, ifaces)).toBe(state.profiles[0]?.id);
+    },
+  );
 });

--- a/src/renderer/lib/reticulum/interfaceProfiles.test.ts
+++ b/src/renderer/lib/reticulum/interfaceProfiles.test.ts
@@ -7,6 +7,7 @@ import {
   deleteInterfaceProfile,
   emptyInterfaceProfilesState,
   enabledInterfaceNames,
+  isSystemManagedInterfaceProfileName,
   renameInterfaceProfile,
   saveCurrentAsInterfaceProfile,
   updateDefaultInterfaceMembersIfCustom,
@@ -75,5 +76,45 @@ describe('interfaceProfiles', () => {
     });
     expect(res.ok).toBe(false);
     expect(calls).toEqual([{ id: 'a', enabled: false }]);
+  });
+
+  it('skips SharedInstanceServer when applying empty profile', async () => {
+    const withShared = [
+      ...ifaces,
+      {
+        id: 'rns-0',
+        name: 'SharedInstanceServer',
+        enabled: true,
+        type: 'Full',
+      },
+    ];
+    const calls: { id: string; enabled: boolean }[] = [];
+    const res = await applyInterfaceEnableSet(withShared, new Set(), (id, enabled) => {
+      calls.push({ id, enabled });
+    });
+    expect(res.ok).toBe(true);
+    expect(res.changed).toBe(true);
+    expect(calls.some((c) => c.id === 'rns-0')).toBe(false);
+    expect(calls).toEqual([
+      { id: 'a', enabled: false },
+      { id: 'c', enabled: false },
+    ]);
+  });
+
+  it('omits SharedInstanceServer from saved profile members and active match', () => {
+    expect(isSystemManagedInterfaceProfileName('SharedInstanceServer')).toBe(true);
+    const withShared = [
+      ...ifaces,
+      {
+        id: 'rns-0',
+        name: 'SharedInstanceServer',
+        enabled: true,
+        type: 'Full',
+      },
+    ];
+    const state = saveCurrentAsInterfaceProfile(emptyInterfaceProfilesState(), 'Home', withShared);
+    expect(state.profiles[0]?.members).toEqual(['Alpha', 'Gamma']);
+    expect(activeInterfaceProfileId(state, withShared)).toBe(state.profiles[0]?.id);
+    expect(activeInterfaceProfileId(state, ifaces)).toBe(state.profiles[0]?.id);
   });
 });

--- a/src/renderer/lib/reticulum/interfaceProfiles.ts
+++ b/src/renderer/lib/reticulum/interfaceProfiles.ts
@@ -4,9 +4,23 @@
  */
 
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
+import { getReticulumInterfaceHelp } from '@/renderer/lib/reticulum/reticulumInterfaceHelp';
+import {
+  RETICULUM_SHARED_INSTANCE_CLIENT_NAME,
+  RETICULUM_SHARED_INSTANCE_NAME,
+} from '@/renderer/lib/reticulum/reticulumSharedInstanceNames';
 
 export const INTERFACE_PROFILES_STORAGE_KEY = 'mesh-client:reticulumInterfaceProfiles';
 export const INTERFACE_PROFILES_VERSION = 1;
+
+/** Runtime-only shared-instance rows are not config-toggleable (e.g. rns-0). */
+export function isSystemManagedInterfaceProfileName(name: string): boolean {
+  return name === RETICULUM_SHARED_INSTANCE_NAME || name === RETICULUM_SHARED_INSTANCE_CLIENT_NAME;
+}
+
+function filterProfileMemberNames(members: readonly string[]): string[] {
+  return members.filter((m) => m.length > 0 && !isSystemManagedInterfaceProfileName(m));
+}
 
 export interface InterfaceProfile {
   id: string;
@@ -58,7 +72,7 @@ export function loadInterfaceProfiles(): InterfaceProfilesState {
       if (!id || seen.has(id)) continue;
       seen.add(id);
       const members = Array.isArray(p.members)
-        ? p.members.filter((m): m is string => typeof m === 'string' && m.length > 0)
+        ? filterProfileMemberNames(p.members.filter((m): m is string => typeof m === 'string'))
         : [];
       const name = typeof p.name === 'string' && p.name ? p.name : 'Profile';
       profiles.push({ id, name, members });
@@ -68,7 +82,7 @@ export function loadInterfaceProfiles(): InterfaceProfilesState {
       version: INTERFACE_PROFILES_VERSION,
       profiles,
       defaultMembers: Array.isArray(dm)
-        ? dm.filter((m): m is string => typeof m === 'string')
+        ? filterProfileMemberNames(dm.filter((m): m is string => typeof m === 'string'))
         : null,
     };
   } catch (e) {
@@ -97,16 +111,23 @@ export function saveInterfaceProfiles(state: InterfaceProfilesState): void {
 }
 
 export function enabledInterfaceNames(
-  interfaces: readonly { name: string; enabled: boolean }[],
+  interfaces: readonly {
+    name: string;
+    enabled: boolean;
+  }[],
 ): Set<string> {
-  return new Set(interfaces.filter((i) => i.enabled).map((i) => i.name));
+  return new Set(
+    interfaces
+      .filter((i) => i.enabled && !isSystemManagedInterfaceProfileName(i.name))
+      .map((i) => i.name),
+  );
 }
 
 export function membersExisting(
   profile: InterfaceProfile,
   interfaceNames: ReadonlySet<string>,
 ): Set<string> {
-  return new Set(profile.members.filter((m) => interfaceNames.has(m)));
+  return new Set(filterProfileMemberNames(profile.members).filter((m) => interfaceNames.has(m)));
 }
 
 export function activeInterfaceProfileId(
@@ -133,7 +154,14 @@ export function createInterfaceProfile(
   const id = newProfileId(ids);
   return {
     ...state,
-    profiles: [...state.profiles, { id, name: name.trim() || 'Profile', members: [...members] }],
+    profiles: [
+      ...state.profiles,
+      {
+        id,
+        name: name.trim() || 'Profile',
+        members: filterProfileMemberNames(members),
+      },
+    ],
   };
 }
 
@@ -174,7 +202,7 @@ export function setInterfaceProfileMembers(
 ): InterfaceProfilesState {
   const seen = new Set<string>();
   const ordered: string[] = [];
-  for (const m of members) {
+  for (const m of filterProfileMemberNames(members)) {
     if (!validNames.has(m) || seen.has(m)) continue;
     seen.add(m);
     ordered.push(m);
@@ -235,14 +263,25 @@ export type InterfaceEnableToggle = (
  * Stops early when a toggle reports failure (`false`).
  */
 export async function applyInterfaceEnableSet(
-  interfaces: readonly { id: string; name: string; enabled: boolean; type: string }[],
+  interfaces: readonly {
+    id: string;
+    name: string;
+    enabled: boolean;
+    type: string;
+    serial_port?: string | null;
+  }[],
   members: ReadonlySet<string>,
   toggle: InterfaceEnableToggle,
 ): Promise<{ changed: boolean; needsRestartHint: boolean; ok: boolean }> {
   let changed = false;
   let needsRestartHint = false;
+  const wantNames = new Set(filterProfileMemberNames([...members]));
   for (const iface of interfaces) {
-    const want = members.has(iface.name);
+    // SharedInstanceServer / Client are runtime-only (not in config); enable/disable 404s.
+    if (getReticulumInterfaceHelp(iface).isSystemManaged) {
+      continue;
+    }
+    const want = wantNames.has(iface.name);
     if (iface.enabled === want) continue;
     changed = true;
     const result = await Promise.resolve(toggle(iface.id, want, iface.type));

--- a/src/renderer/lib/reticulum/interfaceProfiles.ts
+++ b/src/renderer/lib/reticulum/interfaceProfiles.ts
@@ -5,6 +5,7 @@
 
 import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
 import { getReticulumInterfaceHelp } from '@/renderer/lib/reticulum/reticulumInterfaceHelp';
+import { reticulumInterfaceChangeRequiresStackRestart } from '@/renderer/lib/reticulum/reticulumInterfaceStackRestart';
 import {
   RETICULUM_SHARED_INSTANCE_CLIENT_NAME,
   RETICULUM_SHARED_INSTANCE_NAME,
@@ -288,7 +289,9 @@ export async function applyInterfaceEnableSet(
     if (result === false) {
       return { changed, needsRestartHint, ok: false };
     }
-    if (want) needsRestartHint = true;
+    if (want && reticulumInterfaceChangeRequiresStackRestart(iface.type)) {
+      needsRestartHint = true;
+    }
   }
   return { changed, needsRestartHint, ok: true };
 }


### PR DESCRIPTION
## Summary
- Interface profiles no longer include or toggle system-managed SharedInstanceServer/Client rows (fixes `interface not found: rns-0` when applying an empty profile).
- Profile apply uses deferred stack restart so enabling multiple interfaces sets a single restart hint instead of restarting the stack once per interface.

## Test plan
- [x] Unit tests: `interfaceProfiles.test.ts` (skip SharedInstanceServer on empty apply; omit from saved members)
- [ ] Reticulum Connection → save current as Home, create empty profile, switch to empty — no restart loop, no `rns-0` error
- [ ] Switch back to Home — interfaces re-enable; at most a restart hint, not N restarts
- [ ] Manual single-interface enable still restarts when required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reticulum interface profiles now exclude system-managed shared-instance interfaces from profile membership and enablement.
  - Loading, saving, and applying profiles now consistently filters out system-managed interfaces.
  - Toggling interfaces from the profiles section no longer triggers an unnecessary stack restart.
  - Interface profile application now handles runtime-only interfaces and serial connection details more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->