### PR TITLE
fix: point Docker act:ci at real ci.yaml work jobs

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -221,6 +221,8 @@ Do not use `npm install`; it will create a `package-lock.json` and may not respe
 
 Container mode runs GitHub Actions jobs inside Linux containers using a Docker-compatible engine (Podman preferred). Host mode runs the same pnpm/cargo steps directly — use this when no container engine is available or act cannot reach the daemon. `pnpm run check:environment` warns if no container engine or act is missing but does not block commits. Use **native** scripts when no Docker-compatible engine is available or act cannot reach the daemon.
 
+Docker `pnpm run act:ci` runs the real `ci.yaml` work jobs (`quality`, `lint`, `typecheck`, `app-build`, `policy-scanners`) in sequence. It does **not** invoke the `Build & Test` aggregator (`build`) — that job only checks sibling results on GitHub so the required check name stays stable. Path-filtered Flatpak checks are not part of container `act:ci` (native `act:ci:native` still runs them; or change Flatpak inputs and use the `flatpak` job / `act:flatpak`).
+
 **macOS note:** [Podman Desktop](https://podman.io/) is the preferred Docker-compatible engine for local CI. When Docker compatibility is enabled, Podman exposes a Docker-compatible socket at `/var/run/docker.sock`; pass that path to `act` via `ACT_DOCKER_SOCKET`, or let `act` detect it automatically if Podman created the symlink. If you use Docker Desktop instead, its socket is typically under `~/.docker/run/docker.sock`.
 
 Install act (container mode only):
@@ -247,6 +249,8 @@ pnpm run act:pull-images
 pnpm run act:list
 
 # PR parity — container (act + Podman/Docker)
+# act:ci runs quality / lint / typecheck / app-build / policy-scanners
+# (not the GitHub-only Build & Test aggregator job)
 pnpm run act:ci
 pnpm run act:tests
 pnpm run act:pr

--- a/scripts/run-act.mjs
+++ b/scripts/run-act.mjs
@@ -48,13 +48,22 @@ export const FLATPAK_CONTAINER_IMAGE =
 
 export const ACT_PULL_IMAGES = [ACT_PLATFORM_IMAGE, FLATPAK_CONTAINER_IMAGE];
 
+/**
+ * Real `ci.yaml` work jobs for Docker `act:ci`.
+ * Do not include `build` — that is the GitHub-required "Build & Test" aggregator
+ * that only checks sibling results, so `act -j build` does no lint/typecheck/build.
+ * `changes` / `flatpak` stay path-gated on GitHub; native `act:ci:native` still
+ * runs the Flatpak checks.
+ */
+export const ACT_CI_JOBS = ['quality', 'lint', 'typecheck', 'app-build', 'policy-scanners'];
+
 /** @type {Record<string, ActInvocation | ActInvocation[]>} */
 export const ACT_TARGETS = {
-  ci: {
+  ci: ACT_CI_JOBS.map((job) => ({
     event: 'workflow_dispatch',
     workflow: '.github/workflows/ci.yaml',
-    job: 'build',
-  },
+    job,
+  })),
   tests: {
     event: 'workflow_dispatch',
     workflow: '.github/workflows/tests.yaml',
@@ -514,7 +523,7 @@ Modes (default: docker / act in containers):
   MESH_CLIENT_ACT_MODE=native|docker
 
 Targets:
-  ci                 CI workflow (lint, typecheck, build, flatpak checks)
+  ci                 CI work jobs (quality, lint, typecheck, app-build, policy-scanners)
   tests              Tests workflow (coverage)
   build-linux        build.yaml ubuntu-latest leg (dist:linux)
   reticulum-sidecar  Reticulum sidecar Linux jobs

--- a/scripts/run-act.test.mjs
+++ b/scripts/run-act.test.mjs
@@ -1,9 +1,14 @@
 // @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ACT_CI_JOBS,
   ACT_PLATFORM_IMAGE,
   ACT_PULL_IMAGES,
+  ACT_TARGETS,
   buildActArgs,
   buildActBaseArgs,
   parseActMode,
@@ -155,6 +160,57 @@ describe('run-act buildActBaseArgs', () => {
       '-P',
       `ubuntu-latest=${ACT_PLATFORM_IMAGE}`,
       '-n',
+    ]);
+  });
+});
+
+describe('run-act ACT_TARGETS.ci', () => {
+  const ciWorkflow = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', '.github/workflows/ci.yaml'),
+    'utf8',
+  );
+
+  it('points Docker act:ci at real ci.yaml work jobs, not the Build & Test aggregator', () => {
+    expect(ACT_CI_JOBS).toEqual(['quality', 'lint', 'typecheck', 'app-build', 'policy-scanners']);
+    expect(ACT_CI_JOBS).not.toContain('build');
+    expect(Array.isArray(ACT_TARGETS.ci)).toBe(true);
+    if (!Array.isArray(ACT_TARGETS.ci)) {
+      throw new Error('expected ACT_TARGETS.ci to be an invocation list');
+    }
+
+    const jobs = ACT_TARGETS.ci.map((invocation) => invocation.job);
+    expect(jobs).toEqual(ACT_CI_JOBS);
+
+    for (const invocation of ACT_TARGETS.ci) {
+      expect(invocation.workflow).toBe('.github/workflows/ci.yaml');
+      expect(invocation.event).toBe('workflow_dispatch');
+      expect(ciWorkflow).toContain(`  ${invocation.job}:`);
+    }
+
+    // Required GitHub check name stays on the aggregator job; act must not target it.
+    expect(ciWorkflow).toContain('name: Build & Test');
+    expect(ciWorkflow).toMatch(/^ {2}build:/m);
+  });
+
+  it('builds act args for each ci work job', () => {
+    if (!Array.isArray(ACT_TARGETS.ci)) {
+      throw new Error('expected ACT_TARGETS.ci to be an invocation list');
+    }
+    expect(
+      buildActArgs(ACT_TARGETS.ci[0], {
+        hostArch: 'x64',
+        dockerSocket: '/var/run/docker.sock',
+      }),
+    ).toEqual([
+      '-P',
+      `ubuntu-latest=${ACT_PLATFORM_IMAGE}`,
+      '--container-daemon-socket',
+      '/var/run/docker.sock',
+      '-W',
+      '.github/workflows/ci.yaml',
+      '-j',
+      'quality',
+      'workflow_dispatch',
     ]);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Docker `pnpm run act:ci` targeted `ci.yaml` job `build` (`Build & Test`). That job only checks sibling results so the GitHub required-check name stays stable. Under `act -j build`, the sibling lanes do not run, so container “PR parity” often skipped lint, typecheck, and app-build. Native `act:ci:native` already ran the real steps.

## Approach

Keep the GitHub aggregator and required check name intact. Point Docker `ACT_TARGETS.ci` at the real work jobs, matching current `ci.yaml` IDs after #991:

- `quality`
- `lint`
- `typecheck`
- `app-build`
- `policy-scanners` (existing #991 lane; not reinvented here)

`changes` / `flatpak` stay path-gated on GitHub. Native `act:ci:native` still runs the Flatpak checks.

## Changes

- `scripts/run-act.mjs` — `ACT_CI_JOBS` + array of act invocations (same pattern as `reticulum-sidecar` / `flatpak`)
- `scripts/run-act.test.mjs` — contract that Docker `act:ci` lists those jobs and does **not** target `build`
- `docs/ci-cd.md` — document what container `act:ci` actually runs

`package.json` script names are unchanged (`act:ci` still means Docker/act).

## Out of scope

- No new scanners
- No changes to the #991 `policy-scanners` job itself
- `ci.yaml` job graph / required-check names unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be1ed464-9bb3-5a3f-9b06-b7597e628867?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be1ed464-9bb3-5a3f-9b06-b7597e628867&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

