### PR TITLE
fix(rrc): demote stale Connected UI when hub link is already dead

### DIFF
--- a/reticulum-sidecar/src/stack/rrc_link.rs
+++ b/reticulum-sidecar/src/stack/rrc_link.rs
@@ -657,6 +657,8 @@ mod tests {
         assert!(rrc_disconnect_should_drop_path("resource_offers_closed"));
         assert!(!rrc_disconnect_should_drop_path("local_close"));
         assert!(!rrc_disconnect_should_drop_path("local_disconnect"));
+        // Silent event-channel end — reconnect with Refresh, not DropPath.
+        assert!(!rrc_disconnect_should_drop_path("link_ended"));
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/rrc_session.rs
+++ b/reticulum-sidecar/src/stack/rrc_session.rs
@@ -1018,7 +1018,65 @@ async fn session_loop(
                         }
                     }
                     None => {
+                        // Event channel ended without Closed (task drop / channel close).
+                        // Treat like an unintended link death so the UI is not left Active.
                         link = None;
+                        let reason = "link_ended".to_string();
+                        let should_reconnect =
+                            reconnect_intent.is_some() && connect_job.is_none();
+                        {
+                            let mut g = inner.lock().await;
+                            if should_reconnect {
+                                g.status = RrcSessionStatus::Reconnecting;
+                            } else if connect_job.is_none() {
+                                g.status = RrcSessionStatus::Disconnected;
+                                g.rooms.clear();
+                            }
+                            g.last_error = Some(reason.clone());
+                        }
+                        emit(
+                            &event_tx,
+                            "rrc.disconnected",
+                            json!({
+                                "hub_dest_hash": hex,
+                                "reason": reason,
+                                "will_reconnect": should_reconnect,
+                            }),
+                        );
+                        if should_reconnect {
+                            if let Some((dest_hash, dest_hash_hex, hops, intent_nick)) =
+                                reconnect_intent.clone()
+                            {
+                                let nickname =
+                                    resolve_reconnect_nickname(&inner, &intent_nick).await;
+                                let delay = backoff_ms;
+                                let path_refresh = if rrc_disconnect_should_drop_path(&reason) {
+                                    RrcPathRefresh::DropAndRefresh
+                                } else {
+                                    RrcPathRefresh::Refresh
+                                };
+                                debug!(
+                                    reason = %reason,
+                                    ?path_refresh,
+                                    "rrc reconnecting to {dest_hash_hex} in {delay}ms after link_ended"
+                                );
+                                backoff_ms =
+                                    (backoff_ms.saturating_mul(2)).min(RECONNECT_MAX_MS);
+                                connect_job = Some(spawn_connect_job(
+                                    transport_tx.clone(),
+                                    identity.clone(),
+                                    Arc::clone(&inner),
+                                    event_tx.clone(),
+                                    dest_hash,
+                                    dest_hash_hex,
+                                    hops,
+                                    nickname,
+                                    delay,
+                                    path_refresh,
+                                    None,
+                                ));
+                            }
+                        }
                     }
                 }
             }

--- a/src/renderer/components/RrcPanel.tsx
+++ b/src/renderer/components/RrcPanel.tsx
@@ -17,6 +17,7 @@ import {
   type OpenRrcHubDetail,
   takePendingRrcHubOpen,
 } from '@/renderer/lib/openRrcHubFromLink';
