### PR TITLE
fix: ConnectionPanel i18n and status-text pulse split

### DIFF
--- a/src/renderer/components/ConnectionPanel.test.tsx
+++ b/src/renderer/components/ConnectionPanel.test.tsx
@@ -1229,6 +1229,84 @@ describe('ConnectionPanel firmware status indicator', () => {
   });
 });
 
+describe('ConnectionPanel status i18n and pulse', () => {
+  it('translates radio status, connection type, and docs link when connected', () => {
+    renderWithFirmware();
+    expect(screen.getByText('Configured')).toBeInTheDocument();
+    expect(screen.getByText('Bluetooth')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Docs ↗' })).toHaveAttribute(
+      'href',
+      'https://github.com/Colorado-Mesh/mesh-client/blob/main/docs/troubleshooting.md',
+    );
+    expect(screen.queryByText('configured')).not.toBeInTheDocument();
+    expect(screen.queryByText('ble')).not.toBeInTheDocument();
+  });
+
+  it('pulses the reconnecting radio status dot, not the status text', () => {
+    render(
+      <ConnectionPanel
+        state={{ ...configuredState, status: 'reconnecting' }}
+        onConnect={vi.fn().mockResolvedValue(undefined)}
+        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+        onDisconnect={vi.fn().mockResolvedValue(undefined)}
+        mqttStatus="disconnected"
+        protocol="meshtastic"
+      />,
+    );
+    const statusText = screen.getByText('Reconnecting');
+    expect(statusText).not.toHaveClass('animate-pulse');
+    expect(statusText.previousElementSibling).toHaveClass('animate-pulse');
+  });
+
+  it('pulses the MQTT connecting dot, not the status text', () => {
+    render(
+      <ConnectionPanel
+        state={disconnectedState}
+        onConnect={vi.fn().mockResolvedValue(undefined)}
+        onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+        onDisconnect={vi.fn().mockResolvedValue(undefined)}
+        mqttStatus="connecting"
+        protocol="meshtastic"
+      />,
+    );
+    const mqttCard = screen.getByText('MQTT Connection').closest('.bg-deep-black');
+    expect(mqttCard).toBeTruthy();
+    const statusText = within(mqttCard as HTMLElement).getByText('connecting');
+    expect(statusText).not.toHaveClass('animate-pulse');
+    expect(statusText.parentElement).toHaveClass('text-yellow-400');
+    expect(statusText.parentElement).not.toHaveClass('animate-pulse');
+    expect(statusText.previousElementSibling).toHaveClass('animate-pulse');
+  });
+
+  it('translates last-connection transport type', () => {
+    const lastConnKey = 'mesh-client:lastConnection:meshtastic';
+    localStorage.setItem(
+      lastConnKey,
+      JSON.stringify({ type: 'http', httpAddress: '192.168.1.20' }),
+    );
+    try {
+      render(
+        <ConnectionPanel
+          state={disconnectedState}
+          onConnect={vi.fn().mockResolvedValue(undefined)}
+          onAutoConnect={vi.fn().mockResolvedValue(undefined)}
+          onDisconnect={vi.fn().mockResolvedValue(undefined)}
+          mqttStatus="disconnected"
+          protocol="meshtastic"
+        />,
+      );
+      const lastCard = screen
+        .getByRole('button', { name: /^Reconnect$/i })
+        .closest('.bg-deep-black');
+      expect(lastCard).toBeTruthy();
+      expect(within(lastCard as HTMLElement).getByText('WiFi/HTTP')).toBeInTheDocument();
+      expect(within(lastCard as HTMLElement).queryByText(/^http$/i)).not.toBeInTheDocument();
+    } finally {
+      localStorage.removeItem(lastConnKey);
+    }
+  });
+});
+
 describe("ConnectionPanel Meshtastic MQTT presets — Liam's server", () => {
   function renderMeshtasticMqtt() {
     return render(

--- a/src/renderer/components/ConnectionPanel.tsx
+++ b/src/renderer/components/ConnectionPanel.tsx
@@ -52,6 +52,10 @@ import {
   humanizeSerialError,
 } from '../lib/connectionPanelErrorHumanize';
 import {
+  connectionPanelConnectionTypeLabel,
+  connectionPanelRadioStatusLabel,
+} from '../lib/connectionPanelLabels';
+import {
   COLORADO_MQTT_REGION_ACK_KEY,
   meshcoreMqttNeedsColoradoRegionAck,
   runConnectionPanelStorageMigrations,
@@ -2225,21 +2229,28 @@ export default function ConnectionPanel({
           mqttStatus === 'connected'
             ? 'text-brand-green'
             : mqttStatus === 'connecting'
-              ? 'animate-pulse text-yellow-400'
+              ? 'text-yellow-400'
               : mqttStatus === 'error'
                 ? 'text-red-400'
                 : 'text-gray-300'
         }`}
         aria-live="polite"
       >
-        <span aria-hidden="true">● </span>
-        {mqttStatus === 'connected'
-          ? t('connectionPanel.mqttStatusConnected')
-          : mqttStatus === 'connecting'
-            ? t('connectionPanel.mqttStatusConnecting')
-            : mqttStatus === 'error'
-              ? t('connectionPanel.mqttStatusError')
-              : t('connectionPanel.mqttStatusDisconnected')}
+        <span
+          aria-hidden="true"
+          className={mqttStatus === 'connecting' ? 'inline-block animate-pulse' : undefined}
+        >
+          ●{' '}
+        </span>
+        <span>
+          {mqttStatus === 'connected'
+            ? t('connectionPanel.mqttStatusConnected')
+            : mqttStatus === 'connecting'
+              ? t('connectionPanel.mqttStatusConnecting')
+              : mqttStatus === 'error'
+                ? t('connectionPanel.mqttStatusError')
+                : t('connectionPanel.mqttStatusDisconnected')}
+        </span>
       </span>
     </div>
   );
@@ -3104,7 +3115,7 @@ export default function ConnectionPanel({
                 rel="noreferrer"
                 className="hover:text-brand-green text-xs text-gray-300 transition-colors"
               >
-                Docs ↗
+                {t('diagnosticsPanel.docsLink')}
               </a>
               <span
                 className={`inline-flex items-center gap-1 text-xs font-medium ${
@@ -3116,16 +3127,20 @@ export default function ConnectionPanel({
                     ●
                   </span>
                 ) : (
-                  <>●</>
+                  <span aria-hidden>●</span>
                 )}{' '}
-                {state.status}
+                <span>{connectionPanelRadioStatusLabel(t, state.status)}</span>
               </span>
             </div>
           </div>
           <div className="space-y-3 p-4">
             <div className="flex justify-between text-sm">
               <span className="text-muted">{t('connectionPanel.connectionType')}</span>
-              <span className="text-gray-200 uppercase">{state.connectionType}</span>
+              <span className="text-gray-200">
+                {state.connectionType
+                  ? connectionPanelConnectionTypeLabel(t, state.connectionType, protocol)
+                  : null}
+              </span>
             </div>
             {state.connectionType === 'ble' && lastBleIdentity ? (
               <div className="flex justify-between text-sm">
@@ -3256,7 +3271,9 @@ export default function ConnectionPanel({
                 {lastConnection.type === 'ble' && lastBleIdentity ? (
                   <p className="text-muted font-mono text-xs">{lastBleIdentity.display}</p>
                 ) : (
-                  <p className="text-muted text-xs uppercase">{lastConnection.type}</p>
+                  <p className="text-muted text-xs">
+                    {connectionPanelConnectionTypeLabel(t, lastConnection.type, protocol)}
+                  </p>
                 )}
               </div>
             </div>
@@ -3298,7 +3315,7 @@ export default function ConnectionPanel({
               rel="noreferrer"
               className="hover:text-brand-green text-xs text-gray-300 transition-colors"
             >
-              Docs ↗
+              {t('diagnosticsPanel.docsLink')}
             </a>
             <span className="text-xs font-medium text-gray-400">
               {t('connectionPanel.disconnected')}

--- a/src/renderer/components/DiagnosticsPanel.test.tsx
+++ b/src/renderer/components/DiagnosticsPanel.test.tsx
@@ -810,3 +810,43 @@ describe('DiagnosticsPanel reticulum scope', () => {
     expect(screen.getByRole('button', { name: /edit interface/i })).toBeInTheDocument();
   });
 });
+
+describe('DiagnosticsPanel tracing pulse', () => {
+  it('pulses a decorative dot, not the tracing label', () => {
+    const nodeId = 0x1234;
+    const node = minimalNode(nodeId);
+    const row: RoutingDiagnosticRow = {
+      kind: 'routing',
+      id: `routing:${nodeId}`,
+      nodeId,
+      type: 'hop_goblin',
+      severity: 'warning',
+      description: 'Test anomaly',
+      detectedAt: Date.now(),
+    };
+    diagnosticsStoreState.diagnosticRows = [row];
+    diagnosticsStoreState.packetStats = new Map();
+
+    render(
+      <DiagnosticsPanel
+        nodes={new Map<number, MeshNode>([[nodeId, node]])}
+        myNodeNum={0}
+        onTraceRoute={() => new Promise(() => {})}
+        isConnected
+        traceRouteResults={new Map()}
+        getFullNodeLabel={vi.fn().mockReturnValue('Unknown')}
+        protocol="meshtastic"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Trace Route/i }));
+    const labels = screen.getAllByText('Tracing…');
+    expect(labels.length).toBeGreaterThan(0);
+    for (const label of labels) {
+      expect(label).not.toHaveClass('animate-pulse');
+    }
+    expect(
+      labels.some((label) => label.previousElementSibling?.classList.contains('animate-pulse')),
+    ).toBe(true);
+  });
+});

--- a/src/renderer/components/DiagnosticsPanel.tsx
+++ b/src/renderer/components/DiagnosticsPanel.tsx
@@ -722,7 +722,12 @@ export default function DiagnosticsPanel({
           </td>
           <td className="text-muted px-4 py-2.5 text-right text-xs">
             {isPending ? (
-              <span className="animate-pulse text-blue-400">{t('diagnosticsPanel.tracing')}</span>
+              <span className="inline-flex items-center justify-end gap-1 text-blue-400">
+                <span aria-hidden className="inline-block animate-pulse">
+                  ●
+                </span>
+                <span>{t('diagnosticsPanel.tracing')}</span>
+              </span>
             ) : (
               formatRowTime(anomaly.detectedAt)
             )}

--- a/src/renderer/components/ReticulumStackPanel.test.tsx
+++ b/src/renderer/components/ReticulumStackPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
@@ -110,7 +110,7 @@ describe('ReticulumStackPanel', () => {
       />,
     );
 
-    const status = await screen.findByText('● connectionPanel.disconnected');
+    const status = (await screen.findByText('connectionPanel.disconnected')).parentElement;
     const startButton = screen.getByRole('button', {
       name: 'connectionPanel.reticulumStartStack',
     });
@@ -119,6 +119,29 @@ describe('ReticulumStackPanel', () => {
     expect(startButton).toHaveClass('bg-amber-700', 'text-white', 'hover:bg-amber-800');
     hydrateAxeThemeColors(container);
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('pulses the connecting stack status dot, not the text', async () => {
+    vi.mocked(window.electronAPI.reticulum.getStatus).mockResolvedValue({
+      running: false,
+      port: 0,
+      pid: null,
+      interfaceIssueAlert: null,
+    });
+
+    render(
+      <ReticulumStackPanel connecting onStartStack={async () => {}} onStopStack={async () => {}} />,
+    );
+
+    const title = await screen.findByText('connectionPanel.reticulumStackTitle');
+    const header = title.closest('.bg-secondary-dark');
+    expect(header).toBeTruthy();
+    const statusText = within(header as HTMLElement).getByText('connectionPanel.connecting');
+    const status = statusText.parentElement;
+    expect(status).toHaveClass('text-yellow-400');
+    expect(statusText).not.toHaveClass('animate-pulse');
+    expect(status).not.toHaveClass('animate-pulse');
+    expect(statusText.previousElementSibling).toHaveClass('animate-pulse');
   });
 
   it('shows local interface alert when serial port is stale', async () => {

--- a/src/renderer/components/ReticulumStackPanel.tsx
+++ b/src/renderer/components/ReticulumStackPanel.tsx
@@ -252,7 +252,7 @@ export function ReticulumStackPanel({
   if (sidecarUiRunning) {
     stackStatusClass = 'text-brand-green';
   } else if (connecting) {
-    stackStatusClass = 'animate-pulse text-yellow-400';
+    stackStatusClass = 'text-yellow-400';
   }
 
   let stackStatusText = t('connectionPanel.disconnected');
@@ -297,7 +297,14 @@ export function ReticulumStackPanel({
       <div className="bg-deep-black overflow-hidden rounded-lg border border-gray-700">
         <div className="bg-secondary-dark flex items-center justify-between border-b border-gray-700 px-4 py-3">
           <h2 className="font-medium text-gray-200">{t('connectionPanel.reticulumStackTitle')}</h2>
-          <span className={`text-xs font-medium ${stackStatusClass}`}>● {stackStatusText}</span>
+          <span
+            className={`inline-flex items-center gap-1 text-xs font-medium ${stackStatusClass}`}
+          >
+            <span aria-hidden className={connecting ? 'inline-block animate-pulse' : undefined}>
+              ●
+            </span>{' '}
+            <span>{stackStatusText}</span>
+          </span>
         </div>
         <div className="space-y-3 p-4">
           <p className="text-muted text-xs">{t('connectionPanel.reticulumStackHint')}</p>

--- a/src/renderer/lib/connectionPanelLabels.test.ts
+++ b/src/renderer/lib/connectionPanelLabels.test.ts
@@ -1,0 +1,39 @@
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+
+import {
+  connectionPanelConnectionTypeLabel,
+  connectionPanelRadioStatusLabel,
+} from './connectionPanelLabels';
+import type { ConnectionStatus, ConnectionType, MeshProtocol } from './types';
+
+function mockT(): TFunction {
+  return ((key: string) => key) as TFunction;
+}
+
+describe('connectionPanelRadioStatusLabel', () => {
+  it.each<[ConnectionStatus, string]>([
+    ['disconnected', 'app.deviceStatus.disconnected'],
+    ['connecting', 'app.deviceStatus.connecting'],
+    ['connected', 'app.deviceStatus.connected'],
+    ['configured', 'app.deviceStatus.configured'],
+    ['stale', 'app.deviceStatus.stale'],
+    ['reconnecting', 'app.deviceStatus.reconnecting'],
+  ])('maps %s to %s', (status, key) => {
+    expect(connectionPanelRadioStatusLabel(mockT(), status)).toBe(key);
+  });
+});
+
+describe('connectionPanelConnectionTypeLabel', () => {
+  it.each<[ConnectionType, MeshProtocol, string]>([
+    ['ble', 'meshtastic', 'connectionPanel.bluetooth'],
+    ['serial', 'meshtastic', 'connectionPanel.usbSerial'],
+    ['tcp', 'meshtastic', 'connectionPanel.wifiTcp'],
+    ['http', 'meshtastic', 'connectionPanel.wifiHttp'],
+    ['http', 'meshcore', 'connectionPanel.tcpIp'],
+    ['ble', 'meshcore', 'connectionPanel.bluetooth'],
+    ['http', 'reticulum', 'connectionPanel.wifiHttp'],
+  ])('maps %s/%s to %s', (type, protocol, key) => {
+    expect(connectionPanelConnectionTypeLabel(mockT(), type, protocol)).toBe(key);
+  });
+});

--- a/src/renderer/lib/connectionPanelLabels.ts
+++ b/src/renderer/lib/connectionPanelLabels.ts
@@ -1,0 +1,47 @@
+import type { TFunction } from 'i18next';
+
+import type { ConnectionStatus, ConnectionType, MeshProtocol } from './types';
+
+/** Localized radio status for ConnectionPanel (reuses header `app.deviceStatus` keys). */
+export function connectionPanelRadioStatusLabel(t: TFunction, status: ConnectionStatus): string {
+  switch (status) {
+    case 'disconnected':
+      return t('app.deviceStatus.disconnected');
+    case 'connecting':
+      return t('app.deviceStatus.connecting');
+    case 'connected':
+      return t('app.deviceStatus.connected');
+    case 'configured':
+      return t('app.deviceStatus.configured');
+    case 'stale':
+      return t('app.deviceStatus.stale');
+    case 'reconnecting':
+      return t('app.deviceStatus.reconnecting');
+    default: {
+      const _x: never = status;
+      return _x;
+    }
+  }
+}
+
+/** Localized transport label matching the Connection type selector. */
+export function connectionPanelConnectionTypeLabel(
+  t: TFunction,
+  type: ConnectionType,
+  protocol: MeshProtocol,
+): string {
+  switch (type) {
+    case 'ble':
+      return t('connectionPanel.bluetooth');
+    case 'serial':
+      return t('connectionPanel.usbSerial');
+    case 'tcp':
+      return t('connectionPanel.wifiTcp');
+    case 'http':
+      return protocol === 'meshcore' ? t('connectionPanel.tcpIp') : t('connectionPanel.wifiHttp');
+    default: {
+      const _x: never = type;
+      return _x;
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small Connection-status UI cleanup. Does **not** touch `useProtocolFacade`, MeshCore runtime, or TCP bridges.

### Changed

1. **ConnectionPanel status / type / Docs are i18n’d**
   - Radio status uses existing `app.deviceStatus.*` (Configured, Reconnecting, …) instead of raw `state.status`.
   - Connection type (connected card + last-device subtitle) uses the same labels as the type selector (`Bluetooth`, `USB Serial`, `WiFi/HTTP`, `WiFi/TCP`, MeshCore `TCP/IP`) instead of uppercase `ble`/`http`/`tcp`/`serial`.
   - Troubleshooting **Docs ↗** reuses `diagnosticsPanel.docsLink` (same English string, already translated). No new locale keys.

2. **`animate-pulse` moved off small status text**
   - MQTT connecting, radio reconnecting, Diagnostics “Tracing…”, and Reticulum stack connecting now pulse a decorative `●` (`aria-hidden`). The text span stays fully opaque, matching `ProtocolUnreadBadge` / header guidance.
   - Connection-status **header** pulses remain the documented exception and were already split.

### Deferred (follow-up)

- Notifier / outbox English `Error.message` keys (`useChatOutbox` already i18n’s its throws; remaining notifier strings are not adjacent to this UI).
- App header still appends raw `(BLE)` / `(HTTP)` next to the translated device status — out of this ConnectionPanel-only scope.
- Facade adoption, dead-code sweeps, main-process TCP dedupe.

### Proof

- Pre-commit: typecheck + related Vitest **194 passed** (ConnectionPanel, DiagnosticsPanel, ReticulumStackPanel, label helper).
- `check:i18n:branch` passed (no new English keys).

## Test plan

- [x] `connectionPanelLabels` unit tests (all statuses + types)
- [x] ConnectionPanel: translated Configured / Bluetooth / Docs ↗; pulse on reconnecting + MQTT connecting dots only
- [x] DiagnosticsPanel: tracing label has no `animate-pulse`; decorative dot does
- [x] ReticulumStackPanel: connecting status text has no pulse; dot does
- [ ] Smoke Connection tab in a running app (locale switch + reconnecting / MQTT connecting) if desired

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbb243d1-9b73-5041-9e37-10e2e27b1750?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbb243d1-9b73-5041-9e37-10e2e27b1750&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Connection statuses and connection types now display localized, user-friendly labels across connection and reconnect views.
  - Troubleshooting links now use translated link text.
  - Connection, MQTT, and stack connection indicators now animate the status dot instead of the status text.
  - Diagnostics tracing indicators now show a pulsing dot alongside the localized “Tracing…” label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->