### PR TITLE
fix(rrc): failover stale hub path after link-proof timeout

### DIFF
--- a/reticulum-sidecar/src/stack/path_failover.rs
+++ b/reticulum-sidecar/src/stack/path_failover.rs
@@ -61,6 +61,13 @@ fn via_blocked(via: Option<&str>, blocked_vias: &[String]) -> bool {
     via.is_some_and(|v| blocked_vias.iter().any(|b| b.eq_ignore_ascii_case(v)))
 }
 
+/// True when a path-slot JSON object is marked expired.
+pub fn slot_expired(slot: &serde_json::Value) -> bool {
+    slot.get("expired")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
 /// Parse hops / interface / via from a path-slot JSON object.
 pub fn slot_candidate(slot: &serde_json::Value) -> Option<PathSlotCandidate> {
     let hops = slot
@@ -128,6 +135,9 @@ pub fn select_unblocked_slot(
 ) -> Option<PathSlotCandidate> {
     let mut fallback: Option<PathSlotCandidate> = None;
     for slot in slots {
+        if slot_expired(slot) {
+            continue;
+        }
         let Some(cand) = slot_candidate(slot) else {
             continue;
         };
@@ -385,6 +395,34 @@ mod tests {
         let prefer = vec!["Local Transport Pi".into()];
         assert!(
             select_unblocked_slot(&slots, &blocked_ifaces, &blocked_vias, Some(via), &prefer)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn select_unblocked_skips_expired_including_fallback() {
+        let slots = [
+            serde_json::json!({
+                "active": false,
+                "hops": 1,
+                "interface": "Ratspeak",
+                "via_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "expired": true,
+            }),
+            serde_json::json!({
+                "active": false,
+                "hops": 4,
+                "interface": "Local Transport Pi",
+                "via_hash": "dddddddddddddddddddddddddddddddd",
+                "expired": false,
+            }),
+        ];
+        let found = select_unblocked_slot(&slots, &[], &[], None, &["Ratspeak".into()])
+            .expect("live fallback");
+        assert_eq!(found.iface.as_deref(), Some("Local Transport Pi"));
+        assert_eq!(found.hops, 4);
+        assert!(
+            select_unblocked_slot(&[slots[0].clone()], &[], &[], None, &["Ratspeak".into()])
                 .is_none()
         );
     }

--- a/reticulum-sidecar/src/stack/rrc_link.rs
+++ b/reticulum-sidecar/src/stack/rrc_link.rs
@@ -24,7 +24,7 @@ use tracing::{debug, info, warn};
 
 use super::path_failover::{
     self, PathSlotCandidate, VIA_FAILOVER_POLL_INTERVAL, VIA_FAILOVER_PROBE_WAIT,
-    record_path_failover_attempt, select_unblocked_slot, via_prefix,
+    record_path_failover_attempt, select_unblocked_slot, slot_expired, via_prefix,
 };
 
 const PATH_LOOKUP_TIMEOUT: Duration = Duration::from_secs(15);
@@ -604,23 +604,34 @@ async fn query_path_slots_json(
     }
 }
 
+fn path_table_entry_expired(expires: f64) -> bool {
+    unix_now_secs() > expires
+}
+
+fn unix_now_secs() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
 fn path_table_slot_json(entry: &PathTableRpcEntry) -> serde_json::Value {
     serde_json::json!({
         "active": true,
         "hops": entry.hops,
         "via_hash": entry.via.map(hex::encode),
         "interface": entry.interface,
-        "expired": false,
+        "expires": entry.expires,
+        "expired": path_table_entry_expired(entry.expires),
     })
 }
 
 fn best_slot_route(slots: &[serde_json::Value]) -> Option<RrcResolvedRoute> {
+    let live = |slot: &&serde_json::Value| !slot_expired(slot);
     let active = slots.iter().find(|slot| {
-        slot.get("active")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false)
-            && !slot
-                .get("expired")
+        live(slot)
+            && slot
+                .get("active")
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false)
     });
@@ -629,6 +640,7 @@ fn best_slot_route(slots: &[serde_json::Value]) -> Option<RrcResolvedRoute> {
     }
     slots
         .iter()
+        .filter(live)
         .filter_map(path_failover::slot_candidate)
         .min_by_key(|c| c.hops)
         .map(route_from_candidate)
@@ -758,7 +770,7 @@ mod tests {
             timestamp: 1.0,
             via: Some(via),
             hops,
-            expires: 100.0,
+            expires: unix_now_secs() + 86_400.0,
             interface: iface.into(),
             interface_id: 1,
             interface_mode: InterfaceMode::Full,
@@ -1229,6 +1241,71 @@ mod tests {
         assert!(!is_rrc_link_proof_timeout(&RrcLinkError::Timeout(
             "DropPath"
         )));
+    }
+
+    #[test]
+    fn path_table_slot_json_preserves_expires() {
+        let dest = [0xAB; 16];
+        let via = [0x7C; 16];
+        let live = test_path_table_entry(dest, via, 2, "RNS DFW Central");
+        let live_json = path_table_slot_json(&live);
+        assert_eq!(
+            live_json.get("expires").and_then(serde_json::Value::as_f64),
+            Some(live.expires)
+        );
+        assert_eq!(
+            live_json
+                .get("expired")
+                .and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+
+        let mut expired = live.clone();
+        expired.expires = 1.0;
+        let expired_json = path_table_slot_json(&expired);
+        assert_eq!(
+            expired_json
+                .get("expires")
+                .and_then(serde_json::Value::as_f64),
+            Some(1.0)
+        );
+        assert_eq!(
+            expired_json
+                .get("expired")
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn best_slot_route_skips_expired_including_fallback() {
+        let slots = vec![
+            serde_json::json!({
+                "active": true,
+                "hops": 1,
+                "via_hash": "11111111111111111111111111111111",
+                "interface": "RNS DFW Central",
+                "expired": true,
+            }),
+            serde_json::json!({
+                "active": false,
+                "hops": 2,
+                "via_hash": "22222222222222222222222222222222",
+                "interface": "Expired Backup",
+                "expired": true,
+            }),
+            serde_json::json!({
+                "active": false,
+                "hops": 4,
+                "via_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "interface": "Ratspeak",
+                "expired": false,
+            }),
+        ];
+        let picked = best_slot_route(&slots).expect("live fallback");
+        assert_eq!(picked.iface.as_deref(), Some("Ratspeak"));
+        assert_eq!(picked.hops, 4);
+        assert!(best_slot_route(&slots[..2]).is_none());
     }
 
     #[test]

--- a/reticulum-sidecar/src/stack/rrc_link.rs
+++ b/reticulum-sidecar/src/stack/rrc_link.rs
@@ -15,10 +15,17 @@ use rns_runtime::link_session::{
     LinkSession, LinkSessionCloseReason, LinkSessionConfig, LinkSessionError, LinkSessionEvent,
     discover_destination,
 };
-use rns_transport::messages::{TransportMessage, TransportQuery, TransportQueryResponse};
+use rns_transport::messages::{
+    PathTableRpcEntry, TransportMessage, TransportQuery, TransportQueryResponse,
+};
 use thiserror::Error;
 use tokio::sync::{Semaphore, mpsc, oneshot};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
+
+use super::path_failover::{
+    self, PathSlotCandidate, VIA_FAILOVER_POLL_INTERVAL, VIA_FAILOVER_PROBE_WAIT,
+    record_path_failover_attempt, select_unblocked_slot, via_prefix,
+};
 
 const PATH_LOOKUP_TIMEOUT: Duration = Duration::from_secs(15);
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -96,9 +103,58 @@ impl RrcLinkHandle {
 pub enum RrcPathRefresh {
     /// RequestPath even when identity is cached (fresh next-hop advertisement).
     Refresh,
-    /// DropPath + RequestPath so LRPROOF can attach on a live interface after
-    /// keepalive timeout / transport death (stale via pin otherwise keeps failing).
+    /// Suppress the failed iface/via, DropPath + RequestPath so LRPROOF can
+    /// attach on a live interface after keepalive timeout / transport death
+    /// (stale TCP via pin otherwise keeps failing).
     DropAndRefresh,
+}
+
+/// Route chosen for the next RRC Link (hops must match the live path slot).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RrcResolvedRoute {
+    pub hops: u8,
+    pub iface: Option<String>,
+    pub via: Option<String>,
+}
+
+/// Accumulated iface/via blocks across reconnect proof failures (Nomad-style).
+#[derive(Debug, Clone, Default)]
+pub struct RrcPathFailoverState {
+    pub blocked_ifaces: Vec<String>,
+    pub blocked_vias: Vec<String>,
+    pub last_route: Option<RrcResolvedRoute>,
+    pub rounds: u8,
+}
+
+impl RrcPathFailoverState {
+    pub fn clear(&mut self) {
+        self.blocked_ifaces.clear();
+        self.blocked_vias.clear();
+        self.last_route = None;
+        self.rounds = 0;
+    }
+}
+
+/// Hops for Link / reconnect_intent: prefer the rediscovered slot.
+pub fn rrc_reconnect_hops(fallback: u8, route: Option<&RrcResolvedRoute>) -> u8 {
+    route.map(|r| r.hops).filter(|&h| h > 0).unwrap_or(fallback)
+}
+
+/// True when establish failed because LRPROOF never arrived.
+pub fn is_rrc_link_proof_timeout(err: &RrcLinkError) -> bool {
+    matches!(err, RrcLinkError::Timeout(what) if *what == "link proof")
+}
+
+/// Stable warn fields for app-log assertions (one `target=rrc` line).
+pub fn rrc_link_proof_timeout_log_fields(
+    dest_hex: &str,
+    route: Option<&RrcResolvedRoute>,
+    path_refresh: RrcPathRefresh,
+) -> String {
+    let hops = route.map(|r| r.hops);
+    let iface = route.and_then(|r| r.iface.as_deref()).unwrap_or("-");
+    let via = via_prefix(route.and_then(|r| r.via.as_deref())).unwrap_or_else(|| "-".into());
+    format!("hub={dest_hex} iface={iface} hops={hops:?} via={via} path_refresh={path_refresh:?}")
 }
 
 pub async fn open_rrc_link_with_path_refresh(
@@ -107,17 +163,19 @@ pub async fn open_rrc_link_with_path_refresh(
     dest_hash: [u8; 16],
     hops: u8,
     path_refresh: RrcPathRefresh,
-) -> Result<RrcLinkHandle, RrcLinkError> {
-    refresh_hub_path(&transport_tx, dest_hash, path_refresh).await?;
+    failover: &mut RrcPathFailoverState,
+) -> Result<(RrcLinkHandle, RrcResolvedRoute), RrcLinkError> {
+    let route = refresh_hub_path(&transport_tx, dest_hash, hops, path_refresh, failover).await?;
     let entry = discover_destination(&transport_tx, dest_hash, PATH_LOOKUP_TIMEOUT)
         .await
         .map_err(map_link_session_error)?;
     let pubkey = entry.public_key.ok_or(RrcLinkError::PubkeyNotDiscovered)?;
+    let link_hops = rrc_reconnect_hops(hops, Some(&route));
 
     let config = LinkSessionConfig {
         destination_hash: dest_hash,
         remote_public_key: pubkey,
-        hops,
+        hops: link_hops,
         establishment_timeout: HANDSHAKE_TIMEOUT,
         client_label: "rrc.link".into(),
         identify: true,
@@ -255,11 +313,14 @@ pub async fn open_rrc_link_with_path_refresh(
         }
     });
 
-    Ok(RrcLinkHandle {
-        cmd_tx,
-        event_rx,
-        link_id,
-    })
+    Ok((
+        RrcLinkHandle {
+            cmd_tx,
+            event_rx,
+            link_id,
+        },
+        route,
+    ))
 }
 
 /// When the resource-offers receiver ends, prefer an already-queued session
@@ -329,11 +390,18 @@ pub fn rrc_disconnect_should_drop_path(reason: &str) -> bool {
 async fn refresh_hub_path(
     transport_tx: &mpsc::Sender<TransportMessage>,
     dest_hash: [u8; 16],
+    fallback_hops: u8,
     mode: RrcPathRefresh,
-) -> Result<(), RrcLinkError> {
+    failover: &mut RrcPathFailoverState,
+) -> Result<RrcResolvedRoute, RrcLinkError> {
     let mut options = DestinationResolveOptions::new(PATH_LOOKUP_TIMEOUT);
     options.refresh_cached_path = true;
+    let mut snapshot = None;
     if mode == RrcPathRefresh::DropAndRefresh {
+        snapshot = query_path_route(transport_tx, dest_hash).await;
+        if let Some(ref failed) = snapshot {
+            apply_failed_route_failover(transport_tx, dest_hash, failed, failover).await;
+        }
         // Explicit DropPath covers both cached and uncached identities. Clear
         // drop_existing_path so resolve_destination does not DropPath again on
         // a cache miss.
@@ -362,7 +430,230 @@ async fn refresh_hub_path(
     )
     .await
     .map_err(|e| map_resolve_error(&e))?;
-    Ok(())
+
+    let resolved = if mode == RrcPathRefresh::DropAndRefresh && snapshot.is_some() {
+        if let Some(route) = poll_unblocked_route(
+            transport_tx,
+            dest_hash,
+            failover,
+            snapshot.as_ref().and_then(|s| s.via.as_deref()),
+        )
+        .await
+        {
+            Some(route)
+        } else if let Some(route) = query_path_route(transport_tx, dest_hash).await {
+            Some(route)
+        } else {
+            snapshot.clone()
+        }
+    } else {
+        query_path_route(transport_tx, dest_hash).await
+    };
+
+    let route = resolved.unwrap_or(RrcResolvedRoute {
+        hops: fallback_hops,
+        iface: snapshot.as_ref().and_then(|s| s.iface.clone()),
+        via: snapshot.as_ref().and_then(|s| s.via.clone()),
+    });
+    failover.last_route = Some(route.clone());
+    Ok(route)
+}
+
+/// Suppress the failed iface and drop its next hop so RequestPath can attach elsewhere.
+async fn apply_failed_route_failover(
+    transport_tx: &mpsc::Sender<TransportMessage>,
+    dest_hash: [u8; 16],
+    failed: &RrcResolvedRoute,
+    failover: &mut RrcPathFailoverState,
+) {
+    if failover.rounds < path_failover::MAX_VIA_FAILOVERS {
+        record_path_failover_attempt(
+            &mut Vec::new(),
+            &mut failover.blocked_ifaces,
+            &mut failover.blocked_vias,
+            failed.iface.as_deref(),
+            failed.via.as_deref(),
+        );
+    }
+    let ops = path_failover::build_path_failover_control_ops(
+        dest_hash,
+        &failover.blocked_vias,
+        failed.via.as_deref(),
+        &[],
+    );
+    let _ = transport_rpc(
+        transport_tx,
+        TransportQuery::SuppressCurrentPathInterface {
+            dest: dest_hash,
+            duration: ops.suppress_secs,
+        },
+        PATH_LOOKUP_TIMEOUT,
+    )
+    .await;
+    for via_hex in &ops.vias_to_drop {
+        let Some(next_hop) = parse_dest_hash(via_hex) else {
+            continue;
+        };
+        let _ = transport_rpc(
+            transport_tx,
+            TransportQuery::DropAllVia { next_hop },
+            PATH_LOOKUP_TIMEOUT,
+        )
+        .await;
+    }
+    info!(
+        target: "rrc",
+        dest = %hex::encode(dest_hash),
+        iface = ?failed.iface,
+        hops = failed.hops,
+        via = ?via_prefix(failed.via.as_deref()),
+        blocked_ifaces = ?failover.blocked_ifaces,
+        "rrc DropAndRefresh failover"
+    );
+}
+
+async fn poll_unblocked_route(
+    transport_tx: &mpsc::Sender<TransportMessage>,
+    dest_hash: [u8; 16],
+    failover: &RrcPathFailoverState,
+    failed_via: Option<&str>,
+) -> Option<RrcResolvedRoute> {
+    let deadline = tokio::time::Instant::now() + VIA_FAILOVER_PROBE_WAIT;
+    loop {
+        let slots = query_path_slots_json(transport_tx, dest_hash).await;
+        if let Some(cand) = select_unblocked_slot(
+            &slots,
+            &failover.blocked_ifaces,
+            &failover.blocked_vias,
+            failed_via,
+            &[],
+        ) {
+            return Some(route_from_candidate(cand));
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(VIA_FAILOVER_POLL_INTERVAL).await;
+    }
+}
+
+async fn query_path_route(
+    transport_tx: &mpsc::Sender<TransportMessage>,
+    dest_hash: [u8; 16],
+) -> Option<RrcResolvedRoute> {
+    let slots = query_path_slots_json(transport_tx, dest_hash).await;
+    best_slot_route(&slots)
+}
+
+async fn query_path_slots_json(
+    transport_tx: &mpsc::Sender<TransportMessage>,
+    dest_hash: [u8; 16],
+) -> Vec<serde_json::Value> {
+    if let Ok(TransportQueryResponse::PathSlots(entry)) = transport_rpc(
+        transport_tx,
+        TransportQuery::GetPathSlots { dest: dest_hash },
+        PATH_LOOKUP_TIMEOUT,
+    )
+    .await
+    {
+        return entry
+            .slots
+            .iter()
+            .map(|slot| {
+                serde_json::json!({
+                    "active": slot.active,
+                    "hops": slot.hops,
+                    "via_hash": slot.via.map(hex::encode),
+                    "interface": slot.interface,
+                    "expired": slot.expired,
+                })
+            })
+            .collect();
+    }
+    match transport_rpc(
+        transport_tx,
+        TransportQuery::GetPathTable,
+        PATH_LOOKUP_TIMEOUT,
+    )
+    .await
+    {
+        Ok(TransportQueryResponse::PathTable(entries)) => entries
+            .iter()
+            .filter(|e| e.hash == dest_hash)
+            .map(path_table_slot_json)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn path_table_slot_json(entry: &PathTableRpcEntry) -> serde_json::Value {
+    serde_json::json!({
+        "active": true,
+        "hops": entry.hops,
+        "via_hash": entry.via.map(hex::encode),
+        "interface": entry.interface,
+        "expired": false,
+    })
+}
+
+fn best_slot_route(slots: &[serde_json::Value]) -> Option<RrcResolvedRoute> {
+    let active = slots.iter().find(|slot| {
+        slot.get("active")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+            && !slot
+                .get("expired")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false)
+    });
+    if let Some(slot) = active {
+        return path_failover::slot_candidate(slot).map(route_from_candidate);
+    }
+    slots
+        .iter()
+        .filter_map(path_failover::slot_candidate)
+        .min_by_key(|c| c.hops)
+        .map(route_from_candidate)
+}
+
+fn route_from_candidate(cand: PathSlotCandidate) -> RrcResolvedRoute {
+    RrcResolvedRoute {
+        hops: cand.hops,
+        iface: cand.iface,
+        via: cand.via,
+    }
+}
+
+fn parse_dest_hash(hex_str: &str) -> Option<[u8; 16]> {
+    let clean: String = hex_str.chars().filter(char::is_ascii_hexdigit).collect();
+    if clean.len() != 32 {
+        return None;
+    }
+    let bytes = hex::decode(&clean).ok()?;
+    bytes.try_into().ok()
+}
+
+async fn transport_rpc(
+    transport_tx: &mpsc::Sender<TransportMessage>,
+    query: TransportQuery,
+    timeout: Duration,
+) -> Result<TransportQueryResponse, RrcLinkError> {
+    let (response_tx, response_rx) = oneshot::channel();
+    let result = tokio::time::timeout(timeout, async {
+        transport_tx
+            .send(TransportMessage::Rpc { query, response_tx })
+            .await
+            .map_err(|_| RrcLinkError::TransportUnavailable)?;
+        response_rx
+            .await
+            .map_err(|_| RrcLinkError::TransportUnavailable)
+    })
+    .await;
+    match result {
+        Err(_) => Err(RrcLinkError::Timeout("transport rpc")),
+        Ok(Err(e)) => Err(e),
+        Ok(Ok(response)) => Ok(response),
+    }
 }
 
 /// Bound DropPath RPC (send + reply) so a hung transport cannot stall reconnect.
@@ -531,6 +822,21 @@ mod tests {
                 let msg = transport_rx.recv().await.expect("transport message");
                 match msg {
                     TransportMessage::Rpc {
+                        query: TransportQuery::GetPathSlots { dest: d },
+                        response_tx,
+                    } => {
+                        assert_eq!(d, dest);
+                        response_tx.send(TransportQueryResponse::Ok).unwrap();
+                    }
+                    TransportMessage::Rpc {
+                        query: TransportQuery::GetPathTable,
+                        response_tx,
+                    } => {
+                        response_tx
+                            .send(TransportQueryResponse::PathTable(Vec::new()))
+                            .unwrap();
+                    }
+                    TransportMessage::Rpc {
                         query: TransportQuery::DropPath { dest: d },
                         response_tx,
                     } => {
@@ -609,9 +915,16 @@ mod tests {
             drop_count == 1 && saw_request
         });
 
-        refresh_hub_path(&transport_tx, dest, RrcPathRefresh::DropAndRefresh)
-            .await
-            .expect("refresh_hub_path");
+        let mut failover = RrcPathFailoverState::default();
+        refresh_hub_path(
+            &transport_tx,
+            dest,
+            1,
+            RrcPathRefresh::DropAndRefresh,
+            &mut failover,
+        )
+        .await
+        .expect("refresh_hub_path");
         assert!(
             responder.await.expect("responder join"),
             "expected single DropPath then RequestPath"
@@ -671,5 +984,156 @@ mod tests {
             Some("remote_close")
         );
         assert!(closed_reason_from_session_event(&LinkSessionEvent::Stale).is_none());
+    }
+
+    #[test]
+    fn reconnect_hops_prefers_resolved_route() {
+        let route = RrcResolvedRoute {
+            hops: 4,
+            iface: Some("Ratspeak".into()),
+            via: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
+        };
+        assert_eq!(rrc_reconnect_hops(2, Some(&route)), 4);
+        assert_eq!(rrc_reconnect_hops(2, None), 2);
+        assert_eq!(
+            rrc_reconnect_hops(
+                2,
+                Some(&RrcResolvedRoute {
+                    hops: 0,
+                    iface: None,
+                    via: None
+                })
+            ),
+            2
+        );
+    }
+
+    #[test]
+    fn link_proof_timeout_log_includes_route_fields() {
+        let route = RrcResolvedRoute {
+            hops: 2,
+            iface: Some("RNS DFW Central".into()),
+            via: Some("7cbbe5ada62d88ee2d4dbe0c3cb1bceb".into()),
+        };
+        let line = rrc_link_proof_timeout_log_fields(
+            "d765e919676aa0340412a1afae006553",
+            Some(&route),
+            RrcPathRefresh::DropAndRefresh,
+        );
+        assert!(line.contains("hub=d765e919676aa0340412a1afae006553"));
+        assert!(line.contains("iface=RNS DFW Central"));
+        assert!(line.contains("hops=Some(2)"));
+        assert!(line.contains("via=7cbbe5ad"));
+        assert!(line.contains("path_refresh=DropAndRefresh"));
+        assert!(is_rrc_link_proof_timeout(&RrcLinkError::Timeout(
+            "link proof"
+        )));
+        assert!(!is_rrc_link_proof_timeout(&RrcLinkError::Timeout(
+            "DropPath"
+        )));
+    }
+
+    #[test]
+    fn unblocked_slot_rejects_pre_drop_via() {
+        let failed_via = "7cbbe5ada62d88ee2d4dbe0c3cb1bceb";
+        let slots = vec![
+            serde_json::json!({
+                "active": true,
+                "hops": 2,
+                "via_hash": failed_via,
+                "interface": "RNS DFW Central",
+                "expired": false,
+            }),
+            serde_json::json!({
+                "active": false,
+                "hops": 3,
+                "via_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "interface": "Ratspeak",
+                "expired": false,
+            }),
+        ];
+        let picked = select_unblocked_slot(
+            &slots,
+            &["RNS DFW Central".into()],
+            &[],
+            Some(failed_via),
+            &[],
+        )
+        .expect("alternate slot");
+        assert_eq!(picked.iface.as_deref(), Some("Ratspeak"));
+        assert_eq!(picked.hops, 3);
+        assert_eq!(
+            select_unblocked_slot(
+                &slots,
+                &["RNS DFW Central".into()],
+                &[failed_via.into()],
+                Some(failed_via),
+                &[]
+            ),
+            Some(PathSlotCandidate {
+                hops: 3,
+                iface: Some("Ratspeak".into()),
+                via: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_and_refresh_failover_sends_suppress_and_drop_all_via() {
+        let dest = [0xD7; 16];
+        let failed_via = [0x7C; 16];
+        let failed = RrcResolvedRoute {
+            hops: 2,
+            iface: Some("RNS DFW Central".into()),
+            via: Some(hex::encode(failed_via)),
+        };
+        let (transport_tx, mut transport_rx) = mpsc::channel(8);
+        let responder = tokio::spawn(async move {
+            let mut saw_suppress = false;
+            let mut saw_drop_via = false;
+            for _ in 0..2 {
+                let msg = transport_rx.recv().await.expect("transport message");
+                match msg {
+                    TransportMessage::Rpc {
+                        query: TransportQuery::SuppressCurrentPathInterface { dest: d, duration },
+                        response_tx,
+                    } => {
+                        assert_eq!(d, dest);
+                        assert!(duration > 0.0);
+                        saw_suppress = true;
+                        response_tx.send(TransportQueryResponse::Ok).unwrap();
+                    }
+                    TransportMessage::Rpc {
+                        query: TransportQuery::DropAllVia { next_hop },
+                        response_tx,
+                    } => {
+                        assert_eq!(next_hop, failed_via);
+                        saw_drop_via = true;
+                        response_tx.send(TransportQueryResponse::Ok).unwrap();
+                    }
+                    other => panic!("unexpected transport message: {other:?}"),
+                }
+            }
+            saw_suppress && saw_drop_via
+        });
+
+        let mut failover = RrcPathFailoverState::default();
+        apply_failed_route_failover(&transport_tx, dest, &failed, &mut failover).await;
+        assert!(
+            responder.await.expect("responder join"),
+            "expected Suppress then DropAllVia"
+        );
+        assert!(
+            failover
+                .blocked_ifaces
+                .iter()
+                .any(|n| n.eq_ignore_ascii_case("RNS DFW Central"))
+        );
+        assert!(
+            failover
+                .blocked_vias
+                .iter()
+                .any(|v| v.eq_ignore_ascii_case(&hex::encode(failed_via)))
+        );
     }
 }

--- a/reticulum-sidecar/src/stack/rrc_link.rs
+++ b/reticulum-sidecar/src/stack/rrc_link.rs
@@ -398,9 +398,11 @@ async fn refresh_hub_path(
     options.refresh_cached_path = true;
     let mut snapshot = None;
     if mode == RrcPathRefresh::DropAndRefresh {
-        snapshot = query_path_route(transport_tx, dest_hash).await;
+        snapshot = query_path_route(transport_tx, dest_hash, PATH_LOOKUP_TIMEOUT).await;
         if let Some(ref failed) = snapshot {
-            apply_failed_route_failover(transport_tx, dest_hash, failed, failover).await;
+            if should_apply_rrc_path_failover(failed, failover.rounds) {
+                apply_failed_route_failover(transport_tx, dest_hash, failed, failover).await;
+            }
         }
         // Explicit DropPath covers both cached and uncached identities. Clear
         // drop_existing_path so resolve_destination does not DropPath again on
@@ -432,22 +434,25 @@ async fn refresh_hub_path(
     .map_err(|e| map_resolve_error(&e))?;
 
     let resolved = if mode == RrcPathRefresh::DropAndRefresh && snapshot.is_some() {
+        let probe_deadline = tokio::time::Instant::now() + VIA_FAILOVER_PROBE_WAIT;
         if let Some(route) = poll_unblocked_route(
             transport_tx,
             dest_hash,
             failover,
             snapshot.as_ref().and_then(|s| s.via.as_deref()),
+            probe_deadline,
         )
         .await
         {
             Some(route)
-        } else if let Some(route) = query_path_route(transport_tx, dest_hash).await {
-            Some(route)
+        } else if let Some(timeout) = remaining_until(probe_deadline) {
+            query_path_route(transport_tx, dest_hash, timeout).await
         } else {
-            snapshot.clone()
+            None
         }
+        .or_else(|| snapshot.clone())
     } else {
-        query_path_route(transport_tx, dest_hash).await
+        query_path_route(transport_tx, dest_hash, PATH_LOOKUP_TIMEOUT).await
     };
 
     let route = resolved.unwrap_or(RrcResolvedRoute {
@@ -459,6 +464,16 @@ async fn refresh_hub_path(
     Ok(route)
 }
 
+/// True when DropAndRefresh has a concrete failed iface/via and budget remains.
+fn should_apply_rrc_path_failover(failed: &RrcResolvedRoute, rounds: u8) -> bool {
+    rounds < path_failover::MAX_VIA_FAILOVERS && (failed.iface.is_some() || failed.via.is_some())
+}
+
+fn remaining_until(deadline: tokio::time::Instant) -> Option<Duration> {
+    let rem = deadline.saturating_duration_since(tokio::time::Instant::now());
+    (!rem.is_zero()).then_some(rem)
+}
+
 /// Suppress the failed iface and drop its next hop so RequestPath can attach elsewhere.
 async fn apply_failed_route_failover(
     transport_tx: &mpsc::Sender<TransportMessage>,
@@ -466,15 +481,16 @@ async fn apply_failed_route_failover(
     failed: &RrcResolvedRoute,
     failover: &mut RrcPathFailoverState,
 ) {
-    if failover.rounds < path_failover::MAX_VIA_FAILOVERS {
-        record_path_failover_attempt(
-            &mut Vec::new(),
-            &mut failover.blocked_ifaces,
-            &mut failover.blocked_vias,
-            failed.iface.as_deref(),
-            failed.via.as_deref(),
-        );
+    if !should_apply_rrc_path_failover(failed, failover.rounds) {
+        return;
     }
+    record_path_failover_attempt(
+        &mut Vec::new(),
+        &mut failover.blocked_ifaces,
+        &mut failover.blocked_vias,
+        failed.iface.as_deref(),
+        failed.via.as_deref(),
+    );
     let ops = path_failover::build_path_failover_control_ops(
         dest_hash,
         &failover.blocked_vias,
@@ -517,10 +533,11 @@ async fn poll_unblocked_route(
     dest_hash: [u8; 16],
     failover: &RrcPathFailoverState,
     failed_via: Option<&str>,
+    deadline: tokio::time::Instant,
 ) -> Option<RrcResolvedRoute> {
-    let deadline = tokio::time::Instant::now() + VIA_FAILOVER_PROBE_WAIT;
     loop {
-        let slots = query_path_slots_json(transport_tx, dest_hash).await;
+        let timeout = remaining_until(deadline)?;
+        let slots = query_path_slots_json(transport_tx, dest_hash, timeout).await;
         if let Some(cand) = select_unblocked_slot(
             &slots,
             &failover.blocked_ifaces,
@@ -530,29 +547,33 @@ async fn poll_unblocked_route(
         ) {
             return Some(route_from_candidate(cand));
         }
-        if tokio::time::Instant::now() >= deadline {
-            return None;
-        }
-        tokio::time::sleep(VIA_FAILOVER_POLL_INTERVAL).await;
+        let rem = remaining_until(deadline)?;
+        tokio::time::sleep(rem.min(VIA_FAILOVER_POLL_INTERVAL)).await;
     }
 }
 
 async fn query_path_route(
     transport_tx: &mpsc::Sender<TransportMessage>,
     dest_hash: [u8; 16],
+    timeout: Duration,
 ) -> Option<RrcResolvedRoute> {
-    let slots = query_path_slots_json(transport_tx, dest_hash).await;
+    let slots = query_path_slots_json(transport_tx, dest_hash, timeout).await;
     best_slot_route(&slots)
 }
 
 async fn query_path_slots_json(
     transport_tx: &mpsc::Sender<TransportMessage>,
     dest_hash: [u8; 16],
+    timeout: Duration,
 ) -> Vec<serde_json::Value> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let Some(first) = remaining_until(deadline) else {
+        return Vec::new();
+    };
     if let Ok(TransportQueryResponse::PathSlots(entry)) = transport_rpc(
         transport_tx,
         TransportQuery::GetPathSlots { dest: dest_hash },
-        PATH_LOOKUP_TIMEOUT,
+        first,
     )
     .await
     {
@@ -570,13 +591,10 @@ async fn query_path_slots_json(
             })
             .collect();
     }
-    match transport_rpc(
-        transport_tx,
-        TransportQuery::GetPathTable,
-        PATH_LOOKUP_TIMEOUT,
-    )
-    .await
-    {
+    let Some(second) = remaining_until(deadline) else {
+        return Vec::new();
+    };
+    match transport_rpc(transport_tx, TransportQuery::GetPathTable, second).await {
         Ok(TransportQueryResponse::PathTable(entries)) => entries
             .iter()
             .filter(|e| e.hash == dest_hash)
@@ -724,7 +742,38 @@ fn map_link_session_error(e: LinkSessionError) -> RrcLinkError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rns_transport::messages::RecalledDestinationRpcEntry;
+    use rns_transport::constants::InterfaceMode;
+    use rns_transport::messages::{InterfaceRole, RecalledDestinationRpcEntry};
+
+    const TEST_TRANSPORT_RECV: Duration = Duration::from_secs(2);
+
+    fn test_path_table_entry(
+        dest: [u8; 16],
+        via: [u8; 16],
+        hops: u8,
+        iface: &str,
+    ) -> PathTableRpcEntry {
+        PathTableRpcEntry {
+            hash: dest,
+            timestamp: 1.0,
+            via: Some(via),
+            hops,
+            expires: 100.0,
+            interface: iface.into(),
+            interface_id: 1,
+            interface_mode: InterfaceMode::Full,
+            interface_role: InterfaceRole::Normal,
+        }
+    }
+
+    async fn recv_transport(
+        transport_rx: &mut mpsc::Receiver<TransportMessage>,
+    ) -> TransportMessage {
+        tokio::time::timeout(TEST_TRANSPORT_RECV, transport_rx.recv())
+            .await
+            .expect("timed out waiting for transport message")
+            .expect("transport channel closed")
+    }
 
     #[tokio::test]
     async fn excess_resource_offers_rejected_when_slots_full() {
@@ -813,13 +862,17 @@ mod tests {
     #[tokio::test]
     async fn drop_and_refresh_sends_drop_path_before_request_path() {
         let dest = [0xAB; 16];
+        let failed_via = [0x7C; 16];
+        let alt_via = [0xAA; 16];
         let public_key = [0xCD; 64];
-        let (transport_tx, mut transport_rx) = mpsc::channel(8);
+        let (transport_tx, mut transport_rx) = mpsc::channel(16);
         let responder = tokio::spawn(async move {
             let mut drop_count = 0usize;
             let mut saw_request = false;
-            while !saw_request {
-                let msg = transport_rx.recv().await.expect("transport message");
+            let mut answered_unblocked = false;
+            let mut seq = Vec::new();
+            while !(saw_request && answered_unblocked) {
+                let msg = recv_transport(&mut transport_rx).await;
                 match msg {
                     TransportMessage::Rpc {
                         query: TransportQuery::GetPathSlots { dest: d },
@@ -832,9 +885,32 @@ mod tests {
                         query: TransportQuery::GetPathTable,
                         response_tx,
                     } => {
+                        let entry = if saw_request {
+                            answered_unblocked = true;
+                            test_path_table_entry(dest, alt_via, 3, "Ratspeak")
+                        } else {
+                            test_path_table_entry(dest, failed_via, 2, "RNS DFW Central")
+                        };
                         response_tx
-                            .send(TransportQueryResponse::PathTable(Vec::new()))
+                            .send(TransportQueryResponse::PathTable(vec![entry]))
                             .unwrap();
+                    }
+                    TransportMessage::Rpc {
+                        query: TransportQuery::SuppressCurrentPathInterface { dest: d, duration },
+                        response_tx,
+                    } => {
+                        assert_eq!(d, dest);
+                        assert!(duration > 0.0);
+                        seq.push("SuppressCurrentPathInterface");
+                        response_tx.send(TransportQueryResponse::Ok).unwrap();
+                    }
+                    TransportMessage::Rpc {
+                        query: TransportQuery::DropAllVia { next_hop },
+                        response_tx,
+                    } => {
+                        assert_eq!(next_hop, failed_via);
+                        seq.push("DropAllVia");
+                        response_tx.send(TransportQueryResponse::Ok).unwrap();
                     }
                     TransportMessage::Rpc {
                         query: TransportQuery::DropPath { dest: d },
@@ -847,6 +923,7 @@ mod tests {
                             drop_count <= 1,
                             "explicit DropPath must not be followed by a second resolver DropPath"
                         );
+                        seq.push("DropPath");
                         response_tx.send(TransportQueryResponse::Ok).unwrap();
                     }
                     TransportMessage::Rpc {
@@ -880,18 +957,121 @@ mod tests {
                     } => {
                         assert_eq!(d, dest);
                         assert_eq!(drop_count, 1, "exactly one DropPath before RequestPath");
+                        seq.push("RequestPath");
                         saw_request = true;
                     }
                     other => panic!("unexpected transport message: {other:?}"),
                 }
             }
-            // Allow the post-RequestPath recall to complete.
-            if let Some(msg) = transport_rx.recv().await {
+            seq
+        });
+
+        let mut failover = RrcPathFailoverState::default();
+        let route = refresh_hub_path(
+            &transport_tx,
+            dest,
+            1,
+            RrcPathRefresh::DropAndRefresh,
+            &mut failover,
+        )
+        .await
+        .expect("refresh_hub_path");
+        assert_eq!(
+            responder.await.expect("responder join"),
+            [
+                "SuppressCurrentPathInterface",
+                "DropAllVia",
+                "DropPath",
+                "RequestPath"
+            ]
+        );
+        assert_eq!(route.hops, 3);
+        assert_eq!(route.iface.as_deref(), Some("Ratspeak"));
+    }
+
+    #[tokio::test]
+    async fn drop_and_refresh_without_live_route_skips_failover() {
+        let dest = [0xAB; 16];
+        let public_key = [0xCD; 64];
+        let (transport_tx, mut transport_rx) = mpsc::channel(8);
+        let responder = tokio::spawn(async move {
+            let mut drop_count = 0usize;
+            let mut saw_request = false;
+            let mut saw_failover = false;
+            while !saw_request {
+                let msg = recv_transport(&mut transport_rx).await;
                 match msg {
                     TransportMessage::Rpc {
-                        query: TransportQuery::RecallDestination { .. },
+                        query: TransportQuery::GetPathSlots { dest: d },
                         response_tx,
                     } => {
+                        assert_eq!(d, dest);
+                        response_tx.send(TransportQueryResponse::Ok).unwrap();
+                    }
+                    TransportMessage::Rpc {
+                        query: TransportQuery::GetPathTable,
+                        response_tx,
+                    } => {
+                        response_tx
+                            .send(TransportQueryResponse::PathTable(Vec::new()))
+                            .unwrap();
+                    }
+                    TransportMessage::Rpc {
+                        query:
+                            TransportQuery::SuppressCurrentPathInterface { .. }
+                            | TransportQuery::DropAllVia { .. },
+                        ..
+                    } => {
+                        saw_failover = true;
+                    }
+                    TransportMessage::Rpc {
+                        query: TransportQuery::DropPath { dest: d },
+                        response_tx,
+                    } => {
+                        assert_eq!(d, dest);
+                        drop_count += 1;
+                        response_tx.send(TransportQueryResponse::Ok).unwrap();
+                    }
+                    TransportMessage::Rpc {
+                        query: TransportQuery::RecallDestination { dest: d },
+                        response_tx,
+                    } => {
+                        assert_eq!(d, dest);
+                        if drop_count == 1 && !saw_request {
+                            response_tx
+                                .send(TransportQueryResponse::RecalledDestination(None))
+                                .unwrap();
+                        } else {
+                            response_tx
+                                .send(TransportQueryResponse::RecalledDestination(Some(
+                                    RecalledDestinationRpcEntry {
+                                        dest_hash: dest,
+                                        public_key,
+                                        app_data: None,
+                                        ratchet: None,
+                                        hops: 1,
+                                        timestamp: 1.0,
+                                    },
+                                )))
+                                .unwrap();
+                        }
+                    }
+                    TransportMessage::RequestPath {
+                        destination_hash: d,
+                    } => {
+                        assert_eq!(d, dest);
+                        saw_request = true;
+                    }
+                    other => panic!("unexpected transport message: {other:?}"),
+                }
+            }
+            // Allow the post-RequestPath recall / path query to complete.
+            if let Ok(msg) = tokio::time::timeout(TEST_TRANSPORT_RECV, transport_rx.recv()).await {
+                match msg {
+                    Some(TransportMessage::Rpc {
+                        query: TransportQuery::RecallDestination { .. },
+                        response_tx,
+                    }) => {
                         response_tx
                             .send(TransportQueryResponse::RecalledDestination(Some(
                                 RecalledDestinationRpcEntry {
@@ -905,14 +1085,30 @@ mod tests {
                             )))
                             .unwrap();
                     }
-                    TransportMessage::Rpc {
+                    Some(TransportMessage::Rpc {
+                        query: TransportQuery::GetPathSlots { dest: d },
+                        response_tx,
+                    }) => {
+                        assert_eq!(d, dest);
+                        response_tx.send(TransportQueryResponse::Ok).unwrap();
+                    }
+                    Some(TransportMessage::Rpc {
+                        query: TransportQuery::GetPathTable,
+                        response_tx,
+                    }) => {
+                        response_tx
+                            .send(TransportQueryResponse::PathTable(Vec::new()))
+                            .unwrap();
+                    }
+                    Some(TransportMessage::Rpc {
                         query: TransportQuery::DropPath { .. },
                         ..
-                    } => panic!("second DropPath must not occur after explicit drop"),
-                    other => panic!("unexpected trailing message: {other:?}"),
+                    }) => panic!("second DropPath must not occur after explicit drop"),
+                    Some(other) => panic!("unexpected trailing message: {other:?}"),
+                    None => {}
                 }
             }
-            drop_count == 1 && saw_request
+            !saw_failover && drop_count == 1 && saw_request
         });
 
         let mut failover = RrcPathFailoverState::default();
@@ -927,8 +1123,10 @@ mod tests {
         .expect("refresh_hub_path");
         assert!(
             responder.await.expect("responder join"),
-            "expected single DropPath then RequestPath"
+            "empty path table must DropPath then RequestPath without failover RPCs"
         );
+        assert!(failover.blocked_ifaces.is_empty());
+        assert!(failover.blocked_vias.is_empty());
     }
 
     #[tokio::test]
@@ -1092,7 +1290,7 @@ mod tests {
             let mut saw_suppress = false;
             let mut saw_drop_via = false;
             for _ in 0..2 {
-                let msg = transport_rx.recv().await.expect("transport message");
+                let msg = recv_transport(&mut transport_rx).await;
                 match msg {
                     TransportMessage::Rpc {
                         query: TransportQuery::SuppressCurrentPathInterface { dest: d, duration },
@@ -1135,5 +1333,50 @@ mod tests {
                 .iter()
                 .any(|v| v.eq_ignore_ascii_case(&hex::encode(failed_via)))
         );
+    }
+
+    #[tokio::test]
+    async fn apply_failed_route_failover_skips_when_rounds_exhausted() {
+        let dest = [0xD7; 16];
+        let failed = RrcResolvedRoute {
+            hops: 2,
+            iface: Some("RNS DFW Central".into()),
+            via: Some(hex::encode([0x7C; 16])),
+        };
+        let (transport_tx, mut transport_rx) = mpsc::channel(4);
+        let mut failover = RrcPathFailoverState {
+            rounds: path_failover::MAX_VIA_FAILOVERS,
+            ..RrcPathFailoverState::default()
+        };
+        apply_failed_route_failover(&transport_tx, dest, &failed, &mut failover).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), transport_rx.recv())
+                .await
+                .is_err(),
+            "SuppressCurrentPathInterface and DropAllVia stay gated by MAX_VIA_FAILOVERS"
+        );
+        assert!(failover.blocked_ifaces.is_empty());
+        assert!(failover.blocked_vias.is_empty());
+    }
+
+    #[test]
+    fn path_failover_requires_failed_route_and_remaining_rounds() {
+        let failed = RrcResolvedRoute {
+            hops: 2,
+            iface: Some("RNS DFW Central".into()),
+            via: Some(hex::encode([0x7C; 16])),
+        };
+        let empty = RrcResolvedRoute {
+            hops: 2,
+            iface: None,
+            via: None,
+        };
+        assert!(should_apply_rrc_path_failover(&failed, 0));
+        assert!(should_apply_rrc_path_failover(&failed, 1));
+        assert!(!should_apply_rrc_path_failover(
+            &failed,
+            path_failover::MAX_VIA_FAILOVERS
+        ));
+        assert!(!should_apply_rrc_path_failover(&empty, 0));
     }
 }

--- a/reticulum-sidecar/src/stack/rrc_session.rs
+++ b/reticulum-sidecar/src/stack/rrc_session.rs
@@ -20,6 +20,7 @@ use sha2::{Digest, Sha256};
 use tokio::sync::{Mutex, broadcast, mpsc, oneshot};
 use tracing::{debug, warn};
 
+use super::path_failover::MAX_VIA_FAILOVERS;
 use super::rrc_codec::{
     RRC_IDENTITY_HASH_LEN, RrcEnvelope, RrcResourceEnvelopeMeta, RrcWelcomeCapabilities,
     RrcWelcomeLimits, apply_advisory_nick, body_as_text, decode_envelope, encode_envelope,
@@ -28,8 +29,9 @@ use super::rrc_codec::{
     parse_welcome_limits, text_body,
 };
 use super::rrc_link::{
-    MAX_CONCURRENT_RRC_RESOURCES, RrcLinkError, RrcLinkEvent, RrcLinkHandle, RrcPathRefresh,
-    open_rrc_link_with_path_refresh, rrc_disconnect_should_drop_path,
+    MAX_CONCURRENT_RRC_RESOURCES, RrcLinkError, RrcLinkEvent, RrcLinkHandle, RrcPathFailoverState,
+    RrcPathRefresh, is_rrc_link_proof_timeout, open_rrc_link_with_path_refresh,
+    rrc_disconnect_should_drop_path, rrc_link_proof_timeout_log_fields, rrc_reconnect_hops,
 };
 
 const CLIENT_NAME: &str = "mesh-client";
@@ -87,6 +89,8 @@ struct RrcSessionInner {
     limits: RrcWelcomeLimits,
     /// FIFO expectations from `T_RESOURCE_ENVELOPE` until RNS Resource completes.
     pending_resources: VecDeque<(RrcResourceEnvelopeMeta, Option<String>, Instant)>,
+    /// Iface/via blocks + last route across consecutive link-proof failures.
+    path_failover: RrcPathFailoverState,
 }
 
 impl RrcSessionInner {
@@ -104,6 +108,7 @@ impl RrcSessionInner {
             capabilities: RrcWelcomeCapabilities::default(),
             limits: RrcWelcomeLimits::default(),
             pending_resources: VecDeque::new(),
+            path_failover: RrcPathFailoverState::default(),
         }
     }
 
@@ -144,6 +149,7 @@ fn reset_hub_metadata(g: &mut RrcSessionInner) {
     g.capabilities = RrcWelcomeCapabilities::default();
     g.limits = RrcWelcomeLimits::default();
     g.pending_resources.clear();
+    g.path_failover.clear();
 }
 
 /// Handle to one hub's session task: a command channel for actions that must
@@ -533,14 +539,15 @@ fn session_json(hex: &str, g: &RrcSessionInner) -> serde_json::Value {
     })
 }
 
+type RrcEstablishResult = Result<(RrcLinkHandle, u8), String>;
+
 /// In-flight establish (user connect or auto-reconnect). Dropping cancels the
 /// future so Disconnect / a new Connect can run without waiting for WELCOME.
 struct ConnectJob {
-    fut: Pin<Box<dyn Future<Output = Result<RrcLinkHandle, String>> + Send>>,
+    fut: Pin<Box<dyn Future<Output = RrcEstablishResult> + Send>>,
     reply: Option<oneshot::Sender<Result<(), String>>>,
     dest_hash: [u8; 16],
     dest_hash_hex: String,
-    hops: u8,
     nickname: String,
 }
 
@@ -596,7 +603,6 @@ fn spawn_connect_job(
         reply,
         dest_hash,
         dest_hash_hex,
-        hops,
         nickname,
     }
 }
@@ -796,16 +802,19 @@ async fn session_loop(
                     reply,
                     dest_hash,
                     dest_hash_hex,
-                    hops,
                     nickname,
                     ..
                 } = job;
                 match result {
-                    Ok(handle) => {
+                    Ok((handle, resolved_hops)) => {
                         link = Some(handle);
                         let hub_hex = dest_hash_hex.clone();
+                        {
+                            let mut g = inner.lock().await;
+                            g.path_failover.clear();
+                        }
                         reconnect_intent =
-                            Some((dest_hash, dest_hash_hex, hops, nickname.clone()));
+                            Some((dest_hash, dest_hash_hex, resolved_hops, nickname.clone()));
                         backoff_ms = RECONNECT_BASE_MS;
                         // Re-join desired rooms after welcome (reconnect path).
                         let rooms: Vec<(String, Option<String>)> = {
@@ -869,7 +878,11 @@ async fn session_loop(
                         if let Some(reply) = reply {
                             let _ = reply.send(Err(e));
                         } else if should_retry {
-                            warn!("rrc reconnect failed; scheduling retry");
+                            warn!(
+                                target: "rrc",
+                                hub = %dest_hash_hex,
+                                "rrc reconnect failed; scheduling retry"
+                            );
                         }
                         if should_retry {
                             if let Some((
@@ -884,8 +897,23 @@ async fn session_loop(
                                     &intent_nick,
                                 )
                                 .await;
+                                let hops = {
+                                    let g = inner.lock().await;
+                                    rrc_reconnect_hops(
+                                        retry_hops,
+                                        g.path_failover.last_route.as_ref(),
+                                    )
+                                };
+                                reconnect_intent = Some((
+                                    retry_dest,
+                                    retry_hex.clone(),
+                                    hops,
+                                    intent_nick.clone(),
+                                ));
                                 let delay = backoff_ms;
                                 debug!(
+                                    target: "rrc",
+                                    hops,
                                     "rrc reconnecting to {retry_hex} in {delay}ms after failure"
                                 );
                                 backoff_ms =
@@ -897,7 +925,7 @@ async fn session_loop(
                                     event_tx.clone(),
                                     retry_dest,
                                     retry_hex,
-                                    retry_hops,
+                                    hops,
                                     nickname,
                                     delay,
                                     RrcPathRefresh::DropAndRefresh,
@@ -1100,16 +1128,48 @@ async fn establish_session(
     hops: u8,
     nickname: &str,
     path_refresh: RrcPathRefresh,
-) -> Result<RrcLinkHandle, String> {
-    let mut handle = open_rrc_link_with_path_refresh(
+) -> Result<(RrcLinkHandle, u8), String> {
+    let mut failover = {
+        let g = inner.lock().await;
+        g.path_failover.clone()
+    };
+    let open = open_rrc_link_with_path_refresh(
         transport_tx.clone(),
         identity,
         dest_hash,
         hops,
         path_refresh,
+        &mut failover,
     )
-    .await
-    .map_err(|e| e.to_string())?;
+    .await;
+    {
+        let mut g = inner.lock().await;
+        g.path_failover = failover.clone();
+    }
+    let (mut handle, route) = match open {
+        Ok(pair) => pair,
+        Err(e) => {
+            if is_rrc_link_proof_timeout(&e) {
+                {
+                    let mut g = inner.lock().await;
+                    if g.path_failover.rounds < MAX_VIA_FAILOVERS {
+                        g.path_failover.rounds = g.path_failover.rounds.saturating_add(1);
+                    }
+                }
+                warn!(
+                    target: "rrc",
+                    "{}",
+                    rrc_link_proof_timeout_log_fields(
+                        dest_hash_hex,
+                        failover.last_route.as_ref(),
+                        path_refresh,
+                    )
+                );
+            }
+            return Err(e.to_string());
+        }
+    };
+    let hops = rrc_reconnect_hops(hops, Some(&route));
 
     {
         let mut g = inner.lock().await;
@@ -1179,7 +1239,7 @@ async fn establish_session(
                             },
                         }),
                     );
-                    return Ok(handle);
+                    return Ok((handle, hops));
                 }
                 if env.msg_type == msg_type::ERROR {
                     let msg = body_as_text(env.body.as_ref()).unwrap_or_else(|| "hub ERROR".into());
@@ -1704,6 +1764,7 @@ fn emit(event_tx: &broadcast::Sender<String>, event_type: &str, payload: serde_j
 
 #[cfg(test)]
 mod tests {
+    use super::super::rrc_link::RrcResolvedRoute;
     use super::*;
 
     #[test]
@@ -1845,10 +1906,32 @@ mod tests {
             Some("general".into()),
             Instant::now(),
         ));
+        inner.path_failover.last_route = Some(RrcResolvedRoute {
+            hops: 2,
+            iface: Some("RNS DFW Central".into()),
+            via: Some("7cbbe5ada62d88ee2d4dbe0c3cb1bceb".into()),
+        });
+        inner.path_failover.rounds = 1;
         reset_hub_metadata(&mut inner);
         assert!(inner.hub_version.is_none());
         assert!(inner.limits.max_nick_bytes.is_none());
         assert!(inner.pending_resources.is_empty());
+        assert!(inner.path_failover.last_route.is_none());
+        assert_eq!(inner.path_failover.rounds, 0);
+    }
+
+    #[test]
+    fn reconnect_hops_follow_last_route() {
+        let mut inner = RrcSessionInner::new([0u8; 16]);
+        inner.path_failover.last_route = Some(RrcResolvedRoute {
+            hops: 5,
+            iface: Some("Ratspeak".into()),
+            via: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
+        });
+        assert_eq!(
+            rrc_reconnect_hops(2, inner.path_failover.last_route.as_ref()),
+            5
+        );
     }
 
     #[test]

--- a/src/main/reticulumSidecarStderrLog.test.ts
+++ b/src/main/reticulumSidecarStderrLog.test.ts
@@ -49,6 +49,11 @@ describe('shouldForwardReticulumSidecarStdout', () => {
         'INFO target=propagation-retrieve pn_hash=abc client /get stalled while establishing',
       ),
     ).toBe(true);
+    expect(
+      shouldForwardReticulumSidecarStdout(
+        '2026-09-12T13:00:00Z INFO rrc: rrc DropAndRefresh failover',
+      ),
+    ).toBe(true);
   });
 
   it('does not forward INFO when PN markers appear only in message text', () => {
@@ -68,6 +73,7 @@ describe('shouldForwardReticulumSidecarStdout', () => {
 describe('resolveSidecarRustLog', () => {
   it('defaults to warn', () => {
     expect(resolveSidecarRustLog({})).toBe(SIDECAR_DEFAULT_RUST_LOG);
+    expect(SIDECAR_DEFAULT_RUST_LOG).toContain('rrc=info');
   });
 
   it('honors MESH_CLIENT_RUST_LOG over RUST_LOG', () => {

--- a/src/main/reticulumSidecarStderrLog.ts
+++ b/src/main/reticulumSidecarStderrLog.ts
@@ -11,7 +11,7 @@ const BEACON_FAIL_WARN_INTERVAL_MS = 60 * MS_PER_SECOND;
 // propagation-retrieve at info for pn_hash / establish / failover lines; per-message
 // inbound delivery records stay debug-only with redacted from_prefix in live.rs.
 export const SIDECAR_DEFAULT_RUST_LOG =
-  'warn,propagation-sync=info,propagation-retrieve=info,propagation-deposit=info,lxmf-outbound=info';
+  'warn,propagation-sync=info,propagation-retrieve=info,propagation-deposit=info,lxmf-outbound=info,rrc=info';
 
 /**
  * Whether a sidecar stdout line should be written to the app log.
@@ -23,6 +23,7 @@ const SIDECAR_STDOUT_INFO_FORWARD_MARKERS = [
   'propagation-retrieve',
   'propagation-deposit',
   'lxmf-outbound',
+  'rrc',
 ] as const;
 
 export function shouldForwardReticulumSidecarStdout(text: string): boolean {
@@ -46,7 +47,7 @@ export function shouldForwardReticulumSidecarStdout(text: string): boolean {
   ) {
     return true;
   }
-  // INFO for PN connect triage only (matches SIDECAR_DEFAULT_RUST_LOG targets).
+  // INFO for PN / RRC triage only (matches SIDECAR_DEFAULT_RUST_LOG targets).
   const isInfo = severity === 'INFO' || severity.startsWith('INFO\u001b[');
   if (!isInfo) return false;
   // Match markers against the tracing target token only — not message text / other fields.


### PR DESCRIPTION
## Summary
- After an RRC keepalive drop, sidecar reconnect was reinstalling the same TCP via (e.g. DFW) so LRPROOF never returned and the hub looped on `timed out waiting for link proof`.
- `DropAndRefresh` now uses Nomad/LXMF failover: suppress the failed iface, `DropAllVia` the dead next hop, RequestPath, then Link with hops from the new slot.
- Link-proof timeouts warn with hub/iface/hops/via, and `rrc=info` is forwarded into `mesh-client.log`.

## Test plan
- [ ] Restart the Reticulum sidecar so this build is running
- [ ] Join Colorado Mesh RRC, let the link sit (or hide the window) until a keepalive `timeout`
- [ ] Confirm reconnect does not stay on a 60s link-proof loop; check Device log for `rrc DropAndRefresh failover` / proof-timeout warn with iface/via
- [ ] If DFW is the only live path, proof may still fail — disable DFW and confirm another backbone (Ratspeak/RMAP) is used
- [ ] Manual Disconnect + Connect still works; successful WELCOME clears failover state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic route failover when establishing and reconnecting RRC links.
  * Connections now select available paths and adjust hop counts based on the resolved route.
  * Failover state resets after successful connections or metadata changes.
* **Bug Fixes**
  * Improved recovery from failed interfaces, stale routes, and proof timeouts.
* **Diagnostics**
  * Added RRC connection details to reconnect warnings and debug logs.
  * RRC informational logs are now enabled and forwarded by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->