### PR TITLE
refactor: expose identity IDs and capabilities on ProtocolFacade

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -111,7 +111,6 @@ import Sidebar from './components/Sidebar';
 import { LinkIcon } from './components/SignalBars';
 import { ToastProvider, useToast } from './components/Toast';
 import UpdateStatusIndicator from './components/UpdateStatusIndicator';
-import { useActiveMeshIdentity } from './hooks/useActiveMeshIdentity';
 import { useAllProtocolPanelActions } from './hooks/useAllProtocolPanelActions';
 import { useAppStartupDbPrune } from './hooks/useAppStartupDbPrune';
 import { useAppTrayUnreadSync } from './hooks/useAppTrayUnreadSync';
@@ -893,15 +892,15 @@ function AppContent() {
     typeof useReticulumPanelActions
   >;
   const activeFacade = useProtocolFacade(protocol, allPanelActions);
-  const panelActions = allPanelActions[protocol];
+  const panelActions = activeFacade.panel.actions;
   const {
     identityIdByProtocol,
     focusedIdentityId,
+    reticulumIdentityId,
     capabilities: activeProtocolCapabilities,
-  } = useActiveMeshIdentity(protocol);
+  } = activeFacade;
   const meshtasticIdentityId = identityIdByProtocol.meshtastic;
   const meshcoreIdentityId = identityIdByProtocol.meshcore;
-  const reticulumIdentityId = identityIdByProtocol.reticulum;
   const meshtasticNodesById = useNodeStore((s) =>
     meshtasticIdentityId ? s.nodes[meshtasticIdentityId] : undefined,
   );

--- a/src/renderer/hooks/useProtocolFacade.test.ts
+++ b/src/renderer/hooks/useProtocolFacade.test.ts
@@ -8,8 +8,8 @@ import {
 } from '../lib/offlineProtocolIdentities';
 import { meshcoreProtocol } from '../lib/protocols/MeshCoreProtocol';
 import { meshtasticProtocol } from '../lib/protocols/MeshtasticProtocol';
-import { reticulumProtocol } from '../lib/protocols/ReticulumProtocol';
 import type { Protocol } from '../lib/protocols/Protocol';
+import { reticulumProtocol } from '../lib/protocols/ReticulumProtocol';
 import type { IdentityId, MeshProtocol } from '../lib/types';
 import { setConnection, useConnectionStore } from '../stores/connectionStore';
 import { addIdentity, useIdentityStore } from '../stores/identityStore';
@@ -175,7 +175,9 @@ describe('useProtocolFacade', () => {
     expect(result.current.reticulumIdentityId).toBe(OFFLINE_RETICULUM_IDENTITY_ID);
     expect(result.current.identityIdByProtocol.reticulum).toBe(OFFLINE_RETICULUM_IDENTITY_ID);
     expect(result.current.identityIdByProtocol.meshcore).toBe(OFFLINE_MESHCORE_IDENTITY_ID);
-    expect(result.current.reticulumIdentityId).not.toBe(result.current.identityIdByProtocol.meshcore);
+    expect(result.current.reticulumIdentityId).not.toBe(
+      result.current.identityIdByProtocol.meshcore,
+    );
     expect(result.current.capabilities.protocol).toBe('reticulum');
   });
 });

--- a/src/renderer/hooks/useProtocolFacade.test.ts
+++ b/src/renderer/hooks/useProtocolFacade.test.ts
@@ -1,9 +1,20 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  ensureOfflineProtocolIdentities,
+  OFFLINE_MESHCORE_IDENTITY_ID,
+  OFFLINE_RETICULUM_IDENTITY_ID,
+} from '../lib/offlineProtocolIdentities';
+import { meshcoreProtocol } from '../lib/protocols/MeshCoreProtocol';
 import { meshtasticProtocol } from '../lib/protocols/MeshtasticProtocol';
+import { reticulumProtocol } from '../lib/protocols/ReticulumProtocol';
+import type { Protocol } from '../lib/protocols/Protocol';
+import type { IdentityId, MeshProtocol } from '../lib/types';
 import { setConnection, useConnectionStore } from '../stores/connectionStore';
-import { addIdentity } from '../stores/identityStore';
+import { addIdentity, useIdentityStore } from '../stores/identityStore';
+import { useMessageStore } from '../stores/messageStore';
+import { useNodeStore } from '../stores/nodeStore';
 import type { PanelActionsByProtocol } from './useAllProtocolPanelActions';
 import { useProtocolFacade } from './useProtocolFacade';
 
@@ -12,6 +23,18 @@ vi.mock('./useConnect', () => ({
 }));
 
 const IDENTITY = 'id-facade-mt';
