### PR TITLE
ci: run always-on policy scanners in GitHub Actions

### DIFF
--- a/.github/workflows/buttonmash.yaml
+++ b/.github/workflows/buttonmash.yaml
@@ -27,21 +27,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413
-
-      - name: Setup Node
-        # actions/setup-node v6.5.0
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
-        with:
-          node-version: '22.23.2'
-          cache: 'pnpm'
-
-      - name: Verify pnpm
-        run: node scripts/ci-verify-pnpm.mjs
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       # Plain-browser Vite development installs the repository's no-op electronAPI
       # bridge. Buttonmash can exercise the renderer without hardware, native

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,9 +162,34 @@ jobs:
       - name: Validate metainfo
         run: appstreamcli validate --no-net flatpak/org.coloradomesh.MeshClient.metainfo.xml
 
+  # Cheap always-on check:* scanners (pre-commit / release). Blocks --no-verify / web edits.
+  policy-scanners:
+    name: Policy scanners
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Always-on policy scanners
+        run: |
+          pnpm run check:electron-security
+          pnpm run check:log-injection
+          pnpm run check:log-service-sinks
+          pnpm run check:codeql-extensions
+          pnpm run check:insecure-temp-files
+          pnpm run check:ipc-contract
+          pnpm run check:console-log
+          pnpm run check:silent-catches
+          pnpm run check:url-hostname-sanitization
+          pnpm run check:xss-patterns
+          pnpm run check:protocol-string-gates
+          pnpm run check:log-panel-filter
+
   build:
     name: Build & Test
-    needs: [changes, quality, lint, typecheck, app-build, flatpak]
+    needs: [changes, quality, lint, typecheck, app-build, flatpak, policy-scanners]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     env:
@@ -174,12 +199,14 @@ jobs:
       TYPECHECK_RESULT: ${{ needs.typecheck.result }}
       BUILD_RESULT: ${{ needs.app-build.result }}
       FLATPAK_RESULT: ${{ needs.flatpak.result }}
+      POLICY_SCANNERS_RESULT: ${{ needs.policy-scanners.result }}
     steps:
       - name: Verify CI fan-out
         shell: bash
         run: |
           required_ok=true
-          for result in "$CHANGES_RESULT" "$QUALITY_RESULT" "$LINT_RESULT" "$TYPECHECK_RESULT" "$BUILD_RESULT"; do
+          for result in "$CHANGES_RESULT" "$QUALITY_RESULT" "$LINT_RESULT" \
+            "$TYPECHECK_RESULT" "$BUILD_RESULT" "$POLICY_SCANNERS_RESULT"; do
             [[ "$result" == 'success' ]] || required_ok=false
           done
           flatpak_ok=false
@@ -194,6 +221,7 @@ jobs:
             echo "- Typecheck: $TYPECHECK_RESULT"
             echo "- Application build: $BUILD_RESULT"
             echo "- Flatpak checks: $FLATPAK_RESULT"
+            echo "- Policy scanners: $POLICY_SCANNERS_RESULT"
           } >> "$GITHUB_STEP_SUMMARY"
 
           [[ "$required_ok" == true && "$flatpak_ok" == true ]]

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -8,7 +8,7 @@ Mesh-Client uses GitHub Actions for continuous integration and deployment.
 
 | Workflow                    | Trigger                                      | Purpose                                                                         |
 | --------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------- |
-| `ci.yaml`                   | Push/PR/`merge_group`/`workflow_dispatch`    | Lint, typecheck, build, Flatpak manifest validation                             |
+| `ci.yaml`                   | Push/PR/`merge_group`/`workflow_dispatch`    | Lint, typecheck, build, policy scanners, Flatpak manifest validation            |
 | `tests.yaml`                | Push/PR/`merge_group`/`workflow_dispatch`    | Vitest coverage + merge; Reticulum sidecar `llvm-cov` when sidecar paths change |
 | `buttonmash.yaml`           | PR/`merge_group`/`workflow_dispatch`         | Browser-based chaos testing of the Vite renderer                                |
 | `e2e.yaml`                  | Daily on `main` + manual `workflow_dispatch` | Playwright Electron E2E (unpackaged build, 3-OS; not a PR gate)                 |
