### PR TITLE
perf(ci): speed up Windows ARM64 sidecar builds

### DIFF
--- a/.github/workflows/reticulum-sidecar.yaml
+++ b/.github/workflows/reticulum-sidecar.yaml
@@ -86,11 +86,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: ${{ matrix.target }}
+      - name: Test sidecar (stub)
+        working-directory: reticulum-sidecar
+        run: cargo test
       - name: Build sidecar (stub)
         working-directory: reticulum-sidecar
-        run: |
-          cargo test
-          cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }}
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -130,11 +131,12 @@ jobs:
       - name: Install Linux BLE build deps
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Test sidecar (rns-stack)
+        working-directory: reticulum-sidecar
+        run: cargo test --features rns-stack,rns-ble,rns-rnode-tcp
       - name: Build sidecar (rns-stack)
         working-directory: reticulum-sidecar
-        run: |
-          cargo test --features rns-stack,rns-ble,rns-rnode-tcp
-          cargo build --release --target ${{ matrix.target }} --features rns-stack,rns-ble,rns-rnode-tcp
+        run: cargo build --release --target ${{ matrix.target }} --features rns-stack,rns-ble,rns-rnode-tcp
       - name: Upload rns-stack artifact
         uses: actions/upload-artifact@v7
         with:
@@ -158,11 +160,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: aarch64-pc-windows-msvc
+      # Swatinem/rust-cache v2.9.2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          workspaces: reticulum-sidecar -> target
+          key: aarch64-pc-windows-msvc
+          cache-bin: false
+          cache-workspace-crates: false
+      # Host tests run in the Windows x64 stub matrix job.
       - name: Build WoA sidecar (stub)
         working-directory: reticulum-sidecar
-        run: |
-          cargo test
-          cargo build --release --target aarch64-pc-windows-msvc
+        run: cargo build --release --target aarch64-pc-windows-msvc
       - uses: actions/upload-artifact@v7
         with:
           name: mesh-client-reticulum-win-arm64
@@ -183,11 +191,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: aarch64-pc-windows-msvc
+      # Swatinem/rust-cache v2.9.2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          workspaces: reticulum-sidecar -> target
+          key: aarch64-pc-windows-msvc
+          cache-bin: false
+          cache-workspace-crates: false
+      # Host tests run in the Windows x64 full-stack matrix job.
       - name: Build WoA sidecar (rns-stack)
         working-directory: reticulum-sidecar