+import { reconcileRrcHubAfterDeadSend } from '@/renderer/lib/reconcileRrcSessionsFromSnapshot';
 import { withReticulumIpcSendDeadline } from '@/renderer/lib/reticulum/reticulumIpcDeadline';
 import { isReticulumSidecarRunning } from '@/renderer/lib/reticulum/reticulumSidecarReads';
 import {
@@ -25,7 +26,7 @@ import {
   rrcDmDisplayLabel,
   rrcDmRoomKey,
 } from '@/renderer/lib/rrcDmRoom';
-import { formatRrcErrorMessage } from '@/renderer/lib/rrcErrorHumanize';
+import { formatRrcErrorMessage, isRrcDeadSessionSendError } from '@/renderer/lib/rrcErrorHumanize';
 import { clearRrcHubAutoJoinBackoff } from '@/renderer/lib/rrcHubAutoJoinBackoff';
 import { setRrcHubDisconnectSuppressed } from '@/renderer/lib/rrcHubDisconnectSuppress';
 import {
@@ -824,17 +825,24 @@ export default function RrcPanel({
     [activeRoom, addMessage, setActiveRoom],
   );
 
-  const setRrcSendError = useCallback((message: string | null) => {
-    if (!message) {
-      useRrcSessionStore.getState().setError(null);
-      return;
-    }
-    if (isRrcHubMsgBodyLimitError(message) || isRrcHubNickLimitError(message)) {
-      // Composer / field counters already explain hub WELCOME limits.
-      return;
-    }
-    useRrcSessionStore.getState().setError(message);
-  }, []);
+  const setRrcSendError = useCallback(
+    (message: string | null) => {
+      if (!message) {
+        useRrcSessionStore.getState().setError(null);
+        return;
+      }
+      if (isRrcHubMsgBodyLimitError(message) || isRrcHubNickLimitError(message)) {
+        // Composer / field counters already explain hub WELCOME limits.
+        return;
+      }
+      useRrcSessionStore.getState().setError(message);
+      // Sidecar already rejected the send — demote Connected before the next click.
+      if (isRrcDeadSessionSendError(message) && hubDestHash) {
+        void reconcileRrcHubAfterDeadSend(hubDestHash);
+      }
+    },
+    [hubDestHash],
+  );
 
   const handleSend = useCallback(
     async (text: string) => {

--- a/src/renderer/lib/reconcileRrcSessionsFromSnapshot.test.ts
+++ b/src/renderer/lib/reconcileRrcSessionsFromSnapshot.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  reconcileRrcHubAfterDeadSend,
+  reconcileRrcSessionsFromSnapshot,
+} from '@/renderer/lib/reconcileRrcSessionsFromSnapshot';
+import { useRrcSessionStore } from '@/renderer/stores/rrcSessionStore';
+import type { RrcMultiSessionSnapshot } from '@/shared/rrc-types';
+
+const HUB_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const HUB_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function snap(sessions: RrcMultiSessionSnapshot['sessions']): RrcMultiSessionSnapshot {
+  return { sessions, identity_hash: 'cccccccccccccccccccccccccccccccc' };
+}
+
+describe('reconcileRrcSessionsFromSnapshot', () => {
+  beforeEach(() => {
+    useRrcSessionStore.getState().clearSession();
+  });
+
+  it('clears a UI-active hub missing from the sidecar snapshot', () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('active');
+
+    reconcileRrcSessionsFromSnapshot(snap([]));
+
+    expect(useRrcSessionStore.getState().sessionsByHub.has(HUB_A)).toBe(false);
+  });
+
+  it('demotes UI-active to reconnecting when sidecar is reconnecting', () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+
+    reconcileRrcSessionsFromSnapshot(
+      snap([
+        {
+          status: 'reconnecting',
+          hub_dest_hash: HUB_A,
+          hub_name: 'Hub A',
+          rooms: [],
+          error: 'timeout',
+        },
+      ]),
+    );
+
+    const ui = useRrcSessionStore.getState().sessionsByHub.get(HUB_A);
+    expect(ui?.status).toBe('reconnecting');
+    expect(ui?.lastError).toBe('timeout');
+  });
+
+  it('leaves an already-active matching hub alone', () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+
+    reconcileRrcSessionsFromSnapshot(
+      snap([
+        {
+          status: 'active',
+          hub_dest_hash: HUB_A,
+          hub_name: 'Hub A',
+          rooms: [],
+        },
+      ]),
+    );
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('active');
+  });
+
+  it('does not demote when disconnectIntent is set', () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    useRrcSessionStore.getState().setDisconnectIntent(true, HUB_A);
+
+    reconcileRrcSessionsFromSnapshot(snap([]));
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('active');
+  });
+
+  it('only reconciles the requested hub when hubDestHash is set', () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    useRrcSessionStore.getState().applyStatus('active', HUB_B, 'Hub B');
+
+    reconcileRrcSessionsFromSnapshot(snap([]), { hubDestHash: HUB_A });
+
+    expect(useRrcSessionStore.getState().sessionsByHub.has(HUB_A)).toBe(false);
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_B)?.status).toBe('active');
+  });
+});
+
+describe('reconcileRrcHubAfterDeadSend', () => {
+  beforeEach(() => {
+    useRrcSessionStore.getState().clearSession();
+  });
+
+  it('forces reconnecting when snapshot still claims active', async () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    const getStatus = vi.fn().mockResolvedValue(
+      snap([
+        {
+          status: 'active',
+          hub_dest_hash: HUB_A,
+          hub_name: 'Hub A',
+          rooms: [],
+        },
+      ]),
+    );
+
+    await reconcileRrcHubAfterDeadSend(HUB_A, getStatus);
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('reconnecting');
+  });
+
+  it('clears the hub when sidecar snapshot has no session', async () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    const getStatus = vi.fn().mockResolvedValue(snap([]));
+
+    await reconcileRrcHubAfterDeadSend(HUB_A, getStatus);
+
+    expect(useRrcSessionStore.getState().sessionsByHub.has(HUB_A)).toBe(false);
+  });
+
+  it('demotes to reconnecting when getStatus throws', async () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    const getStatus = vi.fn().mockRejectedValue(new Error('down'));
+
+    await reconcileRrcHubAfterDeadSend(HUB_A, getStatus);
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('reconnecting');
+  });
+});

