### PR TITLE
refactor: drop unused Linux Web Bluetooth ipcMain.on path

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -181,7 +181,7 @@ else
   printf 'pre-commit: skip check:db-migrations (no DB schema paths staged)\n' >&2
 fi
 
-if staged_match '^(src/shared/electron-api\.types\.ts|src/preload/|src/main/index\.ts|src/main/ipc/|src/main/updater\.ts|src/main/database\.ts|src/main/mqtt-manager\.ts|src/main/meshcore-mqtt-adapter\.ts|src/main/log-service\.ts|scripts/check-ipc-contract\.mjs)'; then
+if staged_match '^(src/shared/electron-api\.types\.ts|src/preload/|src/main/index\.ts|src/main/ipc/|src/main/updater\.ts|src/main/linuxWebBluetoothCancelIpc\.ts|scripts/check-ipc-contract\.mjs)'; then
   pnpm run check:ipc-contract || fail 'pnpm run check:ipc-contract'
 else
   printf 'pre-commit: skip check:ipc-contract (no IPC contract paths staged)\n' >&2

--- a/scripts/check-ipc-contract.mjs
+++ b/scripts/check-ipc-contract.mjs
@@ -24,10 +24,6 @@ const PRELOAD_FILE = path.join(ROOT, 'src', 'preload', 'index.ts');
 const MAIN_FILES = [
   path.join(ROOT, 'src', 'main', 'index.ts'),
   path.join(ROOT, 'src', 'main', 'updater.ts'),
-  path.join(ROOT, 'src', 'main', 'database.ts'),
-  path.join(ROOT, 'src', 'main', 'mqtt-manager.ts'),
-  path.join(ROOT, 'src', 'main', 'meshcore-mqtt-adapter.ts'),
-  path.join(ROOT, 'src', 'main', 'log-service.ts'),
   // Linux Web Bluetooth cancel handlers live beside the session helper (not under ipc/).
   path.join(ROOT, 'src', 'main', 'linuxWebBluetoothCancelIpc.ts'),
   ...collectIpcHandlerFiles(path.join(ROOT, 'src', 'main', 'ipc')),
@@ -128,6 +124,13 @@ function main() {
   for (const ch of mainHandles) {
     if (!rendererInvokes.has(ch)) {
       warnings.push(`  Main handles '${ch}' but preload never invokes it (dead handler)`);
+    }
+  }
+
+  // Every ipcMain.on that isn't sent from preload is a dead handler (warning only)
+  for (const ch of mainOns) {
+    if (!rendererSends.has(ch)) {
+      warnings.push(`  Main ons '${ch}' but preload never sends it (dead handler)`);
     }
   }
 

--- a/src/main/linuxWebBluetoothCancelIpc.test.ts
+++ b/src/main/linuxWebBluetoothCancelIpc.test.ts
@@ -42,28 +42,22 @@ describe('linuxWebBluetoothCancelIpc', () => {
     return call![1] as (event: unknown, generation: unknown) => { cancelled: boolean };
   }
 
-  function getCancelledHandler(): (event: unknown, generation: unknown) => void {
-    const call = on.mock.calls.find((c) => c[0] === 'bluetooth-device-cancelled');
-    expect(call).toBeDefined();
-    return call![1] as (event: unknown, generation: unknown) => void;
-  }
+  it('registers invoke cancel only (no fire-and-forget on path)', () => {
+    expect(handle.mock.calls.map((c) => c[0])).toEqual(['bluetooth-device-cancel']);
+    expect(on).not.toHaveBeenCalled();
+  });
 
-  it('rejects unauthorized senders on both cancel channels', () => {
+  it('rejects unauthorized senders on invoke cancel', () => {
     vi.mocked(assertIpcSender).mockImplementation((_event, channel) => {
       throw new Error(`${channel}: unauthorized sender`);
     });
     const invokeHandler = getCancelHandler();
-    const sendHandler = getCancelledHandler();
     const badEvent = makeEvent(null);
 
     expect(() => invokeHandler(badEvent, 1)).toThrow(
       'bluetooth-device-cancel: unauthorized sender',
     );
-    expect(() => {
-      sendHandler(badEvent, 1);
-    }).toThrow('bluetooth-device-cancelled: unauthorized sender');
     expect(assertIpcSender).toHaveBeenCalledWith(badEvent, 'bluetooth-device-cancel');
-    expect(assertIpcSender).toHaveBeenCalledWith(badEvent, 'bluetooth-device-cancelled');
   });
 
   it('invoke cancel returns { cancelled } and respects generation', () => {
@@ -85,20 +79,6 @@ describe('linuxWebBluetoothCancelIpc', () => {
     expect(linuxWebBluetoothDeviceSelection.hasPendingSelection()).toBe(false);
 
     expect(assertIpcSender).toHaveBeenCalledWith(event, 'bluetooth-device-cancel');
-    debug.mockRestore();
-  });
-
-  it('fire-and-forget cancelled force-clears when generation is omitted', () => {
-    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
-    const cb = vi.fn();
-    linuxWebBluetoothDeviceSelection.beginOrMergeDiscovery([{ deviceId: 'aa:bb' }], cb);
-    const sendHandler = getCancelledHandler();
-    const event = makeEvent('file:///index.html');
-
-    sendHandler(event, undefined);
-    expect(cb).toHaveBeenCalledWith('');
-    expect(linuxWebBluetoothDeviceSelection.hasPendingSelection()).toBe(false);
-    expect(assertIpcSender).toHaveBeenCalledWith(event, 'bluetooth-device-cancelled');
     debug.mockRestore();
   });
 

--- a/src/main/linuxWebBluetoothCancelIpc.ts
+++ b/src/main/linuxWebBluetoothCancelIpc.ts
@@ -1,5 +1,5 @@
 /**
- * Linux Web Bluetooth chooser cancel IPC (awaitable invoke + fire-and-forget send).
+ * Linux Web Bluetooth chooser cancel IPC (awaitable invoke).
  *
  * Extracted from index.ts so sender validation and generation handling can be
  * exercised without loading the full Electron main entrypoint.
@@ -39,11 +39,5 @@ export function registerLinuxWebBluetoothCancelIpcHandlers(): void {
   ipcMain.handle('bluetooth-device-cancel', (event, generation: unknown) => {
     assertIpcSender(event, 'bluetooth-device-cancel');
     return applyLinuxWebBluetoothCancelIpc(generation);
-  });
-
-  // Fire-and-forget path (Cancel button / teardown). Connect must use the invoke handle.
-  ipcMain.on('bluetooth-device-cancelled', (event, generation: unknown) => {
-    assertIpcSender(event, 'bluetooth-device-cancelled');
-    applyLinuxWebBluetoothCancelIpc(generation);
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Subtractive IPC cleanup only. No TCP-bridge migration, no orphan-script sweep, no CI policy-scanner retarget.

Follows #979–#982 (dead-code passes). This PR is the Linux Web Bluetooth cancel `on` path + unused-`ipcMain.on` checker hole.

## Changed

| Item | Why |
| --- | --- |
| `ipcMain.on('bluetooth-device-cancelled')` | Unreachable. Preload `cancelBluetoothSelection()` only `invoke`s `bluetooth-device-cancel`. Connect/Cancel already await that invoke. |
| `linuxWebBluetoothCancelIpc.test.ts` | Drop fire-and-forget `on` cases; assert invoke-only registration; keep generation + force `applyLinuxWebBluetoothCancelIpc()` coverage. |
| `check-ipc-contract.mjs` unused `on` | Same spirit as unused `handle`: warn when `ipcMain.on` has no preload `send`. This dead path would have been flagged. |
| `MAIN_FILES` / pre-commit path-gate | Keep `src/main/linuxWebBluetoothCancelIpc.ts` (already scanned; now also path-gated). Drop `database.ts`, `mqtt-manager.ts`, `meshcore-mqtt-adapter.ts`, `log-service.ts` — they do not register `ipcMain`. |

## Left alone

- `applyLinuxWebBluetoothCancelIpc()` + `ipcMain.handle('bluetooth-device-cancel')`
- Preload `cancelBluetoothSelection()` invoke contract
- `log:line` push lives in `log-service.ts` (no `ipcMain` registration). Dropped from `MAIN_FILES` per this hole-close; push-listen check for that channel is no longer in this scanner.
- Orphan scripts, TCP bridge / `assertIpcSender` boil-the-ocean, CI `policy-scanners` / `act:ci`, docs-only comment sweeps

## Proof

- Grepped preload: only `ipcRenderer.invoke('bluetooth-device-cancel')`; no `send('bluetooth-device-cancelled')`
- `pnpm run check:ipc-contract`
- Narrow main tests: `src/main/linuxWebBluetoothCancelIpc.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d2dcb20-ee02-595d-a04f-bf83c5357389?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d2dcb20-ee02-595d-a04f-bf83c5357389&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPC contract validation by warning when handlers lack a matching preload send call.
  * Restricted Linux Web Bluetooth cancellation to the supported invoke-based channel.
  * Rejected unauthorized senders for Bluetooth cancellation requests.

* **Tests**
  * Updated coverage to verify invoke-only Bluetooth cancellation and sender authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->