### PR TITLE
docs: add M0Rf30 as contributor

### DIFF
--- a/docs/credits.md
+++ b/docs/credits.md
@@ -14,6 +14,7 @@
 - [Letark](https://github.com/Letark) - Apple code signing & notarization CI
 - FuzzyChaos (ADL) - Donation for devices
 - [M3SHGH0ST](https://github.com/cj-vana)
+- [M0Rf30](https://github.com/M0Rf30) - Flatpak Electron packaging
 
 ## Colorado Mesh
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "WB3IHY https://github.com/WB3IHY",
     "Letark https://github.com/Letark",
     "FuzzyChaos (ADL)",
-    "M3SHGH0ST https://github.com/cj-vana"
+    "M3SHGH0ST https://github.com/cj-vana",
+    "M0Rf30 https://github.com/M0Rf30"
   ],
   "main": "dist-electron/main/index.js",
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add [M0Rf30](https://github.com/M0Rf30) to the project contributor credits.

This is a credit-only change for their work on the project, including the recent Flatpak Electron strip-components fix.

**Files touched**
- `docs/credits.md` — appended under Contributors, with a short Flatpak note consistent with existing entries
- `package.json` — matching `contributors` entry in the same order

README and other docs do not list individual contributors, so they were left unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b26b2874-2f2a-5be3-b136-227c655f6e1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b26b2874-2f2a-5be3-b136-227c655f6e1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added M0Rf30 to the project’s contributor credits for Flatpak Electron packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->