--- a/src/renderer/lib/reconcileRrcSessionsFromSnapshot.test.ts
+++ b/src/renderer/lib/reconcileRrcSessionsFromSnapshot.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   reconcileRrcHubAfterDeadSend,
   reconcileRrcSessionsFromSnapshot,
+  scheduleRrcSessionStatusReconcile,
 } from '@/renderer/lib/reconcileRrcSessionsFromSnapshot';
 import { useRrcSessionStore } from '@/renderer/stores/rrcSessionStore';
 import type { RrcMultiSessionSnapshot } from '@/shared/rrc-types';
@@ -12,6 +13,20 @@ const HUB_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
 function snap(sessions: RrcMultiSessionSnapshot['sessions']): RrcMultiSessionSnapshot {
   return { sessions, identity_hash: 'cccccccccccccccccccccccccccccccc' };
+}
+
+function deferredStatus(): {
+  promise: Promise<RrcMultiSessionSnapshot>;
+  resolve: (value: RrcMultiSessionSnapshot) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: RrcMultiSessionSnapshot) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<RrcMultiSessionSnapshot>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe('reconcileRrcSessionsFromSnapshot', () => {
@@ -83,6 +98,19 @@ describe('reconcileRrcSessionsFromSnapshot', () => {
     expect(useRrcSessionStore.getState().sessionsByHub.has(HUB_A)).toBe(false);
     expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_B)?.status).toBe('active');
   });
+
+  it('skips hubs whose expected generation is stale', () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    const gen = useRrcSessionStore.getState().sessionsByHub.get(HUB_A)!.generation;
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+
+    reconcileRrcSessionsFromSnapshot(snap([]), {
+      hubDestHash: HUB_A,
+      expectedGenerations: new Map([[HUB_A, gen]]),
+    });
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('active');
+  });
 });
 
 describe('reconcileRrcHubAfterDeadSend', () => {
@@ -124,5 +152,87 @@ describe('reconcileRrcHubAfterDeadSend', () => {
     await reconcileRrcHubAfterDeadSend(HUB_A, getStatus);
 
     expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('reconnecting');
+  });
+
+  it('does not clear when a newer connect bumps generation before getStatus returns', async () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    const delayed = deferredStatus();
+    const getStatus = vi.fn().mockReturnValue(delayed.promise);
+
+    const pending = reconcileRrcHubAfterDeadSend(HUB_A, getStatus);
+    // Newer connect event while status fetch is in flight.
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    delayed.resolve(snap([]));
+    await pending;
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('active');
+  });
+
+  it('does not force reconnecting when generation advances before getStatus fails', async () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    const delayed = deferredStatus();
+    const getStatus = vi.fn().mockReturnValue(delayed.promise);
+
+    const pending = reconcileRrcHubAfterDeadSend(HUB_A, getStatus);
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    delayed.reject(new Error('down'));
+    await pending;
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('active');
+  });
+});
+
+describe('scheduleRrcSessionStatusReconcile', () => {
+  beforeEach(() => {
+    useRrcSessionStore.getState().clearSession();
+  });
+
+  it('clears stale hubs when generations are unchanged', async () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    useRrcSessionStore.getState().applyStatus('active', HUB_B, 'Hub B');
+    const getStatus = vi.fn().mockResolvedValue(snap([]));
+
+    await scheduleRrcSessionStatusReconcile('test', getStatus);
+
+    expect(useRrcSessionStore.getState().sessionsByHub.has(HUB_A)).toBe(false);
+    expect(useRrcSessionStore.getState().sessionsByHub.has(HUB_B)).toBe(false);
+  });
+
+  it('does not clear a hub whose generation advanced while getStatus was delayed', async () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    useRrcSessionStore.getState().applyStatus('active', HUB_B, 'Hub B');
+    const delayed = deferredStatus();
+    const getStatus = vi.fn().mockReturnValue(delayed.promise);
+
+    const pending = scheduleRrcSessionStatusReconcile('ws_lag', getStatus);
+    // Hub A reconnects; hub B stays at the captured generation.
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    delayed.resolve(snap([]));
+    await pending;
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('active');
+    expect(useRrcSessionStore.getState().sessionsByHub.has(HUB_B)).toBe(false);
+  });
+
+  it('does not demote to reconnecting when generation advanced before delayed snapshot', async () => {
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    const delayed = deferredStatus();
+    const getStatus = vi.fn().mockReturnValue(delayed.promise);
+
+    const pending = scheduleRrcSessionStatusReconcile('ws_reconnect', getStatus);
+    useRrcSessionStore.getState().applyStatus('active', HUB_A, 'Hub A');
+    delayed.resolve(
+      snap([
+        {
+          status: 'reconnecting',
+          hub_dest_hash: HUB_A,
+          hub_name: 'Hub A',
+          rooms: [],
+        },
+      ]),
+    );
+    await pending;
+
+    expect(useRrcSessionStore.getState().sessionsByHub.get(HUB_A)?.status).toBe('active');
   });
 });