+
+const PROTOCOL_ADAPTER: Record<MeshProtocol, Protocol> = {
+  meshtastic: meshtasticProtocol,
+  meshcore: meshcoreProtocol,
+  reticulum: reticulumProtocol,
+};
+
+const CONNECTED_IDS: Record<MeshProtocol, IdentityId> = {
+  meshtastic: 'id-facade-mt-live',
+  meshcore: 'id-facade-mc-live',
+  reticulum: 'id-facade-rn-live',
+};
 
 function panelActionsStub() {
   return {
@@ -56,9 +79,41 @@ function reticulumPanelActionsStub() {
 const meshtasticActions = panelActionsStub();
 const meshcoreActions = panelActionsStub();
 
+function panelPrebuilt(): PanelActionsByProtocol {
+  return {
+    meshtastic: meshtasticActions,
+    meshcore: meshcoreActions,
+    reticulum: reticulumPanelActionsStub(),
+  } as unknown as PanelActionsByProtocol;
+}
+
+function addConnectedIdentity(protocol: MeshProtocol, id: IdentityId): void {
+  addIdentity({
+    id,
+    protocol: PROTOCOL_ADAPTER[protocol],
+    signature: `sig-facade-${protocol}`,
+    transports: [
+      {
+        transportId: `t-${protocol}`,
+        type: 'ble',
+        status: 'connected',
+        params: { type: 'ble', peripheralId: `${protocol}-ble` },
+      },
+    ],
+    createdAt: 100,
+    lastSeenAt: 100,
+  });
+}
+
 describe('useProtocolFacade', () => {
   beforeEach(() => {
     useConnectionStore.setState({ connections: {} });
+    useIdentityStore.setState({ identities: {}, activeIdentityId: null });
+    useNodeStore.setState({ nodes: {}, traceRoutes: {}, waypoints: {}, neighborInfo: {} });
+    useMessageStore.setState({ messages: {} });
+  });
+
+  it('exposes store-backed connection view and panel actions for the active protocol', () => {
     addIdentity({
       id: IDENTITY,
       protocol: meshtasticProtocol,
@@ -76,17 +131,12 @@ describe('useProtocolFacade', () => {
       queueFree: 2,
       queueMax: 16,
     });
-  });
 
-  it('exposes store-backed connection view and panel actions for the active protocol', () => {
-    const panelPrebuilt = {
-      meshtastic: meshtasticActions,
-      meshcore: meshcoreActions,
-      reticulum: reticulumPanelActionsStub(),
-    } as unknown as PanelActionsByProtocol;
-    const { result } = renderHook(() => useProtocolFacade('meshtastic', panelPrebuilt));
+    const { result } = renderHook(() => useProtocolFacade('meshtastic', panelPrebuilt()));
 
     expect(result.current.focusedIdentityId).toBe(IDENTITY);
+    expect(result.current.identityIdByProtocol.meshtastic).toBe(IDENTITY);
+    expect(result.current.capabilities.protocol).toBe('meshtastic');
     expect(result.current.panel.protocol).toBe('meshtastic');
     expect(result.current.connectionView.state.status).toBe('configured');
     expect(result.current.connectionView.state.myNodeNum).toBe(0xabc);
@@ -98,5 +148,34 @@ describe('useProtocolFacade', () => {
         ? result.current.panel.actions.setConfig
         : undefined,
     ).toBe(meshtasticActions.setConfig);
+  });
+
+  it.each(['meshtastic', 'meshcore', 'reticulum'] as const)(
+    'resolves focused and per-protocol identity IDs for %s',
+    (protocol) => {
+      for (const p of ['meshtastic', 'meshcore', 'reticulum'] as const) {
+        addConnectedIdentity(p, CONNECTED_IDS[p]);
+      }
+
+      const { result } = renderHook(() => useProtocolFacade(protocol, panelPrebuilt()));
+
+      expect(result.current.focusedIdentityId).toBe(CONNECTED_IDS[protocol]);
+      expect(result.current.identityIdByProtocol).toEqual(CONNECTED_IDS);
+      expect(result.current.reticulumIdentityId).toBe(CONNECTED_IDS.reticulum);
+      expect(result.current.capabilities.protocol).toBe(protocol);
+    },
+  );
+
+  it('resolves reticulum to its own offline bucket, not meshcore', () => {
+    ensureOfflineProtocolIdentities();
+
+    const { result } = renderHook(() => useProtocolFacade('reticulum', panelPrebuilt()));
+
+    expect(result.current.focusedIdentityId).toBe(OFFLINE_RETICULUM_IDENTITY_ID);
+    expect(result.current.reticulumIdentityId).toBe(OFFLINE_RETICULUM_IDENTITY_ID);
+    expect(result.current.identityIdByProtocol.reticulum).toBe(OFFLINE_RETICULUM_IDENTITY_ID);
+    expect(result.current.identityIdByProtocol.meshcore).toBe(OFFLINE_MESHCORE_IDENTITY_ID);
+    expect(result.current.reticulumIdentityId).not.toBe(result.current.identityIdByProtocol.meshcore);
+    expect(result.current.capabilities.protocol).toBe('reticulum');
   });
 });

--- a/src/renderer/hooks/useProtocolFacade.ts
+++ b/src/renderer/hooks/useProtocolFacade.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
-import type { MeshProtocol } from '../lib/types';
+import type { ProtocolCapabilities } from '../lib/radio/BaseRadioProvider';
+import type { IdentityId, MeshProtocol } from '../lib/types';
 import { useActiveMeshIdentity } from './useActiveMeshIdentity';
 import type { PanelActionsByProtocol } from './useAllProtocolPanelActions';
 import { useConnectionQueue } from './useConnectionStatus';
@@ -12,9 +13,10 @@ import { useProtocolConnectionActions } from './useProtocolConnection';
 
 export interface ProtocolFacade {
   protocol: MeshProtocol;
-  focusedIdentityId: string | null;
-  meshtasticIdentityId: string | null;
-  meshcoreIdentityId: string | null;
+  focusedIdentityId: IdentityId | null;
+  identityIdByProtocol: Record<MeshProtocol, IdentityId | null>;
+  reticulumIdentityId: IdentityId | null;
+  capabilities: ProtocolCapabilities;
   connection: ReturnType<typeof useProtocolConnectionActions>;
   connectionView: ReturnType<typeof useConnectionView>;
   queue: ReturnType<typeof useConnectionQueue>;
@@ -31,9 +33,8 @@ export function useProtocolFacade(
   protocol: MeshProtocol,
   panelPrebuilt: PanelActionsByProtocol,
 ): ProtocolFacade {
-  const { identityIdByProtocol, focusedIdentityId } = useActiveMeshIdentity(protocol);
-  const meshtasticIdentityId = identityIdByProtocol.meshtastic;
-  const meshcoreIdentityId = identityIdByProtocol.meshcore;
+  const { identityIdByProtocol, focusedIdentityId, capabilities } = useActiveMeshIdentity(protocol);
+  const reticulumIdentityId = identityIdByProtocol.reticulum;
   const connection = useProtocolConnectionActions(protocol);
   const connectionView = useConnectionView(focusedIdentityId);
   const queue = useConnectionQueue(focusedIdentityId);
@@ -45,8 +46,9 @@ export function useProtocolFacade(
     () => ({
       protocol,
       focusedIdentityId,
-      meshtasticIdentityId,
-      meshcoreIdentityId,
+      identityIdByProtocol,
+      reticulumIdentityId,
+      capabilities,
       connection,
       connectionView,
       queue,
@@ -57,8 +59,9 @@ export function useProtocolFacade(
     [
       protocol,
       focusedIdentityId,
-      meshtasticIdentityId,
-      meshcoreIdentityId,
+      identityIdByProtocol,
+      reticulumIdentityId,
+      capabilities,
       connection,
       connectionView,
       queue,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Facade adoption **PR1** (identity / capabilities only). Branched from current `main` after **#992–#994**. Behavior-preserving: one identity hook site, now inside `useProtocolFacade`.

`useActiveMeshIdentity` remains the resolver; App no longer calls it a second time.

### Moved

- `ProtocolFacade` now exposes:
  - `identityIdByProtocol`
  - `reticulumIdentityId`
  - top-level `capabilities` (from `useActiveMeshIdentity`)
- `App.tsx` reads focused IDs + capabilities from `activeFacade` and drops the extra `useActiveMeshIdentity(protocol)` call
- Shared panel methods (`getFullNodeLabel`, `getPickerStyleNodeLabel`, `setNodeFavorited`, `requestRefresh`) come from `activeFacade.panel.actions`
- Dropped unused facade exports `meshtasticIdentityId` / `meshcoreIdentityId` — App uses `identityIdByProtocol` instead
- `useProtocolFacade.test.ts` covers meshtastic, meshcore, and reticulum identity resolution (including reticulum offline-bucket isolation)

### Left in place (intentional)

- Per-protocol panel casts (`meshtasticPanelActions` / `meshcorePanelActions`) for remote-admin, rooms, and other extra methods
- `useActiveMeshIdentity` itself (single hook site, called from the facade)
- `ConnectionPanel` / `ChatDmPaperControls` still call `useActiveMeshIdentity` locally (not App orchestration)

### Deferred (PR2–PR5)

- Killing `as unknown as MeshtasticRuntime`
- Collapsing three ConnectionPanels into one
- `useAllProtocolConnectionActions`
- Display adapters / Chat on `facade.messages`
- MeshCore runtime splits / hook-local mirror retirement

## Test plan

- [x] `pnpm exec vitest run src/renderer/hooks/useProtocolFacade.test.ts` (5 tests)
- [x] `pnpm run typecheck`
- [x] Pre-commit: typecheck + related Vitest (`useProtocolFacade`, `sourcePolicy`)
- [x] App has one identity hook (inside the facade)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d096e49-3af0-55c5-9fa7-2aa7babe5399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d096e49-3af0-55c5-9fa7-2aa7babe5399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved identity and capability handling across Meshtastic, MeshCore, and Reticulum connections.
  - Reticulum now consistently resolves to its own offline identity when no live identities are available.
  - Panel actions and focused identity information are now sourced consistently from the active protocol connection.
  - Improved consistency when switching between supported protocol connections and viewing connection-specific panel information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->