### PR TITLE
refactor: type App activeRuntime as ProtocolRuntime

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -784,6 +784,57 @@ describe('App accessibility', () => {
     });
   });
 
+  it('passes Meshtastic channel pills from ProtocolRuntime.channels to ChatPanel', async () => {
+    useDeviceMock.mockReturnValue({
+      ...createDeviceMock(),
+      state: { status: 'configured', myNodeNum: 1, connectionType: 'serial' },
+      selfNodeId: 1,
+      channels: [{ index: 0, name: 'Primary' }, { index: 1, name: 'Ops' }, { name: 'no-index' }],
+    });
+
+    renderApp();
+    fireEvent.click(screen.getByRole('tab', { name: /^Chat/ }));
+
+    await waitFor(() => {
+      expect(lastChatPanelProps.current?.channels).toEqual([
+        { index: 0, name: 'Primary' },
+        { index: 1, name: 'Ops' },
+      ]);
+      expect(lastChatPanelProps.current?.myNodeNum).toBe(1);
+    });
+  });
+
+  it('builds node-detail hop labels from ProtocolRuntime traceRouteResults', async () => {
+    setConnection(MESHTASTIC_TEST_IDENTITY, {
+      status: 'configured',
+      myNodeNum: 1,
+      connectionType: 'serial',
+    });
+    useDeviceMock.mockReturnValue({
+      ...createDeviceMock(),
+      state: { status: 'configured', myNodeNum: 1, connectionType: 'serial' },
+      selfNodeId: 1,
+      getFullNodeLabel: vi.fn((id: number) => (id === 1 ? '' : `N${id.toString(16)}`)),
+      traceRouteResults: new Map([[0x23456789, { route: [0x11], from: 0x23456789, timestamp: 1 }]]),
+    });
+
+    renderApp();
+    fireEvent.click(screen.getByRole('tab', { name: /^Chat/ }));
+
+    await waitFor(() => {
+      expect(lastChatPanelProps.current).not.toBeNull();
+    });
+    const onNodeClick = lastChatPanelProps.current?.onNodeClick as
+      ((nodeId: number) => void) | null;
+    act(() => {
+      onNodeClick?.(0x23456789);
+    });
+
+    await waitFor(() => {
+      expect(lastNodeDetailModalProps.current?.traceRouteHops).toEqual(['Me', 'N11', 'N23456789']);
+    });
+  });
+
   it('wires header waiting-message sync to syncWaitingMessages, not getWaitingMessages', async () => {
     getStoredMeshProtocolMock.mockReturnValue('meshcore');
     const syncWaitingMessages = vi.fn().mockResolvedValue(undefined);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -59,10 +59,7 @@ import {
   writeMeshcoreAutoOffloadWhenFull,
 } from '@/renderer/lib/meshcore/meshcoreContactCapacityPush';
 import { isMeshcoreTcpOpenHopDeadAccepted } from '@/renderer/lib/meshcore/meshcoreTcpInitBurst';
-import {
-  meshcoreConfiguredChannelIndexSet,
-  meshcoreConfiguredChatChannels,
-} from '@/renderer/lib/meshcoreConfiguredChatChannels';
+import { meshcoreConfiguredChannelIndexSet } from '@/renderer/lib/meshcoreConfiguredChatChannels';
 import { persistMeshcoreSelfNodeId } from '@/renderer/lib/meshcoreLastSelfNodeId';
 import { resolveMeshcoreOwnNodeIdSet } from '@/renderer/lib/meshcoreOwnNodeIds';
 import { getMeshcoreCompanionRepeaterRfBusySnapshot } from '@/renderer/lib/meshcoreRepeaterRpcInFlight';
@@ -72,6 +69,21 @@ import { meshcoreWaitingMessagesVisibleForProtocol } from '@/renderer/lib/meshco
 import { meshtasticMqttOwnNodeIds } from '@/renderer/lib/meshtasticMqttIdentity';
 import { remoteConfigChannelRetryRoute } from '@/renderer/lib/meshtasticRemoteAdminSnapshot';
 import { Z_NODE_DETAIL_MODAL } from '@/renderer/lib/modalZIndex';
+import {
+  asChannelIndexPills,
+  asEnvironmentTelemetryPoints,
+  asGpsIntervalChange,
+  asMqttConnectionLoss,
+  asNeighborInfoMap,
+  asNumericNodeId,
+  asOurPosition,
+  asRadioDeviceOwner,
+  asTelemetryPoints,
+  asTraceRouteResultsMap,
+  asWaypointMap,
+  chatChannelsFromRuntimeChannels,
+  traceRouteHopLabels,
+} from '@/renderer/lib/protocolRuntimeAdapters';
 import { useReticulumRawPacketPoll } from '@/renderer/lib/reticulum/useReticulumRawPacketPoll';
 import { persistReticulumSelfLxmfHash } from '@/renderer/lib/reticulumLastSelfLxmfHash';
 import { resolveReticulumOwnNodeIdSet } from '@/renderer/lib/reticulumOwnNodeIds';
@@ -200,7 +212,6 @@ import {
   TELEMETRY_PANEL_INDEX,
   TOPOLOGY_PANEL_INDEX,
 } from './lib/appTabMappings';
-import { dedupeChannelPillsByIndex } from './lib/channelListDedupe';
 import { playMessageNotification } from './lib/chatNotifications';
 import {
   deviceHeaderVariant,
@@ -289,7 +300,6 @@ import {
   useAllRuntimes,
   useRuntime,
 } from './runtime/ProtocolRuntimeContext';
-import type { MeshcoreRuntime, MeshtasticRuntime } from './runtime/runtimeTypes';
 import { useMeshcoreRuntime } from './runtime/useMeshcoreRuntime';
 import { useMeshtasticRuntime } from './runtime/useMeshtasticRuntime';
 import { useReticulumRuntime } from './runtime/useReticulumRuntime';
@@ -512,12 +522,11 @@ export default function App() {
   const meshcoreRuntime = useMeshcoreRuntime();
   const reticulumRuntime = useReticulumRuntime();
   const runtimeMap = useMemo<RuntimeMap>(
-    () =>
-      ({
-        meshtastic: meshtasticRuntime,
-        meshcore: meshcoreRuntime,
-        reticulum: reticulumRuntime,
-      }) as unknown as RuntimeMap,
+    () => ({
+      meshtastic: meshtasticRuntime,
+      meshcore: meshcoreRuntime,
+      reticulum: reticulumRuntime,
+    }),
     [meshtasticRuntime, meshcoreRuntime, reticulumRuntime],
   );
   return (
@@ -568,8 +577,8 @@ function AppContent() {
   }, []);
 
   const runtimes = useAllRuntimes();
-  const meshtasticRuntime = runtimes.meshtastic as unknown as MeshtasticRuntime;
-  const meshcoreRuntime = runtimes.meshcore as unknown as MeshcoreRuntime;
+  const meshtasticRuntime = runtimes.meshtastic;
+  const meshcoreRuntime = runtimes.meshcore;
   const reticulumRuntime = runtimes.reticulum;
   const [activeTab, setActiveTab] = useState(0);
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
@@ -1170,7 +1179,24 @@ function AppContent() {
     [sendMessage],
   );
   const { status: takStatus, error: takError, takClientLoss } = useTakServer();
-  const activeRuntime = useRuntime(protocol) as unknown as MeshtasticRuntime;
+  const activeRuntime = useRuntime(protocol);
+  const activeSelfNodeNum = asNumericNodeId(
+    activeRuntime.selfNodeId,
+    activeRuntime.state.myNodeNum,
+  );
+  const activeOurPosition = asOurPosition(activeRuntime.ourPosition);
+  const activeWaypoints = asWaypointMap(activeRuntime.waypoints);
+  const activeTelemetry = asTelemetryPoints(activeRuntime.telemetry);
+  const activeSignalTelemetry = asTelemetryPoints(activeRuntime.signalTelemetry);
+  const activeEnvironmentTelemetry = asEnvironmentTelemetryPoints(
+    activeRuntime.environmentTelemetry,
+  );
+  const activeTraceRouteResults = useMemo(
+    () => asTraceRouteResultsMap(activeRuntime.traceRouteResults),
+    [activeRuntime.traceRouteResults],
+  );
+  const activeNeighborInfo = asNeighborInfoMap(activeRuntime.neighborInfo);
+  const activeChannelPills = asChannelIndexPills(activeRuntime.channels);
   const contactGroupsSelfId =
     typeof activeRuntime.selfNodeId === 'number' ? activeRuntime.selfNodeId : null;
   const contactGroups = useContactGroups(contactGroupsSelfId);
@@ -1510,11 +1536,15 @@ function AppContent() {
   const meshtasticOwnNodeIdsForChat = useMemo(
     () =>
       meshtasticMqttOwnNodeIds(
-        activeRuntime.selfNodeId,
+        asNumericNodeId(meshtasticRuntime.selfNodeId),
         meshtasticRuntime.virtualNodeId,
         meshtasticRuntime.lastRfSelfNodeId,
       ),
-    [activeRuntime.selfNodeId, meshtasticRuntime.virtualNodeId, meshtasticRuntime.lastRfSelfNodeId],
+    [
+      meshtasticRuntime.selfNodeId,
+      meshtasticRuntime.virtualNodeId,
+      meshtasticRuntime.lastRfSelfNodeId,
+    ],
   );
   const reticulumOwnNodeIdsForChat = useMemo(
     () => Array.from(reticulumOwnNodeIdSet),
@@ -1858,9 +1888,11 @@ function AppContent() {
   const effectiveSecurityConfig = isRemoteConfigureTarget
     ? (meshtasticRuntime.remoteConfigSnapshot?.securityConfig ?? null)
     : meshtasticRuntime.securityConfig;
-  const effectiveDeviceOwner = isRemoteConfigureTarget
-    ? (meshtasticRuntime.remoteConfigSnapshot?.deviceOwner ?? null)
-    : activeRuntime.deviceOwner;
+  const effectiveDeviceOwner = asRadioDeviceOwner(
+    isRemoteConfigureTarget
+      ? (meshtasticRuntime.remoteConfigSnapshot?.deviceOwner ?? null)
+      : activeRuntime.deviceOwner,
+  );
   const effectiveDeviceFixedPosition = isRemoteConfigureTarget
     ? (meshtasticRuntime.remoteConfigSnapshot?.deviceFixedPosition ?? null)
     : meshtasticRuntime.deviceFixedPosition;
@@ -2004,13 +2036,11 @@ function AppContent() {
   const traceRouteHops = useMemo(() => {
     if (!selectedNode) return undefined;
     if (!capabilities.hasNeighborInfo) return undefined;
-    const result = activeRuntime.traceRouteResults.get(selectedNode.node_id);
-    if (!result) return undefined;
-    return [
-      panelActions.getFullNodeLabel(activeConnectionView.state.myNodeNum) || 'Me',
-      ...result.route.map((id) => panelActions.getFullNodeLabel(id)),
-      panelActions.getFullNodeLabel(result.from),
-    ];
+    return traceRouteHopLabels(
+      activeRuntime.traceRouteResults.get(selectedNode.node_id),
+      activeConnectionView.state.myNodeNum,
+      panelActions.getFullNodeLabel,
+    );
   }, [
     selectedNode,
     panelActions,
@@ -2020,17 +2050,18 @@ function AppContent() {
   ]);
 
   /** MeshCore chat: only show configured channels (key !== all zeros). */
-  const chatChannels = useMemo(() => {
-    if (capabilities.hasReticulumInterfaceConfig) return [];
-    if (capabilities.hasCompanionContactManagementConfig) {
-      return meshcoreConfiguredChatChannels(activeRuntime.channels);
-    }
-    return dedupeChannelPillsByIndex(activeRuntime.channels);
-  }, [
-    capabilities.hasReticulumInterfaceConfig,
-    capabilities.hasCompanionContactManagementConfig,
-    activeRuntime.channels,
-  ]);
+  const chatChannels = useMemo(
+    () =>
+      chatChannelsFromRuntimeChannels(activeRuntime.channels, {
+        hasReticulumInterfaceConfig: capabilities.hasReticulumInterfaceConfig,
+        hasCompanionContactManagementConfig: capabilities.hasCompanionContactManagementConfig,
+      }),
+    [
+      capabilities.hasReticulumInterfaceConfig,
+      capabilities.hasCompanionContactManagementConfig,
+      activeRuntime.channels,
+    ],
+  );
 
   const [chatTabVisited, setChatTabVisited] = useState(false);
   const [roomsTabVisited, setRoomsTabVisited] = useState(false);
@@ -2856,7 +2887,7 @@ function AppContent() {
     setAlwaysShowMessageActions(alwaysShow);
   }, []);
 
-  const mqttLoss = activeRuntime.mqttConnectionLoss ?? false;
+  const mqttLoss = asMqttConnectionLoss(activeRuntime.mqttConnectionLoss);
   const mqttVariant = mqttHeaderVariant(
     activeConnectionView.mqttStatus ?? 'disconnected',
     mqttLoss,
@@ -3381,11 +3412,7 @@ function AppContent() {
                                 : undefined
                             }
                             meshcoreChannelManagementDisabled={!isOperational}
-                            myNodeNum={
-                              typeof activeRuntime.selfNodeId === 'number'
-                                ? activeRuntime.selfNodeId
-                                : activeRuntime.state.myNodeNum
-                            }
+                            myNodeNum={activeSelfNodeNum}
                             ownNodeIds={
                               protocol === 'reticulum'
                                 ? reticulumOwnNodeIdsForChat
@@ -3718,7 +3745,7 @@ function AppContent() {
                             ) : (
                               <NodeListPanel
                                 nodes={nodesForUi}
-                                myNodeNum={activeRuntime.selfNodeId}
+                                myNodeNum={activeSelfNodeNum}
                                 onNodeClick={(node) => {
                                   setSelectedNodeId(node.node_id);
                                 }}
@@ -3814,9 +3841,9 @@ function AppContent() {
                               capabilities.nodeListTabUsesContactsLabel ? (
                               <MapPanel
                                 nodes={nodesForUi}
-                                myNodeNum={activeRuntime.selfNodeId}
+                                myNodeNum={activeSelfNodeNum}
                                 locationFilter={locationFilter}
-                                ourPosition={activeRuntime.ourPosition}
+                                ourPosition={activeOurPosition}
                                 onLocateMe={
                                   capabilities.hasFullPositionConfig
                                     ? () =>
@@ -3825,7 +3852,7 @@ function AppContent() {
                                           .then((p) => (p ? { lat: p.lat, lon: p.lon } : null))
                                     : undefined
                                 }
-                                waypoints={activeRuntime.waypoints}
+                                waypoints={activeWaypoints}
                                 onSendWaypoint={
                                   capabilities.hasFullPositionConfig
                                     ? meshtasticPanelActions.sendWaypoint
@@ -3924,7 +3951,7 @@ function AppContent() {
                                   }
                                   isConnected={isOperational}
                                   deviceFixedPosition={effectiveDeviceFixedPosition}
-                                  ourPosition={activeRuntime.ourPosition}
+                                  ourPosition={activeOurPosition}
                                   onSendPositionToDevice={resolvePanelPositionSendHandler(
                                     capabilities,
                                     meshtasticPanelActions.sendPositionToDevice,
@@ -4323,9 +4350,9 @@ function AppContent() {
                         <ErrorBoundary>
                           <Suspense fallback={<PanelSkeleton />}>
                             <TelemetryPanel
-                              telemetry={activeRuntime.telemetry}
-                              signalTelemetry={activeRuntime.signalTelemetry}
-                              environmentTelemetry={activeRuntime.environmentTelemetry}
+                              telemetry={activeTelemetry}
+                              signalTelemetry={activeSignalTelemetry}
+                              environmentTelemetry={activeEnvironmentTelemetry}
                               useFahrenheit={useFahrenheit}
                               onToggleFahrenheit={toggleFahrenheit}
                               onRefresh={panelActions.requestRefresh}
@@ -4451,16 +4478,18 @@ function AppContent() {
                                 nodeCount={nodesForUi.size}
                                 myNodeNum={activeRuntime.state.myNodeNum}
                                 messageCount={activeUiMessages.length}
-                                channels={activeRuntime.channels}
+                                channels={activeChannelPills}
                                 onLocationFilterChange={handleLocationFilterChange}
-                                ourPosition={activeRuntime.ourPosition}
+                                ourPosition={activeOurPosition}
                                 onRefreshGps={
                                   capabilities.hasFullPositionConfig
                                     ? meshtasticPanelActions.refreshOurPosition
                                     : undefined
                                 }
                                 gpsLoading={activeRuntime.gpsLoading}
-                                onGpsIntervalChange={activeRuntime.updateGpsInterval}
+                                onGpsIntervalChange={asGpsIntervalChange(
+                                  activeRuntime.updateGpsInterval,
+                                )}
                                 onNodesPruned={refreshNodesFromDb}
                                 onMessagesPruned={refreshMessagesFromDb}
                                 onClearMeshcoreRepeaters={
@@ -4497,11 +4526,7 @@ function AppContent() {
                             <DiagnosticsPanel
                               nodes={nodesForDiagnostics}
                               meshcoreNodes={meshcoreUiNodes}
-                              myNodeNum={
-                                typeof activeRuntime.selfNodeId === 'number'
-                                  ? activeRuntime.selfNodeId
-                                  : 0
-                              }
+                              myNodeNum={asNumericNodeId(activeRuntime.selfNodeId)}
                               meshtasticListenerNodeId={
                                 meshtasticRuntime.state.myNodeNum > 0
                                   ? meshtasticRuntime.state.myNodeNum
@@ -4518,9 +4543,9 @@ function AppContent() {
                                     : () => Promise.resolve(undefined)
                               }
                               isConnected={isOperational}
-                              traceRouteResults={activeRuntime.traceRouteResults}
+                              traceRouteResults={activeTraceRouteResults}
                               getFullNodeLabel={panelActions.getFullNodeLabel}
-                              ourPosition={activeRuntime.ourPosition}
+                              ourPosition={activeOurPosition}
                               onNodeClick={(node) => {
                                 setSelectedNodeId(node.node_id);
                               }}
@@ -4658,7 +4683,7 @@ function AppContent() {
                           <Suspense fallback={<PanelSkeleton />}>
                             <PeerGraphPanel
                               nodes={nodesForUi}
-                              myNodeId={activeRuntime.selfNodeId}
+                              myNodeId={activeSelfNodeNum}
                               onNodeClick={setSelectedNodeId}
                             />
                           </Suspense>
@@ -4910,7 +4935,7 @@ function AppContent() {
             mqttConnected={detailConnectionView.mqttStatus === 'connected'}
             radioConnected={detailIsConnectedOrOperational}
             homeNode={detailHomeNode}
-            neighborInfo={activeRuntime.neighborInfo}
+            neighborInfo={activeNeighborInfo}
             useFahrenheit={useFahrenheit}
             protocol={detailModalProtocol}
             meshcoreTraceResult={

--- a/src/renderer/lib/meshcoreConfiguredChatChannels.test.ts
+++ b/src/renderer/lib/meshcoreConfiguredChatChannels.test.ts
@@ -20,6 +20,20 @@ describe('meshcoreConfiguredChatChannels', () => {
     ]);
   });
 
+  it('ignores unknown channel entries from ProtocolRuntime.channels', () => {
+    const channels = [
+      { index: 0, name: 'General', secret: new Uint8Array(16).fill(0x11) },
+      { name: 'no-index', secret: new Uint8Array(16).fill(0x22) },
+      null,
+      'not-a-channel',
+      { index: 2, name: 'Ops', secret: new Uint8Array(16).fill(0x33) },
+    ];
+    expect(meshcoreConfiguredChatChannels(channels)).toEqual([
+      { index: 0, name: 'General' },
+      { index: 2, name: 'Ops' },
+    ]);
+  });
+
   it('omits channels with all-zero secret', () => {
     const channels = [
       { index: 0, name: 'General', secret: new Uint8Array(16).fill(0x11) },

--- a/src/renderer/lib/meshcoreConfiguredChatChannels.ts
+++ b/src/renderer/lib/meshcoreConfiguredChatChannels.ts
@@ -15,12 +15,25 @@ function channelSecretHex(secret: Uint8Array): string {
     .join('');
 }
 
+function asMeshcoreChatChannelSources(channels: readonly unknown[]): MeshcoreChatChannelSource[] {
+  const out: MeshcoreChatChannelSource[] = [];
+  for (const ch of channels) {
+    if (typeof ch !== 'object' || ch === null) continue;
+    const rec = ch as Record<string, unknown>;
+    if (typeof rec.index !== 'number' || typeof rec.name !== 'string') continue;
+    const source: MeshcoreChatChannelSource = { index: rec.index, name: rec.name };
+    if (rec.secret instanceof Uint8Array) source.secret = rec.secret;
+    out.push(source);
+  }
+  return out;
+}
+
 /** Channel slots with a non-zero PSK — matches Chat channel pills (see App `chatChannels`). */
 export function meshcoreConfiguredChatChannels(
-  channels: readonly MeshcoreChatChannelSource[],
+  channels: readonly unknown[],
 ): { index: number; name: string }[] {
   return dedupeChannelPillsByIndex(
-    channels
+    asMeshcoreChatChannelSources(channels)
       .filter((ch) => {
         const secret = ch.secret;
         return (
@@ -34,7 +47,7 @@ export function meshcoreConfiguredChatChannels(
 }
 
 export function meshcoreConfiguredChannelIndexSet(
-  channels: readonly MeshcoreChatChannelSource[],
+  channels: readonly unknown[],
 ): ReadonlySet<number> {
   return new Set(meshcoreConfiguredChatChannels(channels).map((c) => c.index));
 }

--- a/src/renderer/lib/protocolRuntimeAdapters.test.ts
+++ b/src/renderer/lib/protocolRuntimeAdapters.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  asChannelIndexPills,
+  asEnvironmentTelemetryPoints,
+  asGpsIntervalChange,
+  asMqttConnectionLoss,
+  asNumericNodeId,
+  asOurPosition,
+  asRadioDeviceOwner,
+  asTelemetryPoints,
+  asTraceRouteResult,
+  asTraceRouteResultsMap,
+  asWaypointMap,
+  chatChannelsFromRuntimeChannels,
+  traceRouteHopLabels,
+} from './protocolRuntimeAdapters';
+
+describe('protocolRuntimeAdapters', () => {
+  it('asChannelIndexPills keeps named index slots and drops junk', () => {
+    expect(
+      asChannelIndexPills([
+        { index: 1, name: 'Ops' },
+        { index: 'x', name: 'Bad' },
+        null,
+        { index: 0, name: 'Primary' },
+      ]),
+    ).toEqual([
+      { index: 1, name: 'Ops' },
+      { index: 0, name: 'Primary' },
+    ]);
+  });
+
+  it('chatChannelsFromRuntimeChannels mirrors App: Reticulum empty, MeshCore configured, else pills', () => {
+    const channels = [
+      { index: 0, name: 'General', secret: new Uint8Array(16).fill(0x11) },
+      { index: 1, name: 'Unset', secret: new Uint8Array(16) },
+    ];
+    expect(
+      chatChannelsFromRuntimeChannels(channels, {
+        hasReticulumInterfaceConfig: true,
+        hasCompanionContactManagementConfig: false,
+      }),
+    ).toEqual([]);
+    expect(
+      chatChannelsFromRuntimeChannels(channels, {
+        hasReticulumInterfaceConfig: false,
+        hasCompanionContactManagementConfig: true,
+      }),
+    ).toEqual([{ index: 0, name: 'General' }]);
+    expect(
+      chatChannelsFromRuntimeChannels([{ index: 2, name: 'Secondary' }, { name: 'no-index' }], {
+        hasReticulumInterfaceConfig: false,
+        hasCompanionContactManagementConfig: false,
+      }),
+    ).toEqual([{ index: 2, name: 'Secondary' }]);
+  });
+
+  it('asTraceRouteResult requires route[] and from', () => {
+    expect(asTraceRouteResult(undefined)).toBeUndefined();
+    expect(asTraceRouteResult({ from: 7 })).toBeUndefined();
+    expect(asTraceRouteResult({ route: ['x'], from: 7 })).toBeUndefined();
+    expect(asTraceRouteResult({ route: [2, 3], from: 7, timestamp: 9 })).toEqual({
+      route: [2, 3],
+      from: 7,
+      timestamp: 9,
+    });
+    expect(asTraceRouteResult({ route: [2], from: 7 })).toEqual({
+      route: [2],
+      from: 7,
+      timestamp: 0,
+    });
+  });
+
+  it('traceRouteHopLabels matches the previous App Meshtastic-typed hop list', () => {
+    const labels = (id: number) => (id === 1 ? '' : `N${id.toString(16)}`);
+    expect(traceRouteHopLabels(undefined, 1, labels)).toBeUndefined();
+    expect(traceRouteHopLabels({ route: [2], from: 3 }, 1, labels)).toEqual(['Me', 'N2', 'N3']);
+  });
+
+  it('asTraceRouteResultsMap drops unshaped entries', () => {
+    const map = asTraceRouteResultsMap(
+      new Map<number, unknown>([
+        [1, { route: [2], from: 3, timestamp: 4 }],
+        [2, { from: 9 }],
+      ]),
+    );
+    expect([...map.entries()]).toEqual([[1, { route: [2], from: 3, timestamp: 4 }]]);
+  });
+
+  it('coerces ProtocolRuntime scalars used on the App path', () => {
+    expect(asNumericNodeId(12, 99)).toBe(12);
+    expect(asNumericNodeId('ab', 99)).toBe(99);
+    expect(asNumericNodeId(null)).toBe(0);
+    expect(asMqttConnectionLoss(null)).toBe(false);
+    expect(asMqttConnectionLoss('lost')).toBe(true);
+    expect(asOurPosition(null)).toBeNull();
+    expect(asOurPosition({ lat: 1, lon: 2 })).toBeNull();
+    expect(asOurPosition({ lat: 1, lon: 2, source: 'device', altitudeMeters: 10 })).toEqual({
+      lat: 1,
+      lon: 2,
+      source: 'device',
+      altitudeMeters: 10,
+    });
+    expect(asWaypointMap([])).toBeUndefined();
+    const wp = new Map();
+    expect(asWaypointMap(wp)).toBe(wp);
+    expect(asTelemetryPoints(null)).toEqual([]);
+    expect(asTelemetryPoints([{ timestamp: 1 }])).toEqual([{ timestamp: 1 }]);
+    expect(asEnvironmentTelemetryPoints(null)).toEqual([]);
+    expect(asRadioDeviceOwner(null)).toBeNull();
+    expect(asRadioDeviceOwner({ longName: 'A' })).toEqual({
+      longName: 'A',
+      shortName: '',
+      isLicensed: false,
+    });
+    const gps = vi.fn();
+    asGpsIntervalChange(gps as (...args: never[]) => void)?.(30);
+    expect(gps).toHaveBeenCalledWith(30);
+    expect(asGpsIntervalChange(undefined)).toBeUndefined();
+  });
+});

--- a/src/renderer/lib/protocolRuntimeAdapters.test.ts
+++ b/src/renderer/lib/protocolRuntimeAdapters.test.ts
@@ -165,5 +165,27 @@ describe('protocolRuntimeAdapters', () => {
     expect([...neighbors.entries()]).toEqual([[1, goodNeighbor]]);
     expect(asNeighborInfoMap(undefined).size).toBe(0);
     expect(asNeighborInfoMap([]).size).toBe(0);
+
+    expect(
+      asTelemetryPoints([
+        { timestamp: 1, voltage: 3.7 },
+        { timestamp: 2, voltage: 'bad' },
+      ]),
+    ).toEqual([{ timestamp: 1, voltage: 3.7 }]);
+    expect(
+      asEnvironmentTelemetryPoints([
+        { timestamp: 1, nodeNum: 9, temperature: 12, adcVoltages: [1, undefined, 2] },
+        { timestamp: 2, nodeNum: 9, temperature: 'hot' },
+        { timestamp: 3, nodeNum: 9, adcVoltages: ['x'] },
+      ]),
+    ).toEqual([{ timestamp: 1, nodeNum: 9, temperature: 12, adcVoltages: [1, undefined, 2] }]);
+    expect(
+      asWaypointMap(
+        new Map<number, unknown>([
+          [1, goodWp],
+          [3, { ...goodWp, id: 3, description: 12 }],
+        ]),
+      )!.size,
+    ).toBe(1);
   });
 });

--- a/src/renderer/lib/protocolRuntimeAdapters.test.ts
+++ b/src/renderer/lib/protocolRuntimeAdapters.test.ts
@@ -5,6 +5,7 @@ import {
   asEnvironmentTelemetryPoints,
   asGpsIntervalChange,
   asMqttConnectionLoss,
+  asNeighborInfoMap,
   asNumericNodeId,
   asOurPosition,
   asRadioDeviceOwner,
@@ -108,6 +109,9 @@ describe('protocolRuntimeAdapters', () => {
     expect(asTelemetryPoints(null)).toEqual([]);
     expect(asTelemetryPoints([{ timestamp: 1 }])).toEqual([{ timestamp: 1 }]);
     expect(asEnvironmentTelemetryPoints(null)).toEqual([]);
+    expect(asEnvironmentTelemetryPoints([{ timestamp: 1, nodeNum: 2 }])).toEqual([
+      { timestamp: 1, nodeNum: 2 },
+    ]);
     expect(asRadioDeviceOwner(null)).toBeNull();
     expect(asRadioDeviceOwner({ longName: 'A' })).toEqual({
       longName: 'A',
@@ -118,5 +122,48 @@ describe('protocolRuntimeAdapters', () => {
     asGpsIntervalChange(gps as (...args: never[]) => void)?.(30);
     expect(gps).toHaveBeenCalledWith(30);
     expect(asGpsIntervalChange(undefined)).toBeUndefined();
+  });
+
+  it('drops malformed map and array members before panels see them', () => {
+    const goodWp = {
+      id: 1,
+      latitude: 40,
+      longitude: -105,
+      name: 'Camp',
+      from: 2,
+      timestamp: 3,
+    };
+    const waypoints = asWaypointMap(
+      new Map<number, unknown>([
+        [1, goodWp],
+        [2, { id: 2, name: 'no-coords' }],
+      ]),
+    );
+    expect([...waypoints!.entries()]).toEqual([[1, goodWp]]);
+
+    expect(asTelemetryPoints([{ timestamp: 1 }, { batteryLevel: 80 }, null])).toEqual([
+      { timestamp: 1 },
+    ]);
+    expect(
+      asEnvironmentTelemetryPoints([
+        { timestamp: 1, nodeNum: 9, temperature: 12 },
+        { timestamp: 2 },
+      ]),
+    ).toEqual([{ timestamp: 1, nodeNum: 9, temperature: 12 }]);
+
+    const goodNeighbor = {
+      nodeId: 1,
+      timestamp: 4,
+      neighbors: [{ nodeId: 2, snr: 3, lastRxTime: 5 }],
+    };
+    const neighbors = asNeighborInfoMap(
+      new Map<number, unknown>([
+        [1, goodNeighbor],
+        [2, { nodeId: 2, timestamp: 4, neighbors: [{ nodeId: 'x' }] }],
+      ]),
+    );
+    expect([...neighbors.entries()]).toEqual([[1, goodNeighbor]]);
+    expect(asNeighborInfoMap(undefined).size).toBe(0);
+    expect(asNeighborInfoMap([]).size).toBe(0);
   });
 });

--- a/src/renderer/lib/protocolRuntimeAdapters.ts
+++ b/src/renderer/lib/protocolRuntimeAdapters.ts
@@ -115,13 +115,71 @@ export function asGpsIntervalChange(
   };
 }
 
+function optionalNumber(value: unknown): boolean {
+  return value === undefined || typeof value === 'number';
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+function optionalSparseNumberArray(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (Array.isArray(value) && value.every((item) => item === undefined || typeof item === 'number'))
+  );
+}
+
+function optionalNumbers(rec: Record<string, unknown>, keys: readonly string[]): boolean {
+  return keys.every((key) => optionalNumber(rec[key]));
+}
+
+const TELEMETRY_OPTIONAL_NUMBERS = ['batteryLevel', 'voltage', 'snr', 'rssi'] as const;
+
+const ENV_OPTIONAL_NUMBERS = [
+  'temperature',
+  'mcuTemperature',
+  'relativeHumidity',
+  'barometricPressure',
+  'gasResistance',
+  'iaq',
+  'lux',
+  'windSpeed',
+  'windDirection',
+  'windGust',
+  'windLull',
+  'weight',
+  'rainfall1h',
+  'rainfall24h',
+  'lightningStrikeCount1h',
+  'lightningDistanceKm',
+  'pm10Standard',
+  'pm25Standard',
+  'pm40Standard',
+  'pm100Standard',
+  'co2',
+  'pmTemperature',
+  'pmHumidity',
+  'pmVocIdx',
+  'pmNoxIdx',
+] as const;
+
 function isTelemetryPoint(value: unknown): value is TelemetryPoint {
-  return isRecord(value) && typeof value.timestamp === 'number';
+  return (
+    isRecord(value) &&
+    typeof value.timestamp === 'number' &&
+    optionalNumbers(value, TELEMETRY_OPTIONAL_NUMBERS)
+  );
 }
 
 function isEnvironmentTelemetryPoint(value: unknown): value is EnvironmentTelemetryPoint {
   return (
-    isRecord(value) && typeof value.timestamp === 'number' && typeof value.nodeNum === 'number'
+    isRecord(value) &&
+    typeof value.timestamp === 'number' &&
+    typeof value.nodeNum === 'number' &&
+    optionalNumbers(value, ENV_OPTIONAL_NUMBERS) &&
+    optionalSparseNumberArray(value.adcVoltages) &&
+    optionalSparseNumberArray(value.oneWireTemperatures)
   );
 }
 
@@ -133,7 +191,9 @@ function isMeshWaypoint(value: unknown): value is MeshWaypoint {
     typeof value.longitude === 'number' &&
     typeof value.name === 'string' &&
     typeof value.from === 'number' &&
-    typeof value.timestamp === 'number'
+    typeof value.timestamp === 'number' &&
+    optionalString(value.description) &&
+    optionalNumbers(value, ['icon', 'lockedTo', 'expire'])
   );
 }
 

--- a/src/renderer/lib/protocolRuntimeAdapters.ts
+++ b/src/renderer/lib/protocolRuntimeAdapters.ts
@@ -1,0 +1,143 @@
+import { dedupeChannelPillsByIndex } from '@/renderer/lib/channelListDedupe';
+import type { OurPosition } from '@/renderer/lib/gpsSource';
+import { meshcoreConfiguredChatChannels } from '@/renderer/lib/meshcoreConfiguredChatChannels';
+import type {
+  EnvironmentTelemetryPoint,
+  MeshWaypoint,
+  NeighborInfoRecord,
+  TelemetryPoint,
+} from '@/renderer/lib/types';
+import type { ProtocolRuntimeDeviceOwner } from '@/renderer/runtime/protocolRuntime';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Channel pills App/Chat/AppPanel accept (`index` + `name`). */
+export function asChannelIndexPills(
+  channels: readonly unknown[],
+): { index: number; name: string }[] {
+  const pills: { index: number; name: string }[] = [];
+  for (const ch of channels) {
+    if (!isRecord(ch) || typeof ch.index !== 'number' || typeof ch.name !== 'string') continue;
+    pills.push({ index: ch.index, name: ch.name });
+  }
+  return pills;
+}
+
+/** App `chatChannels` — Reticulum empty, MeshCore configured-PSK only, else last-wins pills. */
+export function chatChannelsFromRuntimeChannels(
+  channels: readonly unknown[],
+  capabilities: {
+    hasReticulumInterfaceConfig: boolean;
+    hasCompanionContactManagementConfig: boolean;
+  },
+): { index: number; name: string }[] {
+  if (capabilities.hasReticulumInterfaceConfig) return [];
+  if (capabilities.hasCompanionContactManagementConfig) {
+    return meshcoreConfiguredChatChannels(channels);
+  }
+  return dedupeChannelPillsByIndex(asChannelIndexPills(channels));
+}
+
+export interface ProtocolTraceRouteResult {
+  route: number[];
+  from: number;
+  timestamp: number;
+}
+
+/** Narrow ProtocolRuntime `traceRouteResults` values (`route` / `from`). */
+export function asTraceRouteResult(value: unknown): ProtocolTraceRouteResult | undefined {
+  if (!isRecord(value) || typeof value.from !== 'number' || !Array.isArray(value.route)) {
+    return undefined;
+  }
+  if (!value.route.every((id) => typeof id === 'number')) return undefined;
+  return {
+    route: value.route,
+    from: value.from,
+    timestamp: typeof value.timestamp === 'number' ? value.timestamp : 0,
+  };
+}
+
+export function asTraceRouteResultsMap(
+  results: Map<number, unknown>,
+): Map<number, ProtocolTraceRouteResult> {
+  const out = new Map<number, ProtocolTraceRouteResult>();
+  for (const [id, value] of results) {
+    const traced = asTraceRouteResult(value);
+    if (traced) out.set(id, traced);
+  }
+  return out;
+}
+
+/** App NodeDetail hop labels — same order as the previous Meshtastic-typed path. */
+export function traceRouteHopLabels(
+  result: unknown,
+  myNodeNum: number,
+  getFullNodeLabel: (id: number) => string,
+): string[] | undefined {
+  const traced = asTraceRouteResult(result);
+  if (!traced) return undefined;
+  return [
+    getFullNodeLabel(myNodeNum) || 'Me',
+    ...traced.route.map((id) => getFullNodeLabel(id)),
+    getFullNodeLabel(traced.from),
+  ];
+}
+
+export function asNumericNodeId(selfNodeId: string | number | null, fallback = 0): number {
+  return typeof selfNodeId === 'number' ? selfNodeId : fallback;
+}
+
+export function asMqttConnectionLoss(value: string | null | boolean | undefined): boolean {
+  return Boolean(value);
+}
+
+export function asOurPosition(value: unknown): OurPosition | null {
+  if (!isRecord(value) || typeof value.lat !== 'number' || typeof value.lon !== 'number') {
+    return null;
+  }
+  const source = value.source;
+  if (source !== 'device' && source !== 'browser' && source !== 'ip' && source !== 'static') {
+    return null;
+  }
+  const pos: OurPosition = { lat: value.lat, lon: value.lon, source };
+  if (typeof value.altitudeMeters === 'number') pos.altitudeMeters = value.altitudeMeters;
+  return pos;
+}
+
+export function asGpsIntervalChange(
+  fn: ((...args: never[]) => void) | undefined,
+): ((secs: number) => void) | undefined {
+  if (!fn) return undefined;
+  return (secs) => {
+    (fn as (intervalSecs: number) => void)(secs);
+  };
+}
+
+export function asWaypointMap(value: unknown): Map<number, MeshWaypoint> | undefined {
+  return value instanceof Map ? (value as Map<number, MeshWaypoint>) : undefined;
+}
+
+export function asTelemetryPoints(value: unknown): TelemetryPoint[] {
+  return Array.isArray(value) ? (value as TelemetryPoint[]) : [];
+}
+
+export function asEnvironmentTelemetryPoints(value: unknown): EnvironmentTelemetryPoint[] {
+  return Array.isArray(value) ? (value as EnvironmentTelemetryPoint[]) : [];
+}
+
+export function asNeighborInfoMap(value: Map<number, unknown>): Map<number, NeighborInfoRecord> {
+  return value as Map<number, NeighborInfoRecord>;
+}
+
+export function asRadioDeviceOwner(
+  value: ProtocolRuntimeDeviceOwner | null,
+): { longName: string; shortName: string; isLicensed: boolean } | null {
+  if (!value) return null;
+  return {
+    longName: value.longName ?? '',
+    shortName: value.shortName ?? '',
+    isLicensed: value.isLicensed ?? false,
+  };
+}

--- a/src/renderer/lib/protocolRuntimeAdapters.ts
+++ b/src/renderer/lib/protocolRuntimeAdapters.ts
@@ -115,20 +115,93 @@ export function asGpsIntervalChange(
   };
 }
 
+function isTelemetryPoint(value: unknown): value is TelemetryPoint {
+  return isRecord(value) && typeof value.timestamp === 'number';
+}
+
+function isEnvironmentTelemetryPoint(value: unknown): value is EnvironmentTelemetryPoint {
+  return (
+    isRecord(value) && typeof value.timestamp === 'number' && typeof value.nodeNum === 'number'
+  );
+}
+
+function isMeshWaypoint(value: unknown): value is MeshWaypoint {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'number' &&
+    typeof value.latitude === 'number' &&
+    typeof value.longitude === 'number' &&
+    typeof value.name === 'string' &&
+    typeof value.from === 'number' &&
+    typeof value.timestamp === 'number'
+  );
+}
+
+function isMeshNeighbor(
+  value: unknown,
+): value is { nodeId: number; snr: number; lastRxTime: number } {
+  return (
+    isRecord(value) &&
+    typeof value.nodeId === 'number' &&
+    typeof value.snr === 'number' &&
+    typeof value.lastRxTime === 'number'
+  );
+}
+
+function isNeighborInfoRecord(value: unknown): value is NeighborInfoRecord {
+  return (
+    isRecord(value) &&
+    typeof value.nodeId === 'number' &&
+    typeof value.timestamp === 'number' &&
+    Array.isArray(value.neighbors) &&
+    value.neighbors.every(isMeshNeighbor)
+  );
+}
+
 export function asWaypointMap(value: unknown): Map<number, MeshWaypoint> | undefined {
-  return value instanceof Map ? (value as Map<number, MeshWaypoint>) : undefined;
+  if (!(value instanceof Map)) return undefined;
+  let allValid = true;
+  for (const [id, wp] of value) {
+    if (typeof id !== 'number' || !isMeshWaypoint(wp)) {
+      allValid = false;
+      break;
+    }
+  }
+  if (allValid) return value as Map<number, MeshWaypoint>;
+  const out = new Map<number, MeshWaypoint>();
+  for (const [id, wp] of value) {
+    if (typeof id === 'number' && isMeshWaypoint(wp)) out.set(id, wp);
+  }
+  return out;
 }
 
 export function asTelemetryPoints(value: unknown): TelemetryPoint[] {
-  return Array.isArray(value) ? (value as TelemetryPoint[]) : [];
+  if (!Array.isArray(value)) return [];
+  return value.every(isTelemetryPoint) ? value : value.filter(isTelemetryPoint);
 }
 
 export function asEnvironmentTelemetryPoints(value: unknown): EnvironmentTelemetryPoint[] {
-  return Array.isArray(value) ? (value as EnvironmentTelemetryPoint[]) : [];
+  if (!Array.isArray(value)) return [];
+  return value.every(isEnvironmentTelemetryPoint)
+    ? value
+    : value.filter(isEnvironmentTelemetryPoint);
 }
 
-export function asNeighborInfoMap(value: Map<number, unknown>): Map<number, NeighborInfoRecord> {
-  return value as Map<number, NeighborInfoRecord>;
+export function asNeighborInfoMap(value: unknown): Map<number, NeighborInfoRecord> {
+  if (!(value instanceof Map)) return new Map();
+  let allValid = true;
+  for (const [id, rec] of value) {
+    if (typeof id !== 'number' || !isNeighborInfoRecord(rec)) {
+      allValid = false;
+      break;
+    }
+  }
+  if (allValid) return value as Map<number, NeighborInfoRecord>;
+  const out = new Map<number, NeighborInfoRecord>();
+  for (const [id, rec] of value) {
+    if (typeof id === 'number' && isNeighborInfoRecord(rec)) out.set(id, rec);
+  }
+  return out;
 }
 
 export function asRadioDeviceOwner(

--- a/src/renderer/runtime/ProtocolRuntimeContext.tsx
+++ b/src/renderer/runtime/ProtocolRuntimeContext.tsx
@@ -35,6 +35,8 @@ export function useRuntime(protocol: MeshProtocol): ProtocolRuntime {
       `useRuntime: ${protocol} not registered — mount ProtocolRuntimeProvider from App`,
     );
   }
+  // Hook ReturnTypes are not assignable to ProtocolRuntime (connect/telemetry shapes).
+  // Single active-path boundary — do not recast as MeshtasticRuntime in App.
   return runtime as ProtocolRuntime;
 }
 

--- a/src/renderer/runtime/ProtocolRuntimeContext.tsx
+++ b/src/renderer/runtime/ProtocolRuntimeContext.tsx
@@ -2,8 +2,14 @@ import { createContext, type ReactNode, useContext } from 'react';
 
 import type { MeshProtocol } from '../lib/types';
 import type { ProtocolRuntime } from './protocolRuntime';
+import type { MeshcoreRuntime, MeshtasticRuntime, ReticulumRuntime } from './runtimeTypes';
 
-export type RuntimeMap = Readonly<Record<MeshProtocol, ProtocolRuntime>>;
+/** Per-protocol slots stay specific; `useRuntime` exposes the shared ProtocolRuntime surface. */
+export type RuntimeMap = Readonly<{
+  meshtastic: MeshtasticRuntime;
+  meshcore: MeshcoreRuntime;
+  reticulum: ReticulumRuntime;
+}>;
 
 const ProtocolRuntimeMapContext = createContext<RuntimeMap | null>(null);
 
@@ -29,7 +35,7 @@ export function useRuntime(protocol: MeshProtocol): ProtocolRuntime {
       `useRuntime: ${protocol} not registered — mount ProtocolRuntimeProvider from App`,
     );
   }
-  return runtime;
+  return runtime as ProtocolRuntime;
 }
 
 export function useAllRuntimes(): RuntimeMap {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Facade adoption **PR2** (active runtime typing only). Branched from current `main` after **#995** (PR1 identity/capabilities). Behavior-preserving: `useRuntime(protocol)` is now `ProtocolRuntime` — no `as unknown as MeshtasticRuntime` on the active App path.

### Changed

- `const activeRuntime = useRuntime(protocol)` is typed as `ProtocolRuntime`
- `RuntimeMap` keeps specific slots (`MeshtasticRuntime` / `MeshcoreRuntime` / `ReticulumRuntime`) so `meshtasticRuntime` / `meshcoreRuntime` / `reticulumRuntime` stay typed for protocol-only fields (`virtualNodeId`, `configureTargetNodeNum`, MeshCore-only, etc.)
- Thin adapters in `protocolRuntimeAdapters.ts` + channel-source narrowing in `meshcoreConfiguredChatChannels`

### Guards added

- `traceRouteResults` `.route` / `.from` (`asTraceRouteResult` / `traceRouteHopLabels`)
- `channels` → `MeshcoreChatChannelSource[]` / `{ index, name }` pills (`asChannelIndexPills`, `chatChannelsFromRuntimeChannels`, unknown-entry filter in `meshcoreConfiguredChatChannels`)
- Panel-shaped `unknown` fields: `ourPosition`, waypoints Map, telemetry arrays, neighbor-info Map, numeric `selfNodeId`, MQTT loss boolean, GPS interval callback, Radio `deviceOwner` defaults
- Collection **members** are filtered (waypoint / telemetry / neighbor-info); missing `neighborInfo` is an empty map

### Review follow-up

- Addressed CodeRabbit: validate waypoint, telemetry, and neighbor-info members (not just the container)
- Skipped intersecting `RuntimeMap` slots with `ProtocolRuntime`: hook `ReturnType`s are not assignable (`connect` / telemetry shapes). The single `as ProtocolRuntime` in `useRuntime` is the intended boundary — intersecting would restore a construction-site `as unknown as` cast

### Deferred (PR3–PR5)

- One ConnectionPanel collapse (PR3)
- `useAllProtocolConnectionActions` (PR4)
- Panel bundle sweep / docs (PR5)
- Display adapters, MeshCore god-file split, hook-local mirrors
- Re-doing PR1 identity work

## Test plan

- [x] `pnpm run typecheck`
- [x] `protocolRuntimeAdapters.test.ts` + `meshcoreConfiguredChatChannels.test.ts` (unknown channel entries + malformed collection members)
- [x] Narrow App tests: Meshtastic channel pills; node-detail hop labels from `traceRouteResults`
- [x] Existing App MeshCore configured-channel test
- [x] Pre-commit: typecheck + related Vitest

No `as unknown as MeshtasticRuntime` remains in the repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fba04590-0f55-5a9d-a3f5-8d1e955cbcd7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fba04590-0f55-5a9d-a3f5-8d1e955cbcd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of channel lists by excluding invalid or incomplete entries.
  - Ensured chat channel pills display correctly across supported protocol configurations.
  - Improved node route details, including accurate hop labels.
  - Improved handling of node IDs, positions, telemetry, waypoints, neighbor data, device ownership, and connection status values.

- **Tests**
  - Added coverage for channel filtering, route display, runtime data validation, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->