--- a/src/renderer/lib/reconcileRrcSessionsFromSnapshot.ts
+++ b/src/renderer/lib/reconcileRrcSessionsFromSnapshot.ts
@@ -1,0 +1,108 @@
+/**
+ * Align renderer RRC session status with sidecar `GET /rrc/status` truth.
+ * Used after WS lag/reconnect and when send discovers a dead hub session.
+ */
+
+import { errLikeToLogString } from '@/renderer/lib/errLikeToLogString';
+import { useRrcSessionStore } from '@/renderer/stores/rrcSessionStore';
+import type { RrcMultiSessionSnapshot, RrcSessionStatus } from '@/shared/rrc-types';
+
+/** UI statuses that can look "still up" when the sidecar has already dropped. */
+const STALE_CONNECTED_STATUSES: ReadonlySet<RrcSessionStatus> = new Set([
+  'active',
+  'awaiting_welcome',
+]);
+
+function normHub(hash: string): string {
+  return hash.trim().toLowerCase();
+}
+
+/**
+ * Demote or clear UI hub sessions that disagree with the sidecar snapshot.
+ * Does not promote disconnected UI hubs to active (events own that path).
+ */
+export function reconcileRrcSessionsFromSnapshot(
+  snap: RrcMultiSessionSnapshot,
+  opts?: { hubDestHash?: string },
+): void {
+  const store = useRrcSessionStore.getState();
+  const sideByHub = new Map<string, NonNullable<(typeof snap.sessions)[number]>>();
+  for (const session of snap.sessions) {
+    const hub = session.hub_dest_hash ? normHub(session.hub_dest_hash) : '';
+    if (hub) sideByHub.set(hub, session);
+  }
+
+  const hubs = opts?.hubDestHash ? [normHub(opts.hubDestHash)] : [...store.sessionsByHub.keys()];
+
+  for (const hub of hubs) {
+    if (!hub) continue;
+    const ui = store.sessionsByHub.get(hub);
+    if (!ui) continue;
+    if (ui.disconnectIntent) continue;
+    if (!STALE_CONNECTED_STATUSES.has(ui.status)) continue;
+
+    const side = sideByHub.get(hub);
+    if (!side || side.status === 'disconnected') {
+      store.clearHubSession(hub);
+      continue;
+    }
+    if (side.status === 'reconnecting' || side.status === 'connecting') {
+      store.applyStatus('reconnecting', hub, side.hub_name ?? undefined);
+      if (side.error) store.setError(side.error, hub);
+      continue;
+    }
+    if (side.status === 'awaiting_welcome') {
+      store.applyStatus('awaiting_welcome', hub, side.hub_name ?? undefined);
+      continue;
+    }
+    // side.status === 'active' — leave UI alone
+  }
+}
+
+/**
+ * After a dead-session send error: pull sidecar status and demote the hub.
+ * If the snapshot still claims active (race / silent teardown), force reconnecting.
+ */
+export async function reconcileRrcHubAfterDeadSend(
+  hubDestHash: string,
+  getStatus: () => Promise<RrcMultiSessionSnapshot> = () =>
+    window.electronAPI.reticulum.rrc.getStatus(),
+): Promise<void> {
+  const hub = normHub(hubDestHash);
+  if (!hub) return;
+  try {
+    const snap = await getStatus();
+    reconcileRrcSessionsFromSnapshot(snap, { hubDestHash: hub });
+    const ui = useRrcSessionStore.getState().sessionsByHub.get(hub);
+    if (ui && STALE_CONNECTED_STATUSES.has(ui.status) && !ui.disconnectIntent) {
+      useRrcSessionStore.getState().applyStatus('reconnecting', hub);
+    }
+  } catch (e: unknown) {
+    // getStatus failed; still demote so the UI leaves Connected after a dead send.
+    console.debug('[reconcileRrcHubAfterDeadSend] getStatus failed ' + errLikeToLogString(e));
+    const ui = useRrcSessionStore.getState().sessionsByHub.get(hub);
+    if (ui && STALE_CONNECTED_STATUSES.has(ui.status) && !ui.disconnectIntent) {
+      useRrcSessionStore.getState().applyStatus('reconnecting', hub);
+    }
+  }
+}
+
+/** Fire-and-forget full multi-hub reconcile (WS lag / reconnect). */
+export function scheduleRrcSessionStatusReconcile(
+  reason: string,
+  getStatus: () => Promise<RrcMultiSessionSnapshot> = () =>
+    window.electronAPI.reticulum.rrc.getStatus(),
+): void {
+  void getStatus()
+    .then((snap) => {
+      reconcileRrcSessionsFromSnapshot(snap);
+    })
+    .catch((e: unknown) => {
+      console.debug(
+        '[reconcileRrcSessionsFromSnapshot] getStatus after ' +
+          reason +
+          ' failed ' +
+          errLikeToLogString(e),
+      );
+    });
+}

