### PR TITLE
chore(ci): collect scoped reports without dependency setup

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -104,12 +104,25 @@ jobs:
         run: node scripts/ci-run-vitest.mjs
 
       - name: Upload blob report
-        if: always() && contains(fromJSON(needs.changes.outputs.vitest_projects), matrix.project)
+        if: >-
+          always() && needs.changes.outputs.vitest_mode == 'full' &&
+          contains(fromJSON(needs.changes.outputs.vitest_projects), matrix.project)
         uses: actions/upload-artifact@v7
         with:
           name: vitest-blob-${{ matrix.project }}-${{ matrix.shard }}
           path: .vitest-reports/*
           include-hidden-files: true
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload scoped test results
+        if: >-
+          always() && needs.changes.outputs.vitest_mode == 'related' &&
+          contains(fromJSON(needs.changes.outputs.vitest_projects), matrix.project)
+        uses: actions/upload-artifact@v7
+        with:
+          name: vitest-junit-${{ matrix.project }}-${{ matrix.shard }}
+          path: test-results/junit-${{ matrix.project }}-${{ matrix.shard }}-${{ matrix.shards }}.xml
           retention-days: 1
           if-no-files-found: error
 
@@ -211,15 +224,15 @@ jobs:
 
       # actions/checkout v6.1.0
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-        if: needs.changes.outputs.vitest_mode != 'skip'
+        if: needs.changes.outputs.vitest_mode == 'full'
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/setup-node-pnpm
-        if: needs.changes.outputs.vitest_mode != 'skip'
+        if: needs.changes.outputs.vitest_mode == 'full'
 
       - name: Download blob reports
-        if: needs.changes.outputs.vitest_mode != 'skip'
+        if: needs.changes.outputs.vitest_mode == 'full'
         uses: actions/download-artifact@v7
         with:
           path: .vitest-reports
@@ -230,9 +243,14 @@ jobs:
         if: needs.changes.outputs.vitest_mode == 'full'
         run: pnpm run test:coverage:merge
 
-      - name: Merge scoped test reports
-        if: needs.changes.outputs.vitest_mode == 'related'
-        run: pnpm exec vitest run --merge-reports
+      # Related shards already wrote JUnit; collecting them needs no repository or dependencies.
+      - name: Download scoped test results
+        if: always() && needs.changes.outputs.vitest_mode == 'related'
+        uses: actions/download-artifact@v7
+        with:
+          path: test-results
+          pattern: vitest-junit-*
+          merge-multiple: true
 
       - name: Record skipped test scope
         if: needs.changes.outputs.vitest_mode == 'skip'

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -61,10 +61,10 @@ Runs on every push, pull request, and merge-queue `merge_group` for `main`:
 2. **Pull requests:** run `vitest related` without coverage for the affected project lanes. Docs-only changes skip Vitest. Shared contracts select all projects.
 3. **Safe fallback:** test infrastructure, dependency manifests, deleted/renamed paths, oversized output, or detector failures run the full matrix.
 4. **Protected events:** `merge_group`, pushes to `main`, and manual runs always run full coverage across `renderer-ui`, `renderer-logic`, and `main`.
-5. **Sharding:** `renderer-ui` runs in three shards; `renderer-logic` and `main` each run once. This applies to both related tests and full coverage. Each shard uploads a uniquely named blob report. The existing `Coverage (...)` required checks verify that detection and every shard succeeded.
-6. **Merge job:** combine scoped blob reports for PR feedback, or run `pnpm run test:coverage:merge` on protected events to enforce global thresholds.
+5. **Sharding:** `renderer-ui` runs in three shards; `renderer-logic` and `main` each run once. This applies to both related tests and full coverage. Full runs upload blob reports; related runs write JUnit reports named `junit-<project>-<shard>-<total>.xml` and print results in each shard's log. The existing `Coverage (...)` required checks verify that detection and every shard succeeded.
+6. **Merge job:** collect related JUnit reports without checkout, Node/pnpm setup, or dependency installation. Full runs (protected events and PRs that cannot be safely scoped) still run `pnpm run test:coverage:merge` to enforce global thresholds.
 7. **`reticulum-sidecar-coverage`:** when sidecar paths change, clone the `.rsstack/` workspace, run `cargo llvm-cov --fail-under-lines 45`, and upload `lcov.info`.
-8. Upload merged test results (retained 7 days).
+8. Upload the `vitest-report` artifact (retained 7 days): separate JUnit files for related shards, including empty shards and available reports from failed runs; one merged `junit.xml` for full runs.
 
 The three `Coverage (...)` job names and `Merge coverage` remain stable for the repository ruleset, including when a project or the whole test matrix has no relevant PR work. Superseded runs for the same pull request or ref are cancelled.
 

--- a/scripts/ci-run-vitest.mjs
+++ b/scripts/ci-run-vitest.mjs
@@ -31,19 +31,32 @@ export function buildCiVitestArgs({ mode, project, relatedPaths = [], shard = ''
   }
 
   const reportSuffix = shard ? `-${shard.replace('/', '-')}` : '';
-  const reportArgs = [
+  const shardArgs = [
     '--project',
     project,
-    '--reporter=blob',
-    `--outputFile.blob=.vitest-reports/blob-${project}${reportSuffix}.json`,
     '--passWithNoTests',
     ...(shard ? [`--shard=${shard}`] : []),
   ];
   if (mode === 'full') {
-    return ['run', '--coverage', '--coverage.clean=false', ...reportArgs];
+    return [
+      'run',
+      '--coverage',
+      '--coverage.clean=false',
+      ...shardArgs,
+      '--reporter=blob',
+      `--outputFile.blob=.vitest-reports/blob-${project}${reportSuffix}.json`,
+    ];
   }
   if (mode === 'related' && relatedPaths.length > 0) {
-    return ['related', '--run', ...reportArgs, ...relatedPaths.map(normalizeRelatedPathForVitest)];
+    return [
+      'related',
+      '--run',
+      ...shardArgs,
+      '--reporter=default',
+      '--reporter=junit',
+      `--outputFile.junit=test-results/junit-${project}${reportSuffix}.xml`,
+      ...relatedPaths.map(normalizeRelatedPathForVitest),
+    ];
   }
   throw new Error(`Invalid Vitest CI selection: mode=${mode}, paths=${relatedPaths.length}`);
 }

--- a/scripts/ci-run-vitest.test.mjs
+++ b/scripts/ci-run-vitest.test.mjs
@@ -16,27 +16,44 @@ describe('ci-run-vitest', () => {
       '--coverage.clean=false',
       '--project',
       'main',
+      '--passWithNoTests',
       '--reporter=blob',
       '--outputFile.blob=.vitest-reports/blob-main.json',
-      '--passWithNoTests',
     ]);
   });
 
-  it.each(['full', 'related'])('shards %s runs without colliding blob reports', (mode) => {
-    const outputs = [1, 2, 3].map((index) => {
+  it.each(['full', 'related'])('shards %s runs without colliding reports', (mode) => {
+    const reporter = mode === 'full' ? 'blob' : 'junit';
+    const shards = [
+      ['renderer-ui', '1/3'],
+      ['renderer-ui', '2/3'],
+      ['renderer-ui', '3/3'],
+      ['renderer-logic', '1/1'],
+      ['main', '1/1'],
+    ];
+    const outputs = shards.map(([project, shard]) => {
       const args = buildCiVitestArgs({
         mode,
-        project: 'renderer-ui',
-        shard: `${index}/3`,
+        project,
+        shard,
         relatedPaths: ['src/renderer/App.tsx'],
       });
-      expect(args).toContain(`--shard=${index}/3`);
+      expect(args).toContain(`--shard=${shard}`);
       expect(args.includes('--coverage')).toBe(mode === 'full');
-      if (mode === 'related') expect(args).toContain('src/renderer/App.tsx');
-      return args.find((arg) => arg.startsWith('--outputFile.blob='));
+      expect(args).toContain(`--reporter=${reporter}`);
+      if (mode === 'related') {
+        expect(args).toContain('src/renderer/App.tsx');
+        expect(args).toContain('--reporter=default');
+        expect(args).not.toContain('--reporter=blob');
+      }
+      return args.find((arg) => arg.startsWith(`--outputFile.${reporter}=`));
     });
-    expect(new Set(outputs).size).toBe(3);
-    expect(outputs[0]).toBe('--outputFile.blob=.vitest-reports/blob-renderer-ui-1-3.json');
+    expect(new Set(outputs).size).toBe(5);
+    expect(outputs[0]).toBe(
+      mode === 'full'
+        ? '--outputFile.blob=.vitest-reports/blob-renderer-ui-1-3.json'
+        : '--outputFile.junit=test-results/junit-renderer-ui-1-3.xml',
+    );
   });
 
   it.each(['0/3', '4/3', '1/0', '-1/3', '1.5/3', '1/3/4', 'invalid', '1/9007199254740992'])(
@@ -50,10 +67,10 @@ describe('ci-run-vitest', () => {
     },
   );
 
-  it('propagates a failing shard exit code', () => {
+  it.each(['full', 'related'])('propagates a failing %s shard exit code', (mode) => {
     expect(
       runCiVitest(
-        { mode: 'full', project: 'renderer-ui', shard: '2/3' },
+        { mode, project: 'renderer-ui', shard: '2/3', relatedPaths: ['src/renderer/App.tsx'] },
         { runVitestArgvFn: () => 1 },
       ),
     ).toBe(1);
@@ -74,9 +91,10 @@ describe('ci-run-vitest', () => {
         '--run',
         '--project',
         'main',
-        '--reporter=blob',
-        '--outputFile.blob=.vitest-reports/blob-main.json',
         '--passWithNoTests',
+        '--reporter=default',
+        '--reporter=junit',
+        '--outputFile.junit=test-results/junit-main.xml',
         relatedPath,
       ],
       expect.objectContaining({ cwd: '/repo' }),

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -172,9 +172,14 @@ describe('CI workflow contracts', () => {
   it('collects related JUnit reports without installing the application in the merge job', () => {
     const mergeJob = testsWorkflow.split('  merge-reports:')[1];
     const steps = mergeJob.split(/^ {6}- /m).slice(1);
-    for (const step of steps.filter((value) =>
-      /actions\/checkout@|setup-node-pnpm|Download blob reports|Merge coverage reports/.test(value),
-    )) {
+    for (const requiredStep of [
+      'uses: actions/checkout@',
+      'uses: ./.github/actions/setup-node-pnpm',
+      'name: Download blob reports',
+      'name: Merge coverage reports',
+    ]) {
+      const step = steps.find((value) => value.startsWith(requiredStep));
+      expect(step, requiredStep).toBeDefined();
       expect(step).toContain("if: needs.changes.outputs.vitest_mode == 'full'");
     }
     expect(mergeJob).not.toContain('pnpm exec vitest run --merge-reports');

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -169,6 +169,74 @@ describe('CI workflow contracts', () => {
     expect(ciWorkflow).toContain('pnpm run lint --concurrency 2');
   });
 
+  it('collects related JUnit reports without installing the application in the merge job', () => {
+    const mergeJob = testsWorkflow.split('  merge-reports:')[1];
+    const steps = mergeJob.split(/^ {6}- /m).slice(1);
+    for (const step of steps.filter((value) =>
+      /actions\/checkout@|setup-node-pnpm|Download blob reports|Merge coverage reports/.test(value),
+    )) {
+      expect(step).toContain("if: needs.changes.outputs.vitest_mode == 'full'");
+    }
+    expect(mergeJob).not.toContain('pnpm exec vitest run --merge-reports');
+    const download = steps.find((step) => step.startsWith('name: Download scoped test results'));
+    expect(download).toContain("if: always() && needs.changes.outputs.vitest_mode == 'related'");
+    expect(download).toContain('uses: actions/download-artifact@v7');
+    expect(download).toContain('pattern: vitest-junit-*');
+    expect(download).toContain('path: test-results');
+    expect(download).toContain('merge-multiple: true');
+    expect(mergeJob).toContain('name: vitest-report');
+    expect(mergeJob).toContain('retention-days: 7');
+    expect(mergeJob).toContain('run: pnpm run test:coverage:merge');
+  });
+
+  it('uploads only the selected report format and retains reports from failing shards', () => {
+    const shards = testsWorkflow.split('  test-shards:')[1].split('  tests:')[0];
+    const steps = shards.split(/^ {6}- /m).slice(1);
+    for (const [name, mode, artifact, reportPath] of [
+      ['Upload blob report', 'full', 'vitest-blob', '.vitest-reports/*'],
+      [
+        'Upload scoped test results',
+        'related',
+        'vitest-junit',
+        'test-results/junit-${{ matrix.project }}-${{ matrix.shard }}-${{ matrix.shards }}.xml',
+      ],
+    ]) {
+      const upload = steps.find((step) => step.startsWith(`name: ${name}\n`));
+      expect(upload).toContain(`always() && needs.changes.outputs.vitest_mode == '${mode}' &&`);
+      expect(upload).toContain(
+        'contains(fromJSON(needs.changes.outputs.vitest_projects), matrix.project)',
+      );
+      expect(upload).toContain(`name: ${artifact}-\${{ matrix.project }}-\${{ matrix.shard }}`);
+      expect(upload).toContain(`path: ${reportPath}`);
+      expect(upload).toContain('if-no-files-found: error');
+    }
+  });
+
+  it.each(['full', 'related', 'skip'])('preserves the final required gate for %s runs', (mode) => {
+    const gate = testsWorkflow
+      .split('      - name: Verify selected test jobs')[1]
+      .split('      # actions/checkout')[0]
+      .split('        run: |\n')[1];
+    const success = {
+      ...process.env,
+      CHANGES_RESULT: 'success',
+      SIDECAR_SELECTED: 'false',
+      SIDECAR_RESULT: 'skipped',
+      TESTS_RESULT: mode === 'skip' ? 'skipped' : 'success',
+      VITEST_MODE: mode,
+    };
+    expect(spawnSync('bash', ['-c', gate], { env: success }).status).toBe(0);
+    for (const status of ['failure', 'cancelled', 'skipped']) {
+      for (const env of [
+        { CHANGES_RESULT: status },
+        { SIDECAR_SELECTED: 'true', SIDECAR_RESULT: status },
+        ...(mode === 'skip' ? [] : [{ TESTS_RESULT: status }]),
+      ]) {
+        expect(spawnSync('bash', ['-c', gate], { env: { ...success, ...env } }).status).toBe(1);
+      }
+    }
+  });
+
   it('scopes pull request tests and keeps protected events on full coverage', () => {
     expect(testsWorkflow).toContain('run: node scripts/ci-test-scope.mjs');
     expect(testsWorkflow).toContain('VITEST_MODE: ${{ needs.changes.outputs.vitest_mode }}');


### PR DESCRIPTION
GitHub records 35 seconds of execution for the [Merge coverage job linked by Joey](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34712835822/job/103604783068?pr=1000): 24 seconds went to Node/pnpm setup and dependency installation, including Electron setup, while the scoped report merge took under a second. The entire Tests workflow ran from 18:59:47 to 19:01:34 UTC (1m 47s), including the wait for preceding jobs. Its JUnit artifact contains 51 test cases from a related-test selection.

Related PR shards now write JUnit directly and print results in their own logs. The final job collects those XML files without checkout, dependency setup, or another Vitest invocation. This removes the setup that accounted for most of the linked job's execution time. It does not remove earlier test or scheduling time; the new hosted duration still needs measurement on a related-test PR.

The `vitest-report` artifact contains `junit-<project>-<shard>-<total>.xml` files for related runs instead of one merged `junit.xml`. Names are unique across projects and shards, and available reports are collected even when a shard fails. Full runs keep blob merging, global coverage thresholds, and the merged `junit.xml`. Required check names and failure gates are preserved.

Validation:

- Focused CI runner, scope detector, and workflow contracts: 57 tests passed.
- Replayed the linked PR's selection through all five shards: all 51 JUnit test cases match the original artifact, with no missing or extra cases.
- Real Vitest fixtures verified passing, failing, skipped, and empty-shard JUnit output, XML escaping, and failure exit codes.
- CodeRabbit follow-up: each full-coverage step must exist before its condition is checked. Removing checkout, dependency setup, blob download, or coverage merge individually makes the workflow test fail.
- `actionlint`, `yamllint`, and `git diff --check` passed.
- `pnpm run check:pr` passed: full lint, typecheck, strict-shared typecheck, and 10,814 tests passed (5 skipped; 1,027 test files passed, 1 skipped).
- Normal commit hooks passed, including policy scanners and staged tests.
- [CI on cb6f7026](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34716878365) passed with full coverage: 10,819 JUnit test cases, including 5 skipped, in a 4m 52s Tests workflow. Changes to test infrastructure select the full suite, so this run validates full-coverage compatibility rather than measuring the related-report speedup. All other applicable CI checks passed, and CodeRabbit's follow-up review covered this commit with no new actionable comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI test result collection for related test runs by generating separate JUnit reports for each project and shard.
  * Ensured test reports remain available when individual shards fail.
  * Limited coverage report processing to full test runs, reducing unnecessary CI work.

* **Documentation**
  * Updated CI/CD documentation to explain reporting behavior for full and related test runs, including shard-specific results and uploaded artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->