### PR TITLE
refactor: delete unused Reticulum sidecar leftovers

### DIFF
--- a/reticulum-sidecar/src/api/voice_memo.rs
+++ b/reticulum-sidecar/src/api/voice_memo.rs
@@ -6,7 +6,7 @@ use axum::Json;
 use axum::extract::State;
 use serde::Deserialize;
 
-use crate::api::validate::{MAX_DEST_HASH_CHARS, reject_oversize};
+use crate::api::validate::reject_oversize;
 use crate::stack::StackHandle;
 
 const MAX_SAMPLES_B64_CHARS: usize = 512 * 1024;
@@ -53,8 +53,6 @@ pub async fn voice_memo_stop(
     if let Some(err) = reject_oversize("session_id", &body.session_id, MAX_SESSION_ID_CHARS) {
         return Json(serde_json::json!({ "ok": false, "error": err }));
     }
-    // Reuse dest-hash char budget as a generic short-id cap when session_id is huge.
-    let _ = MAX_DEST_HASH_CHARS;
     Json(stack.voice_memo_stop(&body.session_id))
 }
 

--- a/reticulum-sidecar/src/stack/config.rs
+++ b/reticulum-sidecar/src/stack/config.rs
@@ -287,18 +287,6 @@ pub fn interfaces_from_config_dir(config_dir: &Path) -> Result<Vec<InterfaceRow>
     interfaces_from_config(&content)
 }
 
-/// Bulk-write interface rows back to config (used by stub persistence paths).
-#[allow(dead_code)]
-pub fn sync_config_interfaces(
-    config_dir: &Path,
-    interfaces: &[InterfaceRow],
-) -> Result<(), String> {
-    let content = read_config(config_dir)?;
-    let mut parsed = parse_config(&content)?;
-    parsed.interfaces = interfaces.iter().map(interface_row_to_block).collect();
-    write_config(config_dir, &serialize_config(&parsed))
-}
-
 pub fn import_config(
     config_dir: &Path,
     content: &str,

--- a/reticulum-sidecar/src/stack/identity_apply.rs
+++ b/reticulum-sidecar/src/stack/identity_apply.rs
@@ -182,7 +182,7 @@ mod rns {
         Ok(Some(from_file))
     }
 
-    #[allow(dead_code)] // retained for tests / future replace-guard paths
+    #[cfg(test)]
     pub fn backup_conflicts_with_file(
         config_dir: &Path,
         backup_identity_hash: &str,

--- a/reticulum-sidecar/src/stack/identity_import.rs
+++ b/reticulum-sidecar/src/stack/identity_import.rs
@@ -111,8 +111,8 @@ pub fn decode_private_key_input(input: &str) -> Result<[u8; RNS_PRIVATE_KEY_LEN]
     ))
 }
 
-/// Decode exactly 64 raw bytes (e.g. from Electron file picker).
-#[allow(dead_code)] // binary import API used by identity_import_private_bytes
+/// Decode exactly 64 raw bytes (Ratspeak `.rsi` vault key + unit tests).
+#[cfg(any(test, feature = "rns-stack"))]
 pub fn decode_private_key_bytes(data: &[u8]) -> Result<[u8; RNS_PRIVATE_KEY_LEN], String> {
     bytes_to_key(data)
 }

