### PR TITLE
flatpak: keep Electron dist layout (strip-components: 0)

### DIFF
--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -110,9 +110,11 @@ modules:
         url: https://github.com/electron/electron/releases/download/v44.1.1/electron-v44.1.1-linux-x64.zip
         sha256: 043327f5bf2c492f744a806544d1aabd0dbec8674f10d3043ef0c455291b3a33
         dest: electron-prebuilt
+        strip-components: 0
         only-arches: [x86_64]
       - type: archive
         url: https://github.com/electron/electron/releases/download/v44.1.1/electron-v44.1.1-linux-arm64.zip
         sha256: b06e4dfbed6689f5b2065666d52a5221e842c266b6902a01f352b7ebd8ce1784
         dest: electron-prebuilt
+        strip-components: 0
         only-arches: [aarch64]

--- a/org.coloradomesh.MeshClient.yml
+++ b/org.coloradomesh.MeshClient.yml
@@ -110,6 +110,7 @@ modules:
         url: https://github.com/electron/electron/releases/download/v44.1.1/electron-v44.1.1-linux-x64.zip
         sha256: 043327f5bf2c492f744a806544d1aabd0dbec8674f10d3043ef0c455291b3a33
         dest: electron-prebuilt
+        # Electron zip has root-level `electron` + `locales/` + `resources/`; default strip-components:1 flattens them.
         strip-components: 0
         only-arches: [x86_64]
       - type: archive

--- a/scripts/check-flatpak.mjs
+++ b/scripts/check-flatpak.mjs
@@ -274,6 +274,23 @@ function checkManifestBranchAndElectronPayload(pkg) {
       });
     }
   }