@@ -31,6 +31,7 @@ Runs on every push, pull request, and merge-queue `merge_group` for `main` (and 
 - **Typecheck:** `pnpm run typecheck`
 - **Application build:** `pnpm run build`
 - **Flatpak checks:** only when Flatpak inputs change; runs `check:flatpak`, `check:flatpak-offline-pnpm`, `desktop-file-validate`, and `appstreamcli validate`
+- **Policy scanners:** cheap always-on `check:*` set from pre-commit/release (`check:electron-security`, log/XSS/console/IPC/protocol-string gates, and the matching cheap scanners) so `--no-verify` and GitHub-only edits cannot skip them
 
 Each Node lane uses the same pinned Node 22/pnpm setup action and frozen install. The final `Build & Test` job aggregates every lane so the existing required check name remains stable. Superseded runs for the same pull request or ref are cancelled.
 
@@ -367,6 +368,7 @@ The ruleset is already **active** with `merge_group` triggers on `ci.yaml` / `te
 All PRs (and merge-queue groups) for `main` must pass the **required check names** listed above. Those jobs cover:
 
 - Lint, format, markdown, licenses, actionlint, yamllint (`pnpm run lint` and related steps in `ci.yaml`)
+- Cheap always-on policy scanners (`check:electron-security`, log/XSS/console/IPC/protocol-string gates, and the matching cheap `check:*` set)
 - Typecheck and build (`pnpm run typecheck`, `pnpm run build`)
 - Affected Vitest tests on pull requests; full Vitest with global coverage thresholds on `merge_group`, `main`, and manual runs
 
@@ -386,7 +388,7 @@ The pre-commit hook (`.githooks/pre-commit`) runs checks beyond what GitHub Acti
 
 **PR CI** ([`tests.yaml`](../.github/workflows/tests.yaml)) selects merge-base-related Vitest work and fails closed to the full suite when scoping is unsafe. The merge queue and **`pnpm run release`** always run full Vitest; green pre-commit does not replace those gates.
 
-CI focuses on lint, typecheck, build, Flatpak metadata validation, and coverage tests. i18n quality is enforced locally via pre-commit and indirectly in CI through Vitest (`locale-quality.test.ts`).
+CI focuses on lint, typecheck, build, cheap always-on policy scanners, Flatpak metadata validation, and coverage tests. i18n quality is enforced locally via pre-commit and indirectly in CI through Vitest (`locale-quality.test.ts`).
 
 ---
 

--- a/scripts/buttonmash-workflow.test.mjs
+++ b/scripts/buttonmash-workflow.test.mjs
@@ -10,13 +10,13 @@ describe('Buttonmash CI', () => {
   it('runs the Vite renderer through the browser-safe Electron API stub', () => {
     expect(workflow).toContain('pnpm exec vite --host 127.0.0.1 --port 4173 --strictPort');
     expect(workflow).toContain('target: http://127.0.0.1:4173');
-    expect(workflow).toContain('pnpm install --frozen-lockfile');
+    expect(workflow).toContain('uses: ./.github/actions/setup-node-pnpm');
   });
 
   it('pins actions and the CLI while keeping the run bounded and safe', () => {
     expect(workflow).toContain('uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803');
     expect(workflow).toContain('persist-credentials: false');
-    expect(workflow).toContain('uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38');
+    expect(workflow).toContain('uses: ./.github/actions/setup-node-pnpm');
     expect(workflow).toContain("node-version: '22.23.2'");
     expect(workflow).toContain('uses: cj-vana/buttonmash@3dfe5aa15e824accfd5f72c176ac64b2f63450db');
     expect(workflow).toContain(

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -83,10 +83,14 @@ describe('CI workflow contracts', () => {
     ]) {
       expect(job).toContain(`pnpm run ${script}`);
     }
-    expect(job).not.toContain('check:pr');
-    expect(job).not.toContain('check:i18n');
-    expect(job).not.toContain('check:licenses');
-    expect(job).not.toContain('check:flatpak');
+    const runs = job
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('pnpm run '));
+    expect(runs.some((line) => line === 'pnpm run check:pr')).toBe(false);
+    expect(runs.some((line) => line.startsWith('pnpm run check:i18n'))).toBe(false);
+    expect(runs.some((line) => line === 'pnpm run check:licenses')).toBe(false);
+    expect(runs.some((line) => line.startsWith('pnpm run check:flatpak'))).toBe(false);
   });
 
   it('blocks required coverage checks when detection or any shard fails', () => {

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -50,15 +50,43 @@ describe('CI workflow contracts', () => {
       'typecheck:',
       'app-build:',
       'flatpak:',
+      'policy-scanners:',
       'build:',
     ]) {
       expect(ciWorkflow).toContain(`  ${job}`);
     }
-    expect(ciWorkflow).toContain('needs: [changes, quality, lint, typecheck, app-build, flatpak]');
+    expect(ciWorkflow).toContain(
+      'needs: [changes, quality, lint, typecheck, app-build, flatpak, policy-scanners]',
+    );
     expect(ciWorkflow).toContain('FLATPAK_RESULT: ${{ needs.flatpak.result }}');
+    expect(ciWorkflow).toContain('POLICY_SCANNERS_RESULT: ${{ needs.policy-scanners.result }}');
     expect(ciWorkflow).toContain(
       '[[ "$FLATPAK_RESULT" == \'success\' || "$FLATPAK_RESULT" == \'skipped\' ]]',
     );
+  });
+
+  it('runs the cheap always-on policy scanners in CI', () => {
+    const job = ciWorkflow.split('  policy-scanners:')[1].split('  build:')[0];
+    for (const script of [
+      'check:electron-security',
+      'check:log-injection',
+      'check:log-service-sinks',
+      'check:codeql-extensions',
+      'check:insecure-temp-files',
+      'check:ipc-contract',
+      'check:console-log',
+      'check:silent-catches',
+      'check:url-hostname-sanitization',
+      'check:xss-patterns',
+      'check:protocol-string-gates',
+      'check:log-panel-filter',
+    ]) {
+      expect(job).toContain(`pnpm run ${script}`);
+    }
+    expect(job).not.toContain('check:pr');
+    expect(job).not.toContain('check:i18n');
+    expect(job).not.toContain('check:licenses');
+    expect(job).not.toContain('check:flatpak');
   });
 
   it('blocks required coverage checks when detection or any shard fails', () => {
@@ -77,7 +105,7 @@ describe('CI workflow contracts', () => {
     }
   });
 
-  it.each(['LINT_RESULT', 'QUALITY_RESULT'])(
+  it.each(['LINT_RESULT', 'QUALITY_RESULT', 'POLICY_SCANNERS_RESULT'])(
     'includes %s failure in the required build gate',
     (job) => {
       const gate = ciWorkflow
@@ -90,6 +118,7 @@ describe('CI workflow contracts', () => {
         LINT_RESULT: 'success',
         TYPECHECK_RESULT: 'success',
         BUILD_RESULT: 'success',
+        POLICY_SCANNERS_RESULT: 'success',
         FLATPAK_RESULT: 'skipped',
         GITHUB_STEP_SUMMARY: '/dev/null',
       };
@@ -150,6 +179,9 @@ describe('CI workflow contracts', () => {
     expect(testsWorkflow).toContain('cancel-in-progress: true');
     expect(ciWorkflow).toContain('uses: ./.github/actions/setup-node-pnpm');
     expect(testsWorkflow).toContain('uses: ./.github/actions/setup-node-pnpm');
+    expect(read('.github/workflows/buttonmash.yaml')).toContain(
+      'uses: ./.github/actions/setup-node-pnpm',
+    );
     expect(setupAction).toContain(`pnpm/action-setup@${PNPM_ACTION_SETUP_SHA}`);
     expect(setupAction).toContain(`actions/setup-node@${SETUP_NODE_SHA}`);
     expect(setupAction).toContain("default: '22.23.2'");
@@ -215,11 +247,11 @@ describe('CI workflow contracts', () => {
   });
 
   it('pins checkout and removes persisted credentials before running repository code', () => {
-    expect(ciWorkflow.match(new RegExp(`actions/checkout@${CHECKOUT_SHA}`, 'g'))).toHaveLength(6);
+    expect(ciWorkflow.match(new RegExp(`actions/checkout@${CHECKOUT_SHA}`, 'g'))).toHaveLength(7);
     expect(testsWorkflow.match(new RegExp(`actions/checkout@${CHECKOUT_SHA}`, 'g'))).toHaveLength(
       4,
     );
-    expect(ciWorkflow.match(/persist-credentials: false/g)).toHaveLength(6);
+    expect(ciWorkflow.match(/persist-credentials: false/g)).toHaveLength(7);
     expect(testsWorkflow.match(/persist-credentials: false/g)).toHaveLength(4);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Pre-commit and `pnpm run release` already run the cheap always-on `check:*` scanners. GitHub Actions did not, so `--no-verify` commits and GitHub-only edits could land policy violations without a CI failure.

## What

Adds one `policy-scanners` job to `.github/workflows/ci.yaml` that reuses the existing pnpm scripts (no new `check:pr:policy` wrapper). The job is required by the existing **Build & Test** aggregate, so the merge-queue required-check name stays the same.

Also a tiny same-PR cleanup: `buttonmash.yaml` now uses `./.github/actions/setup-node-pnpm` instead of duplicating the Node/pnpm install steps.

## Checks added

| Script | Why it is in this job |
| --- | --- |
| `check:electron-security` | Always-on (pre-commit first, release ungated) |
| `check:log-injection` | Always-on cheap scanner |
| `check:log-service-sinks` | Always-on cheap scanner |
| `check:codeql-extensions` | Always-on cheap scanner |
| `check:insecure-temp-files` | Always-on cheap scanner |
| `check:ipc-contract` | Cheap; release always runs it (pre-commit path-gates it) |
| `check:console-log` | Always-on cheap scanner |
| `check:silent-catches` | Always-on cheap scanner |
| `check:url-hostname-sanitization` | Always-on cheap scanner |
| `check:xss-patterns` | Always-on cheap scanner |
| `check:protocol-string-gates` | Always-on cheap protocol-string gate |
| `check:log-panel-filter` | Always-on cheap scanner |

Already covered elsewhere, so **not** duplicated here: `check:licenses` (quality job), `check:flatpak` / `check:flatpak-offline-pnpm` (flatpak job), `check:i18n` (pre-commit / release / Vitest `locale-quality.test.ts`). Path-gated / expensive catalog and sidecar checks stay out of this job.

## Proof

- Required check name remains `Build & Test` (ruleset / `main-merge-queue.json` unchanged).
- Contract tests in `scripts/ci-workflows.test.mjs` assert the scanner list and that a `POLICY_SCANNERS_RESULT` failure fails the aggregate gate.

## Out of scope

- Retargeting `act:ci` / docs rewrite beyond a short `docs/ci-cd.md` note
- New scanners or a `check:pr:policy` local alias
- i18n / licenses / Flatpak / sidecar / DB / reticulum catalog gates already owned by other jobs or path-gated hooks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d8758db-8f9e-5a42-a9b0-749f7d77c5ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8758db-8f9e-5a42-a9b0-749f7d77c5ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added always-on security and policy checks to the continuous integration pipeline.
  - Builds now wait for these checks and report their results with other required checks.
  - Simplified automated environment setup for Buttonmash testing while preserving test execution, logging, and cleanup.

- **Documentation**
  - Updated CI/CD documentation to describe the new policy checks and required status checks.

- **Tests**
  - Updated workflow validation tests to cover the new checks and setup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->