-        run: |
-          cargo test --features rns-stack,rns-ble,rns-rnode-tcp
-          cargo build --release --target aarch64-pc-windows-msvc --features rns-stack,rns-ble,rns-rnode-tcp
+        run: cargo build --release --target aarch64-pc-windows-msvc --features rns-stack,rns-ble,rns-rnode-tcp
       - uses: actions/upload-artifact@v7
         with:
           name: mesh-client-reticulum-rns-win-arm64

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -89,7 +89,9 @@ Local: `pnpm run test:e2e:build`. See [development-environment.md](development-e
 Path-filtered on `reticulum-sidecar/**` and related scripts:
 
 1. **`lint` job (ubuntu-latest)** — `cargo fmt --check` + `cargo clippy` with `rns-stack,rns-ble,rns-rnode-tcp` (`-D warnings`)
-2. **Build matrix** — stub + full-stack `cargo test` and release builds on Linux, macOS, and Windows (including WoA arm64 jobs)
+2. **Build matrix** — stub + full-stack `cargo test` and release builds on Linux, macOS, and Windows. The WoA arm64 jobs cross-compile release binaries on Windows x64 runners; the Windows x64 matrix jobs run the corresponding host tests once.
+
+The two WoA jobs cache Cargo downloads and compiled dependencies with `Swatinem/rust-cache`, separately by job and Rust toolchain. The sidecar workspace crate is excluded from the cache. Every run still clones the current Ratspeak sources, applies overlays, and invokes Cargo to rebuild changed path dependencies and the ARM64 executable. A cache miss performs a normal release build.
 
 CI and local **dev** clones float the `.rsstack/` workspace via `scripts/clone-ratspeak-stack.sh` to `origin/main` (overlays must apply; optional `RS_RETICULUM_REF` / `RS_LXMF_REF` / `RS_NOMAD_REF` / `RS_LXST_REF` / `RS_LRGP_REF` for bisect only — CI never pins Ratspeak SHAs). Open upstream feature PRs needed before they land on `main` (e.g. [rsReticulum#26](https://github.com/ratspeak/rsReticulum/pull/26) ReplyFile, [rsLXMF#7](https://github.com/ratspeak/rsLXMF/pull/7) multi-file attachments) are carried as overlays under `reticulum-sidecar/patches/` and tracked by `RATSPEAK_PATCH_ENTRIES` in `scripts/update.sh`. **Release** packaging (`scripts/build-reticulum-sidecar-release.mjs`) runs the same clone and records the resolved commit SHAs for all five crates in `.rsstack/RESOLVED_SHAS.txt` so artifacts retain the exact source revisions used — set `RS_*_REF` only when a release must not float.
 

--- a/scripts/ci-workflows.test.mjs
+++ b/scripts/ci-workflows.test.mjs
@@ -259,3 +259,67 @@ describe('CI workflow contracts', () => {
     expect(testsWorkflow.match(/persist-credentials: false/g)).toHaveLength(4);
   });
 });
+
+describe('Windows ARM64 sidecar builds', () => {
+  const workflow = read('.github/workflows/reticulum-sidecar.yaml');
+  const variants = [
+    { suffix: '', features: '', artifact: 'mesh-client-reticulum-win-arm64' },
+    {
+      suffix: '-rns-stack',
+      features: ' --features rns-stack,rns-ble,rns-rnode-tcp',
+      artifact: 'mesh-client-reticulum-rns-win-arm64',
+    },
+  ];
+
+  function job(name) {
+    const body = workflow.split(`\n  ${name}:\n`)[1];
+    expect(body, `job ${name}`).toBeDefined();
+    return body.split(/\n {2}[\w-]+:\n/)[0];
+  }
+
+  it.each(variants)('keeps $artifact builds and matching Windows host tests', (variant) => {
+    const native = job(`build${variant.suffix}`);
+    expect(native).toContain('os: windows-latest');
+    expect(native).toContain('target: x86_64-pc-windows-msvc');
+    const testStep = native
+      .split('\n      - ')
+      .find((step) => step.startsWith('name: Test sidecar'));
+    expect(testStep).toBeDefined();
+    expect(testStep.split('\n').map((line) => line.trim())).toContain(
+      `run: cargo test${variant.features}`,
+    );
+    expect(testStep).not.toMatch(/\bif:|cargo build/);
+    expect(native).not.toMatch(/continue-on-error:/);
+
+    const arm64 = job(`build-windows-arm64${variant.suffix}`);
+    expect(arm64).toContain('runs-on: windows-latest');
+    expect(arm64).not.toMatch(/cargo test|\bif:|continue-on-error:/);
+    expect(arm64).toContain(
+      `run: cargo build --release --target aarch64-pc-windows-msvc${variant.features}\n`,
+    );
+    expect(arm64).toContain('working-directory: reticulum-sidecar');
+    expect(arm64).toContain(`name: ${variant.artifact}\n`);
+    expect(arm64).toContain(
+      'path: reticulum-sidecar/target/aarch64-pc-windows-msvc/release/mesh-client-reticulum.exe',
+    );
+  });
+
+  it.each(variants)(
+    'caches dependencies after fresh source/toolchain setup for $artifact',
+    (variant) => {
+      const arm64 = job(`build-windows-arm64${variant.suffix}`);
+      const clone = requireIndex(arm64, 'run: bash scripts/clone-ratspeak-stack.sh', 'clone');
+      const toolchain = requireIndex(arm64, 'targets: aarch64-pc-windows-msvc', 'toolchain');
+      const cache = requireIndex(arm64, 'uses: Swatinem/rust-cache@', 'cache');
+      const build = requireIndex(arm64, 'run: cargo build', 'build');
+      expect(clone).toBeLessThan(cache);
+      expect(toolchain).toBeLessThan(cache);
+      expect(cache).toBeLessThan(build);
+      expect(arm64).toMatch(/Swatinem\/rust-cache@[0-9a-f]{40}\n/);
+      expect(arm64).toContain('workspaces: reticulum-sidecar -> target');
+      expect(arm64).toContain('key: aarch64-pc-windows-msvc');
+      expect(arm64).toContain('cache-workspace-crates: false');
+      expect(arm64).not.toMatch(/shared-key:|add-job-id-key: false/);
+    },
+  );
+});


### PR DESCRIPTION
The Windows ARM64 full-stack sidecar job in [PR #1003's run](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34718476773/job/103619844224?pr=1003) took 11m59s. Its combined build step first compiled and ran x64 host tests (about 3m45s), then compiled the ARM64 release executable (7m40s). The Windows x64 matrix job already runs the same tests with the same features.

This removes duplicate host tests from the two ARM64 cross-build jobs and adds commit-pinned `Swatinem/rust-cache` v2.9.2 for their dependencies. The cache stays separate for the stub and full-stack jobs and excludes the sidecar workspace crate. Every run still clones the current Ratspeak sources, applies overlays, and runs the ARM64 release build. Native test jobs, release features, and artifact names/paths are preserved.

The native matrix jobs now run tests and builds in separate steps. This ensures a successful build cannot mask a failed test through PowerShell's last-command exit status.

Validation:

- Workflow contract tests cover native test retention, unconditional ARM64 release builds, artifacts, and cache setup order/isolation.
- `actionlint` and strict `yamllint` pass.
- Full `pnpm run check:pr` passes after updating to current main: lint, both type-checking passes, and 10,835 tests across 1,028 test files (five tests skipped).
- Normal commit hooks pass, including the 17 workflow contract tests.

Measured Windows ARM64 job durations:

| Job | Original | Cold cache | Cache hit |
| --- | --- | --- | --- |
| Full stack | [11m59s](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34718476773/job/103619844224) | [9m35s](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34719853206/job/103623570071) | [6m16s](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34720366969/job/103624999807) |
| Stub | [3m27s](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34718476773/job/103619844275) | [3m29s](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34719853206/job/103623570240) | [1m39s](https://github.com/Colorado-Mesh/mesh-client/actions/runs/34720366969/job/103624999694) |

The cache-hit full-stack job is about 48% faster than the original; the stub job is about 52% faster. Both caches reported an exact match. Logs show fresh compilation of the sidecar and, for the full stack, Nomad. Both downloaded executables have ARM64 PE machine headers (`0xaa64`).

These are job execution times including cache handling and artifact upload, excluding runner queues. The cache-hit run follows a rebase onto current main (`c61d53ae`); hosted-runner comparisons are not controlled benchmarks. Overall workflow completion also depends on the other platform builds.

All applicable CI checks and platform builds pass on `bf3b5385`, including the complete Reticulum sidecar matrix. CodeRabbit found no actionable issues and carried its review forward to this rebased head.