+  // Electron zips keep `electron`, `locales/` and `resources/` at the archive root.
+  // flatpak-builder defaults to strip-components:1, which flattens locales/*.pak and
+  // resources/default_app.asar into dest; Chromium's ResourceBundle init then fails and
+  // the browser process exits 1 with no output.
+  const electronArchiveBlocks = yaml
+    .split(/^\s*- type: archive\s*$/m)
+    .filter((block) => /electron-v[\d.]+-linux-(?:x64|arm64)\.zip/.test(block));
+  for (const block of electronArchiveBlocks) {
+    if (!/strip-components:\s*0\b/.test(block)) {
+      violations.push({
+        file: rel,
+        message:
+          'electron zip archive sources must set strip-components: 0 (default 1 flattens locales/ and resources/, Electron then exits 1)',
+      });
+      break;
+    }
+  }
 
   if (!yaml.includes('resources /app/lib/mesh-client/')) {
     violations.push({

--- a/scripts/check-flatpak.test.mjs
+++ b/scripts/check-flatpak.test.mjs
@@ -86,3 +86,19 @@ describe('flatpakWorkflowTestBuildContractViolations', () => {
     expect(violations.map((v) => v.message).join('\n')).toMatch(/rename-test-build-artifacts/);
   });
 });
+
+describe('Electron archive sources', () => {
+  it('keep strip-components: 0 in the real manifest', () => {
+    const manifest = fs.readFileSync(path.join(ROOT, 'org.coloradomesh.MeshClient.yml'), 'utf8');
+    const blocks = manifest
+      .split(/^\s*- type: archive\s*$/m)
+      .filter((block) => /electron-v[\d.]+-linux-(?:x64|arm64)\.zip/.test(block));
+
+    expect(blocks).toHaveLength(2);
+    for (const block of blocks) {
+      // strip-components:1 (the flatpak-builder default) flattens locales/ and
+      // resources/ into dest, and Electron then exits 1 with no output.
+      expect(block).toMatch(/strip-components:\s*0\b/);
+    }
+  });
+});

--- a/scripts/sync-flatpak-electron.mjs
+++ b/scripts/sync-flatpak-electron.mjs
@@ -24,7 +24,7 @@ const PNPM_ARCHIVE_SOURCES_RE =
   / {6}- type: archive\n {8}url: https:\/\/github\.com\/pnpm\/pnpm\/releases\/download\/v[\d.]+\/pnpm-linux-x64\.tar\.gz\n {8}sha256: [a-f0-9]{64}\n {8}dest: pnpm-vendor\n {8}#[^\n]*\n {8}strip-components: 0\n {8}only-arches: \[x86_64\]\n {6}- type: archive\n {8}url: https:\/\/github\.com\/pnpm\/pnpm\/releases\/download\/v[\d.]+\/pnpm-linux-arm64\.tar\.gz\n {8}sha256: [a-f0-9]{64}\n {8}dest: pnpm-vendor\n {8}strip-components: 0\n {8}only-arches: \[aarch64\]/;
 
 const ELECTRON_ARCHIVE_SOURCES_RE =
-  / {6}- type: archive\n {8}url: https:\/\/github\.com\/electron\/electron\/releases\/download\/v[\d.]+\/electron-v[\d.]+-linux-x64\.zip\n {8}sha256: [a-f0-9]{64}\n {8}dest: electron-prebuilt\n {8}only-arches: \[x86_64\]\n {6}- type: archive\n {8}url: https:\/\/github\.com\/electron\/electron\/releases\/download\/v[\d.]+\/electron-v[\d.]+-linux-arm64\.zip\n {8}sha256: [a-f0-9]{64}\n {8}dest: electron-prebuilt\n {8}only-arches: \[aarch64\]/;
+  / {6}- type: archive\n {8}url: https:\/\/github\.com\/electron\/electron\/releases\/download\/v[\d.]+\/electron-v[\d.]+-linux-x64\.zip\n {8}sha256: [a-f0-9]{64}\n {8}dest: electron-prebuilt\n {8}#[^\n]*\n {8}strip-components: 0\n {8}only-arches: \[x86_64\]\n {6}- type: archive\n {8}url: https:\/\/github\.com\/electron\/electron\/releases\/download\/v[\d.]+\/electron-v[\d.]+-linux-arm64\.zip\n {8}sha256: [a-f0-9]{64}\n {8}dest: electron-prebuilt\n {8}strip-components: 0\n {8}only-arches: \[aarch64\]/;
 
 export function assertSafeElectronSemverVersion(version) {
   if (typeof version !== 'string' || !SAFE_ELECTRON_SEMVER_RE.test(version)) {
@@ -77,16 +77,19 @@ export function validateElectronSha256ByZipArch(sha256ByZipArch, version) {
 export function buildElectronArchiveSourcesYaml(version, sha256ByZipArch) {
   const safeVersion = assertSafeElectronSemverVersion(version);
   const validated = validateElectronSha256ByZipArch(sha256ByZipArch, safeVersion);
+  const stripComment =
+    '\n        # Electron zip has root-level `electron` + `locales/` + `resources/`; default strip-components:1 flattens them.';
   const blocks = [
-    { zipArch: 'x64', onlyArch: 'x86_64' },
-    { zipArch: 'arm64', onlyArch: 'aarch64' },
+    { zipArch: 'x64', onlyArch: 'x86_64', comment: stripComment },
+    { zipArch: 'arm64', onlyArch: 'aarch64', comment: '' },
   ];
   return blocks
     .map(
-      ({ zipArch, onlyArch }) => `      - type: archive
+      ({ zipArch, onlyArch, comment }) => `      - type: archive
         url: https://github.com/electron/electron/releases/download/v${safeVersion}/electron-v${safeVersion}-linux-${zipArch}.zip
         sha256: ${validated[zipArch]}
-        dest: electron-prebuilt
+        dest: electron-prebuilt${comment}
+        strip-components: 0
         only-arches: [${onlyArch}]`,
     )
     .join('\n');

--- a/scripts/sync-flatpak-electron.test.mjs
+++ b/scripts/sync-flatpak-electron.test.mjs
@@ -33,11 +33,14 @@ const SAMPLE_MANIFEST = `      - type: archive
         url: https://github.com/electron/electron/releases/download/v41.10.0/electron-v41.10.0-linux-x64.zip
         sha256: b5dac00ef6b5ee4e9882cf1424fd8dce7319fb09806757399fdf3b3da06efcd2
         dest: electron-prebuilt
+        # Electron zip has root-level \`electron\` + \`locales/\` + \`resources/\`; default strip-components:1 flattens them.
+        strip-components: 0
         only-arches: [x86_64]
       - type: archive
         url: https://github.com/electron/electron/releases/download/v41.10.0/electron-v41.10.0-linux-arm64.zip
         sha256: 2c063804e14c325cd34de1ff7528f6066d544d49a9d55c9c2937e20dd1e717e3
         dest: electron-prebuilt
+        strip-components: 0
         only-arches: [aarch64]`;
 
 const PNPM_X64_SHA = 'a'.repeat(64);
@@ -119,6 +122,7 @@ describe('sync-flatpak-electron.mjs', () => {
     expect(yaml).toContain('electron-v41.10.1-linux-arm64.zip');
     expect(yaml).toContain('only-arches: [x86_64]');
     expect(yaml).toContain('only-arches: [aarch64]');
+    expect(yaml.match(/strip-components: 0/g)).toHaveLength(2);
   });
 
   it('replaces stale Electron archive URLs and checksums in the manifest', () => {
@@ -129,6 +133,22 @@ describe('sync-flatpak-electron.mjs', () => {
     expect(next).toContain('electron-v41.10.1-linux-arm64.zip');
     expect(next).toContain(sha256ByZipArch.x64);
     expect(next).toContain(sha256ByZipArch.arm64);
+    expect(next.match(/strip-components: 0/g)).toHaveLength(3);
+  });
+
+  it('still matches the real manifest after an Electron bump', () => {
+    const manifestPath = path.join(import.meta.dirname, '..', 'org.coloradomesh.MeshClient.yml');
+    const manifest = fs.readFileSync(manifestPath, 'utf8');
+    const sha256ByZipArch = parseElectronSha256s(FIXTURE_SHASUMS, '41.10.1');
+
+    // Throws when the manifest blocks drift from ELECTRON_ARCHIVE_SOURCES_RE.
+    const next = syncFlatpakElectronManifest(manifest, '41.10.1', sha256ByZipArch);
+    const blocks = next
+      .split(/^\s*- type: archive\s*$/m)
+      .filter((block) => /electron-v[\d.]+-linux-(?:x64|arm64)\.zip/.test(block));
+
+    expect(blocks).toHaveLength(2);
+    for (const block of blocks) expect(block).toMatch(/strip-components:\s*0\b/);
   });
 });
 


### PR DESCRIPTION
## Problem

The flatpak build produces an unstartable app on x86_64 (5.35.0). The `electron-prebuilt` archive sources inherit flatpak-builder's default `strip-components: 1`, which flattens the zip's subdirectories into the dest root. In the installed app:

```
/app/lib/mesh-client/electron/
  electron  icudtl.dat  default_app.asar  af.pak … zh-TW.pak   # 55 locale paks, flat
  (no locales/, no resources/)
```

Chromium's ResourceBundle init then fails and the browser process exits 1 before any JS runs, printing nothing:

```
$ /app/lib/mesh-client/electron/electron --no-sandbox --version
(no output, rc=1)
```

Restoring `locales/` and `resources/default_app.asar` next to the same binary:

```
$ electron-fixed/electron --no-sandbox --version
v44.1.1
```

and the app starts and renders normally.

The sandbox fallback in `flatpak/mesh-client-wrapper.sh` masks this — both attempts die at the same step, so the only user-visible output is the unrelated `host blocks user namespaces; retrying with --no-sandbox` notice.

## Fix

`strip-components: 0` on both Electron archive sources, same as the pnpm sources above already do.

## Verification

Diagnosed on an installed 5.35.0 x86_64 bundle (commit 1a7ac9e); reconstructing the correct layout by hand from the shipped files is sufficient to make Electron and the app start, with no other change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Flatpak packaging for Intel and ARM-based systems so application archives retain their required directory structure during installation.
  - Fixed an issue that could prevent the application from starting correctly after installation by preserving bundled language files and resources.
- **Quality Improvements**
  - Added validation to help ensure future Flatpak packages maintain the correct archive layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->