--- a/src/renderer/lib/reconcileRrcSessionsFromSnapshot.ts
+++ b/src/renderer/lib/reconcileRrcSessionsFromSnapshot.ts
@@ -17,13 +17,33 @@ function normHub(hash: string): string {
   return hash.trim().toLowerCase();
 }
 
+/** Snapshot of per-hub generations before an async getStatus() round-trip. */
+function captureHubGenerations(hubs: Iterable<string>): Map<string, number> {
+  const store = useRrcSessionStore.getState();
+  const out = new Map<string, number>();
+  for (const raw of hubs) {
+    const hub = normHub(raw);
+    if (!hub) continue;
+    const ui = store.sessionsByHub.get(hub);
+    if (ui) out.set(hub, ui.generation);
+  }
+  return out;
+}
+
+function isHubGenerationCurrent(hub: string, expectedGeneration: number): boolean {
+  const ui = useRrcSessionStore.getState().sessionsByHub.get(hub);
+  return ui?.generation === expectedGeneration;
+}
+
 /**
  * Demote or clear UI hub sessions that disagree with the sidecar snapshot.
  * Does not promote disconnected UI hubs to active (events own that path).
+ * When `expectedGenerations` is set, skip hubs whose generation advanced (or that
+ * disappeared) while getStatus() was in flight.
  */
 export function reconcileRrcSessionsFromSnapshot(
   snap: RrcMultiSessionSnapshot,
-  opts?: { hubDestHash?: string },
+  opts?: { hubDestHash?: string; expectedGenerations?: ReadonlyMap<string, number> },
 ): void {
   const store = useRrcSessionStore.getState();
   const sideByHub = new Map<string, NonNullable<(typeof snap.sessions)[number]>>();
@@ -32,10 +52,21 @@ export function reconcileRrcSessionsFromSnapshot(
     if (hub) sideByHub.set(hub, session);
   }
 
-  const hubs = opts?.hubDestHash ? [normHub(opts.hubDestHash)] : [...store.sessionsByHub.keys()];
+  const hubs = opts?.hubDestHash
+    ? [normHub(opts.hubDestHash)]
+    : opts?.expectedGenerations
+      ? [...opts.expectedGenerations.keys()]
+      : [...store.sessionsByHub.keys()];
 
   for (const hub of hubs) {
     if (!hub) continue;
+    const expected = opts?.expectedGenerations?.get(hub);
+    if (
+      opts?.expectedGenerations &&
+      (expected === undefined || !isHubGenerationCurrent(hub, expected))
+    ) {
+      continue;
+    }
     const ui = store.sessionsByHub.get(hub);
     if (!ui) continue;
     if (ui.disconnectIntent) continue;
@@ -62,6 +93,7 @@ export function reconcileRrcSessionsFromSnapshot(
 /**
  * After a dead-session send error: pull sidecar status and demote the hub.
  * If the snapshot still claims active (race / silent teardown), force reconnecting.
+ * Skips when the hub's generation advanced while getStatus() was in flight.
  */
 export async function reconcileRrcHubAfterDeadSend(
   hubDestHash: string,
@@ -70,9 +102,14 @@ export async function reconcileRrcHubAfterDeadSend(
 ): Promise<void> {
   const hub = normHub(hubDestHash);
   if (!hub) return;
+  const expectedGenerations = captureHubGenerations([hub]);
+  const captured = expectedGenerations.get(hub);
+  if (captured === undefined) return;
   try {
     const snap = await getStatus();
-    reconcileRrcSessionsFromSnapshot(snap, { hubDestHash: hub });
+    if (!isHubGenerationCurrent(hub, captured)) return;
+    reconcileRrcSessionsFromSnapshot(snap, { hubDestHash: hub, expectedGenerations });
+    if (!isHubGenerationCurrent(hub, captured)) return;
     const ui = useRrcSessionStore.getState().sessionsByHub.get(hub);
     if (ui && STALE_CONNECTED_STATUSES.has(ui.status) && !ui.disconnectIntent) {
       useRrcSessionStore.getState().applyStatus('reconnecting', hub);
@@ -80,6 +117,7 @@ export async function reconcileRrcHubAfterDeadSend(
   } catch (e: unknown) {
     // getStatus failed; still demote so the UI leaves Connected after a dead send.
     console.debug('[reconcileRrcHubAfterDeadSend] getStatus failed ' + errLikeToLogString(e));
+    if (!isHubGenerationCurrent(hub, captured)) return;
     const ui = useRrcSessionStore.getState().sessionsByHub.get(hub);
     if (ui && STALE_CONNECTED_STATUSES.has(ui.status) && !ui.disconnectIntent) {
       useRrcSessionStore.getState().applyStatus('reconnecting', hub);
@@ -92,10 +130,13 @@ export function scheduleRrcSessionStatusReconcile(
   reason: string,
   getStatus: () => Promise<RrcMultiSessionSnapshot> = () =>
     window.electronAPI.reticulum.rrc.getStatus(),
-): void {
-  void getStatus()
+): Promise<void> {
+  const expectedGenerations = captureHubGenerations(
+    useRrcSessionStore.getState().sessionsByHub.keys(),
+  );
+  return getStatus()
     .then((snap) => {
-      reconcileRrcSessionsFromSnapshot(snap);
+      reconcileRrcSessionsFromSnapshot(snap, { expectedGenerations });
     })
     .catch((e: unknown) => {
       console.debug(

--- a/src/renderer/lib/rrcErrorHumanize.test.ts
+++ b/src/renderer/lib/rrcErrorHumanize.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatRrcErrorMessage, rrcErrorToI18nKey } from './rrcErrorHumanize';
+import {
+  formatRrcErrorMessage,
+  isRrcDeadSessionSendError,
+  rrcErrorToI18nKey,
+} from './rrcErrorHumanize';
 
 describe('rrcErrorHumanize', () => {
   it('maps link proof timeouts', () => {
@@ -31,5 +35,11 @@ describe('rrcErrorHumanize', () => {
     expect(rrcErrorToI18nKey('rrc connect requires live rns-stack sidecar')).toBe(
       'rrc.stackNotReady',
     );
+  });
+
+  it('detects dead-session send errors from the sidecar', () => {
+    expect(isRrcDeadSessionSendError('not connected to an RRC hub')).toBe(true);
+    expect(isRrcDeadSessionSendError('rrc session not active (disconnected)')).toBe(true);
+    expect(isRrcDeadSessionSendError('rate limit exceeded')).toBe(false);
   });
 });

--- a/src/renderer/lib/rrcErrorHumanize.ts
+++ b/src/renderer/lib/rrcErrorHumanize.ts
@@ -26,3 +26,12 @@ export function formatRrcErrorMessage(message: string, t: (key: string) => strin
   if (key) return t(key);
   return formatReticulumProxyErrorMessage(message, t);
 }
+
+/**
+ * True when a send/nick IPC error means the hub Link is already gone (sidecar
+ * rejected the call) while the UI may still show Connected.
+ */
+export function isRrcDeadSessionSendError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return lower.includes('not connected to an rrc hub') || lower.includes('rrc session not active');
+}

--- a/src/renderer/runtime/useReticulumRuntime.rrc.test.ts
+++ b/src/renderer/runtime/useReticulumRuntime.rrc.test.ts
@@ -185,6 +185,18 @@ describe('useReticulumRuntime RRC event routing (regression)', () => {
     expect(SOURCE).toMatch(/voluntary='/);
     expect(SOURCE).toMatch(/will_reconnect='/);
   });
+
+  it('reconciles RRC session status after WS lag and reconnect', () => {
+    expect(SOURCE).toMatch(
+      /import \{ scheduleRrcSessionStatusReconcile \} from '@\/renderer\/lib\/reconcileRrcSessionsFromSnapshot'/,
+    );
+    expect(SOURCE).toMatch(
+      /evt\.type === 'events_lagged'[\s\S]*?scheduleRrcSessionStatusReconcile\('events_lagged'\)/,
+    );
+    expect(SOURCE).toMatch(
+      /evt\.type === 'ws_connected'[\s\S]*?reconnect === true[\s\S]*?scheduleRrcSessionStatusReconcile\('ws_reconnect'\)/,
+    );
+  });
 });
 
 describe('useReticulumRuntime RRC empty-K_ROOM hub-scoped routing', () => {

--- a/src/renderer/runtime/useReticulumRuntime.rrc.test.ts
+++ b/src/renderer/runtime/useReticulumRuntime.rrc.test.ts
@@ -191,10 +191,10 @@ describe('useReticulumRuntime RRC event routing (regression)', () => {
       /import \{ scheduleRrcSessionStatusReconcile \} from '@\/renderer\/lib\/reconcileRrcSessionsFromSnapshot'/,
     );
     expect(SOURCE).toMatch(
-      /evt\.type === 'events_lagged'[\s\S]*?scheduleRrcSessionStatusReconcile\('events_lagged'\)/,
+      /evt\.type === 'events_lagged'[\s\S]*?void scheduleRrcSessionStatusReconcile\('events_lagged'\)/,
     );
     expect(SOURCE).toMatch(
-      /evt\.type === 'ws_connected'[\s\S]*?reconnect === true[\s\S]*?scheduleRrcSessionStatusReconcile\('ws_reconnect'\)/,
+      /evt\.type === 'ws_connected'[\s\S]*?reconnect === true[\s\S]*?void scheduleRrcSessionStatusReconcile\('ws_reconnect'\)/,
     );
   });
 });

--- a/src/renderer/runtime/useReticulumRuntime.ts
+++ b/src/renderer/runtime/useReticulumRuntime.ts
@@ -903,7 +903,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
             '[useReticulumRuntime] catch-up after events_lagged failed ' + errLikeToLogString(e),
           );
         });
-        scheduleRrcSessionStatusReconcile('events_lagged');
+        void scheduleRrcSessionStatusReconcile('events_lagged');
       }
       if (evt.type === 'ws_connected' && evt.payload && typeof evt.payload === 'object') {
         const reconnect = (evt.payload as { reconnect?: boolean }).reconnect === true;
@@ -914,7 +914,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
               '[useReticulumRuntime] catch-up after ws_reconnect failed ' + errLikeToLogString(e),
             );
           });
-          scheduleRrcSessionStatusReconcile('ws_reconnect');
+          void scheduleRrcSessionStatusReconcile('ws_reconnect');
         }
       }
       if (evt.type === 'lxmf_outbound_status' && evt.payload && typeof evt.payload === 'object') {

--- a/src/renderer/runtime/useReticulumRuntime.ts
+++ b/src/renderer/runtime/useReticulumRuntime.ts
@@ -29,6 +29,7 @@ import {
   MAX_RAW_PACKET_LOG_ENTRIES,
   type ReticulumRawPacketEntry,
 } from '@/renderer/lib/rawPacketLogConstants';
+import { scheduleRrcSessionStatusReconcile } from '@/renderer/lib/reconcileRrcSessionsFromSnapshot';
 import { announceDestinationHashes } from '@/renderer/lib/reticulum/announceDestinationHashes';
 import {
   applyReticulumOutboundDeliveryStatus,
@@ -902,6 +903,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
             '[useReticulumRuntime] catch-up after events_lagged failed ' + errLikeToLogString(e),
           );
         });
+        scheduleRrcSessionStatusReconcile('events_lagged');
       }
       if (evt.type === 'ws_connected' && evt.payload && typeof evt.payload === 'object') {
         const reconnect = (evt.payload as { reconnect?: boolean }).reconnect === true;
@@ -912,6 +914,7 @@ export function useReticulumRuntime(): ProtocolRuntime {
               '[useReticulumRuntime] catch-up after ws_reconnect failed ' + errLikeToLogString(e),
             );
           });
+          scheduleRrcSessionStatusReconcile('ws_reconnect');
         }
       }
       if (evt.type === 'lxmf_outbound_status' && evt.payload && typeof evt.payload === 'object') {

--- a/src/renderer/stores/rrcSessionStore.ts
+++ b/src/renderer/stores/rrcSessionStore.ts
@@ -123,9 +123,33 @@ function coalesceRoomAliases(
   return { key, existing, rooms: next };
 }
 
+/**
+ * Survives clearHubSession so a clear+reconnect cannot reuse a pre-await generation
+ * and let a stale getStatus() wipe the new session.
+ */
+const hubGenerationCeiling = new Map<string, number>();
+
+/** Next monotonic generation for `hub` (also advances the clear/recreate ceiling). */
+export function nextRrcHubGeneration(hub: string, existingGeneration = 0): number {
+  const ceiling = hubGenerationCeiling.get(hub) ?? 0;
+  const next = Math.max(existingGeneration, ceiling) + 1;
+  hubGenerationCeiling.set(hub, next);
+  return next;
+}
+
+/** Test/helper: reset clear/recreate generation ceilings. */
+export function resetRrcHubGenerationCeilings(): void {
+  hubGenerationCeiling.clear();
+}
+
 /** Per-hub RRC session state, keyed by lowercase hub destination hash in `sessionsByHub`. */
 export interface RrcHubSessionState {
   status: RrcSessionStatus;
+  /**
+   * Monotonic per-hub counter bumped on status apply / clear. Async status reconcile
+   * captures this before getStatus() and skips hubs that advanced while awaiting.
+   */
+  generation: number;
   hubName: string | null;
   capabilities: RrcHubCapabilities;
   /** WELCOME hub operational limits (bytes / rates). */
@@ -152,6 +176,7 @@ export interface RrcHubSessionState {
 export function emptyHubSession(): RrcHubSessionState {
   return {
     status: 'disconnected',
+    generation: 0,
     hubName: null,
     capabilities: {},
     limits: {},
@@ -241,6 +266,9 @@ function mutateHubSession(
  */
 function removeHubSession(s: RrcSessionStoreState, hub: string): Partial<RrcSessionStoreState> {
   const session = s.sessionsByHub.get(hub);
+  // Advance ceiling so an in-flight reconcile that captured the old generation cannot
+  // mistreat a clear+reconnect as still "current".
+  nextRrcHubGeneration(hub, session?.generation ?? 0);
   const sessionsByHub = new Map(s.sessionsByHub);
   sessionsByHub.delete(hub);
 
@@ -772,6 +800,7 @@ export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
       const nextSession: RrcHubSessionState = {
         ...existing,
         status,
+        generation: nextRrcHubGeneration(targetHub, existing.generation),
         hubName: hubName !== undefined ? hubName : existing.hubName,
         whoRequestedRooms: reHandshake ? new Set() : existing.whoRequestedRooms,
       };
@@ -1023,6 +1052,7 @@ export const useRrcSessionStore = create<RrcSessionStoreState>((set, get) => ({
   },
 
   clearSession: () => {
+    resetRrcHubGenerationCeilings();
     set(() => ({
       sessionsByHub: new Map(),
       focusedHubHash: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Demote RRC UI from Connected when the sidecar hub link is already dead, instead of only discovering that on send.
- After dead-session send errors (`not connected to an RRC hub` / `rrc session not active`), reconcile status and force `reconnecting` if still marked active.
- On WS `events_lagged` and reconnect, reconcile RRC sessions from `getStatus()` (not only LXMF catch-up).
- Sidecar: when the link event channel ends as `None`, emit `rrc.disconnected` with `reason=link_ended` (same path as `Closed`).

## Test plan
- [x] Unit tests: `reconcileRrcSessionsFromSnapshot`, dead-session error detection, runtime WS reconcile contract
- [x] Pre-commit (typecheck, related vitest, sidecar checks) green on this branch
- [ ] Manual: connect RRC, drop hub/link without UI noticing — status should flip without sending
- [ ] Manual: if send happens first against a dead hub, banner still shows and status demotes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fe07ff3-f7ba-4bbf-8c5d-d2c9f14812af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fe07ff3-f7ba-4bbf-8c5d-d2c9f14812af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RRC session recovery when a connection ends unexpectedly.
  * Automatically retries connections with backoff and accurately updates session status.
  * Reconciles stale or missing session states after send failures, delayed events, and WebSocket reconnections.
  * Preserves intentional disconnects while preventing stale sessions from appearing connected.
* **Tests**
  * Added coverage for unexpected link endings, session reconciliation, dead-session errors, and reconnection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->