### PR TITLE
ci: avoid running Prettier twice

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-pnpm
       # Bound worker count because each type-aware worker loads TypeScript programs.
-      - run: pnpm run lint --concurrency 2
+      - run: pnpm run lint --concurrency 2 --config eslint.ci.config.mjs
 
   typecheck:
     name: Typecheck

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -27,7 +27,7 @@ Mesh-Client uses GitHub Actions for continuous integration and deployment.
 Runs on every push, pull request, and merge-queue `merge_group` for `main` (and `workflow_dispatch`). Independent lanes start concurrently; only Flatpak waits for change detection:
 
 - **Code quality:** format, markdownlint, license allowlist, actionlint, dependency audit, and yamllint
-- **ESLint:** full repository lint with two workers, in parallel with formatting; all type-aware rules and the zero-warning gate remain enabled
+- **ESLint:** full repository lint with two workers, using `eslint.ci.config.mjs` to avoid running Prettier again for extensions already covered by the required Code quality job. All type-aware rules and the zero-warning gate remain enabled; local lint still checks formatting.
 - **Typecheck:** `pnpm run typecheck`
 - **Application build:** `pnpm run build`
 - **Flatpak checks:** only when Flatpak inputs change; runs `check:flatpak`, `check:flatpak-offline-pnpm`, `desktop-file-validate`, and `appstreamcli validate`

--- a/eslint.ci.config.mjs
+++ b/eslint.ci.config.mjs
@@ -1,0 +1,11 @@
+import config from './eslint.config.mjs';
+
+export default [
+  ...config,
+  {
+    // These extensions are checked by format:check in the required Code quality job.
+    // Keep formatting enabled for other ESLint inputs, including .mts and .cts.
+    files: ['**/*.{ts,tsx,js,jsx}'],
+    rules: { 'prettier/prettier': 'off' },
+  },
+];

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ESLint } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -76,25 +77,56 @@ describe('CI workflow contracts', () => {
     }
   });
 
-  it('includes ESLint failure in the required build gate', () => {
-    const gate = ciWorkflow
-      .split('      - name: Verify CI fan-out')[1]
-      .split('        run: |\n')[1];
-    const success = {
-      ...process.env,
-      CHANGES_RESULT: 'success',
-      QUALITY_RESULT: 'success',
-      LINT_RESULT: 'success',
-      TYPECHECK_RESULT: 'success',
-      BUILD_RESULT: 'success',
-      FLATPAK_RESULT: 'skipped',
-      GITHUB_STEP_SUMMARY: '/dev/null',
-    };
-    for (const lint of ['success', 'failure', 'cancelled', 'skipped']) {
-      const result = spawnSync('bash', ['-c', gate], {
-        env: { ...success, LINT_RESULT: lint },
+  it.each(['LINT_RESULT', 'QUALITY_RESULT'])(
+    'includes %s failure in the required build gate',
+    (job) => {
+      const gate = ciWorkflow
+        .split('      - name: Verify CI fan-out')[1]
+        .split('        run: |\n')[1];
+      const success = {
+        ...process.env,
+        CHANGES_RESULT: 'success',
+        QUALITY_RESULT: 'success',
+        LINT_RESULT: 'success',
+        TYPECHECK_RESULT: 'success',
+        BUILD_RESULT: 'success',
+        FLATPAK_RESULT: 'skipped',
+        GITHUB_STEP_SUMMARY: '/dev/null',
+      };
+      for (const status of ['success', 'failure', 'cancelled', 'skipped']) {
+        const result = spawnSync('bash', ['-c', gate], {
+          env: { ...success, [job]: status },
+        });
+        expect(result.status === 0).toBe(status === 'success');
+      }
+    },
+  );
+
+  it('delegates only duplicate formatting rules to the required format check', async () => {
+    const local = new ESLint({ cwd: ROOT });
+    const ci = new ESLint({ cwd: ROOT, overrideConfigFile: 'eslint.ci.config.mjs' });
+    const quality = ciWorkflow.split('  quality:')[1].split('  lint:')[0];
+    expect(quality).toContain('run: pnpm run format:check');
+    expect(quality).not.toMatch(/\bif:|continue-on-error:/);
+    expect(ciWorkflow).toContain('pnpm run lint --concurrency 2 --config eslint.ci.config.mjs');
+    const scripts = JSON.parse(read('package.json')).scripts;
+    expect(scripts['format:check']).toContain('**/*.{ts,tsx,js,jsx,json,css,md,sh}');
+    expect(scripts.lint).toBe('eslint . --max-warnings 0');
+
+    for (const file of ['src/shared/tcpPort.ts', 'src/renderer/App.tsx', 'e2e/startup.spec.ts']) {
+      const original = await local.calculateConfigForFile(file);
+      const optimized = await ci.calculateConfigForFile(file);
+      expect(original.rules['prettier/prettier'][0], file).toBe(2);
+      expect(optimized.rules, file).toEqual({
+        ...original.rules,
+        'prettier/prettier': [0],
       });
-      expect(result.status === 0).toBe(lint === 'success');
+    }
+    // format:check does not include these extensions; preserve their existing rules.
+    for (const file of ['vitest.harness.mts', 'scripts/electron-binary.mjs']) {
+      expect((await ci.calculateConfigForFile(file)).rules, file).toEqual(
+        (await local.calculateConfigForFile(file)).rules,
+      );
     }
   });
 


### PR DESCRIPTION
CI runs a full Prettier check in Code quality, then repeats formatting checks inside ESLint. This removes the duplicate pass for the file extensions already covered by `format:check` using a CI-only ESLint config. Other extensions retain their existing formatting rules, and local lint stays unchanged.

The required Build & Test gate still requires both Code quality and ESLint to succeed. Regression tests compare the resolved local and CI rules and execute the aggregate gate with failed, cancelled, and skipped formatting/lint jobs.

Local measurements on the same checkout: full two-worker lint took **56.08s before and 49.90s after**, about **11% faster**. These are local timings, not a guaranteed GitHub Actions speedup; the recent CI lint step took 185s before this change.

Validation: `pnpm run check:pr`, `pnpm run format:check`, the exact optimized CI lint command, actionlint, yamllint, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Updated automated quality checks to avoid duplicate formatting validation while preserving linting coverage.
  - CI continues to run with parallel workers for efficient feedback.

- **Documentation**
  - Clarified how linting and formatting checks are handled in the CI workflow.

- **Tests**
  - Expanded workflow validation to cover both lint and quality check failures.
  - Added coverage confirming formatting responsibilities are correctly divided between checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->