--- a/reticulum-sidecar/src/stack/live.rs
+++ b/reticulum-sidecar/src/stack/live.rs
@@ -479,12 +479,8 @@ impl LiveBridge {
         // Outbound Direct reusable links ACK peer replies via LinkProof even when the
         // plaintext is not forwarded — wire set_inbound_packet_sender so backchannel
         // DATA reaches the same unpack path as peer-initiated lxmf.delivery links.
-        let mut outbound_driver = LxmfOutboundDriver::new(
-            handle.transport_tx.clone(),
-            &identity,
-            lxmf_hash_hex.clone(),
-            display_name.clone(),
-        );
+        let mut outbound_driver =
+            LxmfOutboundDriver::new(handle.transport_tx.clone(), &identity, &lxmf_hash_hex);
         outbound_driver.set_inbound_packet_sender(spawn_lxmf_outbound_backchannel(
             lxmf_dest_hash,
             router.clone(),
@@ -547,7 +543,6 @@ impl LiveBridge {
                 handle.transport_tx.clone(),
                 identity.clone(),
                 event_tx.clone(),
-                storage_dir.clone(),
                 config_dir.clone(),
             )),
             voice_session: Arc::new(VoiceSessionManager::spawn(
@@ -7115,7 +7110,7 @@ mod announce_display_name_tests {
         let hash = "d765e919676aa0340412a1afae006553";
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         assert!(!driver.has_path_to(hash));
 
         let mut peer_via_cache: HashMap<String, String> =
@@ -7165,7 +7160,7 @@ mod announce_display_name_tests {
         let dest_hash: [u8; 16] = hex::decode(hash).unwrap().try_into().unwrap();
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         driver.update_path_table(&[PathTableRoute {
             hash: dest_hash,
             hops: 3,

--- a/reticulum-sidecar/src/stack/lxmf_outbound.rs
+++ b/reticulum-sidecar/src/stack/lxmf_outbound.rs
@@ -201,20 +201,13 @@ pub struct LxmfOutboundDriver {
     local_prop_node: Option<Arc<Mutex<PropagationNode>>>,
     /// Effective PN deposit size limit (from `propagation_limit_kb`).
     propagation_max_message_size: usize,
-    /// Local LXMF identity (retained for driver construction / future failed-detail payloads).
-    #[allow(dead_code)]
-    self_lxmf_hash: String,
-    #[allow(dead_code)]
-    self_display_name: String,
 }
 
 impl LxmfOutboundDriver {
-    #[allow(clippy::needless_pass_by_value)] // hash hex is cloned into driver state at construction
     pub fn new(
         transport_tx: mpsc::Sender<TransportMessage>,
         identity: &Identity,
-        self_lxmf_hash: String,
-        self_display_name: String,
+        self_lxmf_hash: &str,
     ) -> Self {
         let mut driver = Self {
             transport_tx: transport_tx.clone(),
@@ -244,10 +237,8 @@ impl LxmfOutboundDriver {
             local_prop_node: None,
             propagation_max_message_size:
                 crate::stack::pn_hosting_policy::DEFAULT_PROPAGATION_LIMIT_KB.saturating_mul(1024),
-            self_lxmf_hash: self_lxmf_hash.clone(),
-            self_display_name,
         };
-        driver.register_identity_key(&self_lxmf_hash, identity.get_public_key());
+        driver.register_identity_key(self_lxmf_hash, identity.get_public_key());
         driver
     }
 
@@ -1807,27 +1798,6 @@ pub(crate) fn choose_lxmf_send_route(
 /// Cap on retained destination public keys (announce / path flood bound).
 const MAX_KNOWN_IDENTITIES: usize = 4096;
 
-/// Convenience wrapper around [`emit_outbound_status_with_via`] (hash/to/sent_via from payload).
-#[allow(dead_code)] // kept for callers that already hold a full lxmf_message payload
-pub fn emit_outbound_status(
-    event_tx: &broadcast::Sender<String>,
-    message_payload: &serde_json::Value,
-    status: &str,
-    delivery_method: &str,
-) {
-    emit_outbound_status_with_via(
-        event_tx,
-        message_payload.get("message_hash").cloned(),
-        message_payload.get("to_hash").cloned(),
-        status,
-        Some(delivery_method),
-        message_payload
-            .get("sent_via")
-            .and_then(|v| v.as_str())
-            .map(str::to_string),
-    );
-}
-
 pub fn emit_outbound_status_with_via(
     event_tx: &broadcast::Sender<String>,
     message_hash: Option<serde_json::Value>,
@@ -2160,7 +2130,7 @@ mod tests {
 
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let dest_hash = dest(0xab);
         let msg_hash = [0x42u8; 32];
         let pn_hash = dest(0x11);
@@ -2207,7 +2177,7 @@ mod tests {
 
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let dest_hash = dest(0xcd);
         let mut msg = LxMessage::new(
             dest_hash,
@@ -2261,7 +2231,7 @@ mod tests {
     fn clear_path_to_removes_stale_route_so_refresh_can_reinstall() {
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let dest_hash = dest(0xab);
         let dest_hex = hex::encode(dest_hash);
         // Stale cached route (5 hops).
@@ -2324,7 +2294,7 @@ mod tests {
     fn clear_all_paths_empties_every_path_map() {
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let routes = [seeded_route(0xa1), seeded_route(0xa2), seeded_route(0xa3)];
         driver.update_path_table(&routes);
         for route in &routes {
@@ -2349,7 +2319,7 @@ mod tests {
     fn clear_all_paths_on_empty_driver_is_noop() {
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         driver.clear_all_paths();
         driver.clear_all_paths();
         assert!(driver.path_table_hashes.is_empty());
@@ -2360,7 +2330,7 @@ mod tests {
     fn clear_all_paths_leaves_driver_able_to_reinstall_routes() {
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let dest_hash = dest(0xb7);
         let dest_hex = hex::encode(dest_hash);
         driver.update_path_table(&[PathTableRoute {
@@ -2390,7 +2360,7 @@ mod tests {
     fn clear_all_paths_resets_path_request_backoff() {
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let dest_hash = dest(0xc4);
         // Exhaust the gate so decide() would refuse further path requests.
         for _ in 0..PATH_REQUEST_MAX_ATTEMPTS {
@@ -2421,7 +2391,7 @@ mod tests {
 
         let identity = Identity::new();
         let (tx, mut rx) = mpsc::channel(32);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let dest_hash = dest(0xcd);
         let msg_hash = [0x42u8; 32];
         driver.update_path_table(&[PathTableRoute {
@@ -2548,7 +2518,7 @@ mod tests {
 
         let identity = Identity::new();
         let (tx, mut rx) = mpsc::channel(64);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         driver.update_interfaces(vec![
             iface_row("Auto", "auto", true, "up", None),
             iface_row(
@@ -2615,7 +2585,7 @@ mod tests {
     fn healthy_auto_with_down_sibling_does_not_preempt() {
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         driver.update_interfaces(vec![
             iface_row("Auto", "auto", true, "up", None),
             iface_row("Auto Backup", "auto", true, "down", None),
@@ -2651,7 +2621,7 @@ mod tests {
     fn register_identity_key_is_retrievable() {
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let dest = "0123456789abcdef0123456789abcdef";
         let key = [0x7au8; 64];
         driver.register_identity_key(dest, key);
@@ -2663,7 +2633,7 @@ mod tests {
     fn pin_identity_survives_eviction_flood() {
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let pn_hex = "deadbeef".to_string() + &"ab".repeat(12);
         let pn_key = [0x42u8; 64];
         driver.pin_identity_for_propagation(&pn_hex, pn_key);
@@ -2755,7 +2725,7 @@ mod tests {
         // cover end-to-end delivery. Without this call, LDM Acks and drops plaintext.
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(8);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let (inbound_tx, mut inbound_rx) = mpsc::unbounded_channel::<(Vec<u8>, [u8; 16])>();
         driver.set_inbound_packet_sender(inbound_tx.clone());
         // Prove the UnboundedSender we installed is live (clone still delivers).
@@ -2777,7 +2747,7 @@ mod tests {
 
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(32);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let preferred = [0x11u8; 16];
         let next_remote = [0x22u8; 16];
         let local = [0x99u8; 16];
@@ -2911,7 +2881,7 @@ mod tests {
 
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(32);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         // Fixture hashes from Joey Prefer (9f3f…) / w0rmt Prefer (deadbeef).
         let prefer = hex::decode("9f3f189e9f3f189e9f3f189e9f3f189e")
             .ok()
@@ -3002,7 +2972,7 @@ mod tests {
 
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(32);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let prefer = [0x9fu8; 16];
         let dest_hash = dest(0xcd);
         let msg_hash = [0x43u8; 32];
@@ -3064,7 +3034,7 @@ mod tests {
 
         let identity = Identity::new();
         let (tx, _rx) = mpsc::channel(32);
-        let mut driver = LxmfOutboundDriver::new(tx, &identity, "aabb".repeat(8), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &identity, &"aabb".repeat(8));
         let prefer = [0x9fu8; 16];
         let next = [0xdeu8; 16];
         let dest_hash = dest(0xcd);
@@ -3157,8 +3127,7 @@ mod tests {
             Destination::hash_from_name_and_identity("lxmf.delivery", Some(&sender.hash));
         let recipient_delivery =
             Destination::hash_from_name_and_identity("lxmf.delivery", Some(&recipient.hash));
-        let mut driver =
-            LxmfOutboundDriver::new(tx, &sender, hex::encode(sender_delivery), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &sender, &hex::encode(sender_delivery));
         driver.register_identity_key(&hex::encode(recipient_delivery), recipient.get_public_key());
         driver.set_local_prop_node(Some(bridge.local_node()));
         driver.set_pn_cascade_candidates(vec![PnCascadeCandidate {
@@ -3265,8 +3234,7 @@ mod tests {
             Destination::hash_from_name_and_identity("lxmf.delivery", Some(&sender.hash));
         let recipient_delivery =
             Destination::hash_from_name_and_identity("lxmf.delivery", Some(&recipient.hash));
-        let mut driver =
-            LxmfOutboundDriver::new(tx, &sender, hex::encode(sender_delivery), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &sender, &hex::encode(sender_delivery));
         driver.register_identity_key(&hex::encode(recipient_delivery), recipient.get_public_key());
         driver.set_local_prop_node(Some(bridge.local_node()));
         driver.set_pn_cascade_candidates(vec![PnCascadeCandidate {
@@ -3372,8 +3340,7 @@ mod tests {
             Destination::hash_from_name_and_identity("lxmf.delivery", Some(&sender.hash));
         let recipient_delivery =
             Destination::hash_from_name_and_identity("lxmf.delivery", Some(&recipient.hash));
-        let mut driver =
-            LxmfOutboundDriver::new(tx, &sender, hex::encode(sender_delivery), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &sender, &hex::encode(sender_delivery));
         driver.register_identity_key(&hex::encode(recipient_delivery), recipient.get_public_key());
         driver.set_local_prop_node(Some(bridge.local_node()));
         driver.set_pn_cascade_candidates(vec![PnCascadeCandidate {
@@ -3483,8 +3450,7 @@ mod tests {
             Destination::hash_from_name_and_identity("lxmf.delivery", Some(&sender.hash));
         let other_delivery =
             Destination::hash_from_name_and_identity("lxmf.delivery", Some(&other.hash));
-        let mut driver =
-            LxmfOutboundDriver::new(tx, &sender, hex::encode(sender_delivery), "me".into());
+        let mut driver = LxmfOutboundDriver::new(tx, &sender, &hex::encode(sender_delivery));
         driver.register_identity_key(&hex::encode(other_delivery), other.get_public_key());
         driver.set_local_prop_node(Some(bridge.local_node()));
         driver.set_pn_cascade_candidates(vec![PnCascadeCandidate {

--- a/reticulum-sidecar/src/stack/mod.rs
+++ b/reticulum-sidecar/src/stack/mod.rs
@@ -602,16 +602,6 @@ impl StackHandle {
         (stored, effective)
     }
 
-    /// Public API for outbound transport resolution from enabled interfaces.
-    #[allow(dead_code)] // renderer IPC may call before all call sites are wired
-    pub async fn resolve_outbound_sent_via_for_interfaces(
-        &self,
-        interfaces: &[InterfaceRow],
-    ) -> &'static str {
-        let (_, effective) = self.primary_local_serial_interface_ids().await;
-        via::resolve_outbound_sent_via_with_primary(interfaces, effective.as_deref())
-    }
-
     pub async fn set_primary_local_serial_interface(
         &self,
         id: &str,
@@ -807,39 +797,6 @@ impl StackHandle {
         {
             let bytes = identity_import::decode_private_key_input(private_key)?;
             let rns_identity = identity_apply::identity_from_private_bytes(&bytes)?;
-            let mut inner = self.inner.write().await;
-            let identity = identity_apply::apply_unified_identity(
-                &mut inner,
-                &self.config_dir,
-                &self.storage_dir,
-                &rns_identity,
-                display_name,
-                None,
-            )?;
-            drop(inner);
-            self.maybe_emit_identity_restart();
-            Ok(identity)
-        }
-        #[cfg(not(feature = "rns-stack"))]
-        {
-            Err("identity operations require an rns-stack sidecar build".into())
-        }
-    }
-
-    /// Binary private-key import (file picker / IPC).
-    #[allow(dead_code)] // public identity API; not all builds expose the route yet
-    pub async fn identity_import_private_bytes(
-        &self,
-        bytes: &[u8],
-        display_name: Option<String>,
-        replace: bool,
-    ) -> Result<StackIdentity, String> {
-        identity_apply::identity_requires_rns_stack()?;
-        self.ensure_identity_replace_allowed(replace).await?;
-        #[cfg(feature = "rns-stack")]
-        {
-            let key = identity_import::decode_private_key_bytes(bytes)?;
-            let rns_identity = identity_apply::identity_from_private_bytes(&key)?;
             let mut inner = self.inner.write().await;
             let identity = identity_apply::apply_unified_identity(
                 &mut inner,
@@ -2348,9 +2305,7 @@ impl StackHandle {
     }
 
     pub async fn list_rrc_hubs(&self) -> Vec<RrcHubRow> {
-        let mut inner = self.inner.write().await;
-        inner.seed_rrc_default_hubs();
-        inner.rrc_hubs.clone()
+        self.inner.read().await.rrc_hubs.clone()
     }
 
     pub async fn upsert_rrc_hub(

--- a/reticulum-sidecar/src/stack/nomad_timeouts.rs
+++ b/reticulum-sidecar/src/stack/nomad_timeouts.rs
@@ -44,7 +44,7 @@ pub fn nomad_page_overall_timeout_secs(egress_via: &str, hops: u8) -> u64 {
 /// Resolve egress from enabled interfaces and compute overall timeout.
 /// Prefer [`resolve_nomad_page_timeout_secs`] with a path-table interface when known —
 /// a local BLE/RNode being enabled must not force RF budgets for TCP-routed peers.
-#[allow(dead_code)] // kept for tests + call sites that lack a path interface
+#[cfg(test)]
 pub fn nomad_page_timeout_secs_for_interfaces(interfaces: &[InterfaceRow], hops: u8) -> u64 {
     let egress = resolve_outbound_sent_via(interfaces);
     nomad_page_overall_timeout_secs(egress, hops)

--- a/reticulum-sidecar/src/stack/nomad_timeouts.rs
+++ b/reticulum-sidecar/src/stack/nomad_timeouts.rs
@@ -1,6 +1,7 @@
 //! Nomad page fetch timeouts (MeshChat + Python RNS per-hop scaling on RF).
 
 use super::types::InterfaceRow;
+#[cfg(test)]
 use super::via::resolve_outbound_sent_via;
 
 /// MeshChat `NomadnetDownloader.download()` path_lookup_timeout default.

--- a/reticulum-sidecar/src/stack/packet_log.rs
+++ b/reticulum-sidecar/src/stack/packet_log.rs
@@ -2,7 +2,6 @@ use std::collections::VecDeque;
 use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast;
 
 pub const MAX_WIRE_PACKET_LOG: usize = 2500;
 
@@ -62,14 +61,6 @@ impl PacketLogBuffer {
             buf.clear();
         }
     }
-}
-
-/// Formerly emitted live `wire_packet` on the shared WS bus. Kept for unit tests /
-/// egress helpers; production PacketTap only fills [`PacketLogBuffer`] (Sniffer polls HTTP).
-#[allow(dead_code)]
-pub fn emit_wire_packet_event(event_tx: &broadcast::Sender<String>, row: &WirePacketRow) {
-    let msg = serde_json::json!({ "type": "wire_packet", "payload": row });
-    let _ = event_tx.send(msg.to_string());
 }
 
 /// Collect PacketTap Tx interface names for LXMF egress evidence.

--- a/reticulum-sidecar/src/stack/persistence.rs
+++ b/reticulum-sidecar/src/stack/persistence.rs
@@ -125,13 +125,6 @@ impl PersistedState {
             });
         }
         self.sync_local_propagation_hash();
-        self.seed_rrc_default_hubs();
-    }
-
-    /// No-op: curated RRC hub catalog is empty (Favourites are user-starred only).
-    #[allow(clippy::unused_self)] // method slot on PersistedState for future default seeding
-    pub fn seed_rrc_default_hubs(&mut self) {
-        let _ = super::rrc_defaults::RRC_DEFAULT_HUBS;
     }
 
     pub fn sync_local_propagation_hash(&mut self) {
@@ -513,7 +506,7 @@ impl PersistedState {
         let now = Self::now_secs();
         let recommended = super::rrc_defaults::RRC_DEFAULT_HUBS
             .iter()
-            .any(|h| h.destination_hash.eq_ignore_ascii_case(&key));
+            .any(|h| h.eq_ignore_ascii_case(&key));
         let incoming_name_source = name_source.unwrap_or(match source {
             "recommended" => "recommended",
             "manual" => "manual",
@@ -597,7 +590,7 @@ impl PersistedState {
         }
         let recommended = super::rrc_defaults::RRC_DEFAULT_HUBS
             .iter()
-            .any(|h| h.destination_hash.eq_ignore_ascii_case(&key));
+            .any(|h| h.eq_ignore_ascii_case(&key));
         self.rrc_hubs.push(RrcHubRow {
             destination_hash: hash.to_string(),
             identity_hash: None,

--- a/reticulum-sidecar/src/stack/propagation_bridge.rs
+++ b/reticulum-sidecar/src/stack/propagation_bridge.rs
@@ -482,12 +482,6 @@ impl PropagationBridge {
         }
     }
 
-    /// Whether a post-loop terminal success (progress 100) should be emitted.
-    #[allow(dead_code)] // used by peer-sync progress emitter + unit tests
-    pub fn should_emit_terminal_success(last_finished_ok: Option<bool>) -> bool {
-        last_finished_ok != Some(false)
-    }
-
     /// Start a client `/get` download of our own mail from `pn_hash`.
     ///
     /// This is the retrieval half of Sync (Python
@@ -948,158 +942,6 @@ impl PropagationBridge {
         }
         terminal
     }
-
-    /// Emit peer `/offer` sync progress over WS (offer probe / host diagnostics).
-    /// User Sync drives UI from the client `/get` path instead.
-    #[allow(dead_code)] // retained for offer-probe / peer-sync diagnostics
-    pub fn spawn_sync_progress_emitter(
-        self: &Arc<Self>,
-        event_tx: broadcast::Sender<String>,
-        cancel: Arc<AtomicBool>,
-        run_id: u64,
-        active_run_id: Arc<AtomicU64>,
-        on_terminal: Option<Arc<dyn Fn() + Send + Sync>>,
-    ) {
-        let bridge = Arc::clone(self);
-        tokio::spawn(async move {
-            const SYNC_STALL_TIMEOUT: Duration = Duration::from_secs(45);
-            let mut interval = tokio::time::interval(Duration::from_millis(500));
-            let started = Instant::now();
-            let clear_pins = || {
-                bridge.run_if_current(&active_run_id, run_id, || {
-                    if let Some(ref cb) = on_terminal {
-                        cb();
-                    }
-                });
-            };
-            loop {
-                interval.tick().await;
-                if cancel.load(Ordering::SeqCst) {
-                    bridge.run_if_current(&active_run_id, run_id, || {
-                        bridge.cancel_sync();
-                        tracing::info!(
-                            target: "propagation-sync",
-                            progress = bridge.sync_progress(),
-                            establish_error = ?bridge.last_establish_error(),
-                            "propagation sync cancelled"
-                        );
-                    });
-                    break;
-                }
-                let active = bridge.sync_active();
-                let finished_ok = bridge.last_finished_ok();
-                let offer_error = bridge.last_offer_error();
-                let establish_error = bridge.last_establish_error();
-                // Complete/Failed immediately collapse to Idle (progress 0). Use sticky
-                // last_finished_ok so success (e.g. HaveAll) is not reported as failure.
-                let progress = if active {
-                    bridge.sync_progress()
-                } else {
-                    match finished_ok {
-                        Some(true) => 100.0,
-                        Some(false) => 0.0,
-                        None => bridge.sync_progress(),
-                    }
-                };
-                if active && progress <= 10.0 && started.elapsed() > SYNC_STALL_TIMEOUT {
-                    bridge.run_if_current(&active_run_id, run_id, || {
-                        if let Ok(mut slot) = bridge.last_establish_error.lock() {
-                            if slot.is_none() {
-                                *slot = Some("NoLinkProof");
-                            }
-                        }
-                        bridge.cancel_sync();
-                        let message = bridge
-                            .last_establish_error()
-                            .or(establish_error)
-                            .map(|e| format!("propagation establish failed: {e}"))
-                            .unwrap_or_else(|| {
-                                "propagation establish failed: NoLinkProof".to_string()
-                            });
-                        tracing::info!(
-                            target: "propagation-sync",
-                            message = %message,
-                            progress,
-                            "propagation sync stalled while establishing"
-                        );
-                        let payload = serde_json::json!({
-                            "active": false,
-                            "progress": 0.0,
-                            "message": message,
-                        });
-                        let frame = serde_json::json!({
-                            "type": "propagation_sync",
-                            "payload": payload,
-                        });
-                        let _ = event_tx.send(frame.to_string());
-                    });
-                    break;
-                }
-                let fail_message = if !active && progress == 0.0 {
-                    offer_error
-                        .map(|e| format!("propagation offer rejected: {e}"))
-                        .or_else(|| {
-                            establish_error.map(|e| format!("propagation establish failed: {e}"))
-                        })
-                } else {
-                    None
-                };
-                let payload = serde_json::json!({
-                    "active": active,
-                    "progress": progress,
-                    "message": fail_message,
-                });
-                let frame = serde_json::json!({
-                    "type": "propagation_sync",
-                    "payload": payload,
-                });
-                // Drop stale progress frames when a newer sync run has taken ownership.
-                if !bridge.run_if_current(&active_run_id, run_id, || {
-                    let _ = event_tx.send(frame.to_string());
-                }) {
-                    break;
-                }
-                if !active && (progress >= 99.0 || finished_ok.is_some()) {
-                    if finished_ok == Some(true) {
-                        let peak = bridge.last_peak_progress();
-                        let peer_outcome = if peak >= 70.0 { "transfer" } else { "have_all" };
-                        tracing::info!(
-                            target: "propagation-sync",
-                            progress,
-                            peak_progress = peak,
-                            peer_outcome,
-                            "propagation peer sync completed successfully"
-                        );
-                    } else if let Some(ref msg) = fail_message {
-                        tracing::info!(
-                            target: "propagation-sync",
-                            message = %msg,
-                            progress,
-                            "propagation sync terminal failure"
-                        );
-                    }
-                    break;
-                }
-            }
-            clear_pins();
-            // Do not emit a blanket progress=100 after a real failure/cancel terminal.
-            bridge.run_if_current(&active_run_id, run_id, || {
-                if !Self::should_emit_terminal_success(bridge.last_finished_ok()) {
-                    return;
-                }
-                let payload = serde_json::json!({
-                    "active": false,
-                    "progress": 100.0,
-                    "message": null,
-                });
-                let frame = serde_json::json!({
-                    "type": "propagation_sync",
-                    "payload": payload,
-                });
-                let _ = event_tx.send(frame.to_string());
-            });
-        });
-    }
 }
 
 /// Merge peer-handled transient IDs into the router peer and persist (lxmd parity).
@@ -1505,15 +1347,6 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn should_emit_terminal_success_skips_explicit_failure() {
-        assert!(!PropagationBridge::should_emit_terminal_success(Some(
-            false
-        )));
-        assert!(PropagationBridge::should_emit_terminal_success(Some(true)));
-        assert!(PropagationBridge::should_emit_terminal_success(None));
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/propagation_bridge.rs
+++ b/reticulum-sidecar/src/stack/propagation_bridge.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use lxmf_core::message::LxMessage;
 use lxmf_core::peer::OutboundOfferPolicy;
@@ -18,7 +18,7 @@ use lxmf_core::types::PropagationTransientId;
 use rns_identity::destination::Destination;
 use rns_identity::identity::Identity;
 use rns_transport::messages::TransportMessage;
-use tokio::sync::{Notify, broadcast, mpsc};
+use tokio::sync::{Notify, mpsc};
 
 use super::propagation_download::{ClientDownloadPoll, decode_downloaded_propagated_blob};
 
@@ -1023,6 +1023,8 @@ fn persist_router_peer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
     use lxmf_core::constants::DeliveryMethod;
 
     /// Manual blob → drain (partial loopback). Full outbound→stored_locally→drain

--- a/reticulum-sidecar/src/stack/rf_profiles.rs
+++ b/reticulum-sidecar/src/stack/rf_profiles.rs
@@ -30,11 +30,6 @@ fn load_profiles() -> Vec<RfProfile> {
         .unwrap_or_default()
 }
 
-#[allow(dead_code)] // catalog helper; presets use rf_profile_by_id
-pub fn all_rf_profiles() -> Vec<RfProfile> {
-    load_profiles()
-}
-
 pub fn rf_profile_by_id(id: &str) -> Option<RfProfile> {
     load_profiles().into_iter().find(|p| p.id == id)
 }

--- a/reticulum-sidecar/src/stack/rncp_transfer.rs
+++ b/reticulum-sidecar/src/stack/rncp_transfer.rs
@@ -166,8 +166,6 @@ pub struct RncpTransferManager {
     transport_tx: mpsc::Sender<TransportMessage>,
     identity: Identity,
     event_tx: broadcast::Sender<String>,
-    #[allow(dead_code)] // retained for future default save/fetch dir helpers
-    storage_dir: PathBuf,
     /// rnsd config dir — used to read `announce_interval_sec` for listen announces.
     config_dir: PathBuf,
     active: Mutex<HashMap<String, ActiveTransfer>>,
@@ -181,14 +179,12 @@ impl RncpTransferManager {
         transport_tx: mpsc::Sender<TransportMessage>,
         identity: Identity,
         event_tx: broadcast::Sender<String>,
-        storage_dir: PathBuf,
         config_dir: PathBuf,
     ) -> Self {
         Self {
             transport_tx,
             identity,
             event_tx,
-            storage_dir,
             config_dir,
             active: Mutex::new(HashMap::new()),
             pending_offers: Arc::new(Mutex::new(HashMap::new())),
@@ -1156,7 +1152,6 @@ mod tests {
                 Identity::new(),
                 event_tx,
                 storage_dir.to_path_buf(),
-                storage_dir.to_path_buf(),
             ),
             event_rx,
         )
@@ -1650,7 +1645,6 @@ mod tests {
             Identity::new(),
             event_tx,
             dir.path().to_path_buf(),
-            dir.path().to_path_buf(),
         );
         manager
             .configure_policy("ask", vec![], vec![])
@@ -1732,7 +1726,6 @@ loglevel = 4
             Identity::new(),
             event_tx,
             dir.path().to_path_buf(),
-            dir.path().to_path_buf(),
         );
         manager
             .configure_policy("ask", vec![], vec![])
@@ -1780,7 +1773,6 @@ loglevel = 4
             transport_tx,
             Identity::new(),
             event_tx,
-            dir.path().to_path_buf(),
             dir.path().to_path_buf(),
         );
         manager

--- a/reticulum-sidecar/src/stack/rrc_defaults.rs
+++ b/reticulum-sidecar/src/stack/rrc_defaults.rs
@@ -3,13 +3,5 @@
 
 pub const RRC_HUB_ASPECT: &str = "rrc.hub";
 
-#[derive(Debug, Clone, Copy)]
-#[allow(dead_code)] // catalog fields kept for TS parity when hubs are added
-pub struct RrcDefaultHub {
-    pub id: &'static str,
-    pub label: &'static str,
-    pub destination_hash: &'static str,
-}
-
-/// No predefined hubs — users favourite from discovery or manual connect.
-pub const RRC_DEFAULT_HUBS: &[RrcDefaultHub] = &[];
+/// Destination hashes of curated hubs (empty until hubs are added).
+pub const RRC_DEFAULT_HUBS: &[&str] = &[];

--- a/reticulum-sidecar/src/stack/via.rs
+++ b/reticulum-sidecar/src/stack/via.rs
@@ -72,16 +72,6 @@ pub fn classify_path_interface_name(
     classify_interface(path_interface_name)
 }
 
-/// Resolve transport for a peer destination hash from a path-table interface name.
-/// Prefer [`resolve_path_sent_via`] when local interface rows are available.
-#[allow(dead_code)] // legacy path-table helper; live stack uses resolve_path_sent_via
-pub fn resolve_peer_sent_via(peer_interface: Option<&str>) -> &'static str {
-    match peer_interface {
-        Some(name) if !name.is_empty() => classify_interface(name),
-        _ => "network",
-    }
-}
-
 /// Path-table egress label: match local interface row when possible.
 pub fn resolve_path_sent_via(
     peer_interface: Option<&str>,
@@ -125,12 +115,6 @@ pub fn resolve_lxmf_sent_via(
         return via.to_string();
     }
     resolve_outbound_sent_via_with_primary(interfaces, primary_local_serial_id).to_string()
-}
-
-/// Pick the primary outbound transport from enabled stub interfaces.
-#[allow(dead_code)] // stub-stack egress; live stack uses resolve_outbound_sent_via_with_primary
-pub fn resolve_stub_sent_via(interfaces: &[InterfaceRow]) -> &'static str {
-    resolve_outbound_sent_via_with_primary(interfaces, None)
 }
 
 /// Local capability egress (enabled interfaces). For Nomad timeouts / no-path fallback only —
@@ -446,7 +430,6 @@ mod tests {
             tx_queue_max: None,
             extra_config: std::collections::HashMap::new(),
         }];
-        assert_eq!(resolve_stub_sent_via(&ifaces), "rf");
         assert_eq!(resolve_outbound_sent_via(&ifaces), "rf");
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Subtractive `#[allow(dead_code)]` sweep in `reticulum-sidecar/**` only. No PN/propagation rewrite, no vault edits, no renderer changes.

Follows #979 / #980 / #981 (renderer leftovers). This PR is the sidecar pass.

## Deleted (verified unused: no callers, no HTTP/IPC route)

| Item | Why dead |
| --- | --- |
| `spawn_sync_progress_emitter` + `should_emit_terminal_success` | Never spawned; user Sync is `/get`-primary |
| `emit_wire_packet_event` | Packet tap is HTTP-buffer only (`GET /api/v1/packets`) |
| `resolve_peer_sent_via` / `resolve_stub_sent_via` | Superseded by `resolve_path_sent_via` / `resolve_outbound_sent_via` |
| `sync_config_interfaces` | No callers |
| `resolve_outbound_sent_via_for_interfaces` | Unwired stack wrapper |
| `identity_import_private_bytes` | HTTP uses string `identity_import_private` only |
| `emit_outbound_status` wrapper | Callers use `emit_outbound_status_with_via` |
| unread `self_lxmf_hash` / `self_display_name` fields | Hash still passed into `register_identity_key`; fields never read |
| unread `RncpTransferManager.storage_dir` | Config dir remains |
| `all_rf_profiles` | Presets use `rf_profile_by_id` / `load_profiles` |
| empty RRC hub seed (`seed_rrc_default_hubs` + unused catalog struct) | Catalog still empty; recommended lookup uses hash slice |
| no-op `MAX_DEST_HASH_CHARS` line in `voice_memo_stop` | Session id already capped |

## Gated (test-only, kept)

- `nomad_page_timeout_secs_for_interfaces` → `#[cfg(test)]`
- `backup_conflicts_with_file` → `#[cfg(test)]`

## Left alone (used or required)

- `decode_private_key_bytes` — Ratspeak `.rsi` vault restore (`identity_backup.rs`, `rns-stack`)
- `persistence.rs` `upsert_contact*` — LXMF must not auto-promote Contacts
- `live.rs` inbound LXMF Arc keep-alive
- Vendored `vendor/ratspeak_vault.rs`
- Renderer `wire_packet` WS branch — sidecar no longer emits; poll path is the real Sniffer/Stats source. Left in place to keep this PR sidecar-only.

## Proof

- Grepped sidecar + HTTP routes (`/api/v1/identity/import-private` is the string path)
- Docs: `docs/agents/reticulum.md`, `docs/reticulum.md` (packet tap is HTTP-buffer; Sync is `/get`-primary)
- `cargo test --features rns-stack,rns-ble,rns-rnode-tcp`: **652 passed**
- `cargo clippy --all-targets --features rns-stack,rns-ble,rns-rnode-tcp -- -D warnings`: sidecar clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c18e2f6-01b4-5132-89f7-9c498612d56c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c18e2f6-01b4-5132-89f7-9c498612d56c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined background networking and message-delivery components.
  - Removed obsolete interface, identity-import, packet-event, and outbound-status pathways.
  - Reduced unused runtime processing and improved build efficiency.

- **Behavior Changes**
  - Packet logs are now retrieved through polling rather than live event broadcasts.
  - RRC hub listings now reflect persisted entries without automatically adding default hubs.
  - Peer offer synchronization no longer reports incremental sync progress events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->